### PR TITLE
chore: enable biome recommended rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": false,
+      "recommended": true,
       "suspicious": {
         "noExplicitAny": "error"
       }

--- a/packages/core/src/di/boot-executor.ts
+++ b/packages/core/src/di/boot-executor.ts
@@ -34,7 +34,7 @@ export class BootExecutor {
 
     this.services.set(instr.id, {
       methods: instr.factory.methods(deps, state),
-      onDestroy: instr.factory.onDestroy ? () => instr.factory.onDestroy!(deps, state) : undefined,
+      onDestroy: instr.factory.onDestroy ? () => instr.factory.onDestroy?.(deps, state) : undefined,
     });
   }
 

--- a/packages/core/src/immutability/__tests__/dev-proxy.test.ts
+++ b/packages/core/src/immutability/__tests__/dev-proxy.test.ts
@@ -36,6 +36,8 @@ describe('createImmutableProxy', () => {
   it('preserves identity for nested object access', () => {
     const obj = { user: { name: 'John' } };
     const proxy = createImmutableProxy(obj, 'ctx');
-    expect(proxy.user === proxy.user).toBe(true);
+    const first = proxy.user;
+    const second = proxy.user;
+    expect(first === second).toBe(true);
   });
 });

--- a/packages/core/src/immutability/__tests__/freeze.test.ts
+++ b/packages/core/src/immutability/__tests__/freeze.test.ts
@@ -20,8 +20,8 @@ describe('deepFreeze', () => {
     const obj = { items: [{ id: 1 }, { id: 2 }] };
     deepFreeze(obj);
     expect(Object.isFrozen(obj.items)).toBe(true);
-    expect(Object.isFrozen(obj.items[0]!)).toBe(true);
-    expect(Object.isFrozen(obj.items[1]!)).toBe(true);
+    expect(Object.isFrozen(obj.items[0])).toBe(true);
+    expect(Object.isFrozen(obj.items[1])).toBe(true);
   });
 
   it('returns primitives as-is', () => {

--- a/packages/core/src/middleware/__tests__/middleware-runner.test.ts
+++ b/packages/core/src/middleware/__tests__/middleware-runner.test.ts
@@ -50,7 +50,7 @@ describe('runMiddlewareChain', () => {
   });
 
   it('makes injected services available on ctx', async () => {
-    const mockService = { verify: (token: string) => ({ id: '42' }) };
+    const mockService = { verify: (_token: string) => ({ id: '42' }) };
     const middlewares: ResolvedMiddleware[] = [
       {
         name: 'auth',

--- a/packages/core/src/router/__tests__/trie.test.ts
+++ b/packages/core/src/router/__tests__/trie.test.ts
@@ -10,8 +10,8 @@ describe('Trie', () => {
     const result = trie.match('GET', '/hello');
 
     expect(result).not.toBeNull();
-    expect(result!.handler).toBe(handler);
-    expect(result!.params).toEqual({});
+    expect(result?.handler).toBe(handler);
+    expect(result?.params).toEqual({});
   });
 
   it('matches a param route and extracts params', () => {
@@ -22,8 +22,8 @@ describe('Trie', () => {
     const result = trie.match('GET', '/users/123');
 
     expect(result).not.toBeNull();
-    expect(result!.handler).toBe(handler);
-    expect(result!.params).toEqual({ id: '123' });
+    expect(result?.handler).toBe(handler);
+    expect(result?.params).toEqual({ id: '123' });
   });
 
   it('matches a wildcard route and captures rest path', () => {
@@ -34,8 +34,8 @@ describe('Trie', () => {
     const result = trie.match('GET', '/files/docs/readme.md');
 
     expect(result).not.toBeNull();
-    expect(result!.handler).toBe(handler);
-    expect(result!.params).toEqual({ '*': 'docs/readme.md' });
+    expect(result?.handler).toBe(handler);
+    expect(result?.params).toEqual({ '*': 'docs/readme.md' });
   });
 
   it('prioritizes static over param over wildcard', () => {
@@ -49,13 +49,13 @@ describe('Trie', () => {
     trie.add('GET', '/items/special', staticHandler);
 
     const staticResult = trie.match('GET', '/items/special');
-    expect(staticResult!.handler).toBe(staticHandler);
+    expect(staticResult?.handler).toBe(staticHandler);
 
     const paramResult = trie.match('GET', '/items/123');
-    expect(paramResult!.handler).toBe(paramHandler);
+    expect(paramResult?.handler).toBe(paramHandler);
 
     const wildcardResult = trie.match('GET', '/items/a/b/c');
-    expect(wildcardResult!.handler).toBe(wildcardHandler);
+    expect(wildcardResult?.handler).toBe(wildcardHandler);
   });
 
   it('extracts multiple nested params', () => {
@@ -66,8 +66,8 @@ describe('Trie', () => {
     const result = trie.match('GET', '/users/42/posts/99');
 
     expect(result).not.toBeNull();
-    expect(result!.handler).toBe(handler);
-    expect(result!.params).toEqual({ userId: '42', postId: '99' });
+    expect(result?.handler).toBe(handler);
+    expect(result?.params).toEqual({ userId: '42', postId: '99' });
   });
 
   it('returns null when no route matches', () => {
@@ -85,8 +85,8 @@ describe('Trie', () => {
     trie.add('GET', '/users', getHandler);
     trie.add('POST', '/users', postHandler);
 
-    expect(trie.match('GET', '/users')!.handler).toBe(getHandler);
-    expect(trie.match('POST', '/users')!.handler).toBe(postHandler);
+    expect(trie.match('GET', '/users')?.handler).toBe(getHandler);
+    expect(trie.match('POST', '/users')?.handler).toBe(postHandler);
     expect(trie.match('DELETE', '/users')).toBeNull();
   });
 
@@ -98,8 +98,8 @@ describe('Trie', () => {
     const result = trie.match('GET', '/');
 
     expect(result).not.toBeNull();
-    expect(result!.handler).toBe(handler);
-    expect(result!.params).toEqual({});
+    expect(result?.handler).toBe(handler);
+    expect(result?.params).toEqual({});
   });
 
   it('returns allowed methods for a matched path', () => {
@@ -128,8 +128,8 @@ describe('Trie', () => {
     trie.add('GET', '/files/*', getHandler);
     trie.add('POST', '/files/*', postHandler);
 
-    expect(trie.match('GET', '/files/a/b/c')!.handler).toBe(getHandler);
-    expect(trie.match('POST', '/files/a/b/c')!.handler).toBe(postHandler);
+    expect(trie.match('GET', '/files/a/b/c')?.handler).toBe(getHandler);
+    expect(trie.match('POST', '/files/a/b/c')?.handler).toBe(postHandler);
   });
 
   it('throws when param names conflict at the same position', () => {

--- a/packages/core/src/router/trie.ts
+++ b/packages/core/src/router/trie.ts
@@ -67,10 +67,12 @@ export class Trie<T = unknown> {
       return node.paramChild.node;
     }
 
-    if (!node.staticChildren.has(segment)) {
-      node.staticChildren.set(segment, createNode());
+    let child = node.staticChildren.get(segment);
+    if (!child) {
+      child = createNode();
+      node.staticChildren.set(segment, child);
     }
-    return node.staticChildren.get(segment)!;
+    return child;
   }
 
   private findNode(node: TrieNode<T>, segments: string[], index: number): TrieNode<T> | null {

--- a/packages/core/src/server/__tests__/cors.test.ts
+++ b/packages/core/src/server/__tests__/cors.test.ts
@@ -16,9 +16,9 @@ describe('handleCors', () => {
     const response = handleCors(config, request);
 
     expect(response).not.toBeNull();
-    expect(response!.status).toBe(204);
-    expect(response!.headers.get('access-control-allow-origin')).toBe('*');
-    expect(response!.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(response?.status).toBe(204);
+    expect(response?.headers.get('access-control-allow-origin')).toBe('*');
+    expect(response?.headers.get('access-control-allow-methods')).toContain('POST');
   });
 
   it('returns null for non-OPTIONS requests', () => {
@@ -40,7 +40,7 @@ describe('handleCors', () => {
 
     const response = handleCors(config, request);
 
-    expect(response!.headers.get('access-control-allow-origin')).toBe('http://app.com');
+    expect(response?.headers.get('access-control-allow-origin')).toBe('http://app.com');
   });
 
   it('includes credentials and max-age headers', () => {
@@ -52,8 +52,8 @@ describe('handleCors', () => {
 
     const response = handleCors(config, request);
 
-    expect(response!.headers.get('access-control-allow-credentials')).toBe('true');
-    expect(response!.headers.get('access-control-max-age')).toBe('86400');
+    expect(response?.headers.get('access-control-allow-credentials')).toBe('true');
+    expect(response?.headers.get('access-control-max-age')).toBe('86400');
   });
 });
 

--- a/packages/core/src/server/__tests__/request-utils.test.ts
+++ b/packages/core/src/server/__tests__/request-utils.test.ts
@@ -33,7 +33,7 @@ describe('parseRequest', () => {
     const parsed = parseRequest(request);
 
     // Per HTTP spec, duplicate headers are combined with ", "
-    expect(parsed.headers['accept']).toBe('text/html, application/json');
+    expect(parsed.headers.accept).toBe('text/html, application/json');
   });
 
   it('handles path without query string', () => {

--- a/packages/schema/src/__tests__/integration/named-schemas.test.ts
+++ b/packages/schema/src/__tests__/integration/named-schemas.test.ts
@@ -6,8 +6,8 @@ describe('Integration: Named Schemas', () => {
     const userId = s.uuid().id('UserId');
     const jsonSchema = userId.toJSONSchema();
     expect(jsonSchema.$ref).toBe('#/$defs/UserId');
-    expect(jsonSchema.$defs!['UserId']).toBeDefined();
-    expect(jsonSchema.$defs!['UserId'].format).toBe('uuid');
+    expect(jsonSchema.$defs?.UserId).toBeDefined();
+    expect(jsonSchema.$defs?.UserId.format).toBe('uuid');
   });
 
   it('named object with named nested schemas', () => {
@@ -26,8 +26,8 @@ describe('Integration: Named Schemas', () => {
       .id('UserWithAddress');
 
     const jsonSchema = userSchema.toJSONSchema();
-    expect(jsonSchema.$defs!['UserWithAddress']).toBeDefined();
-    expect(jsonSchema.$defs!['Address']).toBeDefined();
+    expect(jsonSchema.$defs?.UserWithAddress).toBeDefined();
+    expect(jsonSchema.$defs?.Address).toBeDefined();
   });
 
   it('JSON Schema output with $defs and $ref', () => {
@@ -37,7 +37,7 @@ describe('Integration: Named Schemas', () => {
       secondary: emailType,
     });
     const jsonSchema = contactSchema.toJSONSchema();
-    expect(jsonSchema.$defs!['Email']).toBeDefined();
+    expect(jsonSchema.$defs?.Email).toBeDefined();
     // Both properties should reference the same $ref
     const props = jsonSchema.properties as Record<string, { $ref: string }>;
     expect(props.primary.$ref).toBe('#/$defs/Email');
@@ -45,7 +45,7 @@ describe('Integration: Named Schemas', () => {
   });
 
   it('SchemaRegistry contains named schemas', () => {
-    const testSchema = s.string().id('TestRegistrySchema');
+    const _testSchema = s.string().id('TestRegistrySchema');
     expect(SchemaRegistry.get('TestRegistrySchema')).toBeDefined();
   });
 });

--- a/packages/schema/src/__tests__/integration/recursive-schemas.test.ts
+++ b/packages/schema/src/__tests__/integration/recursive-schemas.test.ts
@@ -11,7 +11,7 @@ describe('Integration: Recursive Schemas', () => {
       })
       .id('TreeNodeIntegration');
 
-    type TreeNode = Infer<typeof treeSchema>;
+    type _TreeNode = Infer<typeof treeSchema>;
 
     const data = {
       value: 'root',
@@ -59,7 +59,7 @@ describe('Integration: Recursive Schemas', () => {
 
     const jsonSchema = nodeSchema.toJSONSchema();
     expect(jsonSchema.$ref).toBe('#/$defs/RecursiveNode');
-    expect(jsonSchema.$defs!['RecursiveNode']).toBeDefined();
+    expect(jsonSchema.$defs?.RecursiveNode).toBeDefined();
     // Should not hang or stack overflow
   });
 });

--- a/packages/schema/src/core/__tests__/parse-context.test.ts
+++ b/packages/schema/src/core/__tests__/parse-context.test.ts
@@ -27,7 +27,7 @@ describe('ParseContext', () => {
     ctx.popPath();
     ctx.popPath();
 
-    expect(ctx.issues[0]!.path).toEqual(['user', 'name']);
+    expect(ctx.issues[0]?.path).toEqual(['user', 'name']);
     expect(ctx.path).toEqual([]);
   });
 });

--- a/packages/schema/src/core/__tests__/schema.test.ts
+++ b/packages/schema/src/core/__tests__/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Schema } from '../schema';
-import { ParseContext } from '../parse-context';
+import type { ParseContext } from '../parse-context';
 import { ErrorCode, ParseError } from '../errors';
 import { SchemaType } from '../types';
 import { SchemaRegistry } from '../registry';
@@ -54,7 +54,7 @@ describe('Schema base class', () => {
     expect(failure.success).toBe(false);
     if (!failure.success) {
       expect(failure.error).toBeInstanceOf(ParseError);
-      expect(failure.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(failure.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
   });
 

--- a/packages/schema/src/core/registry.ts
+++ b/packages/schema/src/core/registry.ts
@@ -1,18 +1,19 @@
 import type { SchemaAny } from './schema';
 
+// biome-ignore lint/complexity/noStaticOnlyClass: registry pattern — class groups related operations under a namespace
 export class SchemaRegistry {
   private static _schemas = new Map<string, SchemaAny>();
 
   static register(name: string, schema: SchemaAny): void {
-    this._schemas.set(name, schema);
+    SchemaRegistry._schemas.set(name, schema);
   }
 
   static get(name: string): SchemaAny | undefined {
-    return this._schemas.get(name);
+    return SchemaRegistry._schemas.get(name);
   }
 
   static getOrThrow(name: string): SchemaAny {
-    const schema = this._schemas.get(name);
+    const schema = SchemaRegistry._schemas.get(name);
     if (!schema) {
       throw new Error(`Schema "${name}" not found in registry`);
     }
@@ -20,15 +21,15 @@ export class SchemaRegistry {
   }
 
   static has(name: string): boolean {
-    return this._schemas.has(name);
+    return SchemaRegistry._schemas.has(name);
   }
 
   /** Returns a read-only view of the internal map. Do not cast to Map to mutate. */
   static getAll(): ReadonlyMap<string, SchemaAny> {
-    return this._schemas;
+    return SchemaRegistry._schemas;
   }
 
   static clear(): void {
-    this._schemas.clear();
+    SchemaRegistry._schemas.clear();
   }
 }

--- a/packages/schema/src/core/schema.ts
+++ b/packages/schema/src/core/schema.ts
@@ -433,7 +433,7 @@ export class CatchSchema<O, I = O> extends Schema<O, I> {
     this._fallback = fallback;
   }
 
-  _parse(value: unknown, ctx: ParseContext): O {
+  _parse(value: unknown, _ctx: ParseContext): O {
     const innerCtx = new ParseContext();
     const result = this._inner._runPipeline(value, innerCtx);
     if (innerCtx.hasIssues()) {

--- a/packages/schema/src/introspection/__tests__/json-schema.test.ts
+++ b/packages/schema/src/introspection/__tests__/json-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { RefTracker, toJSONSchema } from '../json-schema';
 import { Schema } from '../../core/schema';
-import { ParseContext } from '../../core/parse-context';
+import type { ParseContext } from '../../core/parse-context';
 import { ErrorCode } from '../../core/errors';
 import { SchemaType } from '../../core/types';
 

--- a/packages/schema/src/introspection/__tests__/openapi-output.test.ts
+++ b/packages/schema/src/introspection/__tests__/openapi-output.test.ts
@@ -30,7 +30,7 @@ describe('OpenAPI v3.1 Output', () => {
     }).id('User');
     const jsonSchema = userSchema.toJSONSchema();
     expect(jsonSchema.$defs).toBeDefined();
-    expect(jsonSchema.$defs!['User']).toBeDefined();
+    expect(jsonSchema.$defs?.User).toBeDefined();
     expect(jsonSchema.$ref).toBe('#/$defs/User');
   });
 
@@ -43,8 +43,8 @@ describe('OpenAPI v3.1 Output', () => {
       address: addressSchema,
     }).id('User');
     const jsonSchema = userSchema.toJSONSchema();
-    expect(jsonSchema.$defs!['User']).toBeDefined();
-    expect(jsonSchema.$defs!['Address']).toBeDefined();
+    expect(jsonSchema.$defs?.User).toBeDefined();
+    expect(jsonSchema.$defs?.Address).toBeDefined();
   });
 
   it('recursive schema uses $ref without infinite recursion', () => {
@@ -55,7 +55,7 @@ describe('OpenAPI v3.1 Output', () => {
     }).id('TreeNode') as ObjectSchema<TreeNode>;
     const jsonSchema = treeSchema.toJSONSchema();
     expect(jsonSchema.$ref).toBe('#/$defs/TreeNode');
-    expect(jsonSchema.$defs!['TreeNode']).toBeDefined();
+    expect(jsonSchema.$defs?.TreeNode).toBeDefined();
   });
 
   it('object with required/optional properties', () => {

--- a/packages/schema/src/refinements/__tests__/refine.test.ts
+++ b/packages/schema/src/refinements/__tests__/refine.test.ts
@@ -13,7 +13,7 @@ describe('.refine()', () => {
     const result = schema.safeParse('');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.Custom);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.Custom);
     }
   });
 
@@ -22,7 +22,7 @@ describe('.refine()', () => {
     const result = schema.safeParse('');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.message).toBe('Must not be empty');
+      expect(result.error.issues[0]?.message).toBe('Must not be empty');
     }
   });
 
@@ -34,7 +34,7 @@ describe('.refine()', () => {
     const result = schema.safeParse('');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.path).toEqual(['name']);
+      expect(result.error.issues[0]?.path).toEqual(['name']);
     }
   });
 });

--- a/packages/schema/src/refinements/__tests__/super-refine.test.ts
+++ b/packages/schema/src/refinements/__tests__/super-refine.test.ts
@@ -16,8 +16,8 @@ describe('.superRefine()', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues.length).toBe(2);
-      expect(result.error.issues[0]!.message).toBe('Too short');
-      expect(result.error.issues[1]!.message).toBe('Missing @');
+      expect(result.error.issues[0]?.message).toBe('Too short');
+      expect(result.error.issues[1]?.message).toBe('Missing @');
     }
   });
 
@@ -30,7 +30,7 @@ describe('.superRefine()', () => {
     const result = schema.safeParse('user');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.Custom);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.Custom);
     }
   });
 
@@ -44,7 +44,7 @@ describe('.superRefine()', () => {
     const result = schema.safeParse('');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.message).toBe('Empty');
+      expect(result.error.issues[0]?.message).toBe('Empty');
     }
   });
 });

--- a/packages/schema/src/schemas/__tests__/array.test.ts
+++ b/packages/schema/src/schemas/__tests__/array.test.ts
@@ -16,7 +16,7 @@ describe('ArraySchema', () => {
       const result = schema.safeParse(value);
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+        expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
       }
     }
   });
@@ -27,8 +27,8 @@ describe('ArraySchema', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues.length).toBe(2);
-      expect(result.error.issues[0]!.path).toEqual([1]);
-      expect(result.error.issues[1]!.path).toEqual([3]);
+      expect(result.error.issues[0]?.path).toEqual([1]);
+      expect(result.error.issues[1]?.path).toEqual([3]);
     }
   });
 
@@ -38,7 +38,7 @@ describe('ArraySchema', () => {
     const result = schema.safeParse(['a']);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.TooSmall);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.TooSmall);
     }
   });
 
@@ -48,7 +48,7 @@ describe('ArraySchema', () => {
     const result = schema.safeParse(['a', 'b', 'c']);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.TooBig);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.TooBig);
     }
   });
 
@@ -58,12 +58,12 @@ describe('ArraySchema', () => {
     const tooShort = schema.safeParse(['a']);
     expect(tooShort.success).toBe(false);
     if (!tooShort.success) {
-      expect(tooShort.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(tooShort.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
     const tooLong = schema.safeParse(['a', 'b', 'c', 'd']);
     expect(tooLong.success).toBe(false);
     if (!tooLong.success) {
-      expect(tooLong.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(tooLong.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/date.test.ts
+++ b/packages/schema/src/schemas/__tests__/date.test.ts
@@ -34,13 +34,13 @@ describe('DateSchema', () => {
     const tooEarly = schema.safeParse(new Date('2023-12-31'));
     expect(tooEarly.success).toBe(false);
     if (!tooEarly.success) {
-      expect(tooEarly.error.issues[0]!.message).toBe('Too early');
+      expect(tooEarly.error.issues[0]?.message).toBe('Too early');
     }
 
     const tooLate = schema.safeParse(new Date('2025-01-01'));
     expect(tooLate.success).toBe(false);
     if (!tooLate.success) {
-      expect(tooLate.error.issues[0]!.message).toBe('Too late');
+      expect(tooLate.error.issues[0]?.message).toBe('Too late');
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
+++ b/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
@@ -21,8 +21,8 @@ describe('DiscriminatedUnionSchema', () => {
     const result = schema.safeParse({ meow: 'loud' });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
-      expect(result.error.issues[0]!.message).toContain('Missing discriminator');
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidUnion);
+      expect(result.error.issues[0]?.message).toContain('Missing discriminator');
     }
   });
 
@@ -31,8 +31,8 @@ describe('DiscriminatedUnionSchema', () => {
     const result = schema.safeParse({ type: 'fish', fins: 2 });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
-      expect(result.error.issues[0]!.message).toContain("'fish'");
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidUnion);
+      expect(result.error.issues[0]?.message).toContain("'fish'");
     }
   });
 
@@ -65,7 +65,7 @@ describe('DiscriminatedUnionSchema', () => {
     const result = schema.safeParse('not-an-object');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
   });
 });

--- a/packages/schema/src/schemas/__tests__/enum.test.ts
+++ b/packages/schema/src/schemas/__tests__/enum.test.ts
@@ -15,7 +15,7 @@ describe('EnumSchema', () => {
     const result = schema.safeParse('yellow');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidEnumValue);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidEnumValue);
     }
   });
 
@@ -44,7 +44,7 @@ describe('EnumSchema', () => {
       const result = schema.safeParse(value);
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidEnumValue);
+        expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidEnumValue);
       }
     }
   });

--- a/packages/schema/src/schemas/__tests__/intersection.test.ts
+++ b/packages/schema/src/schemas/__tests__/intersection.test.ts
@@ -20,7 +20,7 @@ describe('IntersectionSchema', () => {
     const result = schema.safeParse({ name: 'Alice' });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidIntersection);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidIntersection);
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/lazy.test.ts
+++ b/packages/schema/src/schemas/__tests__/lazy.test.ts
@@ -43,7 +43,7 @@ describe('LazySchema', () => {
     }).id('TreeNode') as ObjectSchema<TreeNode>;
     const jsonSchema = treeSchema.toJSONSchema();
     expect(jsonSchema.$defs).toBeDefined();
-    expect(jsonSchema.$defs!['TreeNode']).toBeDefined();
+    expect(jsonSchema.$defs?.TreeNode).toBeDefined();
     expect(jsonSchema.$ref).toBe('#/$defs/TreeNode');
   });
 

--- a/packages/schema/src/schemas/__tests__/literal.test.ts
+++ b/packages/schema/src/schemas/__tests__/literal.test.ts
@@ -19,7 +19,7 @@ describe('LiteralSchema', () => {
     const result = schema.safeParse('world');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidLiteral);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidLiteral);
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/number.test.ts
+++ b/packages/schema/src/schemas/__tests__/number.test.ts
@@ -89,14 +89,14 @@ describe('NumberSchema', () => {
     const gtResult = gtSchema.safeParse(5);
     expect(gtResult.success).toBe(false);
     if (!gtResult.success) {
-      expect(gtResult.error.issues[0]!.message).toBe('Must be above 5');
+      expect(gtResult.error.issues[0]?.message).toBe('Must be above 5');
     }
 
     const ltSchema = new NumberSchema().lt(10, 'Must be below 10');
     const ltResult = ltSchema.safeParse(10);
     expect(ltResult.success).toBe(false);
     if (!ltResult.success) {
-      expect(ltResult.error.issues[0]!.message).toBe('Must be below 10');
+      expect(ltResult.error.issues[0]?.message).toBe('Must be below 10');
     }
   });
 
@@ -105,7 +105,7 @@ describe('NumberSchema', () => {
     const result = schema.safeParse(0);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.message).toBe('Must be at least 1');
+      expect(result.error.issues[0]?.message).toBe('Must be at least 1');
     }
 
     const jsonSchema = new NumberSchema().gte(0).lt(100).int().multipleOf(5).toJSONSchema();

--- a/packages/schema/src/schemas/__tests__/object.test.ts
+++ b/packages/schema/src/schemas/__tests__/object.test.ts
@@ -22,7 +22,7 @@ describe('ObjectSchema', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBeInstanceOf(ParseError);
-        expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+        expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
       }
     }
   });
@@ -34,7 +34,7 @@ describe('ObjectSchema', () => {
     if (!result.success) {
       const missingIssue = result.error.issues.find((i) => i.code === ErrorCode.MissingProperty);
       expect(missingIssue).toBeDefined();
-      expect(missingIssue!.path).toEqual(['age']);
+      expect(missingIssue?.path).toEqual(['age']);
     }
   });
 
@@ -71,7 +71,7 @@ describe('ObjectSchema', () => {
     if (!result.success) {
       const issue = result.error.issues.find((i) => i.code === ErrorCode.UnrecognizedKeys);
       expect(issue).toBeDefined();
-      expect(issue!.message).toContain('extra');
+      expect(issue?.message).toContain('extra');
     }
   });
 
@@ -183,7 +183,7 @@ describe('ObjectSchema', () => {
     if (!result.success) {
       const issue = result.error.issues.find((i) => i.code === ErrorCode.MissingProperty);
       expect(issue).toBeDefined();
-      expect(issue!.path).toEqual(['role']);
+      expect(issue?.path).toEqual(['role']);
     }
   });
 
@@ -247,7 +247,7 @@ describe('ObjectSchema', () => {
     const result = schema.safeParse({ user: { name: 'Alice', address: { city: 42 } } });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.path).toEqual(['user', 'address', 'city']);
+      expect(result.error.issues[0]?.path).toEqual(['user', 'address', 'city']);
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/record.test.ts
+++ b/packages/schema/src/schemas/__tests__/record.test.ts
@@ -22,7 +22,7 @@ describe('RecordSchema', () => {
     const result = schema.safeParse({ a: 1, b: 'bad' });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.path).toEqual(['b']);
+      expect(result.error.issues[0]?.path).toEqual(['b']);
     }
   });
 
@@ -31,7 +31,7 @@ describe('RecordSchema', () => {
     const result = schema.safeParse('not-object');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/string.test.ts
+++ b/packages/schema/src/schemas/__tests__/string.test.ts
@@ -45,7 +45,7 @@ describe('StringSchema', () => {
     const result = schema.safeParse('ab');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.message).toBe('Must be 4 chars');
+      expect(result.error.issues[0]?.message).toBe('Must be 4 chars');
     }
   });
 
@@ -55,7 +55,7 @@ describe('StringSchema', () => {
     const result = schema.safeParse('Hello123');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.message).toBe('Invalid: must match /^[a-z]+$/');
+      expect(result.error.issues[0]?.message).toBe('Invalid: must match /^[a-z]+$/');
     }
   });
 
@@ -101,12 +101,12 @@ describe('StringSchema', () => {
     const minResult = schema.safeParse('ab');
     expect(minResult.success).toBe(false);
     if (!minResult.success) {
-      expect(minResult.error.issues[0]!.message).toBe('Too short');
+      expect(minResult.error.issues[0]?.message).toBe('Too short');
     }
     const maxResult = schema.safeParse('a]'.repeat(6));
     expect(maxResult.success).toBe(false);
     if (!maxResult.success) {
-      expect(maxResult.error.issues[0]!.message).toBe('Too long');
+      expect(maxResult.error.issues[0]?.message).toBe('Too long');
     }
   });
 

--- a/packages/schema/src/schemas/__tests__/tuple.test.ts
+++ b/packages/schema/src/schemas/__tests__/tuple.test.ts
@@ -16,7 +16,7 @@ describe('TupleSchema', () => {
     const result = schema.safeParse(['hello', 'not-a-number']);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.path).toEqual([1]);
+      expect(result.error.issues[0]?.path).toEqual([1]);
     }
   });
 
@@ -32,7 +32,7 @@ describe('TupleSchema', () => {
     const result = schema.safeParse(['hello', 1, 'bad']);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.path).toEqual([2]);
+      expect(result.error.issues[0]?.path).toEqual([2]);
     }
   });
 
@@ -59,7 +59,7 @@ describe('TupleSchema', () => {
     const result = schema.safeParse('not-an-array');
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidType);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
   });
 });

--- a/packages/schema/src/schemas/__tests__/union.test.ts
+++ b/packages/schema/src/schemas/__tests__/union.test.ts
@@ -20,7 +20,7 @@ describe('UnionSchema', () => {
     const result = schema.safeParse(true);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]!.code).toBe(ErrorCode.InvalidUnion);
+      expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidUnion);
     }
   });
 

--- a/packages/schema/src/schemas/array.ts
+++ b/packages/schema/src/schemas/array.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -20,7 +20,7 @@ export class ArraySchema<T> extends Schema<T[]> {
     if (!Array.isArray(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected array, received ' + typeof value,
+        message: `Expected array, received ${typeof value}`,
       });
       return value as T[];
     }

--- a/packages/schema/src/schemas/bigint.ts
+++ b/packages/schema/src/schemas/bigint.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -10,7 +10,7 @@ export class BigIntSchema extends Schema<bigint> {
     if (typeof value !== 'bigint') {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected bigint, received ' + typeof value,
+        message: `Expected bigint, received ${typeof value}`,
       });
       return value as bigint;
     }

--- a/packages/schema/src/schemas/boolean.ts
+++ b/packages/schema/src/schemas/boolean.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -10,7 +10,7 @@ export class BooleanSchema extends Schema<boolean> {
     if (typeof value !== 'boolean') {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected boolean, received ' + typeof value,
+        message: `Expected boolean, received ${typeof value}`,
       });
       return value as boolean;
     }

--- a/packages/schema/src/schemas/coerced.ts
+++ b/packages/schema/src/schemas/coerced.ts
@@ -1,4 +1,4 @@
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { StringSchema } from './string';
 import { NumberSchema } from './number';

--- a/packages/schema/src/schemas/custom.ts
+++ b/packages/schema/src/schemas/custom.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/date.ts
+++ b/packages/schema/src/schemas/date.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -15,7 +15,7 @@ export class DateSchema extends Schema<Date> {
     if (!(value instanceof Date)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected Date, received ' + typeof value,
+        message: `Expected Date, received ${typeof value}`,
       });
       return value as Date;
     }

--- a/packages/schema/src/schemas/discriminated-union.ts
+++ b/packages/schema/src/schemas/discriminated-union.ts
@@ -1,9 +1,9 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import { LiteralSchema } from './literal';
-import { ObjectSchema } from './object';
+import type { ObjectSchema } from './object';
 import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
 
 type DiscriminatedOptions = [ObjectSchema, ...ObjectSchema[]];
@@ -44,7 +44,7 @@ export class DiscriminatedUnionSchema<T extends DiscriminatedOptions> extends Sc
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected object, received ' + receivedType(value),
+        message: `Expected object, received ${receivedType(value)}`,
       });
       return value as InferDiscriminatedUnion<T>;
     }

--- a/packages/schema/src/schemas/enum.ts
+++ b/packages/schema/src/schemas/enum.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/file.ts
+++ b/packages/schema/src/schemas/file.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/formats/__tests__/email.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/email.test.ts
@@ -28,8 +28,8 @@ describe('EmailSchema', () => {
   it('does not hang on adversarial input (ReDoS)', () => {
     const schema = new EmailSchema();
     const start = Date.now();
-    schema.safeParse('a@' + 'a-'.repeat(50) + '.com');
-    schema.safeParse('a@' + 'a.'.repeat(50) + 'x');
+    schema.safeParse(`a@${'a-'.repeat(50)}.com`);
+    schema.safeParse(`a@${'a.'.repeat(50)}x`);
     expect(Date.now() - start).toBeLessThan(100);
   });
 });

--- a/packages/schema/src/schemas/formats/format-schema.ts
+++ b/packages/schema/src/schemas/formats/format-schema.ts
@@ -1,4 +1,4 @@
-import { ParseContext } from '../../core/parse-context';
+import type { ParseContext } from '../../core/parse-context';
 import { ErrorCode } from '../../core/errors';
 import { StringSchema } from '../string';
 import type { RefTracker, JSONSchemaObject } from '../../introspection/json-schema';

--- a/packages/schema/src/schemas/instanceof.ts
+++ b/packages/schema/src/schemas/instanceof.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/intersection.ts
+++ b/packages/schema/src/schemas/intersection.ts
@@ -1,5 +1,5 @@
 import { Schema, type SchemaAny } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/lazy.ts
+++ b/packages/schema/src/schemas/lazy.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
 import type { JSONSchemaObject } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/literal.ts
+++ b/packages/schema/src/schemas/literal.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/map.ts
+++ b/packages/schema/src/schemas/map.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -19,7 +19,7 @@ export class MapSchema<K, V> extends Schema<Map<K, V>> {
     if (!(value instanceof Map)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected Map, received ' + typeof value,
+        message: `Expected Map, received ${typeof value}`,
       });
       return value as Map<K, V>;
     }

--- a/packages/schema/src/schemas/nan.ts
+++ b/packages/schema/src/schemas/nan.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/schemas/number.ts
+++ b/packages/schema/src/schemas/number.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -26,7 +26,7 @@ export class NumberSchema extends Schema<number> {
     if (typeof value !== 'number' || Number.isNaN(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected number, received ' + typeof value,
+        message: `Expected number, received ${typeof value}`,
       });
       return value as number;
     }

--- a/packages/schema/src/schemas/record.ts
+++ b/packages/schema/src/schemas/record.ts
@@ -1,5 +1,5 @@
 import { Schema, type SchemaAny } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';
@@ -31,7 +31,7 @@ export class RecordSchema<V> extends Schema<Record<string, V>> {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected object, received ' + receivedType(value),
+        message: `Expected object, received ${receivedType(value)}`,
       });
       return value as Record<string, V>;
     }

--- a/packages/schema/src/schemas/set.ts
+++ b/packages/schema/src/schemas/set.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -20,7 +20,7 @@ export class SetSchema<V> extends Schema<Set<V>> {
     if (!(value instanceof Set)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected Set, received ' + typeof value,
+        message: `Expected Set, received ${typeof value}`,
       });
       return value as Set<V>;
     }

--- a/packages/schema/src/schemas/special.ts
+++ b/packages/schema/src/schemas/special.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -48,7 +48,7 @@ export class NullSchema extends Schema<null> {
     if (value !== null) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected null, received ' + typeof value,
+        message: `Expected null, received ${typeof value}`,
       });
       return value as null;
     }
@@ -73,7 +73,7 @@ export class UndefinedSchema extends Schema<undefined> {
     if (value !== undefined) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected undefined, received ' + typeof value,
+        message: `Expected undefined, received ${typeof value}`,
       });
       return value as undefined;
     }
@@ -98,11 +98,9 @@ export class VoidSchema extends Schema<void> {
     if (value !== undefined) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected void (undefined), received ' + typeof value,
+        message: `Expected void (undefined), received ${typeof value}`,
       });
-      return value as void;
     }
-    return value;
   }
 
   _schemaType(): SchemaType {

--- a/packages/schema/src/schemas/string.ts
+++ b/packages/schema/src/schemas/string.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -27,7 +27,7 @@ export class StringSchema extends Schema<string> {
     if (typeof value !== 'string') {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected string, received ' + typeof value,
+        message: `Expected string, received ${typeof value}`,
       });
       return value as string;
     }

--- a/packages/schema/src/schemas/symbol.ts
+++ b/packages/schema/src/schemas/symbol.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -10,7 +10,7 @@ export class SymbolSchema extends Schema<symbol> {
     if (typeof value !== 'symbol') {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected symbol, received ' + typeof value,
+        message: `Expected symbol, received ${typeof value}`,
       });
       return value as symbol;
     }

--- a/packages/schema/src/schemas/tuple.ts
+++ b/packages/schema/src/schemas/tuple.ts
@@ -1,5 +1,5 @@
 import { Schema, type SchemaAny } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';
@@ -23,7 +23,7 @@ export class TupleSchema<T extends TupleItems> extends Schema<InferTuple<T>> {
     if (!Array.isArray(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: 'Expected array, received ' + typeof value,
+        message: `Expected array, received ${typeof value}`,
       });
       return value as InferTuple<T>;
     }
@@ -42,7 +42,7 @@ export class TupleSchema<T extends TupleItems> extends Schema<InferTuple<T>> {
     const result: unknown[] = [];
     for (let i = 0; i < this._items.length; i++) {
       ctx.pushPath(i);
-      result.push(this._items[i]!._runPipeline(value[i], ctx));
+      result.push(this._items[i]?._runPipeline(value[i], ctx));
       ctx.popPath();
     }
     if (this._rest) {

--- a/packages/schema/src/schemas/union.ts
+++ b/packages/schema/src/schemas/union.ts
@@ -1,5 +1,5 @@
 import { Schema, type SchemaAny } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import { SchemaType } from '../core/types';
 import type { RefTracker } from '../introspection/json-schema';

--- a/packages/schema/src/transforms/__tests__/transform.test.ts
+++ b/packages/schema/src/transforms/__tests__/transform.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { StringSchema } from '../../schemas/string';
-import { NumberSchema } from '../../schemas/number';
 
 describe('.transform()', () => {
   it('changes output value', () => {

--- a/packages/schema/src/transforms/preprocess.ts
+++ b/packages/schema/src/transforms/preprocess.ts
@@ -1,5 +1,5 @@
 import { Schema } from '../core/schema';
-import { ParseContext } from '../core/parse-context';
+import type { ParseContext } from '../core/parse-context';
 import { ErrorCode } from '../core/errors';
 import type { SchemaType } from '../core/types';
 import type { RefTracker, JSONSchemaObject } from '../introspection/json-schema';

--- a/packages/schema/src/utils/__tests__/type-inference.test.ts
+++ b/packages/schema/src/utils/__tests__/type-inference.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type { Infer, Output, Input } from '../type-inference';
 import { Schema } from '../../core/schema';
-import { ParseContext } from '../../core/parse-context';
+import type { ParseContext } from '../../core/parse-context';
 import { ErrorCode } from '../../core/errors';
 import { SchemaType } from '../../core/types';
 

--- a/packages/testing/src/__tests__/test-app.test.ts
+++ b/packages/testing/src/__tests__/test-app.test.ts
@@ -192,7 +192,7 @@ describe('createTestApp', () => {
       {
         method: 'GET',
         path: '/',
-        handler: (ctx) => ({ token: ctx.headers['authorization'] }),
+        handler: (ctx) => ({ token: ctx.headers.authorization }),
       },
     ]);
 

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -180,7 +180,7 @@ export function createTestApp(): TestApp {
         if (entry.responseSchema) {
           const validation = entry.responseSchema.safeParse(result);
           if (!validation.success) {
-            throw new ResponseValidationError(validation.error!.message);
+            throw new ResponseValidationError(validation.error.message);
           }
         }
 
@@ -245,6 +245,7 @@ export function createTestApp(): TestApp {
         perRequest.middlewares.set(middleware, result);
         return builder;
       },
+      // biome-ignore lint/suspicious/noThenProperty: intentional PromiseLike for await support
       then(onfulfilled, onrejected) {
         return executeRequest(method, path, options, perRequest).then(onfulfilled, onrejected);
       },

--- a/packages/testing/src/test-service.ts
+++ b/packages/testing/src/test-service.ts
@@ -38,6 +38,7 @@ export function createTestService<TDeps, TState, TMethods>(
       serviceMocks.set(service, impl);
       return builder;
     },
+    // biome-ignore lint/suspicious/noThenProperty: intentional PromiseLike for await support
     then(onfulfilled, onrejected) {
       return resolve().then(onfulfilled, onrejected);
     },


### PR DESCRIPTION
## Summary

- Enables \`recommended: true\` in biome linter config — turns on all recommended rules across correctness, suspicious, style, and complexity categories
- Fixes all 172 violations across 64 files in the three packages (core, schema, testing)
- Only 3 intentional suppressions: \`noThenProperty\` (PromiseLike pattern in test builders), \`noStaticOnlyClass\` (SchemaRegistry)

### Breakdown by rule

| Rule | Count | Fix |
|---|---|---|
| noNonNullAssertion | 93 | \`!\` → \`?.\` or restructured |
| useImportType | 30 | auto-fixed |
| useTemplate | 18 | auto-fixed |
| useLiteralKeys | 13 | auto-fixed |
| noThisInStatic | 6 | auto-fixed |
| noVoidTypeReturn | 2 | removed explicit returns |
| noThenProperty | 2 | suppressed (intentional) |
| noUnusedFunctionParameters | 2 | underscore prefix |
| noSelfCompare | 1 | restructured |
| noStaticOnlyClass | 1 | suppressed (intentional) |
| others | 4 | auto-fixed or removed |

## Test plan

- [x] All 158 core tests pass
- [x] All 292 schema tests pass
- [x] All 32 testing tests pass
- [x] \`biome check ./packages\` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)