### PR TITLE
feat(schema): implement Phase 10 Effects (Brand, Readonly)

### DIFF
--- a/packages/schema/src/effects/__tests__/brand.test.ts
+++ b/packages/schema/src/effects/__tests__/brand.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { StringSchema } from '../../schemas/string';
+import type { Infer } from '../../utils/type-inference';
+
+describe('.brand()', () => {
+  it('passes value through unchanged at runtime', () => {
+    const schema = new StringSchema().brand<'UserId'>();
+    expect(schema.parse('abc')).toBe('abc');
+  });
+
+  it('infers branded type with __brand property', () => {
+    const schema = new StringSchema().brand<'UserId'>();
+    type Result = Infer<typeof schema>;
+    expectTypeOf<Result>().toMatchTypeOf<string & { readonly __brand: 'UserId' }>();
+  });
+
+  it('different brands produce incompatible types', () => {
+    const userIdSchema = new StringSchema().brand<'UserId'>();
+    const postIdSchema = new StringSchema().brand<'PostId'>();
+    type UserId = Infer<typeof userIdSchema>;
+    type PostId = Infer<typeof postIdSchema>;
+    expectTypeOf<UserId>().not.toMatchTypeOf<PostId>();
+  });
+
+  it('toJSONSchema ignores brand', () => {
+    const schema = new StringSchema().brand<'UserId'>();
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+});

--- a/packages/schema/src/effects/__tests__/readonly.test.ts
+++ b/packages/schema/src/effects/__tests__/readonly.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { ObjectSchema } from '../../schemas/object';
+import { StringSchema } from '../../schemas/string';
+import { NumberSchema } from '../../schemas/number';
+import { ArraySchema } from '../../schemas/array';
+import type { Infer } from '../../utils/type-inference';
+
+describe('.readonly()', () => {
+  it('output is frozen (Object.isFrozen)', () => {
+    const schema = new ObjectSchema({
+      name: new StringSchema(),
+      age: new NumberSchema(),
+    }).readonly();
+    const result = schema.parse({ name: 'Alice', age: 30 });
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it('properties are not writable', () => {
+    const schema = new ObjectSchema({
+      name: new StringSchema(),
+    }).readonly();
+    const result = schema.parse({ name: 'Alice' });
+    expect(() => { (result as any).name = 'Bob'; }).toThrow();
+  });
+
+  it('infers Readonly<T> type', () => {
+    const schema = new ObjectSchema({
+      name: new StringSchema(),
+      age: new NumberSchema(),
+    }).readonly();
+    type Result = Infer<typeof schema>;
+    expectTypeOf<Result>().toMatchTypeOf<Readonly<{ name: string; age: number }>>();
+  });
+
+  it('freezes arrays', () => {
+    const schema = new ArraySchema(new StringSchema()).readonly();
+    const result = schema.parse(['a', 'b']);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(() => { (result as any).push('c'); }).toThrow();
+  });
+
+  it('passes primitives through unchanged', () => {
+    const schema = new NumberSchema().readonly();
+    expect(schema.parse(42)).toBe(42);
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,6 +11,8 @@ export {
   TransformSchema,
   PipeSchema,
   CatchSchema,
+  BrandedSchema,
+  ReadonlySchema,
 } from './core/schema';
 export { ErrorCode, ParseError } from './core/errors';
 export type { ValidationIssue } from './core/errors';


### PR DESCRIPTION
## Summary

- **BrandedSchema** (`.brand<B>()`) — type-level branding that passes values through unchanged at runtime. Different brands produce incompatible types, enabling nominal typing patterns (e.g., `UserId` vs `PostId`). JSON Schema output ignores brand.
- **ReadonlySchema** (`.readonly()`) — wraps output with `Object.freeze()` for runtime immutability. Works on objects and arrays. Primitives pass through unchanged. Infers `Readonly<T>` at the type level.
- 168 tests passing (9 new)

## Test plan

- [x] Brand passes value through unchanged at runtime
- [x] Brand infers `__brand` property in output type
- [x] Different brands produce incompatible types
- [x] Brand JSON Schema ignores brand (delegates to inner)
- [x] Readonly output is frozen (`Object.isFrozen`)
- [x] Readonly properties are not writable (throws on mutation)
- [x] Readonly infers `Readonly<T>` type
- [x] Readonly freezes arrays (can't push)
- [x] Readonly passes primitives through unchanged
- [x] Full test suite: 168 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)