### PR TITLE
feat(schema): implement Phase 9 Refinements and Transforms

### DIFF
--- a/packages/schema/src/effects/__tests__/catch.test.ts
+++ b/packages/schema/src/effects/__tests__/catch.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import { NumberSchema } from '../../schemas/number';
+
+describe('.catch()', () => {
+  it('returns fallback value on parse failure', () => {
+    const schema = new StringSchema().catch('default');
+    expect(schema.parse(42)).toBe('default');
+  });
+
+  it('calls fallback function on parse failure', () => {
+    const schema = new NumberSchema().catch(() => 0);
+    expect(schema.parse('not-a-number')).toBe(0);
+  });
+
+  it('returns normal value on successful parse (fallback ignored)', () => {
+    const schema = new StringSchema().catch('default');
+    expect(schema.parse('hello')).toBe('hello');
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,8 +1,17 @@
 // @vertz/schema — Public API
-// Phase 1: Core Infrastructure
 
 // Core
-export { Schema, OptionalSchema, NullableSchema, DefaultSchema } from './core/schema';
+export {
+  Schema,
+  OptionalSchema,
+  NullableSchema,
+  DefaultSchema,
+  RefinedSchema,
+  SuperRefinedSchema,
+  TransformSchema,
+  PipeSchema,
+  CatchSchema,
+} from './core/schema';
 export { ErrorCode, ParseError } from './core/errors';
 export type { ValidationIssue } from './core/errors';
 export { ParseContext } from './core/parse-context';
@@ -33,6 +42,9 @@ export { UnionSchema } from './schemas/union';
 export { DiscriminatedUnionSchema } from './schemas/discriminated-union';
 export { IntersectionSchema } from './schemas/intersection';
 export { RecordSchema } from './schemas/record';
+
+// Transforms
+export { preprocess } from './transforms/preprocess';
 
 // Type inference utilities
 export type { Infer, Output, Input } from './utils/type-inference';

--- a/packages/schema/src/refinements/__tests__/refine.test.ts
+++ b/packages/schema/src/refinements/__tests__/refine.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import { ErrorCode } from '../../core/errors';
+
+describe('.refine()', () => {
+  it('passes when predicate returns true', () => {
+    const schema = new StringSchema().refine((val) => val.length > 0);
+    expect(schema.parse('hello')).toBe('hello');
+  });
+
+  it('fails with Custom error when predicate returns false', () => {
+    const schema = new StringSchema().refine((val) => val.length > 0);
+    const result = schema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.Custom);
+    }
+  });
+
+  it('uses custom error message', () => {
+    const schema = new StringSchema().refine((val) => val.length > 0, 'Must not be empty');
+    const result = schema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.message).toBe('Must not be empty');
+    }
+  });
+
+  it('uses custom path from params object', () => {
+    const schema = new StringSchema().refine((val) => val.length > 0, { message: 'Required', path: ['name'] });
+    const result = schema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.path).toEqual(['name']);
+    }
+  });
+});

--- a/packages/schema/src/refinements/__tests__/super-refine.test.ts
+++ b/packages/schema/src/refinements/__tests__/super-refine.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import { ErrorCode } from '../../core/errors';
+
+describe('.superRefine()', () => {
+  it('can add multiple issues via ctx.addIssue', () => {
+    const schema = new StringSchema().superRefine((val, ctx) => {
+      if (val.length < 3) {
+        ctx.addIssue({ code: ErrorCode.Custom, message: 'Too short' });
+      }
+      if (!val.includes('@')) {
+        ctx.addIssue({ code: ErrorCode.Custom, message: 'Missing @' });
+      }
+    });
+    const result = schema.safeParse('ab');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBe(2);
+      expect(result.error.issues[0]!.message).toBe('Too short');
+      expect(result.error.issues[1]!.message).toBe('Missing @');
+    }
+  });
+
+  it('ctx.addIssue supports custom error codes', () => {
+    const schema = new StringSchema().superRefine((val, ctx) => {
+      if (val !== 'admin') {
+        ctx.addIssue({ code: ErrorCode.Custom, message: 'Not admin' });
+      }
+    });
+    const result = schema.safeParse('user');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.code).toBe(ErrorCode.Custom);
+    }
+  });
+
+  it('.check() is an alias for superRefine', () => {
+    const schema = new StringSchema().check((val, ctx) => {
+      if (val.length === 0) {
+        ctx.addIssue({ code: ErrorCode.Custom, message: 'Empty' });
+      }
+    });
+    expect(schema.parse('hello')).toBe('hello');
+    const result = schema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.message).toBe('Empty');
+    }
+  });
+});

--- a/packages/schema/src/transforms/__tests__/pipe.test.ts
+++ b/packages/schema/src/transforms/__tests__/pipe.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import { NumberSchema } from '../../schemas/number';
+
+describe('.pipe()', () => {
+  it('chains two schemas — first output feeds into second input', () => {
+    const schema = new StringSchema()
+      .transform((val) => parseInt(val, 10))
+      .pipe(new NumberSchema().min(1));
+    expect(schema.parse('42')).toBe(42);
+  });
+
+  it('validation errors from either schema propagate', () => {
+    const schema = new StringSchema()
+      .transform((val) => parseInt(val, 10))
+      .pipe(new NumberSchema().min(10));
+    const result = schema.safeParse('5');
+    expect(result.success).toBe(false);
+  });
+
+  it('validation errors from first schema propagate', () => {
+    const schema = new StringSchema()
+      .min(1)
+      .transform((val) => parseInt(val, 10))
+      .pipe(new NumberSchema());
+    const result = schema.safeParse('');
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schema/src/transforms/__tests__/preprocess.test.ts
+++ b/packages/schema/src/transforms/__tests__/preprocess.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { preprocess } from '../preprocess';
+import { NumberSchema } from '../../schemas/number';
+
+describe('preprocess()', () => {
+  it('transforms input before validation', () => {
+    const schema = preprocess((val) => Number(val), new NumberSchema());
+    expect(schema.parse('42')).toBe(42);
+  });
+
+  it('preprocessed value is what the schema validates', () => {
+    const schema = preprocess((val) => Number(val), new NumberSchema().min(10));
+    const result = schema.safeParse('5');
+    expect(result.success).toBe(false);
+  });
+
+  it('safeParse catches exceptions thrown by preprocess function', () => {
+    const schema = preprocess(() => { throw new Error('Preprocess exploded'); }, new NumberSchema());
+    const result = schema.safeParse('hello');
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schema/src/transforms/__tests__/transform.test.ts
+++ b/packages/schema/src/transforms/__tests__/transform.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import { NumberSchema } from '../../schemas/number';
+
+describe('.transform()', () => {
+  it('changes output value', () => {
+    const schema = new StringSchema().transform((val) => val.length);
+    expect(schema.parse('hello')).toBe(5);
+  });
+
+  it('changes output type (string → number)', () => {
+    const schema = new StringSchema().transform((val) => parseInt(val, 10));
+    expect(schema.parse('42')).toBe(42);
+  });
+
+  it('chaining: .refine().transform() — refine sees pre-transform value', () => {
+    const schema = new StringSchema()
+      .refine((val) => val.length > 0)
+      .transform((val) => val.toUpperCase());
+    expect(schema.parse('hello')).toBe('HELLO');
+    expect(schema.safeParse('').success).toBe(false);
+  });
+
+  it('safeParse catches exceptions thrown by transform function', () => {
+    const schema = new StringSchema().transform(() => {
+      throw new Error('Transform exploded');
+    });
+    const result = schema.safeParse('hello');
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schema/src/transforms/preprocess.ts
+++ b/packages/schema/src/transforms/preprocess.ts
@@ -1,0 +1,46 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import type { SchemaType } from '../core/types';
+import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
+
+class PreprocessSchema<O> extends Schema<O> {
+  private readonly _preprocess: (value: unknown) => unknown;
+  private readonly _inner: Schema<O>;
+
+  constructor(preprocess: (value: unknown) => unknown, inner: Schema<O>) {
+    super();
+    this._preprocess = preprocess;
+    this._inner = inner;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): O {
+    let processed: unknown;
+    try {
+      processed = this._preprocess(value);
+    } catch (e) {
+      ctx.addIssue({
+        code: ErrorCode.Custom,
+        message: e instanceof Error ? e.message : 'Preprocess failed',
+      });
+      return value as O;
+    }
+    return this._inner._runPipeline(processed, ctx);
+  }
+
+  _schemaType(): SchemaType {
+    return this._inner._schemaType();
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return this._inner._toJSONSchemaWithRefs(tracker);
+  }
+
+  _clone(): PreprocessSchema<O> {
+    return this._cloneBase(new PreprocessSchema(this._preprocess, this._inner));
+  }
+}
+
+export function preprocess<O>(fn: (value: unknown) => unknown, schema: Schema<O>): Schema<O> {
+  return new PreprocessSchema(fn, schema);
+}


### PR DESCRIPTION
## Summary
- **`.refine(predicate)`**: Simple predicate-based validation with Custom error code, supports custom message and path
- **`.superRefine((val, ctx) => {...})`**: Full ctx.addIssue() access for adding multiple custom issues
- **`.check()`**: Alias for `.superRefine()`
- **`.transform(fn)`**: Changes output value and type, safely catches exceptions from transform functions
- **`.pipe(schema)`**: Chains two schemas — first output feeds into second input
- **`preprocess(fn, schema)`**: Standalone function to transform input before validation, safely catches exceptions
- **`.catch(fallback)`**: Returns fallback value (or calls fallback function) on parse failure

All wrapper schemas co-located in `core/schema.ts` alongside existing OptionalSchema/NullableSchema/DefaultSchema to avoid circular imports.

## Test plan
- [ ] 4 refine tests: pass/fail predicate, custom message, custom path
- [ ] 3 superRefine tests: multiple issues, custom codes, .check() alias
- [ ] 4 transform tests: change value, change type, chaining with refine, exception safety
- [ ] 3 pipe tests: chaining, first/second schema error propagation
- [ ] 3 preprocess tests: input transform, validation after preprocess, exception safety
- [ ] 3 catch tests: fallback value, fallback function, successful parse ignores fallback
- [ ] Full suite: 159 tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)