### PR TITLE
docs: add design whys document

### DIFF
--- a/plans/vertz-design-whys.md
+++ b/plans/vertz-design-whys.md
@@ -145,6 +145,7 @@ schemas/
 ```
 
 Not a single file with all schemas, and not inline in the router. Separate files because:
+- A single schema file inevitably grows large enough to split — and then you have two patterns for organizing schemas. Starting with one file per endpoint avoids that fork entirely.
 - An LLM generating a new endpoint creates one file — clear scope
 - Code review shows exactly what changed per endpoint
 - No merge conflicts from multiple people editing the same schema file


### PR DESCRIPTION
## Summary
- Adds `plans/vertz-design-whys.md` — a document that answers the natural "why?" questions developers ask when reading Vertz code and conventions
- Each entry traces a specific design choice back to the manifesto's beliefs
- Covers: functions over decorators, middleware returns, deps vs ctx, immutability, generics, builder vs compound, response schemas, mock by reference, test app mirroring, natural speech naming, schema files, flat modules

## Relationship to other docs
- **Manifesto** declares *what we believe*
- **Design Whys** explains *why the code looks the way it does*
- **Core API Design** shows *how the API works*
- **Testing Design** shows *how testing works*

## Test plan
- [ ] Review each "Why?" entry for accuracy against current API design
- [ ] Verify no overlap with manifesto (beliefs stay there, reasoning stays here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)