### PR TITLE
feat(schema): implement Phase 14 LazySchema for recursive types

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -49,6 +49,7 @@ export { SetSchema } from './schemas/set';
 export { FileSchema } from './schemas/file';
 export { CustomSchema } from './schemas/custom';
 export { InstanceOfSchema } from './schemas/instanceof';
+export { LazySchema } from './schemas/lazy';
 export {
   CoercedStringSchema,
   CoercedNumberSchema,

--- a/packages/schema/src/schemas/__tests__/lazy.test.ts
+++ b/packages/schema/src/schemas/__tests__/lazy.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { LazySchema } from '../lazy';
+import { StringSchema } from '../string';
+import { ObjectSchema } from '../object';
+import { NullableSchema } from '../../core/schema';
+
+describe('LazySchema', () => {
+  it('defers schema resolution until first use', () => {
+    let called = false;
+    const schema = new LazySchema(() => {
+      called = true;
+      return new StringSchema();
+    });
+    expect(called).toBe(false);
+    schema.parse('hello');
+    expect(called).toBe(true);
+  });
+
+  it('parses recursive structures (tree nodes)', () => {
+    type TreeNode = { value: string; children: TreeNode | null };
+    const treeSchema: ObjectSchema<TreeNode> = new ObjectSchema({
+      value: new StringSchema(),
+      children: new NullableSchema(new LazySchema(() => treeSchema)),
+    });
+    const data = {
+      value: 'root',
+      children: {
+        value: 'child',
+        children: null,
+      },
+    };
+    const result = treeSchema.parse(data);
+    expect(result.value).toBe('root');
+    expect((result.children as TreeNode).value).toBe('child');
+    expect((result.children as TreeNode).children).toBe(null);
+  });
+
+  it('toJSONSchema uses $ref for named lazy schemas', () => {
+    type TreeNode = { value: string; children: TreeNode | null };
+    const treeSchema: ObjectSchema<TreeNode> = new ObjectSchema({
+      value: new StringSchema(),
+      children: new NullableSchema(new LazySchema(() => treeSchema)),
+    }).id('TreeNode') as ObjectSchema<TreeNode>;
+    const jsonSchema = treeSchema.toJSONSchema();
+    expect(jsonSchema.$defs).toBeDefined();
+    expect(jsonSchema.$defs!['TreeNode']).toBeDefined();
+    expect(jsonSchema.$ref).toBe('#/$defs/TreeNode');
+  });
+
+  it('validates deeply nested recursive data', () => {
+    type TreeNode = { value: string; children: TreeNode | null };
+    const treeSchema: ObjectSchema<TreeNode> = new ObjectSchema({
+      value: new StringSchema(),
+      children: new NullableSchema(new LazySchema(() => treeSchema)),
+    });
+    const deepData = {
+      value: 'level1',
+      children: {
+        value: 'level2',
+        children: {
+          value: 'level3',
+          children: {
+            value: 'level4',
+            children: null,
+          },
+        },
+      },
+    };
+    const result = treeSchema.parse(deepData);
+    expect(((result.children as TreeNode).children as TreeNode).value).toBe('level3');
+  });
+
+  it('rejects invalid data in recursive structures', () => {
+    type TreeNode = { value: string; children: TreeNode | null };
+    const treeSchema: ObjectSchema<TreeNode> = new ObjectSchema({
+      value: new StringSchema(),
+      children: new NullableSchema(new LazySchema(() => treeSchema)),
+    });
+    const badData = {
+      value: 'root',
+      children: {
+        value: 123, // should be string
+        children: null,
+      },
+    };
+    const result = treeSchema.safeParse(badData);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['children', 'value']);
+    }
+  });
+});

--- a/packages/schema/src/schemas/lazy.ts
+++ b/packages/schema/src/schemas/lazy.ts
@@ -1,0 +1,38 @@
+import { Schema } from '../core/schema';
+import { ParseContext } from '../core/parse-context';
+import { SchemaType } from '../core/types';
+import type { RefTracker } from '../introspection/json-schema';
+import type { JSONSchemaObject } from '../introspection/json-schema';
+
+export class LazySchema<T> extends Schema<T> {
+  private readonly _getter: () => Schema<T>;
+  private _cached: Schema<T> | undefined;
+
+  constructor(getter: () => Schema<T>) {
+    super();
+    this._getter = getter;
+  }
+
+  private _resolve(): Schema<T> {
+    if (!this._cached) {
+      this._cached = this._getter();
+    }
+    return this._cached;
+  }
+
+  _parse(value: unknown, ctx: ParseContext): T {
+    return this._resolve()._runPipeline(value, ctx);
+  }
+
+  _schemaType(): SchemaType {
+    return SchemaType.Lazy;
+  }
+
+  _toJSONSchema(tracker: RefTracker): JSONSchemaObject {
+    return this._resolve()._toJSONSchemaWithRefs(tracker);
+  }
+
+  _clone(): LazySchema<T> {
+    return this._cloneBase(new LazySchema(this._getter));
+  }
+}


### PR DESCRIPTION
## Summary
- Add **LazySchema** with deferred resolution — getter is called on first use, not at construction
- Support recursive type definitions (e.g., tree nodes with self-referencing children)
- JSON Schema output delegates to resolved inner schema, works with `.id()` for `$ref`/`$defs`
- Validates deeply nested recursive data with proper error paths

## Test plan
- [x] Deferred resolution — getter not called until first parse
- [x] Recursive tree node parsing (4 levels deep)
- [x] JSON Schema with `$ref` for named lazy schemas
- [x] Deep recursive validation
- [x] Rejects invalid data in recursive structures with correct path
- [x] 249 tests passing across 53 test files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)