### PR TITLE
feat(schema): implement Phase 17 Integration Tests

### DIFF
--- a/packages/schema/src/__tests__/integration/complex-compositions.test.ts
+++ b/packages/schema/src/__tests__/integration/complex-compositions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { s } from '../..';
+
+describe('Integration: Complex Compositions', () => {
+  it('object pick → extend → partial chain', () => {
+    const fullUser = s.object({
+      id: s.string(),
+      name: s.string(),
+      email: s.email(),
+      age: s.number(),
+    });
+
+    const nameOnly = fullUser.pick(['name']);
+    expect(nameOnly.parse({ name: 'John' })).toEqual({ name: 'John' });
+
+    const extended = nameOnly.extend({ role: s.string() });
+    expect(extended.parse({ name: 'John', role: 'admin' })).toEqual({ name: 'John', role: 'admin' });
+
+    const partial = extended.partial();
+    expect(partial.parse({})).toEqual({});
+    expect(partial.parse({ name: 'John' })).toEqual({ name: 'John' });
+  });
+
+  it('discriminated union with named schemas', () => {
+    const successSchema = s.object({
+      status: s.literal('success'),
+      data: s.string(),
+    });
+    const errorSchema = s.object({
+      status: s.literal('error'),
+      message: s.string(),
+    });
+    const responseSchema = s.discriminatedUnion('status', [successSchema, errorSchema]);
+
+    expect(responseSchema.parse({ status: 'success', data: 'hello' })).toEqual({
+      status: 'success',
+      data: 'hello',
+    });
+    expect(responseSchema.parse({ status: 'error', message: 'fail' })).toEqual({
+      status: 'error',
+      message: 'fail',
+    });
+    expect(responseSchema.safeParse({ status: 'pending' }).success).toBe(false);
+  });
+
+  it('transform pipeline: string → parse → number → validate', () => {
+    const stringToNumber = s.string()
+      .transform((v) => parseInt(v, 10))
+      .pipe(s.number().int().gte(0));
+
+    expect(stringToNumber.parse('42')).toBe(42);
+    expect(stringToNumber.safeParse('abc').success).toBe(false);
+    expect(stringToNumber.safeParse('-5').success).toBe(false);
+  });
+
+  it('intersection of two objects', () => {
+    const withName = s.object({ name: s.string() });
+    const withAge = s.object({ age: s.number() });
+    const combined = s.intersection(withName, withAge);
+
+    expect(combined.parse({ name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
+    expect(combined.safeParse({ name: 'John' }).success).toBe(false);
+  });
+
+  it('array of discriminated union', () => {
+    const catSchema = s.object({ type: s.literal('cat'), name: s.string() });
+    const dogSchema = s.object({ type: s.literal('dog'), breed: s.string() });
+    const animalSchema = s.discriminatedUnion('type', [catSchema, dogSchema]);
+    const animalsSchema = s.array(animalSchema);
+
+    const result = animalsSchema.parse([
+      { type: 'cat', name: 'Whiskers' },
+      { type: 'dog', breed: 'Labrador' },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/packages/schema/src/__tests__/integration/named-schemas.test.ts
+++ b/packages/schema/src/__tests__/integration/named-schemas.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { s, SchemaRegistry } from '../..';
+
+describe('Integration: Named Schemas', () => {
+  it('named primitive with $ref + $defs', () => {
+    const userId = s.uuid().id('UserId');
+    const jsonSchema = userId.toJSONSchema();
+    expect(jsonSchema.$ref).toBe('#/$defs/UserId');
+    expect(jsonSchema.$defs!['UserId']).toBeDefined();
+    expect(jsonSchema.$defs!['UserId'].format).toBe('uuid');
+  });
+
+  it('named object with named nested schemas', () => {
+    const addressSchema = s.object({
+      street: s.string(),
+      city: s.string(),
+    }).id('Address');
+
+    const userSchema = s.object({
+      name: s.string(),
+      address: addressSchema,
+    }).id('UserWithAddress');
+
+    const jsonSchema = userSchema.toJSONSchema();
+    expect(jsonSchema.$defs!['UserWithAddress']).toBeDefined();
+    expect(jsonSchema.$defs!['Address']).toBeDefined();
+  });
+
+  it('JSON Schema output with $defs and $ref', () => {
+    const emailType = s.email().id('Email');
+    const contactSchema = s.object({
+      primary: emailType,
+      secondary: emailType,
+    });
+    const jsonSchema = contactSchema.toJSONSchema();
+    expect(jsonSchema.$defs!['Email']).toBeDefined();
+    // Both properties should reference the same $ref
+    const props = jsonSchema.properties as Record<string, any>;
+    expect(props.primary.$ref).toBe('#/$defs/Email');
+    expect(props.secondary.$ref).toBe('#/$defs/Email');
+  });
+
+  it('SchemaRegistry contains named schemas', () => {
+    const testSchema = s.string().id('TestRegistrySchema');
+    expect(SchemaRegistry.get('TestRegistrySchema')).toBeDefined();
+  });
+});

--- a/packages/schema/src/__tests__/integration/recursive-schemas.test.ts
+++ b/packages/schema/src/__tests__/integration/recursive-schemas.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { s } from '../..';
+import type { Infer } from '../..';
+
+describe('Integration: Recursive Schemas', () => {
+  it('tree node with s.lazy() and .id()', () => {
+    const treeSchema = s.object({
+      value: s.string(),
+      children: s.lazy(() => treeSchema).nullable(),
+    }).id('TreeNodeIntegration');
+
+    type TreeNode = Infer<typeof treeSchema>;
+
+    const data = {
+      value: 'root',
+      children: {
+        value: 'child',
+        children: null,
+      },
+    };
+    const result = treeSchema.parse(data);
+    expect(result.value).toBe('root');
+  });
+
+  it('parses deeply nested tree structure', () => {
+    const treeSchema = s.object({
+      value: s.number(),
+      left: s.lazy(() => treeSchema).nullable(),
+      right: s.lazy(() => treeSchema).nullable(),
+    });
+
+    const bst = {
+      value: 10,
+      left: {
+        value: 5,
+        left: { value: 2, left: null, right: null },
+        right: { value: 7, left: null, right: null },
+      },
+      right: {
+        value: 15,
+        left: null,
+        right: { value: 20, left: null, right: null },
+      },
+    };
+
+    const result = treeSchema.parse(bst);
+    expect(result.value).toBe(10);
+  });
+
+  it('JSON Schema output with $ref for recursive schema', () => {
+    const nodeSchema = s.object({
+      name: s.string(),
+      children: s.array(s.lazy(() => nodeSchema)),
+    }).id('RecursiveNode');
+
+    const jsonSchema = nodeSchema.toJSONSchema();
+    expect(jsonSchema.$ref).toBe('#/$defs/RecursiveNode');
+    expect(jsonSchema.$defs!['RecursiveNode']).toBeDefined();
+    // Should not hang or stack overflow
+  });
+});

--- a/packages/schema/src/__tests__/integration/schema-usage.test.ts
+++ b/packages/schema/src/__tests__/integration/schema-usage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { s } from '../..';
+import type { Infer } from '../..';
+
+describe('Integration: Schema Usage', () => {
+  const userSchema = s.object({
+    name: s.string().min(1),
+    email: s.email(),
+    age: s.number().int().gte(0),
+    createdAt: s.date().optional(),
+    role: s.string().default('user'),
+  });
+
+  type User = Infer<typeof userSchema>;
+
+  it('parses valid data and returns typed result', () => {
+    const result = userSchema.parse({
+      name: 'John',
+      email: 'john@example.com',
+      age: 30,
+    });
+    expect(result.name).toBe('John');
+    expect(result.email).toBe('john@example.com');
+    expect(result.age).toBe(30);
+    expect(result.role).toBe('user');
+  });
+
+  it('parses invalid data and aggregates issues with paths', () => {
+    const result = userSchema.safeParse({
+      name: '',
+      email: 123,
+      age: -1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
+      const paths = result.error.issues.map((i) => i.path?.join('.'));
+      expect(paths).toContain('name');
+      expect(paths).toContain('email');
+      expect(paths).toContain('age');
+    }
+  });
+
+  it('validates nested objects with full error paths', () => {
+    const addressSchema = s.object({
+      street: s.string().min(1),
+      city: s.string(),
+    });
+    const profileSchema = s.object({
+      user: s.object({ name: s.string() }),
+      address: addressSchema,
+    });
+    const result = profileSchema.safeParse({
+      user: { name: 123 },
+      address: { street: '', city: 'NYC' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path?.join('.'));
+      expect(paths).toContain('user.name');
+      expect(paths).toContain('address.street');
+    }
+  });
+
+  it('type inference matches expected type', () => {
+    expectTypeOf<User>().toHaveProperty('name');
+    expectTypeOf<User>().toHaveProperty('email');
+    expectTypeOf<User>().toHaveProperty('age');
+    expectTypeOf<User>().toHaveProperty('role');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 4 integration test files covering end-to-end schema usage patterns
- Tests schema composition chains (pick → extend → partial), discriminated unions, transform pipelines, intersections
- Tests recursive schemas with s.lazy(), named schemas with $ref/$defs, and SchemaRegistry
- Tests nested object validation with full error paths, type inference, and error aggregation

## Test plan
- [x] All 292 tests pass across 59 files
- [x] Integration tests cover: basic usage, named schemas, recursive schemas, complex compositions
- [x] No regressions in existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)