### PR TITLE
feat(schema): implement Phase 13 Map, Set, File, Custom, InstanceOf schemas

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -44,6 +44,11 @@ export { UnionSchema } from './schemas/union';
 export { DiscriminatedUnionSchema } from './schemas/discriminated-union';
 export { IntersectionSchema } from './schemas/intersection';
 export { RecordSchema } from './schemas/record';
+export { MapSchema } from './schemas/map';
+export { SetSchema } from './schemas/set';
+export { FileSchema } from './schemas/file';
+export { CustomSchema } from './schemas/custom';
+export { InstanceOfSchema } from './schemas/instanceof';
 export {
   CoercedStringSchema,
   CoercedNumberSchema,

--- a/packages/schema/src/schemas/__tests__/custom.test.ts
+++ b/packages/schema/src/schemas/__tests__/custom.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { CustomSchema } from '../custom';
+
+describe('CustomSchema', () => {
+  it('accepts when predicate returns true', () => {
+    const schema = new CustomSchema<number>((v) => typeof v === 'number' && (v as number) > 0);
+    expect(schema.parse(42)).toBe(42);
+  });
+
+  it('rejects when predicate returns false', () => {
+    const schema = new CustomSchema<number>((v) => typeof v === 'number' && (v as number) > 0, 'Must be positive');
+    const result = schema.safeParse(-1);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Must be positive');
+    }
+  });
+});

--- a/packages/schema/src/schemas/__tests__/file.test.ts
+++ b/packages/schema/src/schemas/__tests__/file.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { FileSchema } from '../file';
+
+describe('FileSchema', () => {
+  it('accepts Blob instances', () => {
+    const schema = new FileSchema();
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+    expect(schema.parse(blob)).toBe(blob);
+  });
+
+  it('rejects non-Blob values', () => {
+    const schema = new FileSchema();
+    expect(schema.safeParse('hello').success).toBe(false);
+    expect(schema.safeParse(42).success).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+});

--- a/packages/schema/src/schemas/__tests__/instanceof.test.ts
+++ b/packages/schema/src/schemas/__tests__/instanceof.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { InstanceOfSchema } from '../instanceof';
+
+describe('InstanceOfSchema', () => {
+  it('accepts instances of the specified class', () => {
+    const schema = new InstanceOfSchema(Date);
+    const date = new Date();
+    expect(schema.parse(date)).toBe(date);
+  });
+
+  it('rejects non-instances', () => {
+    const schema = new InstanceOfSchema(Date);
+    expect(schema.safeParse('2024-01-01').success).toBe(false);
+    expect(schema.safeParse(42).success).toBe(false);
+  });
+
+  it('works with subclasses', () => {
+    class Animal {}
+    class Dog extends Animal {}
+    const schema = new InstanceOfSchema(Animal);
+    expect(schema.parse(new Dog())).toBeInstanceOf(Animal);
+  });
+});

--- a/packages/schema/src/schemas/__tests__/map.test.ts
+++ b/packages/schema/src/schemas/__tests__/map.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { MapSchema } from '../map';
+import { StringSchema } from '../string';
+import { NumberSchema } from '../number';
+
+describe('MapSchema', () => {
+  it('accepts Map instances with valid key/value types', () => {
+    const schema = new MapSchema(new StringSchema(), new NumberSchema());
+    const input = new Map([['a', 1], ['b', 2]]);
+    const result = schema.parse(input);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.get('a')).toBe(1);
+  });
+
+  it('rejects non-Map values', () => {
+    const schema = new MapSchema(new StringSchema(), new NumberSchema());
+    expect(schema.safeParse({}).success).toBe(false);
+    expect(schema.safeParse([]).success).toBe(false);
+    expect(schema.safeParse('hello').success).toBe(false);
+  });
+
+  it('validates each key and value', () => {
+    const schema = new MapSchema(new StringSchema(), new NumberSchema());
+    const input = new Map<any, any>([['a', 'not-number']]);
+    const result = schema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('toJSONSchema returns array of tuples', () => {
+    const schema = new MapSchema(new StringSchema(), new NumberSchema());
+    expect(schema.toJSONSchema()).toEqual({
+      type: 'array',
+      items: {
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+        items: false,
+      },
+    });
+  });
+});

--- a/packages/schema/src/schemas/__tests__/set.test.ts
+++ b/packages/schema/src/schemas/__tests__/set.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { SetSchema } from '../set';
+import { StringSchema } from '../string';
+
+describe('SetSchema', () => {
+  it('accepts Set instances with valid element types', () => {
+    const schema = new SetSchema(new StringSchema());
+    const input = new Set(['a', 'b', 'c']);
+    const result = schema.parse(input);
+    expect(result).toBeInstanceOf(Set);
+    expect(result.has('a')).toBe(true);
+  });
+
+  it('rejects non-Set values', () => {
+    const schema = new SetSchema(new StringSchema());
+    expect(schema.safeParse([]).success).toBe(false);
+    expect(schema.safeParse('hello').success).toBe(false);
+  });
+
+  it('validates element count with .min()/.max()/.size()', () => {
+    const schema = new SetSchema(new StringSchema()).min(2).max(4);
+    expect(schema.safeParse(new Set(['a'])).success).toBe(false);
+    expect(schema.parse(new Set(['a', 'b']))).toBeInstanceOf(Set);
+    expect(schema.safeParse(new Set(['a', 'b', 'c', 'd', 'e'])).success).toBe(false);
+
+    const exact = new SetSchema(new StringSchema()).size(3);
+    expect(exact.parse(new Set(['a', 'b', 'c']))).toBeInstanceOf(Set);
+    expect(exact.safeParse(new Set(['a', 'b'])).success).toBe(false);
+  });
+
+  it('toJSONSchema returns array with uniqueItems', () => {
+    const schema = new SetSchema(new StringSchema());
+    expect(schema.toJSONSchema()).toEqual({
+      type: 'array',
+      uniqueItems: true,
+      items: { type: 'string' },
+    });
+  });
+
+  it('toJSONSchema includes minItems/maxItems from constraints', () => {
+    const minMax = new SetSchema(new StringSchema()).min(2).max(5);
+    expect(minMax.toJSONSchema()).toEqual({
+      type: 'array',
+      uniqueItems: true,
+      items: { type: 'string' },
+      minItems: 2,
+      maxItems: 5,
+    });
+
+    const exact = new SetSchema(new StringSchema()).size(3);
+    expect(exact.toJSONSchema()).toEqual({
+      type: 'array',
+      uniqueItems: true,
+      items: { type: 'string' },
+      minItems: 3,
+      maxItems: 3,
+    });
+  });
+});

--- a/packages/schema/src/schemas/custom.ts
+++ b/packages/schema/src/schemas/custom.ts
@@ -1,0 +1,36 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class CustomSchema<T> extends Schema<T> {
+  private readonly _check: (value: unknown) => boolean;
+  private readonly _message: string;
+
+  constructor(check: (value: unknown) => boolean, message?: string) {
+    super();
+    this._check = check;
+    this._message = message ?? 'Custom validation failed';
+  }
+
+  _parse(value: unknown, ctx: ParseContext): T {
+    if (!this._check(value)) {
+      ctx.addIssue({ code: ErrorCode.Custom, message: this._message });
+    }
+    return value as T;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Custom;
+  }
+
+  _toJSONSchema(_tracker: RefTracker): JSONSchemaObject {
+    return {};
+  }
+
+  _clone(): CustomSchema<T> {
+    return this._cloneBase(new CustomSchema(this._check, this._message));
+  }
+}

--- a/packages/schema/src/schemas/file.ts
+++ b/packages/schema/src/schemas/file.ts
@@ -1,0 +1,28 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class FileSchema extends Schema<Blob> {
+  _parse(value: unknown, ctx: ParseContext): Blob {
+    if (!(value instanceof Blob)) {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: 'Expected File or Blob' });
+      return value as Blob;
+    }
+    return value;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.File;
+  }
+
+  _toJSONSchema(_tracker: RefTracker): JSONSchemaObject {
+    return { type: 'string', contentMediaType: 'application/octet-stream' };
+  }
+
+  _clone(): FileSchema {
+    return this._cloneBase(new FileSchema());
+  }
+}

--- a/packages/schema/src/schemas/instanceof.ts
+++ b/packages/schema/src/schemas/instanceof.ts
@@ -1,0 +1,35 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class InstanceOfSchema<T> extends Schema<T> {
+  private readonly _cls: new (...args: any[]) => T;
+
+  constructor(cls: new (...args: any[]) => T) {
+    super();
+    this._cls = cls;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): T {
+    if (!(value instanceof this._cls)) {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: `Expected instance of ${this._cls.name}` });
+      return value as T;
+    }
+    return value;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.InstanceOf;
+  }
+
+  _toJSONSchema(_tracker: RefTracker): JSONSchemaObject {
+    return {};
+  }
+
+  _clone(): InstanceOfSchema<T> {
+    return this._cloneBase(new InstanceOfSchema(this._cls));
+  }
+}

--- a/packages/schema/src/schemas/map.ts
+++ b/packages/schema/src/schemas/map.ts
@@ -1,0 +1,57 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class MapSchema<K, V> extends Schema<Map<K, V>> {
+  private readonly _keySchema: Schema<K>;
+  private readonly _valueSchema: Schema<V>;
+
+  constructor(keySchema: Schema<K>, valueSchema: Schema<V>) {
+    super();
+    this._keySchema = keySchema;
+    this._valueSchema = valueSchema;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): Map<K, V> {
+    if (!(value instanceof Map)) {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: 'Expected Map, received ' + typeof value });
+      return value as Map<K, V>;
+    }
+    const result = new Map<K, V>();
+    let index = 0;
+    for (const [k, v] of value) {
+      ctx.pushPath(index);
+      const parsedKey = this._keySchema._runPipeline(k, ctx);
+      const parsedValue = this._valueSchema._runPipeline(v, ctx);
+      result.set(parsedKey, parsedValue);
+      ctx.popPath();
+      index++;
+    }
+    return result;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Map;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return {
+      type: 'array',
+      items: {
+        type: 'array',
+        prefixItems: [
+          this._keySchema._toJSONSchemaWithRefs(tracker),
+          this._valueSchema._toJSONSchemaWithRefs(tracker),
+        ],
+        items: false,
+      },
+    };
+  }
+
+  _clone(): MapSchema<K, V> {
+    return this._cloneBase(new MapSchema(this._keySchema, this._valueSchema));
+  }
+}

--- a/packages/schema/src/schemas/set.ts
+++ b/packages/schema/src/schemas/set.ts
@@ -1,0 +1,88 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { ErrorCode } from '../core/errors';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class SetSchema<V> extends Schema<Set<V>> {
+  private readonly _valueSchema: Schema<V>;
+  private _min: number | undefined;
+  private _max: number | undefined;
+  private _size: number | undefined;
+
+  constructor(valueSchema: Schema<V>) {
+    super();
+    this._valueSchema = valueSchema;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): Set<V> {
+    if (!(value instanceof Set)) {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: 'Expected Set, received ' + typeof value });
+      return value as Set<V>;
+    }
+    const result = new Set<V>();
+    let index = 0;
+    for (const item of value) {
+      ctx.pushPath(index);
+      result.add(this._valueSchema._runPipeline(item, ctx));
+      ctx.popPath();
+      index++;
+    }
+    if (this._min !== undefined && result.size < this._min) {
+      ctx.addIssue({ code: ErrorCode.TooSmall, message: `Set must contain at least ${this._min} element(s)` });
+    }
+    if (this._max !== undefined && result.size > this._max) {
+      ctx.addIssue({ code: ErrorCode.TooBig, message: `Set must contain at most ${this._max} element(s)` });
+    }
+    if (this._size !== undefined && result.size !== this._size) {
+      ctx.addIssue({ code: ErrorCode.InvalidType, message: `Set must contain exactly ${this._size} element(s)` });
+    }
+    return result;
+  }
+
+  min(n: number): SetSchema<V> {
+    const clone = this._clone();
+    clone._min = n;
+    return clone;
+  }
+
+  max(n: number): SetSchema<V> {
+    const clone = this._clone();
+    clone._max = n;
+    return clone;
+  }
+
+  size(n: number): SetSchema<V> {
+    const clone = this._clone();
+    clone._size = n;
+    return clone;
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Set;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    const schema: JSONSchemaObject = {
+      type: 'array',
+      uniqueItems: true,
+      items: this._valueSchema._toJSONSchemaWithRefs(tracker),
+    };
+    if (this._min !== undefined) schema.minItems = this._min;
+    if (this._max !== undefined) schema.maxItems = this._max;
+    if (this._size !== undefined) {
+      schema.minItems = this._size;
+      schema.maxItems = this._size;
+    }
+    return schema;
+  }
+
+  _clone(): SetSchema<V> {
+    const clone = this._cloneBase(new SetSchema(this._valueSchema));
+    clone._min = this._min;
+    clone._max = this._max;
+    clone._size = this._size;
+    return clone;
+  }
+}


### PR DESCRIPTION
## Summary
- Add **MapSchema** with key/value validation, path tracking via `pushPath`/`popPath`, and JSON Schema output as array of tuples
- Add **SetSchema** with `.min()`/`.max()`/`.size()` constraints, element validation, and `uniqueItems` JSON Schema output including `minItems`/`maxItems`
- Add **FileSchema** accepting Blob instances with `contentMediaType` JSON Schema output
- Add **CustomSchema** with predicate-based validation and custom error messages
- Add **InstanceOfSchema** with `instanceof` checking and subclass support
- Export all 5 schemas from the package index

## Test plan
- [x] MapSchema: accepts valid Maps, rejects non-Maps, validates keys/values, correct JSON Schema
- [x] SetSchema: accepts valid Sets, rejects non-Sets, validates constraints, correct JSON Schema with minItems/maxItems
- [x] FileSchema: accepts Blobs, rejects non-Blobs
- [x] CustomSchema: accepts when predicate passes, rejects with custom message
- [x] InstanceOfSchema: accepts instances, rejects non-instances, works with subclasses
- [x] 244 tests passing across 52 test files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)