### PR TITLE
feat(schema): implement Phase 8 DiscriminatedUnion, Intersection, Record schemas

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -30,6 +30,9 @@ export { TupleSchema } from './schemas/tuple';
 export { EnumSchema } from './schemas/enum';
 export { LiteralSchema } from './schemas/literal';
 export { UnionSchema } from './schemas/union';
+export { DiscriminatedUnionSchema } from './schemas/discriminated-union';
+export { IntersectionSchema } from './schemas/intersection';
+export { RecordSchema } from './schemas/record';
 
 // Type inference utilities
 export type { Infer, Output, Input } from './utils/type-inference';

--- a/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
+++ b/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { DiscriminatedUnionSchema } from '../discriminated-union';
+import { ObjectSchema } from '../object';
+import { StringSchema } from '../string';
+import { NumberSchema } from '../number';
+import { LiteralSchema } from '../literal';
+import { ErrorCode } from '../../core/errors';
+
+describe('DiscriminatedUnionSchema', () => {
+  const catSchema = new ObjectSchema({ type: new LiteralSchema('cat'), meow: new StringSchema() });
+  const dogSchema = new ObjectSchema({ type: new LiteralSchema('dog'), bark: new NumberSchema() });
+
+  it('dispatches to correct schema based on discriminator', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    expect(schema.parse({ type: 'cat', meow: 'loud' })).toEqual({ type: 'cat', meow: 'loud' });
+    expect(schema.parse({ type: 'dog', bark: 3 })).toEqual({ type: 'dog', bark: 3 });
+  });
+
+  it('rejects missing discriminator property', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    const result = schema.safeParse({ meow: 'loud' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
+      expect(result.error.issues[0]!.message).toContain('Missing discriminator');
+    }
+  });
+
+  it('rejects unknown discriminator value', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    const result = schema.safeParse({ type: 'fish', fins: 2 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
+      expect(result.error.issues[0]!.message).toContain("'fish'");
+    }
+  });
+
+  it('.toJSONSchema() returns { oneOf, discriminator }', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    expect(schema.toJSONSchema()).toEqual({
+      oneOf: [
+        { type: 'object', properties: { type: { const: 'cat' }, meow: { type: 'string' } }, required: ['type', 'meow'] },
+        { type: 'object', properties: { type: { const: 'dog' }, bark: { type: 'number' } }, required: ['type', 'bark'] },
+      ],
+      discriminator: { propertyName: 'type' },
+    });
+  });
+
+  it('throws when option has non-literal discriminator', () => {
+    const badSchema = new ObjectSchema({ type: new StringSchema(), name: new StringSchema() });
+    expect(() => new DiscriminatedUnionSchema('type', [catSchema, badSchema])).toThrow();
+  });
+
+  it('rejects non-object values', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    const result = schema.safeParse('not-an-object');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+    }
+  });
+});

--- a/packages/schema/src/schemas/__tests__/intersection.test.ts
+++ b/packages/schema/src/schemas/__tests__/intersection.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { IntersectionSchema } from '../intersection';
+import { ObjectSchema } from '../object';
+import { StringSchema } from '../string';
+import { NumberSchema } from '../number';
+import { ErrorCode } from '../../core/errors';
+
+describe('IntersectionSchema', () => {
+  it('accepts values satisfying both schemas', () => {
+    const left = new ObjectSchema({ name: new StringSchema() });
+    const right = new ObjectSchema({ age: new NumberSchema() });
+    const schema = new IntersectionSchema(left, right);
+    expect(schema.parse({ name: 'Alice', age: 30 })).toEqual({ name: 'Alice', age: 30 });
+  });
+
+  it('rejects values failing either schema with InvalidIntersection', () => {
+    const left = new ObjectSchema({ name: new StringSchema() });
+    const right = new ObjectSchema({ age: new NumberSchema() });
+    const schema = new IntersectionSchema(left, right);
+    const result = schema.safeParse({ name: 'Alice' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidIntersection);
+    }
+  });
+
+  it('.toJSONSchema() returns { allOf: [left, right] }', () => {
+    const left = new ObjectSchema({ name: new StringSchema() });
+    const right = new ObjectSchema({ age: new NumberSchema() });
+    const schema = new IntersectionSchema(left, right);
+    expect(schema.toJSONSchema()).toEqual({
+      allOf: [
+        { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+        { type: 'object', properties: { age: { type: 'number' } }, required: ['age'] },
+      ],
+    });
+  });
+});

--- a/packages/schema/src/schemas/__tests__/record.test.ts
+++ b/packages/schema/src/schemas/__tests__/record.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { RecordSchema } from '../record';
+import { StringSchema } from '../string';
+import { NumberSchema } from '../number';
+import { ErrorCode } from '../../core/errors';
+
+describe('RecordSchema', () => {
+  it('accepts valid record with string keys and typed values', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    expect(schema.parse({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+
+  it('validates both keys and values with two-arg constructor', () => {
+    const schema = new RecordSchema(new StringSchema().min(2), new NumberSchema());
+    expect(schema.parse({ ab: 1, cd: 2 })).toEqual({ ab: 1, cd: 2 });
+    const result = schema.safeParse({ x: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid values with path', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    const result = schema.safeParse({ a: 1, b: 'bad' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.path).toEqual(['b']);
+    }
+  });
+
+  it('rejects non-object values', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    const result = schema.safeParse('not-object');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+    }
+  });
+
+  it('.toJSONSchema() returns { type: "object", additionalProperties: { ... } }', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    expect(schema.toJSONSchema()).toEqual({
+      type: 'object',
+      additionalProperties: { type: 'number' },
+    });
+  });
+});

--- a/packages/schema/src/schemas/discriminated-union.ts
+++ b/packages/schema/src/schemas/discriminated-union.ts
@@ -1,0 +1,90 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import { LiteralSchema } from './literal';
+import { ObjectSchema } from './object';
+import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
+
+type DiscriminatedOptions = [ObjectSchema<any>, ...ObjectSchema<any>[]];
+type InferDiscriminatedUnion<T extends DiscriminatedOptions> =
+  T[number] extends Schema<infer O> ? O : never;
+
+function receivedType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export class DiscriminatedUnionSchema<T extends DiscriminatedOptions> extends Schema<
+  InferDiscriminatedUnion<T>
+> {
+  private readonly _discriminator: string;
+  private readonly _options: T;
+  private readonly _lookup: Map<unknown, ObjectSchema<any>>;
+
+  constructor(discriminator: string, options: T) {
+    super();
+    this._discriminator = discriminator;
+    this._options = options;
+    this._lookup = new Map();
+
+    for (const option of options) {
+      const discriminatorSchema = option.shape[discriminator];
+      if (!(discriminatorSchema instanceof LiteralSchema)) {
+        throw new Error(
+          `Discriminated union requires all options to have a literal "${discriminator}" property`,
+        );
+      }
+      this._lookup.set(discriminatorSchema.value, option);
+    }
+  }
+
+  _parse(value: unknown, ctx: ParseContext): InferDiscriminatedUnion<T> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidType,
+        message: 'Expected object, received ' + receivedType(value),
+      });
+      return value as any;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const discriminatorValue = obj[this._discriminator];
+
+    if (discriminatorValue === undefined) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidUnion,
+        message: `Missing discriminator property "${this._discriminator}"`,
+      });
+      return value as any;
+    }
+
+    const matchedSchema = this._lookup.get(discriminatorValue);
+    if (!matchedSchema) {
+      const expected = [...this._lookup.keys()].map(k => `'${k}'`).join(' | ');
+      ctx.addIssue({
+        code: ErrorCode.InvalidUnion,
+        message: `Invalid discriminator value. Expected ${expected}, received '${discriminatorValue}'`,
+      });
+      return value as any;
+    }
+
+    return matchedSchema._runPipeline(value, ctx) as any;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.DiscriminatedUnion;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return {
+      oneOf: this._options.map(option => option._toJSONSchemaWithRefs(tracker)),
+      discriminator: { propertyName: this._discriminator },
+    };
+  }
+
+  _clone(): DiscriminatedUnionSchema<T> {
+    return this._cloneBase(new DiscriminatedUnionSchema(this._discriminator, this._options));
+  }
+}

--- a/packages/schema/src/schemas/intersection.ts
+++ b/packages/schema/src/schemas/intersection.ts
@@ -1,0 +1,56 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
+
+export class IntersectionSchema<
+  L extends Schema<any>,
+  R extends Schema<any>,
+> extends Schema<L['_output'] & R['_output']> {
+  private readonly _left: L;
+  private readonly _right: R;
+
+  constructor(left: L, right: R) {
+    super();
+    this._left = left;
+    this._right = right;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): L['_output'] & R['_output'] {
+    const leftResult = this._left.safeParse(value);
+    const rightResult = this._right.safeParse(value);
+
+    if (!leftResult.success || !rightResult.success) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidIntersection,
+        message: 'Value does not satisfy intersection',
+      });
+      return value as any;
+    }
+
+    if (typeof leftResult.data === 'object' && leftResult.data !== null &&
+        typeof rightResult.data === 'object' && rightResult.data !== null) {
+      return { ...leftResult.data, ...rightResult.data };
+    }
+
+    return leftResult.data;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Intersection;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return {
+      allOf: [
+        this._left._toJSONSchemaWithRefs(tracker),
+        this._right._toJSONSchemaWithRefs(tracker),
+      ],
+    };
+  }
+
+  _clone(): IntersectionSchema<L, R> {
+    return this._cloneBase(new IntersectionSchema(this._left, this._right));
+  }
+}

--- a/packages/schema/src/schemas/literal.ts
+++ b/packages/schema/src/schemas/literal.ts
@@ -15,6 +15,10 @@ export class LiteralSchema<T extends LiteralValue> extends Schema<T> {
     this._value = value;
   }
 
+  get value(): T {
+    return this._value;
+  }
+
   _parse(value: unknown, ctx: ParseContext): T {
     if (value !== this._value) {
       ctx.addIssue({

--- a/packages/schema/src/schemas/record.ts
+++ b/packages/schema/src/schemas/record.ts
@@ -1,0 +1,71 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
+
+function receivedType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export class RecordSchema<V> extends Schema<Record<string, V>> {
+  private readonly _keySchema: Schema<string> | undefined;
+  private readonly _valueSchema: Schema<V>;
+
+  constructor(valueSchema: Schema<V>);
+  constructor(keySchema: Schema<string>, valueSchema: Schema<V>);
+  constructor(keyOrValue: Schema<any>, valueSchema?: Schema<V>) {
+    super();
+    if (valueSchema !== undefined) {
+      this._keySchema = keyOrValue;
+      this._valueSchema = valueSchema;
+    } else {
+      this._keySchema = undefined;
+      this._valueSchema = keyOrValue;
+    }
+  }
+
+  _parse(value: unknown, ctx: ParseContext): Record<string, V> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      ctx.addIssue({
+        code: ErrorCode.InvalidType,
+        message: 'Expected object, received ' + receivedType(value),
+      });
+      return value as Record<string, V>;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const result: Record<string, V> = {};
+
+    for (const key of Object.keys(obj)) {
+      ctx.pushPath(key);
+      if (this._keySchema) {
+        this._keySchema._runPipeline(key, ctx);
+      }
+      result[key] = this._valueSchema._runPipeline(obj[key], ctx);
+      ctx.popPath();
+    }
+
+    return result;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Record;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return {
+      type: 'object',
+      additionalProperties: this._valueSchema._toJSONSchemaWithRefs(tracker),
+    };
+  }
+
+  _clone(): RecordSchema<V> {
+    if (this._keySchema) {
+      return this._cloneBase(new RecordSchema(this._keySchema, this._valueSchema));
+    }
+    return this._cloneBase(new RecordSchema(this._valueSchema));
+  }
+}


### PR DESCRIPTION
## Summary
- **DiscriminatedUnionSchema**: O(1) dispatch via discriminator property lookup map, construction-time validation that all options have literal discriminators, `.toJSONSchema()` → `{ oneOf: [...], discriminator: { propertyName } }`
- **IntersectionSchema**: Validates value against both schemas, merges object results, `.toJSONSchema()` → `{ allOf: [left, right] }`
- **RecordSchema**: Single-arg (value schema) and two-arg (key + value schema) constructors, validates keys and values with path tracking, `.toJSONSchema()` → `{ type: "object", additionalProperties: { ... } }`
- **LiteralSchema**: Added public `value` getter for safe discriminator access (eliminates `as any` cast)

## Test plan
- [ ] 6 discriminated union tests: dispatch, missing discriminator, unknown value, toJSONSchema, non-object, non-literal discriminator throws
- [ ] 3 intersection tests: accept both, reject either, toJSONSchema
- [ ] 5 record tests: single-arg, two-arg key validation, invalid values with path, non-object, toJSONSchema
- [ ] Full suite: 139 tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)