### PR TITLE
chore: enable useSortedKeys for JSON config files

### DIFF
--- a/.claude/rules/biome.md
+++ b/.claude/rules/biome.md
@@ -1,0 +1,9 @@
+# Biome Configuration Decisions
+
+## useSortedKeys — JSON only, not JS/TS
+
+`useSortedKeys` is enabled for JSON config files (tsconfig.json, etc.) but disabled for JS/TS source files and package.json.
+
+**Why not JS/TS:** Alphabetical key sorting in source code can change semantics (e.g., middleware registration order, object spread precedence) and hurt readability when properties follow a logical grouping rather than alphabetical order.
+
+**Why not package.json:** The npm ecosystem has a well-known conventional key order (name, version, type, main, exports, scripts, dependencies) that alphabetical sorting would break.

--- a/biome.json
+++ b/biome.json
@@ -31,8 +31,31 @@
     "enabled": true,
     "actions": {
       "source": {
-        "organizeImports": "on"
+        "organizeImports": "on",
+        "useSortedKeys": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.{ts,tsx,js,jsx}"],
+      "assist": {
+        "actions": {
+          "source": {
+            "useSortedKeys": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/package.json"],
+      "assist": {
+        "actions": {
+          "source": {
+            "useSortedKeys": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
     "isolatedDeclarations": true,
-    "outDir": "dist",
-    "rootDir": "src",
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": false
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
     "isolatedDeclarations": true,
-    "outDir": "dist",
-    "rootDir": "src",
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": false
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
     "isolatedDeclarations": true,
-    "outDir": "dist",
-    "rootDir": "src",
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": false
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/testing/tsconfig.typecheck.json
+++ b/packages/testing/tsconfig.typecheck.json
@@ -1,11 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noUncheckedIndexedAccess": false,
     "exactOptionalPropertyTypes": false,
     "noEmit": true,
+    "noUncheckedIndexedAccess": false,
     "skipLibCheck": true,
     "types": ["node"]
   },
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Enables `useSortedKeys` biome assist action for JSON config files (tsconfig.json, etc.)
- Disables it for JS/TS source files and package.json via overrides
- Adds `.claude/rules/biome.md` documenting the rationale

### Why not JS/TS source files?

Alphabetical key sorting in source code can change semantics (e.g., middleware registration order, object spread precedence) and hurt readability when properties follow a logical grouping rather than alphabetical order. May revisit once we have more experience with the codebase patterns.

### Why not package.json?

The npm ecosystem has a well-known conventional key order (`name`, `version`, `type`, `main`, `exports`, `scripts`, `dependencies`) that alphabetical sorting would break.

## Test plan

- [x] All 158 core tests pass
- [x] All 292 schema tests pass
- [x] All 32 testing tests pass
- [x] `biome check ./packages` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)