### PR TITLE
docs: compiler design plan

### DIFF
--- a/plans/vertz-core-api-design.md
+++ b/plans/vertz-core-api-design.md
@@ -159,6 +159,7 @@ export const adminMiddleware = vertz.middleware({
 - `headers` — request headers this middleware validates and reads (typed on `ctx.headers`)
 - `params` — path params this middleware validates and reads (typed on `ctx.params`)
 - `query` — query params this middleware validates and reads (typed on `ctx.query`)
+- `body` — request body this middleware validates and reads (typed on `ctx.body`)
 - `requires` — state from previous middlewares (typed on `ctx.state`)
 - `provides` — state this middleware contributes (enforced on return value)
 

--- a/plans/vertz-testing-design.md
+++ b/plans/vertz-testing-design.md
@@ -474,4 +474,5 @@ Vitest is configured with `globals: true` — `vi`, `describe`, `it`, `expect` a
 - [ ] Snapshot testing support
 - [ ] Test coverage tooling integration
 - [ ] Testing WebSocket routes (future)
+- [ ] Testing SSE routes (future)
 - [ ] Testing background jobs (future)


### PR DESCRIPTION
## Summary

- Comprehensive design plan for `@vertz/compiler` — the mandatory compilation step for all Vertz applications
- Defines the full pipeline: ts-morph AST analysis → IR → Validators → Generators → Output files
- 5 generated outputs: OpenAPI 3.1 spec, boot sequence, route table, schema registry, app manifest
- **Build-time safety guarantees**: Rust-inspired — if `vertz build` succeeds, framework plumbing is guaranteed correct (DI wiring, middleware chains, routes, schemas, module graph)
- **Strict mode** (opt-in): error exhaustiveness, environment completeness, dead code as errors
- **Bun-first runtime** with Node.js as fallback
- **Ink CLI rendering** with syntax-highlighted code frames for diagnostics
- `defineConfig()` typed helper for `vertz.config.ts`
- 12 TDD implementation phases
- IR designed as stable contract for future tools (codegen, UI lib, MCP)

## Key Design Decisions

- OTel auto-instrumentation belongs in runtime (`@vertz/core`), not compiler
- Incremental compilation granularity: per-module
- Schemas executed at compile time (import + `.toJSONSchema()`)
- Diagnostic-based error handling with suggestion fields for LLM consumption
- App manifest as first-class output for LLM/agent consumption

## Test plan

- [ ] Review IR type definitions for completeness
- [ ] Verify build-time safety guarantees cover all framework wiring errors
- [ ] Validate strict mode checks are well-scoped
- [ ] Confirm Bun/Node runtime strategy is practical
- [ ] Review implementation phases for correct ordering and dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)