### PR TITLE
chore: enable Biome linter with noExplicitAny warn rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,9 +12,12 @@
     "lineWidth": 100
   },
   "linter": {
-    "enabled": false,
+    "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": false,
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
     }
   },
   "javascript": {


### PR DESCRIPTION
## Summary

- Enables Biome linter with a single rule: `noExplicitAny` at `warn` level
- Disables the `recommended` ruleset to keep it focused on this one rule
- Surfaces **186 existing `any` violations** across the codebase without blocking builds

### Violation breakdown

| Package | Source | Tests | Total |
|---------|--------|-------|-------|
| `@vertz/schema` | 80 | 7 | 87 |
| `@vertz/core` | 30 | 37 | 67 |
| `@vertz/testing` | 9 | 23 | 32 |

### Next steps

Follow-up PRs will:
1. Fix violations per package (starting with `@vertz/core` source — the RouteConfig `any` problem)
2. Add `// biome-ignore` for legitimate uses (schema internals, test `as any` casts)
3. Upgrade the rule from `warn` to `error` once violations are resolved

## Test plan

- [x] `bun run test` — all 32 tests pass
- [x] `bun run lint` — exits 0 (warnings only, no errors)
- [x] No behavior changes — config-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)