### PR TITLE
refactor(core,testing): add @vertz/core/internals subpath and fix imports

### DIFF
--- a/packages/core/bunup.config.ts
+++ b/packages/core/bunup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'bunup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/internals.ts'],
+  dts: true,
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./internals": {
+      "import": "./dist/internals.js",
+      "types": "./dist/internals.d.ts"
     }
   },
   "files": [

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -1,0 +1,9 @@
+// @vertz/core/internals — internal APIs for official packages (e.g. @vertz/testing)
+// NOT part of the public API. Do not depend on these in user code.
+
+export type { ResolvedMiddleware } from './middleware/middleware-runner';
+export { runMiddlewareChain } from './middleware/middleware-runner';
+export { buildCtx } from './context/ctx-builder';
+export { Trie } from './router/trie';
+export { parseRequest, parseBody } from './server/request-utils';
+export { createJsonResponse, createErrorResponse } from './server/response-utils';

--- a/packages/testing/src/__tests__/test-app.test-d.ts
+++ b/packages/testing/src/__tests__/test-app.test-d.ts
@@ -1,5 +1,4 @@
-import { createMiddleware } from '@vertz/core/src/middleware/middleware-def';
-import { createModuleDef } from '@vertz/core/src/module';
+import { createMiddleware, createModuleDef } from '@vertz/core';
 import { describe, it } from 'vitest';
 
 import { createTestApp } from '../test-app';

--- a/packages/testing/src/__tests__/test-app.test.ts
+++ b/packages/testing/src/__tests__/test-app.test.ts
@@ -1,8 +1,11 @@
-import type { NamedModule } from '@vertz/core/src/module/module';
-import type { NamedServiceDef } from '@vertz/core/src/module/service';
-
-import { createMiddleware } from '@vertz/core/src/middleware/middleware-def';
-import { createModuleDef, createModule, type NamedRouterDef } from '@vertz/core/src/module';
+import {
+  createMiddleware,
+  createModuleDef,
+  createModule,
+  type NamedModule,
+  type NamedServiceDef,
+  type NamedRouterDef,
+} from '@vertz/core';
 import { describe, it, expect } from 'vitest';
 
 import { createTestApp } from '../test-app';

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -1,13 +1,14 @@
-import type { NamedMiddlewareDef } from '@vertz/core/src/middleware/middleware-def';
-import type { ResolvedMiddleware } from '@vertz/core/src/middleware/middleware-runner';
-import type { NamedModule } from '@vertz/core/src/module/module';
-import type { NamedServiceDef } from '@vertz/core/src/module/service';
-
-import { runMiddlewareChain } from '@vertz/core/src/middleware/middleware-runner';
-import { buildCtx } from '@vertz/core/src/context/ctx-builder';
-import { Trie } from '@vertz/core/src/router/trie';
-import { parseRequest, parseBody } from '@vertz/core/src/server/request-utils';
-import { createJsonResponse, createErrorResponse } from '@vertz/core/src/server/response-utils';
+import type { NamedMiddlewareDef, NamedModule, NamedServiceDef } from '@vertz/core';
+import type { ResolvedMiddleware } from '@vertz/core/internals';
+import {
+  runMiddlewareChain,
+  buildCtx,
+  Trie,
+  parseRequest,
+  parseBody,
+  createJsonResponse,
+  createErrorResponse,
+} from '@vertz/core/internals';
 
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];

--- a/packages/testing/tsconfig.typecheck.json
+++ b/packages/testing/tsconfig.typecheck.json
@@ -5,11 +5,7 @@
     "exactOptionalPropertyTypes": false,
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["node"],
-    "paths": {
-      "@vertz/core/*": ["../core/*"],
-      "@vertz/schema": ["../schema/src/index.ts"]
-    }
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -5,12 +5,6 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  resolve: {
-    alias: [
-      { find: /^@vertz\/core\/(.*)/, replacement: resolve(__dirname, '../core/$1') },
-      { find: '@vertz/schema', replacement: resolve(__dirname, '../schema/src/index.ts') },
-    ],
-  },
   test: {
     include: ['src/**/*.test.ts', 'src/**/*.test-d.ts'],
     environment: 'node',


### PR DESCRIPTION
## Summary
- Add `@vertz/core/internals` subpath export for internal APIs used by official packages (e.g. `@vertz/testing`)
- Fix all `@vertz/testing` imports to use public `@vertz/core` API for types and `@vertz/core/internals` for internal utilities
- Update vitest alias and tsconfig paths to resolve the new subpath correctly

## Test plan
- [x] All 24 testing package tests pass (16 runtime + 4 type-level runtime + 4 typecheck)
- [x] All 158 core package tests pass
- [x] All 3 packages build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)