### PR TITLE
feat(testing): typed mock signatures (TDD re-implementation)

### DIFF
--- a/packages/testing/src/__tests__/test-app.test-d.ts
+++ b/packages/testing/src/__tests__/test-app.test-d.ts
@@ -1,0 +1,51 @@
+import { createMiddleware } from '@vertz/core/src/middleware/middleware-def';
+import { createModuleDef } from '@vertz/core/src/module';
+import { describe, it } from 'vitest';
+
+import { createTestApp } from '../test-app';
+
+describe('createTestApp type safety', () => {
+  it('rejects wrong service mock key', () => {
+    const moduleDef = createModuleDef({ name: 'typed' });
+    const service = moduleDef.service({
+      methods: () => ({ greet: (name: string) => `hello ${name}` }),
+    });
+
+    const app = createTestApp();
+    // @ts-expect-error — 'unknown' is not a key on the service methods
+    app.mock(service, { unknown: () => 'bad' });
+  });
+
+  it('accepts correct service mock shape', () => {
+    const moduleDef = createModuleDef({ name: 'typed' });
+    const service = moduleDef.service({
+      methods: () => ({ greet: (name: string) => `hello ${name}`, count: () => 42 }),
+    });
+
+    const app = createTestApp();
+    // Should compile — partial mock with correct method signature
+    app.mock(service, { greet: () => 'mocked' });
+  });
+
+  it('accepts correct middleware mock shape', () => {
+    const authMiddleware = createMiddleware({
+      name: 'auth',
+      handler: () => ({ user: { id: '1', role: 'admin' } }),
+    });
+
+    const app = createTestApp();
+    // Should compile — result matches handler return type
+    app.mockMiddleware(authMiddleware, { user: { id: '1', role: 'admin' } });
+  });
+
+  it('rejects wrong middleware mock shape', () => {
+    const authMiddleware = createMiddleware({
+      name: 'auth',
+      handler: () => ({ user: { id: '1', role: 'admin' } }),
+    });
+
+    const app = createTestApp();
+    // @ts-expect-error — 'wrong' is not a valid key on the middleware provides
+    app.mockMiddleware(authMiddleware, { wrong: 'data' });
+  });
+});

--- a/packages/testing/src/__tests__/test-app.test.ts
+++ b/packages/testing/src/__tests__/test-app.test.ts
@@ -279,4 +279,5 @@ describe('createTestApp', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ message: 'app-level' });
   });
+
 });

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,2 +1,2 @@
 export { createTestApp } from './test-app';
-export type { TestApp, TestResponse, TestRequestBuilder } from './test-app';
+export type { TestApp, TestResponse, TestRequestBuilder, DeepPartial } from './test-app';

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -9,6 +9,10 @@ import { Trie } from '@vertz/core/src/router/trie';
 import { parseRequest, parseBody } from '@vertz/core/src/server/request-utils';
 import { createJsonResponse, createErrorResponse } from '@vertz/core/src/server/response-utils';
 
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
 export interface TestResponse {
   status: number;
   body: unknown;
@@ -17,8 +21,8 @@ export interface TestResponse {
 }
 
 export interface TestRequestBuilder extends PromiseLike<TestResponse> {
-  mock(service: NamedServiceDef, impl: unknown): TestRequestBuilder;
-  mockMiddleware(middleware: NamedMiddlewareDef, result: Record<string, unknown>): TestRequestBuilder;
+  mock<TDeps, TState, TMethods>(service: NamedServiceDef<TDeps, TState, TMethods>, impl: DeepPartial<TMethods>): TestRequestBuilder;
+  mockMiddleware<TReq extends Record<string, unknown>, TProv extends Record<string, unknown>>(middleware: NamedMiddlewareDef<TReq, TProv>, result: TProv): TestRequestBuilder;
 }
 
 interface RequestOptions {
@@ -28,8 +32,8 @@ interface RequestOptions {
 
 export interface TestApp {
   register(module: NamedModule, options?: Record<string, unknown>): TestApp;
-  mock(service: NamedServiceDef, impl: unknown): TestApp;
-  mockMiddleware(middleware: NamedMiddlewareDef, result: Record<string, unknown>): TestApp;
+  mock<TDeps, TState, TMethods>(service: NamedServiceDef<TDeps, TState, TMethods>, impl: DeepPartial<TMethods>): TestApp;
+  mockMiddleware<TReq extends Record<string, unknown>, TProv extends Record<string, unknown>>(middleware: NamedMiddlewareDef<TReq, TProv>, result: TProv): TestApp;
   env(vars: Record<string, unknown>): TestApp;
   get(path: string, options?: RequestOptions): TestRequestBuilder;
   post(path: string, options?: RequestOptions): TestRequestBuilder;

--- a/packages/testing/tsconfig.typecheck.json
+++ b/packages/testing/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "paths": {
+      "@vertz/core/*": ["../core/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -12,8 +12,13 @@ export default defineConfig({
     ],
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test-d.ts'],
     environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.test-d.ts'],
+      tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
+    },
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

Re-implementation of Phase 3 (typed mock signatures) using proper TDD — negative type tests written FIRST, implementation driven by failing tests.

## Differences from PR #44 (implementation-first approach)

This PR exists to compare the TDD vs non-TDD approach. Key differences:

1. **Type tests live in `.test-d.ts` file** — separate from runtime tests, run via `vitest --typecheck`
2. **Negative tests (`@ts-expect-error`) were written FIRST** — they drove the type changes
3. **Added `vitest typecheck` support** — `vitest.config.ts` now includes typecheck config, `tsconfig.typecheck.json` for type test compilation
4. **No type tests in the runtime test file** — type tests are properly isolated

## What TDD surfaced that implementation-first missed

The `@ts-expect-error` tests in PR #44 **were never actually enforced by the test runner**. Vitest strips types via esbuild — `@ts-expect-error` is just a comment at runtime. Without `vitest --typecheck`, those tests pass regardless of whether types are constrained. The TDD approach forced us to discover and fix this gap.

## Test plan

- [x] `@ts-expect-error` for wrong service mock key — RED then GREEN
- [x] `@ts-expect-error` for wrong middleware shape — RED then GREEN
- [x] Positive type tests: correct service/middleware shapes compile
- [x] All 16 runtime tests pass
- [x] All 4 type tests pass via `vitest --typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)