### PR TITLE
fix(schema): replace explicit any with SchemaAny type aliases

### DIFF
--- a/packages/schema/src/__tests__/integration/named-schemas.test.ts
+++ b/packages/schema/src/__tests__/integration/named-schemas.test.ts
@@ -39,7 +39,7 @@ describe('Integration: Named Schemas', () => {
     const jsonSchema = contactSchema.toJSONSchema();
     expect(jsonSchema.$defs!['Email']).toBeDefined();
     // Both properties should reference the same $ref
-    const props = jsonSchema.properties as Record<string, any>;
+    const props = jsonSchema.properties as Record<string, { $ref: string }>;
     expect(props.primary.$ref).toBe('#/$defs/Email');
     expect(props.secondary.$ref).toBe('#/$defs/Email');
   });

--- a/packages/schema/src/core/__tests__/registry.test.ts
+++ b/packages/schema/src/core/__tests__/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SchemaRegistry } from '../registry';
+import type { SchemaAny } from '../schema';
 
 describe('SchemaRegistry', () => {
   beforeEach(() => {
@@ -7,7 +8,7 @@ describe('SchemaRegistry', () => {
   });
 
   it('registers and retrieves a schema by name', () => {
-    const fakeSchema = { _id: 'User' } as any;
+    const fakeSchema = { _id: 'User' } as unknown as SchemaAny;
     SchemaRegistry.register('User', fakeSchema);
 
     expect(SchemaRegistry.has('User')).toBe(true);
@@ -15,8 +16,8 @@ describe('SchemaRegistry', () => {
   });
 
   it('getAll returns all registered schemas and clear empties the registry', () => {
-    const schema1 = { _id: 'User' } as any;
-    const schema2 = { _id: 'Post' } as any;
+    const schema1 = { _id: 'User' } as unknown as SchemaAny;
+    const schema2 = { _id: 'Post' } as unknown as SchemaAny;
     SchemaRegistry.register('User', schema1);
     SchemaRegistry.register('Post', schema2);
 
@@ -36,8 +37,8 @@ describe('SchemaRegistry', () => {
   });
 
   it('overwrites when registering same name', () => {
-    const schema1 = { _id: 'User', version: 1 } as any;
-    const schema2 = { _id: 'User', version: 2 } as any;
+    const schema1 = { _id: 'User', version: 1 } as unknown as SchemaAny;
+    const schema2 = { _id: 'User', version: 2 } as unknown as SchemaAny;
     SchemaRegistry.register('User', schema1);
     SchemaRegistry.register('User', schema2);
 

--- a/packages/schema/src/core/registry.ts
+++ b/packages/schema/src/core/registry.ts
@@ -1,17 +1,17 @@
-import type { Schema } from './schema';
+import type { SchemaAny } from './schema';
 
 export class SchemaRegistry {
-  private static _schemas = new Map<string, Schema<any, any>>();
+  private static _schemas = new Map<string, SchemaAny>();
 
-  static register(name: string, schema: Schema<any, any>): void {
+  static register(name: string, schema: SchemaAny): void {
     this._schemas.set(name, schema);
   }
 
-  static get(name: string): Schema<any, any> | undefined {
+  static get(name: string): SchemaAny | undefined {
     return this._schemas.get(name);
   }
 
-  static getOrThrow(name: string): Schema<any, any> {
+  static getOrThrow(name: string): SchemaAny {
     const schema = this._schemas.get(name);
     if (!schema) {
       throw new Error(`Schema "${name}" not found in registry`);
@@ -24,7 +24,7 @@ export class SchemaRegistry {
   }
 
   /** Returns a read-only view of the internal map. Do not cast to Map to mutate. */
-  static getAll(): ReadonlyMap<string, Schema<any, any>> {
+  static getAll(): ReadonlyMap<string, SchemaAny> {
     return this._schemas;
   }
 

--- a/packages/schema/src/effects/__tests__/readonly.test.ts
+++ b/packages/schema/src/effects/__tests__/readonly.test.ts
@@ -21,7 +21,7 @@ describe('.readonly()', () => {
     }).readonly();
     const result = schema.parse({ name: 'Alice' });
     expect(() => {
-      (result as any).name = 'Bob';
+      (result as Record<string, unknown>).name = 'Bob';
     }).toThrow();
   });
 
@@ -39,7 +39,7 @@ describe('.readonly()', () => {
     const result = schema.parse(['a', 'b']);
     expect(Object.isFrozen(result)).toBe(true);
     expect(() => {
-      (result as any).push('c');
+      (result as unknown[]).push('c');
     }).toThrow();
   });
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -14,6 +14,7 @@ export {
   BrandedSchema,
   ReadonlySchema,
 } from './core/schema';
+export type { SchemaAny } from './core/schema';
 export { ErrorCode, ParseError } from './core/errors';
 export type { ValidationIssue } from './core/errors';
 export { ParseContext } from './core/parse-context';
@@ -147,7 +148,7 @@ import {
   IsoDatetimeSchema,
   IsoDurationSchema,
 } from './schemas/formats';
-import type { Schema } from './core/schema';
+import type { Schema, SchemaAny } from './core/schema';
 
 export const s = {
   // Primitives
@@ -169,17 +170,16 @@ export const s = {
   never: (): NeverSchema => new NeverSchema(),
 
   // Composites
-  object: <T extends Record<string, Schema<any, any>>>(shape: T): ObjectSchema<T> =>
+  object: <T extends Record<string, SchemaAny>>(shape: T): ObjectSchema<T> =>
     new ObjectSchema(shape),
   array: <T>(itemSchema: Schema<T>): ArraySchema<T> => new ArraySchema(itemSchema),
-  tuple: <T extends Schema<any, any>[]>(items: [...T]): TupleSchema<T> => new TupleSchema(items),
+  tuple: <T extends SchemaAny[]>(items: [...T]): TupleSchema<T> => new TupleSchema(items),
   enum: <T extends readonly [string, ...string[]]>(values: T): EnumSchema<T> =>
     new EnumSchema(values),
   literal: <T extends string | number | boolean | null>(value: T): LiteralSchema<T> =>
     new LiteralSchema(value),
-  union: <T extends Schema<any, any>[]>(options: [...T]): UnionSchema<T> =>
-    new UnionSchema(options),
-  discriminatedUnion: <T extends ObjectSchema<any>[]>(
+  union: <T extends SchemaAny[]>(options: [...T]): UnionSchema<T> => new UnionSchema(options),
+  discriminatedUnion: <T extends ObjectSchema[]>(
     discriminator: string,
     options: [...T],
   ): DiscriminatedUnionSchema<T> => new DiscriminatedUnionSchema(discriminator, options),
@@ -192,6 +192,7 @@ export const s = {
   file: (): FileSchema => new FileSchema(),
   custom: <T>(check: (value: unknown) => boolean, message?: string): CustomSchema<T> =>
     new CustomSchema<T>(check, message),
+  // biome-ignore lint/suspicious/noExplicitAny: standard TS pattern for any-constructor constraint
   instanceof: <T>(cls: new (...args: any[]) => T): InstanceOfSchema<T> => new InstanceOfSchema(cls),
   lazy: <T>(getter: () => Schema<T>): LazySchema<T> => new LazySchema(getter),
 

--- a/packages/schema/src/introspection/json-schema.ts
+++ b/packages/schema/src/introspection/json-schema.ts
@@ -1,4 +1,4 @@
-import type { Schema } from '../core/schema';
+import type { SchemaAny } from '../core/schema';
 
 export interface JSONSchemaObject {
   [key: string]: unknown;
@@ -25,6 +25,6 @@ export class RefTracker {
   }
 }
 
-export function toJSONSchema(schema: Schema<any, any>): JSONSchemaObject {
+export function toJSONSchema(schema: SchemaAny): JSONSchemaObject {
   return schema.toJSONSchema();
 }

--- a/packages/schema/src/schemas/__tests__/map.test.ts
+++ b/packages/schema/src/schemas/__tests__/map.test.ts
@@ -24,7 +24,7 @@ describe('MapSchema', () => {
 
   it('validates each key and value', () => {
     const schema = new MapSchema(new StringSchema(), new NumberSchema());
-    const input = new Map<any, any>([['a', 'not-number']]);
+    const input = new Map<string, string>([['a', 'not-number']]);
     const result = schema.safeParse(input);
     expect(result.success).toBe(false);
   });

--- a/packages/schema/src/schemas/coerced.ts
+++ b/packages/schema/src/schemas/coerced.ts
@@ -40,7 +40,7 @@ export class CoercedBigIntSchema extends BigIntSchema {
   _parse(value: unknown, ctx: ParseContext): bigint {
     if (typeof value === 'bigint') return super._parse(value, ctx);
     try {
-      return super._parse(BigInt(value as any), ctx);
+      return super._parse(BigInt(value as string | number | bigint | boolean), ctx);
     } catch {
       ctx.addIssue({ code: ErrorCode.InvalidType, message: 'Expected value coercible to bigint' });
       return value as bigint;
@@ -55,7 +55,7 @@ export class CoercedBigIntSchema extends BigIntSchema {
 export class CoercedDateSchema extends DateSchema {
   _parse(value: unknown, ctx: ParseContext): Date {
     if (value instanceof Date) return super._parse(value, ctx);
-    return super._parse(new Date(value as any), ctx);
+    return super._parse(new Date(value as string | number), ctx);
   }
 
   _clone(): CoercedDateSchema {

--- a/packages/schema/src/schemas/instanceof.ts
+++ b/packages/schema/src/schemas/instanceof.ts
@@ -5,12 +5,13 @@ import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
 import type { JSONSchemaObject } from '../introspection/json-schema';
 
-export class InstanceOfSchema<T> extends Schema<T> {
-  private readonly _cls: new (
-    ...args: any[]
-  ) => T;
+// biome-ignore lint/suspicious/noExplicitAny: standard TS pattern for any-constructor constraint
+type Constructor<T> = new (...args: any[]) => T;
 
-  constructor(cls: new (...args: any[]) => T) {
+export class InstanceOfSchema<T> extends Schema<T> {
+  private readonly _cls: Constructor<T>;
+
+  constructor(cls: Constructor<T>) {
     super();
     this._cls = cls;
   }

--- a/packages/schema/src/schemas/intersection.ts
+++ b/packages/schema/src/schemas/intersection.ts
@@ -1,10 +1,10 @@
-import { Schema } from '../core/schema';
+import { Schema, type SchemaAny } from '../core/schema';
 import { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
 
-export class IntersectionSchema<L extends Schema<any>, R extends Schema<any>> extends Schema<
+export class IntersectionSchema<L extends SchemaAny, R extends SchemaAny> extends Schema<
   L['_output'] & R['_output']
 > {
   private readonly _left: L;
@@ -25,7 +25,7 @@ export class IntersectionSchema<L extends Schema<any>, R extends Schema<any>> ex
         code: ErrorCode.InvalidIntersection,
         message: 'Value does not satisfy intersection',
       });
-      return value as any;
+      return value as L['_output'] & R['_output'];
     }
 
     if (

--- a/packages/schema/src/schemas/record.ts
+++ b/packages/schema/src/schemas/record.ts
@@ -1,4 +1,4 @@
-import { Schema } from '../core/schema';
+import { Schema, type SchemaAny } from '../core/schema';
 import { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
@@ -16,7 +16,7 @@ export class RecordSchema<V> extends Schema<Record<string, V>> {
 
   constructor(valueSchema: Schema<V>);
   constructor(keySchema: Schema<string>, valueSchema: Schema<V>);
-  constructor(keyOrValue: Schema<any>, valueSchema?: Schema<V>) {
+  constructor(keyOrValue: SchemaAny, valueSchema?: Schema<V>) {
     super();
     if (valueSchema !== undefined) {
       this._keySchema = keyOrValue;

--- a/packages/schema/src/schemas/special.ts
+++ b/packages/schema/src/schemas/special.ts
@@ -5,7 +5,9 @@ import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
 import type { JSONSchemaObject } from '../introspection/json-schema';
 
+// biome-ignore lint/suspicious/noExplicitAny: AnySchema intentionally models the any type
 export class AnySchema extends Schema<any> {
+  // biome-ignore lint/suspicious/noExplicitAny: AnySchema intentionally returns any
   _parse(value: unknown, _ctx: ParseContext): any {
     return value;
   }

--- a/packages/schema/src/schemas/tuple.ts
+++ b/packages/schema/src/schemas/tuple.ts
@@ -1,18 +1,18 @@
-import { Schema } from '../core/schema';
+import { Schema, type SchemaAny } from '../core/schema';
 import { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
 import type { JSONSchemaObject } from '../introspection/json-schema';
 
-type TupleItems = [Schema<any>, ...Schema<any>[]];
+type TupleItems = [SchemaAny, ...SchemaAny[]];
 type InferTuple<T extends TupleItems> = {
   [K in keyof T]: T[K] extends Schema<infer O> ? O : never;
 };
 
 export class TupleSchema<T extends TupleItems> extends Schema<InferTuple<T>> {
   private readonly _items: T;
-  private _rest: Schema<any> | undefined;
+  private _rest: SchemaAny | undefined;
 
   constructor(items: T) {
     super();

--- a/packages/schema/src/schemas/union.ts
+++ b/packages/schema/src/schemas/union.ts
@@ -1,11 +1,11 @@
-import { Schema } from '../core/schema';
+import { Schema, type SchemaAny } from '../core/schema';
 import { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
 import type { JSONSchemaObject } from '../introspection/json-schema';
 
-type UnionOptions = [Schema<any>, ...Schema<any>[]];
+type UnionOptions = [SchemaAny, ...SchemaAny[]];
 type InferUnion<T extends UnionOptions> = T[number] extends Schema<infer O> ? O : never;
 
 export class UnionSchema<T extends UnionOptions> extends Schema<InferUnion<T>> {
@@ -27,7 +27,7 @@ export class UnionSchema<T extends UnionOptions> extends Schema<InferUnion<T>> {
       code: ErrorCode.InvalidUnion,
       message: `Invalid input: value does not match any option in the union`,
     });
-    return value as any;
+    return value as InferUnion<T>;
   }
 
   _schemaType(): SchemaType {

--- a/packages/schema/src/utils/type-inference.ts
+++ b/packages/schema/src/utils/type-inference.ts
@@ -1,10 +1,10 @@
-import type { Schema } from '../core/schema';
+import type { SchemaAny } from '../core/schema';
 
 /** Infer the output type of a schema. Alias for Output<T>. */
-export type Infer<T extends Schema<any, any>> = T['_output'];
+export type Infer<T extends SchemaAny> = T['_output'];
 
 /** Infer the output type of a schema. */
-export type Output<T extends Schema<any, any>> = T['_output'];
+export type Output<T extends SchemaAny> = T['_output'];
 
 /** Infer the input type of a schema. Differs from Output when transforms exist. */
-export type Input<T extends Schema<any, any>> = T['_input'];
+export type Input<T extends SchemaAny> = T['_input'];


### PR DESCRIPTION
## Summary

- Centralizes necessary `any` in three biome-ignored type aliases (`SchemaAny`, `InnerSchema<I>`, `InnerTransformFn<O>`) instead of scattering bare `any` across 18 files
- Replaces error-path `value as any` returns with specific type casts (e.g., `value as InferDiscriminatedUnion<T>`)
- Uses proper types in test files (`Record<string, unknown>`, `Map<string, string>`, `unknown as SchemaAny`)
- Adds targeted biome-ignore for genuinely unavoidable `any` usage (AnySchema, Constructor pattern, ObjectSchema shape manipulation)

Schema is **invariant** (`refine()` creates contravariant positions), so `Schema<unknown, unknown>` doesn't work as a replacement for `Schema<any, any>`. The `SchemaAny` alias centralizes this in one documented place.

## Test plan

- [x] All 292 schema tests pass
- [x] All 158 core tests pass (no regressions)
- [x] All 32 testing tests pass (no regressions)
- [x] Biome lint: 0 violations
- [x] TypeScript errors unchanged from main (91 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)