### PR TITLE
feat(core): implement Phase 5 HTTP Server Layer

### DIFF
--- a/packages/core/src/server/__tests__/cors.test.ts
+++ b/packages/core/src/server/__tests__/cors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { handleCors, applyCorsHeaders, type CorsConfig } from '../cors';
+import { handleCors, applyCorsHeaders } from '../cors';
+import type { CorsConfig } from '../../types/app';
 
 describe('handleCors', () => {
   it('returns 204 preflight response for OPTIONS requests', () => {

--- a/packages/core/src/server/__tests__/request-utils.test.ts
+++ b/packages/core/src/server/__tests__/request-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseRequest, parseBody } from '../request-utils';
+import { BadRequestException } from '../../exceptions';
 
 describe('parseRequest', () => {
   it('extracts method, path, query, and headers from a Request', () => {
@@ -88,7 +89,7 @@ describe('parseBody', () => {
       body: '{invalid json',
     });
 
-    await expect(parseBody(request)).rejects.toThrow('Invalid JSON body');
+    await expect(parseBody(request)).rejects.toThrow(BadRequestException);
   });
 
   it('handles charset in content-type for JSON', async () => {

--- a/packages/core/src/server/__tests__/response-utils.test.ts
+++ b/packages/core/src/server/__tests__/response-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createJsonResponse, createErrorResponse } from '../response-utils';
+import { NotFoundException } from '../../exceptions';
 
 describe('createJsonResponse', () => {
   it('creates a JSON response with default 200 status', () => {
@@ -29,18 +30,8 @@ describe('createJsonResponse', () => {
 
 describe('createErrorResponse', () => {
   it('creates an error response from a VertzException', async () => {
-    const response = createErrorResponse({
-      name: 'NotFoundException',
-      message: 'User not found',
-      statusCode: 404,
-      code: 'NotFoundException',
-      toJSON: () => ({
-        error: 'NotFoundException',
-        message: 'User not found',
-        statusCode: 404,
-        code: 'NotFoundException',
-      }),
-    });
+    const error = new NotFoundException('User not found');
+    const response = createErrorResponse(error);
 
     expect(response.status).toBe(404);
     const body = await response.json();

--- a/packages/core/src/server/cors.ts
+++ b/packages/core/src/server/cors.ts
@@ -1,4 +1,3 @@
-export type { CorsConfig } from '../types/app';
 import type { CorsConfig } from '../types/app';
 
 const DEFAULT_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
@@ -7,11 +6,11 @@ const DEFAULT_HEADERS = ['Content-Type', 'Authorization'];
 function resolveOrigin(config: CorsConfig, requestOrigin: string | null): string | null {
   if (config.origins === true || config.origins === '*') return '*';
   if (!requestOrigin) return null;
-  if (typeof config.origins === 'string') {
-    return config.origins === requestOrigin ? requestOrigin : null;
-  }
   if (Array.isArray(config.origins)) {
     return config.origins.includes(requestOrigin) ? requestOrigin : null;
+  }
+  if (typeof config.origins === 'string') {
+    return config.origins === requestOrigin ? requestOrigin : null;
   }
   return null;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -2,4 +2,4 @@ export { parseRequest, parseBody } from './request-utils';
 export type { ParsedRequest } from './request-utils';
 export { createJsonResponse, createErrorResponse } from './response-utils';
 export { handleCors, applyCorsHeaders } from './cors';
-export type { CorsConfig } from './cors';
+export type { CorsConfig } from '../types/app';

--- a/packages/core/src/server/response-utils.ts
+++ b/packages/core/src/server/response-utils.ts
@@ -1,3 +1,5 @@
+import { VertzException } from '../exceptions';
+
 export function createJsonResponse(data: unknown, status = 200, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -8,23 +10,8 @@ export function createJsonResponse(data: unknown, status = 200, headers?: Record
   });
 }
 
-interface VertzLike {
-  statusCode: number;
-  toJSON: () => Record<string, unknown>;
-}
-
-function isVertzException(error: unknown): error is VertzLike {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'statusCode' in error &&
-    'toJSON' in error &&
-    typeof (error as any).toJSON === 'function'
-  );
-}
-
 export function createErrorResponse(error: unknown): Response {
-  if (isVertzException(error)) {
+  if (error instanceof VertzException) {
     return createJsonResponse(error.toJSON(), error.statusCode);
   }
 


### PR DESCRIPTION
## Summary
- Add `parseRequest()` — extracts method, path, query, headers from Web Standard Request
- Add `parseBody()` — handles JSON (with malformed error handling), form-urlencoded, text/plain
- Add `createJsonResponse()` and `createErrorResponse()` — builds JSON Response with VertzException support
- Add `handleCors()` — returns 204 preflight with origin allowlisting, credentials, max-age
- Add `applyCorsHeaders()` — injects CORS headers on actual responses
- All Web Standard APIs, zero dependencies

## Test plan
- [x] parseRequest: extracts method, path, query, headers, raw reference
- [x] parseRequest: handles duplicate headers per HTTP spec
- [x] parseBody: JSON, form-urlencoded, text/plain, charset handling
- [x] parseBody: throws BadRequestException for malformed JSON
- [x] createJsonResponse: default status, custom status, custom headers
- [x] createErrorResponse: VertzException and unknown errors
- [x] CORS preflight: 204, origin allowlisting, credentials, max-age
- [x] CORS headers: injection on responses, exposed headers, blocked origins
- [x] 89 tests pass (22 new server tests + 67 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)