### PR TITLE
feat(schema): implement Phase 12 String Format Schemas

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -52,6 +52,26 @@ export {
   CoercedDateSchema,
 } from './schemas/coerced';
 
+// Formats
+export {
+  EmailSchema,
+  UuidSchema,
+  UrlSchema,
+  HostnameSchema,
+  Ipv4Schema,
+  Ipv6Schema,
+  Base64Schema,
+  HexSchema,
+  JwtSchema,
+  CuidSchema,
+  UlidSchema,
+  NanoidSchema,
+  IsoDateSchema,
+  IsoTimeSchema,
+  IsoDatetimeSchema,
+  IsoDurationSchema,
+} from './schemas/formats';
+
 // Transforms
 export { preprocess } from './transforms/preprocess';
 

--- a/packages/schema/src/schemas/formats/__tests__/base64.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/base64.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { Base64Schema } from '../base64';
+
+describe('Base64Schema', () => {
+  it('accepts valid base64 strings', () => {
+    const schema = new Base64Schema();
+    expect(schema.parse('SGVsbG8=')).toBe('SGVsbG8=');
+    expect(schema.parse('YWJj')).toBe('YWJj');
+    expect(schema.parse('YWJjZA==')).toBe('YWJjZA==');
+  });
+
+  it('rejects invalid base64 strings', () => {
+    const schema = new Base64Schema();
+    expect(schema.safeParse('not base64!').success).toBe(false);
+    expect(schema.safeParse('abc').success).toBe(false); // length not divisible by 4
+  });
+
+  it('toJSONSchema includes contentEncoding', () => {
+    expect(new Base64Schema().toJSONSchema()).toEqual({ type: 'string', contentEncoding: 'base64' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/cuid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/cuid.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CuidSchema } from '../cuid';
+
+describe('CuidSchema', () => {
+  it('accepts valid CUID format', () => {
+    const schema = new CuidSchema();
+    expect(schema.parse('cjld2cyuq0000t3rmniod1foy')).toBe('cjld2cyuq0000t3rmniod1foy');
+  });
+
+  it('rejects invalid CUID', () => {
+    const schema = new CuidSchema();
+    expect(schema.safeParse('not-a-cuid').success).toBe(false);
+    expect(schema.safeParse('xjld2cyuq0000t3rmniod1foy').success).toBe(false); // wrong prefix
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/email.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/email.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { EmailSchema } from '../email';
+
+describe('EmailSchema', () => {
+  it('accepts valid emails', () => {
+    const schema = new EmailSchema();
+    expect(schema.parse('user@domain.com')).toBe('user@domain.com');
+    expect(schema.parse('user+tag@sub.domain.co')).toBe('user+tag@sub.domain.co');
+  });
+
+  it('rejects invalid emails', () => {
+    const schema = new EmailSchema();
+    expect(schema.safeParse('no-at-sign').success).toBe(false);
+    expect(schema.safeParse('double@@domain.com').success).toBe(false);
+    expect(schema.safeParse('@domain.com').success).toBe(false);
+  });
+
+  it('inherits StringSchema methods', () => {
+    const schema = new EmailSchema().min(10);
+    expect(schema.safeParse('a@b.co').success).toBe(false);
+    expect(schema.parse('user@domain.com')).toBe('user@domain.com');
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new EmailSchema().toJSONSchema()).toEqual({ type: 'string', format: 'email' });
+  });
+
+  it('does not hang on adversarial input (ReDoS)', () => {
+    const schema = new EmailSchema();
+    const start = Date.now();
+    schema.safeParse('a@' + 'a-'.repeat(50) + '.com');
+    schema.safeParse('a@' + 'a.'.repeat(50) + 'x');
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/hex.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/hex.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { HexSchema } from '../hex';
+
+describe('HexSchema', () => {
+  it('accepts valid hex strings', () => {
+    const schema = new HexSchema();
+    expect(schema.parse('deadbeef')).toBe('deadbeef');
+    expect(schema.parse('0123456789abcdefABCDEF')).toBe('0123456789abcdefABCDEF');
+  });
+
+  it('rejects non-hex characters', () => {
+    const schema = new HexSchema();
+    expect(schema.safeParse('xyz').success).toBe(false);
+    expect(schema.safeParse('0x1234').success).toBe(false);
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/hostname.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/hostname.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { HostnameSchema } from '../hostname';
+
+describe('HostnameSchema', () => {
+  it('accepts valid hostnames', () => {
+    const schema = new HostnameSchema();
+    expect(schema.parse('example.com')).toBe('example.com');
+    expect(schema.parse('sub.domain.co.uk')).toBe('sub.domain.co.uk');
+    expect(schema.parse('localhost')).toBe('localhost');
+  });
+
+  it('rejects invalid hostnames', () => {
+    const schema = new HostnameSchema();
+    expect(schema.safeParse('-invalid.com').success).toBe(false);
+    expect(schema.safeParse('').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new HostnameSchema().toJSONSchema()).toEqual({ type: 'string', format: 'hostname' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/ipv4.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/ipv4.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { Ipv4Schema } from '../ipv4';
+
+describe('Ipv4Schema', () => {
+  it('accepts valid IPv4 addresses', () => {
+    const schema = new Ipv4Schema();
+    expect(schema.parse('0.0.0.0')).toBe('0.0.0.0');
+    expect(schema.parse('255.255.255.255')).toBe('255.255.255.255');
+    expect(schema.parse('192.168.1.1')).toBe('192.168.1.1');
+  });
+
+  it('rejects invalid IPv4 addresses', () => {
+    const schema = new Ipv4Schema();
+    expect(schema.safeParse('256.0.0.0').success).toBe(false);
+    expect(schema.safeParse('1.2.3').success).toBe(false);
+    expect(schema.safeParse('not-an-ip').success).toBe(false);
+  });
+
+  it('rejects octets with leading zeros', () => {
+    const schema = new Ipv4Schema();
+    expect(schema.safeParse('192.168.001.001').success).toBe(false);
+    expect(schema.safeParse('01.02.03.04').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new Ipv4Schema().toJSONSchema()).toEqual({ type: 'string', format: 'ipv4' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/ipv6.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/ipv6.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { Ipv6Schema } from '../ipv6';
+
+describe('Ipv6Schema', () => {
+  it('accepts valid IPv6 addresses', () => {
+    const schema = new Ipv6Schema();
+    expect(schema.parse('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
+    expect(schema.parse('::1')).toBe('::1');
+    expect(schema.parse('fe80::1')).toBe('fe80::1');
+  });
+
+  it('rejects invalid IPv6 addresses', () => {
+    const schema = new Ipv6Schema();
+    expect(schema.safeParse('not-ipv6').success).toBe(false);
+    expect(schema.safeParse('12345::1').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new Ipv6Schema().toJSONSchema()).toEqual({ type: 'string', format: 'ipv6' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/iso.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/iso.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { IsoDateSchema, IsoTimeSchema, IsoDatetimeSchema, IsoDurationSchema } from '../iso';
+
+describe('IsoDateSchema', () => {
+  it('accepts valid ISO dates', () => {
+    const schema = new IsoDateSchema();
+    expect(schema.parse('2024-01-15')).toBe('2024-01-15');
+  });
+
+  it('rejects invalid ISO dates', () => {
+    const schema = new IsoDateSchema();
+    expect(schema.safeParse('2024-13-01').success).toBe(false);
+    expect(schema.safeParse('2024-00-01').success).toBe(false);
+    expect(schema.safeParse('not-a-date').success).toBe(false);
+  });
+
+  it('rejects impossible dates like Feb 31', () => {
+    const schema = new IsoDateSchema();
+    expect(schema.safeParse('2024-02-31').success).toBe(false);
+    expect(schema.safeParse('2024-04-31').success).toBe(false);
+    expect(schema.safeParse('2025-02-29').success).toBe(false); // not a leap year
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new IsoDateSchema().toJSONSchema()).toEqual({ type: 'string', format: 'date' });
+  });
+});
+
+describe('IsoTimeSchema', () => {
+  it('accepts valid ISO times', () => {
+    const schema = new IsoTimeSchema();
+    expect(schema.parse('14:30:00')).toBe('14:30:00');
+    expect(schema.parse('14:30:00.123Z')).toBe('14:30:00.123Z');
+  });
+
+  it('rejects invalid ISO times', () => {
+    const schema = new IsoTimeSchema();
+    expect(schema.safeParse('25:00:00').success).toBe(false);
+    expect(schema.safeParse('not-a-time').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new IsoTimeSchema().toJSONSchema()).toEqual({ type: 'string', format: 'time' });
+  });
+});
+
+describe('IsoDatetimeSchema', () => {
+  it('accepts valid ISO datetimes', () => {
+    const schema = new IsoDatetimeSchema();
+    expect(schema.parse('2024-01-15T14:30:00Z')).toBe('2024-01-15T14:30:00Z');
+  });
+
+  it('rejects invalid ISO datetimes', () => {
+    const schema = new IsoDatetimeSchema();
+    expect(schema.safeParse('not-a-datetime').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new IsoDatetimeSchema().toJSONSchema()).toEqual({ type: 'string', format: 'date-time' });
+  });
+});
+
+describe('IsoDurationSchema', () => {
+  it('accepts valid ISO durations', () => {
+    const schema = new IsoDurationSchema();
+    expect(schema.parse('P1Y2M3DT4H5M6S')).toBe('P1Y2M3DT4H5M6S');
+    expect(schema.parse('PT1H')).toBe('PT1H');
+    expect(schema.parse('P1D')).toBe('P1D');
+  });
+
+  it('rejects invalid ISO durations', () => {
+    const schema = new IsoDurationSchema();
+    expect(schema.safeParse('not-a-duration').success).toBe(false);
+    expect(schema.safeParse('P').success).toBe(false); // bare P with no components
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new IsoDurationSchema().toJSONSchema()).toEqual({ type: 'string', format: 'duration' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/jwt.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/jwt.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { JwtSchema } from '../jwt';
+
+describe('JwtSchema', () => {
+  it('accepts valid JWT format', () => {
+    const schema = new JwtSchema();
+    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    expect(schema.parse(token)).toBe(token);
+  });
+
+  it('rejects invalid JWT', () => {
+    const schema = new JwtSchema();
+    expect(schema.safeParse('not.a.jwt!').success).toBe(false);
+    expect(schema.safeParse('only-one-part').success).toBe(false);
+    expect(schema.safeParse('two.parts').success).toBe(false);
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/nanoid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/nanoid.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { NanoidSchema } from '../nanoid';
+
+describe('NanoidSchema', () => {
+  it('accepts valid nanoid format', () => {
+    const schema = new NanoidSchema();
+    expect(schema.parse('V1StGXR8_Z5jdHi6B-myT')).toBe('V1StGXR8_Z5jdHi6B-myT');
+  });
+
+  it('rejects invalid nanoid', () => {
+    const schema = new NanoidSchema();
+    expect(schema.safeParse('too-short').success).toBe(false);
+    expect(schema.safeParse('V1StGXR8_Z5jdHi6B-myT!').success).toBe(false); // invalid char
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/ulid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/ulid.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { UlidSchema } from '../ulid';
+
+describe('UlidSchema', () => {
+  it('accepts valid ULID format', () => {
+    const schema = new UlidSchema();
+    expect(schema.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+  });
+
+  it('rejects invalid ULID', () => {
+    const schema = new UlidSchema();
+    expect(schema.safeParse('not-a-ulid').success).toBe(false);
+    expect(schema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FA').success).toBe(false); // too short
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/url.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/url.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { UrlSchema } from '../url';
+
+describe('UrlSchema', () => {
+  it('accepts valid URLs', () => {
+    const schema = new UrlSchema();
+    expect(schema.parse('https://example.com')).toBe('https://example.com');
+    expect(schema.parse('http://example.com/path?q=1')).toBe('http://example.com/path?q=1');
+  });
+
+  it('rejects invalid URLs', () => {
+    const schema = new UrlSchema();
+    expect(schema.safeParse('not-a-url').success).toBe(false);
+    expect(schema.safeParse('://missing-scheme').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new UrlSchema().toJSONSchema()).toEqual({ type: 'string', format: 'uri' });
+  });
+});

--- a/packages/schema/src/schemas/formats/__tests__/uuid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/uuid.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { UuidSchema } from '../uuid';
+
+describe('UuidSchema', () => {
+  it('accepts valid UUIDs', () => {
+    const schema = new UuidSchema();
+    expect(schema.parse('550e8400-e29b-41d4-a716-446655440000')).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(schema.parse('F47AC10B-58CC-4372-A567-0E02B2C3D479')).toBe('F47AC10B-58CC-4372-A567-0E02B2C3D479');
+  });
+
+  it('rejects invalid UUIDs', () => {
+    const schema = new UuidSchema();
+    expect(schema.safeParse('not-a-uuid').success).toBe(false);
+    expect(schema.safeParse('550e8400-e29b-41d4-a716').success).toBe(false);
+  });
+
+  it('toJSONSchema includes format', () => {
+    expect(new UuidSchema().toJSONSchema()).toEqual({ type: 'string', format: 'uuid' });
+  });
+});

--- a/packages/schema/src/schemas/formats/base64.ts
+++ b/packages/schema/src/schemas/formats/base64.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+export class Base64Schema extends FormatSchema {
+  protected _errorMessage = 'Invalid base64 string';
+
+  protected _validate(value: string): boolean {
+    return BASE64_RE.test(value) && value.length % 4 === 0;
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { contentEncoding: 'base64' };
+  }
+}

--- a/packages/schema/src/schemas/formats/cuid.ts
+++ b/packages/schema/src/schemas/formats/cuid.ts
@@ -1,0 +1,11 @@
+import { FormatSchema } from './format-schema';
+
+const CUID_RE = /^c[a-z0-9]{24}$/;
+
+export class CuidSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid CUID';
+
+  protected _validate(value: string): boolean {
+    return CUID_RE.test(value);
+  }
+}

--- a/packages/schema/src/schemas/formats/email.ts
+++ b/packages/schema/src/schemas/formats/email.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const EMAIL_RE = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export class EmailSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid email';
+
+  protected _validate(value: string): boolean {
+    return EMAIL_RE.test(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'email' };
+  }
+}

--- a/packages/schema/src/schemas/formats/format-schema.ts
+++ b/packages/schema/src/schemas/formats/format-schema.ts
@@ -1,0 +1,34 @@
+import { ParseContext } from '../../core/parse-context';
+import { ErrorCode } from '../../core/errors';
+import { StringSchema } from '../string';
+import type { RefTracker, JSONSchemaObject } from '../../introspection/json-schema';
+
+export abstract class FormatSchema extends StringSchema {
+  protected abstract _errorMessage: string;
+
+  protected abstract _validate(value: string): boolean;
+
+  protected _jsonSchemaExtra(): Record<string, unknown> | undefined {
+    return undefined;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): string {
+    const result = super._parse(value, ctx);
+    if (ctx.hasIssues()) return result;
+    if (!this._validate(result)) {
+      ctx.addIssue({ code: ErrorCode.InvalidString, message: this._errorMessage });
+    }
+    return result;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    const extra = this._jsonSchemaExtra();
+    if (!extra) return super._toJSONSchema(tracker);
+    return { ...super._toJSONSchema(tracker), ...extra };
+  }
+
+  _clone(): this {
+    const Ctor = this.constructor as new () => this;
+    return Object.assign(new Ctor(), super._clone());
+  }
+}

--- a/packages/schema/src/schemas/formats/hex.ts
+++ b/packages/schema/src/schemas/formats/hex.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
+
+export class HexSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid hex string';
+
+  protected _validate(value: string): boolean {
+    return HEX_RE.test(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { pattern: '^[0-9a-fA-F]+$' };
+  }
+}

--- a/packages/schema/src/schemas/formats/hostname.ts
+++ b/packages/schema/src/schemas/formats/hostname.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const HOSTNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export class HostnameSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid hostname';
+
+  protected _validate(value: string): boolean {
+    return HOSTNAME_RE.test(value) && value.length <= 253;
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'hostname' };
+  }
+}

--- a/packages/schema/src/schemas/formats/index.ts
+++ b/packages/schema/src/schemas/formats/index.ts
@@ -1,0 +1,13 @@
+export { EmailSchema } from './email';
+export { UuidSchema } from './uuid';
+export { UrlSchema } from './url';
+export { HostnameSchema } from './hostname';
+export { Ipv4Schema } from './ipv4';
+export { Ipv6Schema } from './ipv6';
+export { Base64Schema } from './base64';
+export { HexSchema } from './hex';
+export { JwtSchema } from './jwt';
+export { CuidSchema } from './cuid';
+export { UlidSchema } from './ulid';
+export { NanoidSchema } from './nanoid';
+export { IsoDateSchema, IsoTimeSchema, IsoDatetimeSchema, IsoDurationSchema } from './iso';

--- a/packages/schema/src/schemas/formats/ipv4.ts
+++ b/packages/schema/src/schemas/formats/ipv4.ts
@@ -1,0 +1,17 @@
+import { FormatSchema } from './format-schema';
+
+const IPV4_RE = /^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})$/;
+
+export class Ipv4Schema extends FormatSchema {
+  protected _errorMessage = 'Invalid IPv4 address';
+
+  protected _validate(value: string): boolean {
+    const match = IPV4_RE.exec(value);
+    if (!match) return false;
+    return [match[1], match[2], match[3], match[4]].every(o => Number(o) <= 255);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'ipv4' };
+  }
+}

--- a/packages/schema/src/schemas/formats/ipv6.ts
+++ b/packages/schema/src/schemas/formats/ipv6.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const IPV6_RE = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9]))$/;
+
+export class Ipv6Schema extends FormatSchema {
+  protected _errorMessage = 'Invalid IPv6 address';
+
+  protected _validate(value: string): boolean {
+    return IPV6_RE.test(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'ipv6' };
+  }
+}

--- a/packages/schema/src/schemas/formats/iso.ts
+++ b/packages/schema/src/schemas/formats/iso.ts
@@ -1,0 +1,67 @@
+import { FormatSchema } from './format-schema';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_TIME_RE = /^\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
+const ISO_DURATION_RE = /^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
+
+function validateDateRange(value: string): boolean {
+  const [y, m, d] = value.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+}
+
+function validateTimeRange(value: string): boolean {
+  const [h, min, s] = value.split(':').map(v => Number(v.replace(/[^0-9.]/g, '')));
+  return h >= 0 && h <= 23 && min >= 0 && min <= 59 && s >= 0 && s <= 59;
+}
+
+export class IsoDateSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid ISO date';
+
+  protected _validate(value: string): boolean {
+    return ISO_DATE_RE.test(value) && validateDateRange(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'date' };
+  }
+}
+
+export class IsoTimeSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid ISO time';
+
+  protected _validate(value: string): boolean {
+    return ISO_TIME_RE.test(value) && validateTimeRange(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'time' };
+  }
+}
+
+export class IsoDatetimeSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid ISO datetime';
+
+  protected _validate(value: string): boolean {
+    if (!ISO_DATETIME_RE.test(value)) return false;
+    const [datePart, timePart] = value.split('T');
+    return validateDateRange(datePart) && validateTimeRange(timePart);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'date-time' };
+  }
+}
+
+export class IsoDurationSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid ISO duration';
+
+  protected _validate(value: string): boolean {
+    return ISO_DURATION_RE.test(value) && value !== 'P';
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'duration' };
+  }
+}

--- a/packages/schema/src/schemas/formats/jwt.ts
+++ b/packages/schema/src/schemas/formats/jwt.ts
@@ -1,0 +1,11 @@
+import { FormatSchema } from './format-schema';
+
+const JWT_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+export class JwtSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid JWT';
+
+  protected _validate(value: string): boolean {
+    return JWT_RE.test(value);
+  }
+}

--- a/packages/schema/src/schemas/formats/nanoid.ts
+++ b/packages/schema/src/schemas/formats/nanoid.ts
@@ -1,0 +1,11 @@
+import { FormatSchema } from './format-schema';
+
+const NANOID_RE = /^[A-Za-z0-9_-]{21}$/;
+
+export class NanoidSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid nanoid';
+
+  protected _validate(value: string): boolean {
+    return NANOID_RE.test(value);
+  }
+}

--- a/packages/schema/src/schemas/formats/ulid.ts
+++ b/packages/schema/src/schemas/formats/ulid.ts
@@ -1,0 +1,11 @@
+import { FormatSchema } from './format-schema';
+
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+export class UlidSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid ULID';
+
+  protected _validate(value: string): boolean {
+    return ULID_RE.test(value);
+  }
+}

--- a/packages/schema/src/schemas/formats/url.ts
+++ b/packages/schema/src/schemas/formats/url.ts
@@ -1,0 +1,18 @@
+import { FormatSchema } from './format-schema';
+
+export class UrlSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid URL';
+
+  protected _validate(value: string): boolean {
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'uri' };
+  }
+}

--- a/packages/schema/src/schemas/formats/uuid.ts
+++ b/packages/schema/src/schemas/formats/uuid.ts
@@ -1,0 +1,15 @@
+import { FormatSchema } from './format-schema';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class UuidSchema extends FormatSchema {
+  protected _errorMessage = 'Invalid UUID';
+
+  protected _validate(value: string): boolean {
+    return UUID_RE.test(value);
+  }
+
+  protected _jsonSchemaExtra(): Record<string, unknown> {
+    return { format: 'uuid' };
+  }
+}


### PR DESCRIPTION
## Summary

- **16 format schemas**: email, uuid, url, hostname, ipv4, ipv6, base64, hex, jwt, cuid, ulid, nanoid, iso.date, iso.time, iso.datetime, iso.duration
- **FormatSchema base class** extracted by code simplifier — shared `_parse`, `_toJSONSchema`, and `_clone` logic. Subclasses only implement `_validate()`, `_errorMessage`, and optionally `_jsonSchemaExtra()`
- **Code review fixes**: ISO date validation now uses `Date` constructor for proper calendar validation (rejects Feb 31, non-leap-year Feb 29). IPv4 rejects leading zeros in octets
- 228 tests passing (47 new)

## Test plan

- [x] Email: valid/invalid, StringSchema inheritance, JSON Schema format
- [x] UUID: valid v4, invalid, JSON Schema format
- [x] URL: valid http/https, invalid, JSON Schema format "uri"
- [x] Hostname: valid, invalid (leading dash), JSON Schema format
- [x] IPv4: valid (0.0.0.0, 255.255.255.255), out-of-range, leading zeros rejected
- [x] IPv6: full, abbreviated, ::1, invalid
- [x] Base64: valid, length % 4 check, contentEncoding
- [x] Hex: valid, non-hex rejected
- [x] JWT: valid 3-segment, invalid
- [x] CUID: valid c-prefix, invalid
- [x] ULID: valid 26-char Crockford, invalid
- [x] Nanoid: valid 21-char, invalid
- [x] ISO date: valid, month/day range, impossible dates (Feb 31, non-leap Feb 29)
- [x] ISO time: valid, hour/minute/second range
- [x] ISO datetime: valid with timezone, invalid
- [x] ISO duration: valid, bare P rejected
- [x] Email ReDoS: adversarial input completes < 100ms
- [x] Full test suite: 228 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)