### PR TITLE
feat(testing): add typed mock signatures with DeepPartial

### DIFF
--- a/packages/testing/src/__tests__/test-app.test.ts
+++ b/packages/testing/src/__tests__/test-app.test.ts
@@ -279,4 +279,59 @@ describe('createTestApp', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ message: 'app-level' });
   });
+
+  it('typed mock: accepts correct service mock shape', () => {
+    const moduleDef = createModuleDef({ name: 'typed' });
+    const service = moduleDef.service({
+      methods: () => ({ greet: (name: string) => `hello ${name}`, count: () => 42 }),
+    });
+
+    const app = createTestApp();
+    // Should compile — partial mock with correct method signature
+    app.mock(service, { greet: () => 'mocked' });
+  });
+
+  it('typed mock: rejects wrong service mock key', () => {
+    const moduleDef = createModuleDef({ name: 'typed' });
+    const service = moduleDef.service({
+      methods: () => ({ greet: (name: string) => `hello ${name}` }),
+    });
+
+    const app = createTestApp();
+    // @ts-expect-error — 'unknown' is not a key on the service methods
+    app.mock(service, { unknown: () => 'bad' });
+  });
+
+  it('typed mock: accepts correct middleware mock shape', () => {
+    const authMiddleware = createMiddleware({
+      name: 'auth',
+      handler: () => ({ user: { id: '1', role: 'admin' } }),
+    });
+
+    const app = createTestApp();
+    // Should compile — result matches handler return type
+    app.mockMiddleware(authMiddleware, { user: { id: '1', role: 'admin' } });
+  });
+
+  it('typed mock: accepts mock with array-returning method', () => {
+    const moduleDef = createModuleDef({ name: 'typed' });
+    const service = moduleDef.service({
+      methods: () => ({ getNames: () => ['Alice', 'Bob'] }),
+    });
+
+    const app = createTestApp();
+    // Should compile — mock returns array like the real method
+    app.mock(service, { getNames: () => ['Mocked'] });
+  });
+
+  it('typed mock: rejects wrong middleware mock shape', () => {
+    const authMiddleware = createMiddleware({
+      name: 'auth',
+      handler: () => ({ user: { id: '1', role: 'admin' } }),
+    });
+
+    const app = createTestApp();
+    // @ts-expect-error — 'wrong' is not a valid key on the middleware provides
+    app.mockMiddleware(authMiddleware, { wrong: 'data' });
+  });
 });

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,2 +1,2 @@
 export { createTestApp } from './test-app';
-export type { TestApp, TestResponse, TestRequestBuilder } from './test-app';
+export type { TestApp, TestResponse, TestRequestBuilder, DeepPartial } from './test-app';

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -2,12 +2,15 @@ import type { NamedMiddlewareDef } from '@vertz/core/src/middleware/middleware-d
 import type { ResolvedMiddleware } from '@vertz/core/src/middleware/middleware-runner';
 import type { NamedModule } from '@vertz/core/src/module/module';
 import type { NamedServiceDef } from '@vertz/core/src/module/service';
-
 import { runMiddlewareChain } from '@vertz/core/src/middleware/middleware-runner';
 import { buildCtx } from '@vertz/core/src/context/ctx-builder';
 import { Trie } from '@vertz/core/src/router/trie';
 import { parseRequest, parseBody } from '@vertz/core/src/server/request-utils';
 import { createJsonResponse, createErrorResponse } from '@vertz/core/src/server/response-utils';
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
 
 export interface TestResponse {
   status: number;
@@ -17,8 +20,8 @@ export interface TestResponse {
 }
 
 export interface TestRequestBuilder extends PromiseLike<TestResponse> {
-  mock(service: NamedServiceDef, impl: unknown): TestRequestBuilder;
-  mockMiddleware(middleware: NamedMiddlewareDef, result: Record<string, unknown>): TestRequestBuilder;
+  mock<TDeps, TState, TMethods>(service: NamedServiceDef<TDeps, TState, TMethods>, impl: DeepPartial<TMethods>): TestRequestBuilder;
+  mockMiddleware<TReq extends Record<string, unknown>, TProv extends Record<string, unknown>>(middleware: NamedMiddlewareDef<TReq, TProv>, result: TProv): TestRequestBuilder;
 }
 
 interface RequestOptions {
@@ -28,8 +31,8 @@ interface RequestOptions {
 
 export interface TestApp {
   register(module: NamedModule, options?: Record<string, unknown>): TestApp;
-  mock(service: NamedServiceDef, impl: unknown): TestApp;
-  mockMiddleware(middleware: NamedMiddlewareDef, result: Record<string, unknown>): TestApp;
+  mock<TDeps, TState, TMethods>(service: NamedServiceDef<TDeps, TState, TMethods>, impl: DeepPartial<TMethods>): TestApp;
+  mockMiddleware<TReq extends Record<string, unknown>, TProv extends Record<string, unknown>>(middleware: NamedMiddlewareDef<TReq, TProv>, result: TProv): TestApp;
   env(vars: Record<string, unknown>): TestApp;
   get(path: string, options?: RequestOptions): TestRequestBuilder;
   post(path: string, options?: RequestOptions): TestRequestBuilder;


### PR DESCRIPTION
## Summary

- Add `DeepPartial<T>` type locally in `@vertz/testing` for partial service mocks
- Type-safe `.mock()` on `TestApp` and `TestRequestBuilder` — accepts `DeepPartial<TMethods>` inferred from the service definition
- Type-safe `.mockMiddleware()` — accepts `TProv` inferred from the middleware's provides type
- Export `DeepPartial` from package index

## Test plan

- [x] Positive type tests: correct service mock shape compiles
- [x] Positive type tests: correct middleware mock shape compiles
- [x] Positive type tests: array-returning service methods compile
- [x] Negative type tests: wrong service mock key rejected (`@ts-expect-error`)
- [x] Negative type tests: wrong middleware mock shape rejected (`@ts-expect-error`)
- [x] All 21 tests pass (16 existing behavioral + 5 new type-level)
- [x] Core tests pass (158 tests, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)