### PR TITLE
feat(schema): implement Phase 16 Factory Object and Public API

### DIFF
--- a/packages/schema/src/__tests__/index.test.ts
+++ b/packages/schema/src/__tests__/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { s, schema } from '..';
+import { StringSchema } from '../schemas/string';
+import { NumberSchema } from '../schemas/number';
+import { BooleanSchema } from '../schemas/boolean';
+import { BigIntSchema } from '../schemas/bigint';
+import { DateSchema } from '../schemas/date';
+import { ObjectSchema } from '../schemas/object';
+import { ArraySchema } from '../schemas/array';
+import { EnumSchema } from '../schemas/enum';
+import { LiteralSchema } from '../schemas/literal';
+import { EmailSchema } from '../schemas/formats/email';
+import { IsoDateSchema } from '../schemas/formats/iso';
+import { CoercedStringSchema } from '../schemas/coerced';
+import { ParseError, SchemaRegistry } from '..';
+
+describe('Factory Object', () => {
+  it('s.string() returns StringSchema', () => {
+    expect(s.string()).toBeInstanceOf(StringSchema);
+  });
+
+  it('s.number() returns NumberSchema', () => {
+    expect(s.number()).toBeInstanceOf(NumberSchema);
+  });
+
+  it('all factory methods return correct schema types', () => {
+    expect(s.boolean()).toBeInstanceOf(BooleanSchema);
+    expect(s.bigint()).toBeInstanceOf(BigIntSchema);
+    expect(s.date()).toBeInstanceOf(DateSchema);
+    expect(s.object({ name: s.string() })).toBeInstanceOf(ObjectSchema);
+    expect(s.array(s.string())).toBeInstanceOf(ArraySchema);
+    expect(s.enum(['a', 'b'])).toBeInstanceOf(EnumSchema);
+    expect(s.literal('hello')).toBeInstanceOf(LiteralSchema);
+  });
+
+  it('s.int() returns NumberSchema with .int() applied', () => {
+    const intSchema = s.int();
+    expect(intSchema).toBeInstanceOf(NumberSchema);
+    expect(intSchema.safeParse(1.5).success).toBe(false);
+    expect(intSchema.parse(42)).toBe(42);
+  });
+
+  it('s.coerce.string() returns CoercedStringSchema', () => {
+    const coerced = s.coerce.string();
+    expect(coerced).toBeInstanceOf(CoercedStringSchema);
+    expect(coerced.parse(42)).toBe('42');
+  });
+
+  it('s.email() returns EmailSchema', () => {
+    expect(s.email()).toBeInstanceOf(EmailSchema);
+  });
+
+  it('s.iso.date() returns IsoDateSchema', () => {
+    expect(s.iso.date()).toBeInstanceOf(IsoDateSchema);
+  });
+
+  it('schema and s are the same object', () => {
+    expect(schema).toBe(s);
+  });
+
+  it('all type exports are accessible', () => {
+    expect(ParseError).toBeDefined();
+    expect(SchemaRegistry).toBeDefined();
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -83,3 +83,125 @@ export { preprocess } from './transforms/preprocess';
 
 // Type inference utilities
 export type { Infer, Output, Input } from './utils/type-inference';
+
+// Factory Object
+import { StringSchema } from './schemas/string';
+import { NumberSchema } from './schemas/number';
+import { BooleanSchema } from './schemas/boolean';
+import { BigIntSchema } from './schemas/bigint';
+import { DateSchema } from './schemas/date';
+import { NanSchema } from './schemas/nan';
+import { SymbolSchema } from './schemas/symbol';
+import { AnySchema, UnknownSchema, NullSchema, UndefinedSchema, VoidSchema, NeverSchema } from './schemas/special';
+import { ObjectSchema } from './schemas/object';
+import { ArraySchema } from './schemas/array';
+import { TupleSchema } from './schemas/tuple';
+import { EnumSchema } from './schemas/enum';
+import { LiteralSchema } from './schemas/literal';
+import { UnionSchema } from './schemas/union';
+import { DiscriminatedUnionSchema } from './schemas/discriminated-union';
+import { IntersectionSchema } from './schemas/intersection';
+import { RecordSchema } from './schemas/record';
+import { MapSchema } from './schemas/map';
+import { SetSchema } from './schemas/set';
+import { FileSchema } from './schemas/file';
+import { CustomSchema } from './schemas/custom';
+import { InstanceOfSchema } from './schemas/instanceof';
+import { LazySchema } from './schemas/lazy';
+import {
+  CoercedStringSchema,
+  CoercedNumberSchema,
+  CoercedBooleanSchema,
+  CoercedBigIntSchema,
+  CoercedDateSchema,
+} from './schemas/coerced';
+import {
+  EmailSchema,
+  UuidSchema,
+  UrlSchema,
+  HostnameSchema,
+  Ipv4Schema,
+  Ipv6Schema,
+  Base64Schema,
+  HexSchema,
+  JwtSchema,
+  CuidSchema,
+  UlidSchema,
+  NanoidSchema,
+  IsoDateSchema,
+  IsoTimeSchema,
+  IsoDatetimeSchema,
+  IsoDurationSchema,
+} from './schemas/formats';
+import type { Schema } from './core/schema';
+
+export const s = {
+  // Primitives
+  string: () => new StringSchema(),
+  number: () => new NumberSchema(),
+  boolean: () => new BooleanSchema(),
+  bigint: () => new BigIntSchema(),
+  date: () => new DateSchema(),
+  symbol: () => new SymbolSchema(),
+  nan: () => new NanSchema(),
+  int: () => new NumberSchema().int(),
+
+  // Special
+  any: () => new AnySchema(),
+  unknown: () => new UnknownSchema(),
+  null: () => new NullSchema(),
+  undefined: () => new UndefinedSchema(),
+  void: () => new VoidSchema(),
+  never: () => new NeverSchema(),
+
+  // Composites
+  object: <T extends Record<string, Schema<any, any>>>(shape: T) => new ObjectSchema(shape),
+  array: <T>(itemSchema: Schema<T>) => new ArraySchema(itemSchema),
+  tuple: <T extends Schema<any, any>[]>(items: [...T]) => new TupleSchema(items),
+  enum: <T extends readonly [string, ...string[]]>(values: T) => new EnumSchema(values),
+  literal: <T extends string | number | boolean | null>(value: T) => new LiteralSchema(value),
+  union: <T extends Schema<any, any>[]>(options: [...T]) => new UnionSchema(options),
+  discriminatedUnion: <T extends ObjectSchema<any>[]>(discriminator: string, options: [...T]) =>
+    new DiscriminatedUnionSchema(discriminator, options),
+  intersection: <A, B>(left: Schema<A>, right: Schema<B>) => new IntersectionSchema(left, right),
+  record: <V>(valueSchema: Schema<V>) => new RecordSchema(valueSchema),
+  map: <K, V>(keySchema: Schema<K>, valueSchema: Schema<V>) => new MapSchema(keySchema, valueSchema),
+  set: <V>(valueSchema: Schema<V>) => new SetSchema(valueSchema),
+  file: () => new FileSchema(),
+  custom: <T>(check: (value: unknown) => boolean, message?: string) => new CustomSchema<T>(check, message),
+  instanceof: <T>(cls: new (...args: any[]) => T) => new InstanceOfSchema(cls),
+  lazy: <T>(getter: () => Schema<T>) => new LazySchema(getter),
+
+  // Formats
+  email: () => new EmailSchema(),
+  uuid: () => new UuidSchema(),
+  url: () => new UrlSchema(),
+  hostname: () => new HostnameSchema(),
+  ipv4: () => new Ipv4Schema(),
+  ipv6: () => new Ipv6Schema(),
+  base64: () => new Base64Schema(),
+  hex: () => new HexSchema(),
+  jwt: () => new JwtSchema(),
+  cuid: () => new CuidSchema(),
+  ulid: () => new UlidSchema(),
+  nanoid: () => new NanoidSchema(),
+
+  // ISO formats
+  iso: {
+    date: () => new IsoDateSchema(),
+    time: () => new IsoTimeSchema(),
+    datetime: () => new IsoDatetimeSchema(),
+    duration: () => new IsoDurationSchema(),
+  },
+
+  // Coercion
+  coerce: {
+    string: () => new CoercedStringSchema(),
+    number: () => new CoercedNumberSchema(),
+    boolean: () => new CoercedBooleanSchema(),
+    bigint: () => new CoercedBigIntSchema(),
+    date: () => new CoercedDateSchema(),
+  },
+};
+
+export const schema = s;


### PR DESCRIPTION
## Summary
- Add **`s`/`schema` factory object** as the main public API entry point
- All schema types accessible via `s.string()`, `s.number()`, `s.object({...})`, etc.
- Convenience methods: `s.int()` (NumberSchema with .int()), `s.email()`, `s.uuid()`, etc.
- ISO format namespace: `s.iso.date()`, `s.iso.time()`, `s.iso.datetime()`, `s.iso.duration()`
- Coercion namespace: `s.coerce.string()`, `s.coerce.number()`, etc.
- `schema` is an alias for `s` — both are the same object

## Test plan
- [x] `s.string()` returns StringSchema
- [x] `s.number()` returns NumberSchema
- [x] All factory methods return correct schema types
- [x] `s.int()` rejects floats, accepts integers
- [x] `s.coerce.string()` coerces values
- [x] `s.email()` returns EmailSchema
- [x] `s.iso.date()` returns IsoDateSchema
- [x] `schema` and `s` are the same object
- [x] ParseError, SchemaRegistry exported correctly
- [x] 276 tests passing across 55 test files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)