### PR TITLE
feat(core): implement Phase 2 Immutability

### DIFF
--- a/packages/core/src/immutability/__tests__/dev-proxy.test.ts
+++ b/packages/core/src/immutability/__tests__/dev-proxy.test.ts
@@ -32,4 +32,10 @@ describe('createImmutableProxy', () => {
     expect(proxy.name).toBe('John');
     expect(proxy.nested.value).toBe(42);
   });
+
+  it('preserves identity for nested object access', () => {
+    const obj = { user: { name: 'John' } };
+    const proxy = createImmutableProxy(obj, 'ctx');
+    expect(proxy.user === proxy.user).toBe(true);
+  });
 });

--- a/packages/core/src/immutability/__tests__/freeze.test.ts
+++ b/packages/core/src/immutability/__tests__/freeze.test.ts
@@ -31,4 +31,12 @@ describe('deepFreeze', () => {
     expect(deepFreeze(undefined)).toBe(undefined);
     expect(deepFreeze(true)).toBe(true);
   });
+
+  it('handles circular references without stack overflow', () => {
+    const obj: any = { name: 'root' };
+    obj.self = obj;
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+    expect(obj.self).toBe(obj);
+  });
 });

--- a/packages/core/src/immutability/__tests__/make-immutable.test.ts
+++ b/packages/core/src/immutability/__tests__/make-immutable.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { makeImmutable } from '../index';
+import { describe, it, expect, afterEach } from 'vitest';
+import { makeImmutable } from '../make-immutable';
 
 describe('makeImmutable', () => {
   const originalEnv = process.env.NODE_ENV;

--- a/packages/core/src/immutability/dev-proxy.ts
+++ b/packages/core/src/immutability/dev-proxy.ts
@@ -2,13 +2,23 @@ export function createImmutableProxy<T extends object>(
   obj: T,
   contextName: string,
   rootName?: string,
+  proxyCache: WeakMap<object, any> = new WeakMap(),
 ): T {
+  if (proxyCache.has(obj)) {
+    return proxyCache.get(obj);
+  }
+
   const root = rootName ?? contextName;
-  return new Proxy(obj, {
+  const proxy = new Proxy(obj, {
     get(target, property, receiver) {
       const value = Reflect.get(target, property, receiver);
       if (value !== null && typeof value === 'object' && typeof property === 'string') {
-        return createImmutableProxy(value as object, `${contextName}.${property}`, root);
+        return createImmutableProxy(
+          value as object,
+          `${contextName}.${property}`,
+          root,
+          proxyCache,
+        );
       }
       return value;
     },
@@ -23,4 +33,7 @@ export function createImmutableProxy<T extends object>(
       );
     },
   });
+
+  proxyCache.set(obj, proxy);
+  return proxy;
 }

--- a/packages/core/src/immutability/freeze.ts
+++ b/packages/core/src/immutability/freeze.ts
@@ -1,10 +1,14 @@
-export function deepFreeze<T>(obj: T): T {
+export function deepFreeze<T>(obj: T, visited: WeakSet<object> = new WeakSet()): T {
   if (obj === null || typeof obj !== 'object') {
     return obj;
   }
+  if (visited.has(obj)) {
+    return obj;
+  }
+  visited.add(obj);
   Object.freeze(obj);
   for (const value of Object.values(obj)) {
-    deepFreeze(value);
+    deepFreeze(value, visited);
   }
   return obj;
 }

--- a/packages/core/src/immutability/index.ts
+++ b/packages/core/src/immutability/index.ts
@@ -1,9 +1,3 @@
-import type { DeepReadonly } from '../types/deep-readonly';
-import { createImmutableProxy } from './dev-proxy';
-
-export function makeImmutable<T extends object>(obj: T, contextName: string): DeepReadonly<T> {
-  if (process.env.NODE_ENV === 'development') {
-    return createImmutableProxy(obj, contextName) as DeepReadonly<T>;
-  }
-  return obj as DeepReadonly<T>;
-}
+export { deepFreeze } from './freeze';
+export { createImmutableProxy } from './dev-proxy';
+export { makeImmutable } from './make-immutable';

--- a/packages/core/src/immutability/make-immutable.ts
+++ b/packages/core/src/immutability/make-immutable.ts
@@ -1,0 +1,9 @@
+import type { DeepReadonly } from '../types/deep-readonly';
+import { createImmutableProxy } from './dev-proxy';
+
+export function makeImmutable<T extends object>(obj: T, contextName: string): DeepReadonly<T> {
+  if (process.env.NODE_ENV === 'development') {
+    return createImmutableProxy(obj, contextName) as DeepReadonly<T>;
+  }
+  return obj as DeepReadonly<T>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,4 @@ export {
 } from './exceptions';
 
 // Immutability
-export { makeImmutable } from './immutability';
-export { deepFreeze } from './immutability/freeze';
-export { createImmutableProxy } from './immutability/dev-proxy';
+export { makeImmutable, deepFreeze, createImmutableProxy } from './immutability';


### PR DESCRIPTION
## Summary
- **deepFreeze()**: Recursively freezes nested objects/arrays, no-op on primitives, handles circular references via WeakSet
- **createImmutableProxy()**: Proxy-based immutability with contextual error messages including nested paths (e.g., "Cannot set property 'name' on ctx.user. ctx is immutable."), cached with WeakMap for identity preservation
- **makeImmutable()**: Strategy picker — proxy in development, passthrough in production (TypeScript DeepReadonly provides compile-time safety)

## Test plan
- [x] 14 immutability tests (5 freeze + 5 proxy + 3 makeImmutable + 1 circular ref)
- [x] 342 total tests across monorepo, all passing
- [x] Pre-PR code review: 2 critical bugs found and fixed (circular ref stack overflow, proxy identity loss)
- [x] Code simplifier: extracted makeImmutable to own module, consolidated barrel exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)