### PR TITLE
feat(schema): implement Phase 11 Coercion Schemas

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -44,6 +44,13 @@ export { UnionSchema } from './schemas/union';
 export { DiscriminatedUnionSchema } from './schemas/discriminated-union';
 export { IntersectionSchema } from './schemas/intersection';
 export { RecordSchema } from './schemas/record';
+export {
+  CoercedStringSchema,
+  CoercedNumberSchema,
+  CoercedBooleanSchema,
+  CoercedBigIntSchema,
+  CoercedDateSchema,
+} from './schemas/coerced';
 
 // Transforms
 export { preprocess } from './transforms/preprocess';

--- a/packages/schema/src/schemas/__tests__/coerced.test.ts
+++ b/packages/schema/src/schemas/__tests__/coerced.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CoercedStringSchema,
+  CoercedNumberSchema,
+  CoercedBooleanSchema,
+  CoercedBigIntSchema,
+  CoercedDateSchema,
+} from '../coerced';
+
+describe('CoercedStringSchema', () => {
+  it('coerces number to string', () => {
+    const schema = new CoercedStringSchema();
+    expect(schema.parse(42)).toBe('42');
+  });
+
+  it('coerces boolean to string, null and undefined to empty string', () => {
+    const schema = new CoercedStringSchema();
+    expect(schema.parse(true)).toBe('true');
+    expect(schema.parse(null)).toBe('');
+    expect(schema.parse(undefined)).toBe('');
+  });
+});
+
+describe('CoercedNumberSchema', () => {
+  it('coerces string to number', () => {
+    const schema = new CoercedNumberSchema();
+    expect(schema.parse('42')).toBe(42);
+  });
+
+  it('coerces boolean to number', () => {
+    const schema = new CoercedNumberSchema();
+    expect(schema.parse(true)).toBe(1);
+    expect(schema.parse(false)).toBe(0);
+  });
+});
+
+describe('CoercedBooleanSchema', () => {
+  it('coerces truthy/falsy values to boolean', () => {
+    const schema = new CoercedBooleanSchema();
+    expect(schema.parse(1)).toBe(true);
+    expect(schema.parse(0)).toBe(false);
+    expect(schema.parse('')).toBe(false);
+    expect(schema.parse('hello')).toBe(true);
+  });
+});
+
+describe('CoercedBigIntSchema', () => {
+  it('coerces string and number to bigint', () => {
+    const schema = new CoercedBigIntSchema();
+    expect(schema.parse('42')).toBe(42n);
+    expect(schema.parse(42)).toBe(42n);
+  });
+
+  it('fails on non-coercible values', () => {
+    const schema = new CoercedBigIntSchema();
+    const result = schema.safeParse('not-a-number');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CoercedDateSchema', () => {
+  it('coerces string to Date', () => {
+    const schema = new CoercedDateSchema();
+    const result = schema.parse('2024-01-15');
+    expect(result).toBeInstanceOf(Date);
+    expect(result.toISOString()).toContain('2024-01-15');
+  });
+
+  it('coerces number (timestamp) to Date', () => {
+    const schema = new CoercedDateSchema();
+    const now = Date.now();
+    const result = schema.parse(now);
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getTime()).toBe(now);
+  });
+
+  it('rejects invalid date strings', () => {
+    const schema = new CoercedDateSchema();
+    const result = schema.safeParse('not-a-date');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('coerced schemas inherit constraint methods', () => {
+  it('CoercedNumberSchema supports .min()', () => {
+    const schema = new CoercedNumberSchema().min(10);
+    expect(schema.parse('42')).toBe(42);
+    expect(schema.safeParse('5').success).toBe(false);
+  });
+
+  it('CoercedStringSchema supports .min()', () => {
+    const schema = new CoercedStringSchema().min(3);
+    expect(schema.parse(1234)).toBe('1234');
+    expect(schema.safeParse(12).success).toBe(false);
+  });
+
+  it('JSON Schema output matches non-coerced counterpart', () => {
+    expect(new CoercedStringSchema().toJSONSchema()).toEqual({ type: 'string' });
+    expect(new CoercedNumberSchema().toJSONSchema()).toEqual({ type: 'number' });
+    expect(new CoercedBooleanSchema().toJSONSchema()).toEqual({ type: 'boolean' });
+    expect(new CoercedDateSchema().toJSONSchema()).toEqual({ type: 'string', format: 'date-time' });
+  });
+});

--- a/packages/schema/src/schemas/coerced.ts
+++ b/packages/schema/src/schemas/coerced.ts
@@ -1,0 +1,64 @@
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { StringSchema } from './string';
+import { NumberSchema } from './number';
+import { BooleanSchema } from './boolean';
+import { BigIntSchema } from './bigint';
+import { DateSchema } from './date';
+
+export class CoercedStringSchema extends StringSchema {
+  _parse(value: unknown, ctx: ParseContext): string {
+    return super._parse(value == null ? '' : String(value), ctx);
+  }
+
+  _clone(): CoercedStringSchema {
+    return Object.assign(new CoercedStringSchema(), super._clone());
+  }
+}
+
+export class CoercedNumberSchema extends NumberSchema {
+  _parse(value: unknown, ctx: ParseContext): number {
+    return super._parse(Number(value), ctx);
+  }
+
+  _clone(): CoercedNumberSchema {
+    return Object.assign(new CoercedNumberSchema(), super._clone());
+  }
+}
+
+export class CoercedBooleanSchema extends BooleanSchema {
+  _parse(value: unknown, ctx: ParseContext): boolean {
+    return super._parse(Boolean(value), ctx);
+  }
+
+  _clone(): CoercedBooleanSchema {
+    return Object.assign(new CoercedBooleanSchema(), super._clone());
+  }
+}
+
+export class CoercedBigIntSchema extends BigIntSchema {
+  _parse(value: unknown, ctx: ParseContext): bigint {
+    if (typeof value === 'bigint') return super._parse(value, ctx);
+    try {
+      return super._parse(BigInt(value as any), ctx);
+    } catch {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: 'Expected value coercible to bigint' });
+      return value as bigint;
+    }
+  }
+
+  _clone(): CoercedBigIntSchema {
+    return Object.assign(new CoercedBigIntSchema(), super._clone());
+  }
+}
+
+export class CoercedDateSchema extends DateSchema {
+  _parse(value: unknown, ctx: ParseContext): Date {
+    if (value instanceof Date) return super._parse(value, ctx);
+    return super._parse(new Date(value as any), ctx);
+  }
+
+  _clone(): CoercedDateSchema {
+    return Object.assign(new CoercedDateSchema(), super._clone());
+  }
+}


### PR DESCRIPTION
## Summary

- **CoercedStringSchema** — coerces any value to string via `String()`, maps `null`/`undefined` to `''`
- **CoercedNumberSchema** — coerces via `Number()`, NaN handled by parent NumberSchema
- **CoercedBooleanSchema** — coerces via `Boolean()` (truthy/falsy)
- **CoercedBigIntSchema** — coerces via `BigInt()` with try-catch for non-coercible values
- **CoercedDateSchema** — coerces via `new Date()`, invalid dates caught by parent DateSchema
- All coerced schemas inherit constraint methods from parents (`.min()`, `.max()`, etc.)
- JSON Schema output matches non-coerced counterparts
- 181 tests passing (13 new)

## Test plan

- [x] CoercedString: number → string, boolean → string, null/undefined → ''
- [x] CoercedNumber: string → number, boolean → number
- [x] CoercedBoolean: truthy/falsy → boolean
- [x] CoercedBigInt: string → bigint, number → bigint, non-coercible fails
- [x] CoercedDate: string → Date, number (timestamp) → Date, invalid rejects
- [x] Constraint inheritance: `.min()` works after coercion
- [x] JSON Schema output matches non-coerced counterparts
- [x] Full test suite: 181 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)