### PR TITLE
feat(schema): implement Phase 7 Enum, Literal, Union schemas

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -27,6 +27,9 @@ export { AnySchema, UnknownSchema, NullSchema, UndefinedSchema, VoidSchema, Neve
 export { ObjectSchema } from './schemas/object';
 export { ArraySchema } from './schemas/array';
 export { TupleSchema } from './schemas/tuple';
+export { EnumSchema } from './schemas/enum';
+export { LiteralSchema } from './schemas/literal';
+export { UnionSchema } from './schemas/union';
 
 // Type inference utilities
 export type { Infer, Output, Input } from './utils/type-inference';

--- a/packages/schema/src/schemas/__tests__/enum.test.ts
+++ b/packages/schema/src/schemas/__tests__/enum.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { EnumSchema } from '../enum';
+import { ErrorCode } from '../../core/errors';
+
+describe('EnumSchema', () => {
+  it('accepts valid enum values', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    expect(schema.parse('red')).toBe('red');
+    expect(schema.parse('green')).toBe('green');
+    expect(schema.parse('blue')).toBe('blue');
+  });
+
+  it('rejects invalid values with InvalidEnumValue', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    const result = schema.safeParse('yellow');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidEnumValue);
+    }
+  });
+
+  it('.exclude(values) creates new enum without specified values', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    const excluded = schema.exclude(['red']);
+    expect(excluded.parse('green')).toBe('green');
+    expect(excluded.safeParse('red').success).toBe(false);
+  });
+
+  it('.extract(values) creates new enum with only specified values', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    const extracted = schema.extract(['red', 'green']);
+    expect(extracted.parse('red')).toBe('red');
+    expect(extracted.safeParse('blue').success).toBe(false);
+  });
+
+  it('.toJSONSchema() returns { enum: [...] }', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    expect(schema.toJSONSchema()).toEqual({ enum: ['red', 'green', 'blue'] });
+  });
+
+  it('rejects non-string values with InvalidEnumValue', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']);
+    for (const value of [42, true, null, undefined, {}, []]) {
+      const result = schema.safeParse(value);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidEnumValue);
+      }
+    }
+  });
+});

--- a/packages/schema/src/schemas/__tests__/literal.test.ts
+++ b/packages/schema/src/schemas/__tests__/literal.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { LiteralSchema } from '../literal';
+import { ErrorCode } from '../../core/errors';
+
+describe('LiteralSchema', () => {
+  it('accepts exact string value', () => {
+    const schema = new LiteralSchema('hello');
+    expect(schema.parse('hello')).toBe('hello');
+  });
+
+  it('accepts exact number, boolean, and null values', () => {
+    expect(new LiteralSchema(42).parse(42)).toBe(42);
+    expect(new LiteralSchema(true).parse(true)).toBe(true);
+    expect(new LiteralSchema(null).parse(null)).toBe(null);
+  });
+
+  it('rejects non-matching values with InvalidLiteral', () => {
+    const schema = new LiteralSchema('hello');
+    const result = schema.safeParse('world');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidLiteral);
+    }
+  });
+
+  it('.toJSONSchema() returns { const: value }', () => {
+    expect(new LiteralSchema('hello').toJSONSchema()).toEqual({ const: 'hello' });
+    expect(new LiteralSchema(42).toJSONSchema()).toEqual({ const: 42 });
+    expect(new LiteralSchema(true).toJSONSchema()).toEqual({ const: true });
+    expect(new LiteralSchema(null).toJSONSchema()).toEqual({ const: null });
+  });
+});

--- a/packages/schema/src/schemas/__tests__/union.test.ts
+++ b/packages/schema/src/schemas/__tests__/union.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { UnionSchema } from '../union';
+import { StringSchema } from '../string';
+import { NumberSchema } from '../number';
+import { ErrorCode } from '../../core/errors';
+
+describe('UnionSchema', () => {
+  it('accepts value matching first option', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]);
+    expect(schema.parse('hello')).toBe('hello');
+  });
+
+  it('accepts value matching second option', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]);
+    expect(schema.parse(42)).toBe(42);
+  });
+
+  it('rejects value matching no option with InvalidUnion', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]);
+    const result = schema.safeParse(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
+    }
+  });
+
+  it('.toJSONSchema() returns { anyOf: [...] }', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]);
+    expect(schema.toJSONSchema()).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    });
+  });
+});

--- a/packages/schema/src/schemas/enum.ts
+++ b/packages/schema/src/schemas/enum.ts
@@ -1,0 +1,48 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class EnumSchema<T extends readonly [string, ...string[]]> extends Schema<T[number]> {
+  private readonly _values: T;
+
+  constructor(values: T) {
+    super();
+    this._values = values;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): T[number] {
+    if (!this._values.includes(value as string)) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidEnumValue,
+        message: `Invalid enum value. Expected ${this._values.map(v => `'${v}'`).join(' | ')}, received '${value}'`,
+      });
+    }
+    return value as T[number];
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Enum;
+  }
+
+  _toJSONSchema(_tracker: RefTracker): JSONSchemaObject {
+    return { enum: [...this._values] };
+  }
+
+  exclude<E extends T[number]>(values: E[]): EnumSchema<readonly [string, ...string[]]> {
+    const remaining = this._values.filter(v => !(values as string[]).includes(v)) as unknown as [string, ...string[]];
+    const schema = new EnumSchema(remaining);
+    return this._cloneBase(schema);
+  }
+
+  extract<E extends T[number]>(values: E[]): EnumSchema<readonly [string, ...string[]]> {
+    const schema = new EnumSchema(values as unknown as [string, ...string[]]);
+    return this._cloneBase(schema);
+  }
+
+  _clone(): EnumSchema<T> {
+    return this._cloneBase(new EnumSchema(this._values));
+  }
+}

--- a/packages/schema/src/schemas/literal.ts
+++ b/packages/schema/src/schemas/literal.ts
@@ -1,0 +1,39 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+type LiteralValue = string | number | boolean | null;
+
+export class LiteralSchema<T extends LiteralValue> extends Schema<T> {
+  private readonly _value: T;
+
+  constructor(value: T) {
+    super();
+    this._value = value;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): T {
+    if (value !== this._value) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidLiteral,
+        message: `Expected ${JSON.stringify(this._value)}, received ${JSON.stringify(value)}`,
+      });
+    }
+    return value as T;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Literal;
+  }
+
+  _toJSONSchema(_tracker: RefTracker): JSONSchemaObject {
+    return { const: this._value };
+  }
+
+  _clone(): LiteralSchema<T> {
+    return this._cloneBase(new LiteralSchema(this._value));
+  }
+}

--- a/packages/schema/src/schemas/union.ts
+++ b/packages/schema/src/schemas/union.ts
@@ -1,0 +1,46 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+type UnionOptions = [Schema<any>, ...Schema<any>[]];
+type InferUnion<T extends UnionOptions> = T[number] extends Schema<infer O> ? O : never;
+
+export class UnionSchema<T extends UnionOptions> extends Schema<InferUnion<T>> {
+  private readonly _options: T;
+
+  constructor(options: T) {
+    super();
+    this._options = options;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): InferUnion<T> {
+    for (const option of this._options) {
+      const result = option.safeParse(value);
+      if (result.success) {
+        return result.data;
+      }
+    }
+    ctx.addIssue({
+      code: ErrorCode.InvalidUnion,
+      message: `Invalid input: value does not match any option in the union`,
+    });
+    return value as any;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Union;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return {
+      anyOf: this._options.map(option => option._toJSONSchemaWithRefs(tracker)),
+    };
+  }
+
+  _clone(): UnionSchema<T> {
+    return this._cloneBase(new UnionSchema(this._options));
+  }
+}


### PR DESCRIPTION
## Summary
- **EnumSchema**: Accept valid enum values, reject invalid with `InvalidEnumValue`, `.exclude()`, `.extract()`, `.toJSONSchema()` → `{ enum: [...] }`
- **LiteralSchema**: Accept exact value (string/number/boolean/null), reject non-matching with `InvalidLiteral`, `.toJSONSchema()` → `{ const: value }`
- **UnionSchema**: Accept value matching any option (tries in order, returns first match), reject matching none with `InvalidUnion`, `.toJSONSchema()` → `{ anyOf: [...] }`

## Test plan
- [ ] 6 enum tests: accept valid, reject invalid, exclude, extract, toJSONSchema, non-string values
- [ ] 4 literal tests: accept string, accept number/boolean/null, reject non-matching, toJSONSchema
- [ ] 4 union tests: accept first option, accept second option, reject none matching, toJSONSchema
- [ ] Full suite: 125 tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)