### PR TITLE
fix(core): replace all explicit any with unknown in source files

### DIFF
--- a/packages/core/src/app/app-runner.ts
+++ b/packages/core/src/app/app-runner.ts
@@ -15,7 +15,7 @@ export interface ModuleRegistration {
 }
 
 interface RouteEntry {
-  handler: (ctx: any) => any;
+  handler: (ctx: Record<string, unknown>) => unknown;
   options: Record<string, unknown>;
   services: Record<string, unknown>;
 }
@@ -73,7 +73,7 @@ function registerRoutes(
           options: options ?? {},
           services: resolvedServices,
         };
-        trie.add(route.method, fullPath, entry as any);
+        trie.add(route.method, fullPath, entry);
       }
     }
   }
@@ -84,7 +84,7 @@ export function buildHandler(
   registrations: ModuleRegistration[],
   globalMiddlewares: NamedMiddlewareDef[],
 ): (request: Request) => Promise<Response> {
-  const trie = new Trie();
+  const trie = new Trie<RouteEntry>();
   const basePath = config.basePath ?? '';
   const resolvedMiddlewares = resolveMiddlewares(globalMiddlewares);
   const serviceMap = resolveServices(registrations);
@@ -135,7 +135,7 @@ export function buildHandler(
 
       const middlewareState = await runMiddlewareChain(resolvedMiddlewares, requestCtx);
 
-      const entry = match.handler as unknown as RouteEntry;
+      const entry = match.handler;
 
       const ctx = buildCtx({
         params: match.params,

--- a/packages/core/src/immutability/dev-proxy.ts
+++ b/packages/core/src/immutability/dev-proxy.ts
@@ -2,10 +2,10 @@ export function createImmutableProxy<T extends object>(
   obj: T,
   contextName: string,
   rootName?: string,
-  proxyCache: WeakMap<object, any> = new WeakMap(),
+  proxyCache: WeakMap<object, unknown> = new WeakMap(),
 ): T {
   if (proxyCache.has(obj)) {
-    return proxyCache.get(obj);
+    return proxyCache.get(obj) as T;
   }
 
   const root = rootName ?? contextName;

--- a/packages/core/src/module/router-def.ts
+++ b/packages/core/src/module/router-def.ts
@@ -1,13 +1,13 @@
 import type { RouterDef } from '../types/module';
 
 export interface RouteConfig {
-  params?: any;
-  body?: any;
-  query?: any;
-  response?: any;
-  headers?: any;
-  middlewares?: any[];
-  handler: (ctx: any) => any;
+  params?: unknown;
+  body?: unknown;
+  query?: unknown;
+  response?: unknown;
+  headers?: unknown;
+  middlewares?: unknown[];
+  handler: (ctx: Record<string, unknown>) => unknown;
 }
 
 export interface Route {

--- a/packages/core/src/module/service.ts
+++ b/packages/core/src/module/service.ts
@@ -1,12 +1,12 @@
 import type { ServiceDef } from '../types/module';
 import { deepFreeze } from '../immutability';
 
-export interface NamedServiceDef<TDeps = any, TState = any, TMethods = any>
+export interface NamedServiceDef<TDeps = unknown, TState = unknown, TMethods = unknown>
   extends ServiceDef<TDeps, TState, TMethods> {
   moduleName: string;
 }
 
-export function createServiceDef<TDeps = any, TState = any, TMethods = any>(
+export function createServiceDef<TDeps = unknown, TState = unknown, TMethods = unknown>(
   moduleName: string,
   config: ServiceDef<TDeps, TState, TMethods>,
 ): NamedServiceDef<TDeps, TState, TMethods> {

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -1,2 +1,2 @@
 export { Trie } from './trie';
-export type { RouteHandler, MatchResult } from './trie';
+export type { MatchResult } from './trie';

--- a/packages/core/src/types/boot-sequence.ts
+++ b/packages/core/src/types/boot-sequence.ts
@@ -1,6 +1,6 @@
 import type { ServiceDef } from './module';
 
-export type ServiceFactory<TDeps = any, TState = any, TMethods = any> = ServiceDef<
+export type ServiceFactory<TDeps = unknown, TState = unknown, TMethods = unknown> = ServiceDef<
   TDeps,
   TState,
   TMethods

--- a/packages/core/src/types/middleware.ts
+++ b/packages/core/src/types/middleware.ts
@@ -5,10 +5,10 @@ export interface MiddlewareDef<
   TProvides extends Record<string, unknown> = Record<string, unknown>,
 > {
   inject?: Record<string, unknown>;
-  headers?: Schema<any>;
-  params?: Schema<any>;
-  query?: Schema<any>;
-  body?: Schema<any>;
+  headers?: Schema<unknown>;
+  params?: Schema<unknown>;
+  query?: Schema<unknown>;
+  body?: Schema<unknown>;
   requires?: Schema<TRequires>;
   provides?: Schema<TProvides>;
   handler: (ctx: Record<string, unknown>) => Promise<TProvides> | TProvides;

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -9,7 +9,7 @@ export interface ModuleDef<
   options?: Schema<TOptions>;
 }
 
-export interface ServiceDef<TDeps = any, TState = any, TMethods = any> {
+export interface ServiceDef<TDeps = unknown, TState = unknown, TMethods = unknown> {
   inject?: Record<string, unknown>;
   onInit?: (deps: TDeps) => Promise<TState> | TState;
   methods: (deps: TDeps, state: TState) => TMethods;


### PR DESCRIPTION
## Summary

Eliminates all **30 `noExplicitAny` violations** in `@vertz/core` source files (not tests).

### Changes by category

**Generic defaults `= any` → `= unknown`:**
- `ServiceDef<TDeps, TState, TMethods>` — `types/module.ts`
- `NamedServiceDef` + `createServiceDef` — `module/service.ts`
- `ServiceFactory` — `types/boot-sequence.ts`

**RouteConfig fields `any` → `unknown`:**
- `params`, `body`, `query`, `response`, `headers`: `any` → `unknown`
- `middlewares`: `any[]` → `unknown[]`
- `handler`: `(ctx: any) => any` → `(ctx: Record<string, unknown>) => unknown`

**MiddlewareDef schema fields:**
- `headers`, `params`, `query`, `body`: `Schema<any>` → `Schema<unknown>`

**Trie made generic:**
- `Trie` → `Trie<T = unknown>` with typed `MatchResult<T>`
- Removed `RouteHandler` type alias (was `(...args: any[]) => any`)
- `app-runner.ts`: `new Trie<RouteEntry>()` — eliminates `as any` cast

**dev-proxy:**
- `WeakMap<object, any>` → `WeakMap<object, unknown>` with safe `as T` cast

### Violation count

| Scope | Before | After |
|-------|--------|-------|
| Core source | 30 | **0** |
| Total codebase | 186 | **156** |

## Test plan

- [x] `bun run test` — all 482 tests pass (292 schema + 158 core + 32 testing)
- [x] `bun run build` — all packages build, DTS shows `unknown` defaults
- [x] No behavior changes — only type-level strictness improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)