### PR TITLE
chore: add custom GritQL lint plugins

### DIFF
--- a/.claude/rules/biome.md
+++ b/.claude/rules/biome.md
@@ -7,3 +7,19 @@
 **Why not JS/TS:** Alphabetical key sorting in source code can change semantics (e.g., middleware registration order, object spread precedence) and hurt readability when properties follow a logical grouping rather than alphabetical order.
 
 **Why not package.json:** The npm ecosystem has a well-known conventional key order (name, version, type, main, exports, scripts, dependencies) that alphabetical sorting would break.
+
+## Custom GritQL Plugins (`biome-plugins/`)
+
+All plugins use `warn` severity (except `no-ts-ignore` which is `error`) because GritQL plugins currently don't support `biome-ignore` suppressions or per-file overrides. Warnings serve as guardrails without blocking CI.
+
+### no-internals-import (warn)
+Flags `import ... from '@vertz/core/internals'`. Only `@vertz/testing` should access internal APIs — the 2 warnings in that package are expected.
+
+### no-ts-ignore (error)
+Bans `@ts-ignore`. Use `@ts-expect-error` instead — it fails when the suppressed error is fixed, preventing stale suppressions.
+
+### no-double-cast (warn)
+Flags `as unknown as T` double casts. Usually means the types need rethinking. Legitimate in test mocks (creating fake objects) and some internal schema operations (enum exclude/extract).
+
+### no-throw-plain-error (warn)
+Flags `throw new Error(...)` — prefer VertzException subclasses for proper HTTP error responses. Legitimate in framework setup code (module assembly, env validation) and test assertions where plain Error is appropriate.

--- a/biome-plugins/no-double-cast.grit
+++ b/biome-plugins/no-double-cast.grit
@@ -1,0 +1,10 @@
+// Flag `as unknown as T` double casts — usually a sign that types need
+// rethinking rather than bypassing. Warn-level since test mocks and
+// some internal schema operations legitimately need this.
+`$x as unknown as $T` where {
+    register_diagnostic(
+        span = $x,
+        message = "Avoid double type assertion (as unknown as T). This bypasses type safety — consider restructuring the types instead.",
+        severity = "warn"
+    )
+}

--- a/biome-plugins/no-internals-import.grit
+++ b/biome-plugins/no-internals-import.grit
@@ -1,0 +1,10 @@
+// Prevent importing from @vertz/core/internals.
+// Only @vertz/testing is allowed to access internal APIs.
+// Warn-level: @vertz/testing legitimately imports from internals.
+`'@vertz/core/internals'` as $path where {
+    register_diagnostic(
+        span = $path,
+        message = "Do not import from '@vertz/core/internals'. Use the public API from '@vertz/core' instead. Only @vertz/testing may access internals.",
+        severity = "warn"
+    )
+}

--- a/biome-plugins/no-throw-plain-error.grit
+++ b/biome-plugins/no-throw-plain-error.grit
@@ -1,0 +1,9 @@
+// In framework code, prefer VertzException subclasses over plain Error.
+// Plain Error loses HTTP status codes and structured error responses.
+`throw new Error($msg)` where {
+    register_diagnostic(
+        span = $msg,
+        message = "Prefer throwing a VertzException subclass (e.g. BadRequestException, NotFoundException) instead of plain Error for proper HTTP error responses.",
+        severity = "warn"
+    )
+}

--- a/biome-plugins/no-ts-ignore.grit
+++ b/biome-plugins/no-ts-ignore.grit
@@ -1,0 +1,8 @@
+// Ban @ts-ignore entirely. Use @ts-expect-error instead — it fails when
+// the suppressed error is fixed, preventing stale suppressions.
+`// @ts-ignore` where {
+    register_diagnostic(
+        span = $_,
+        message = "Use @ts-expect-error instead of @ts-ignore. @ts-expect-error will alert you when the suppression is no longer needed."
+    )
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "plugins": [
+    "./biome-plugins/no-internals-import.grit",
+    "./biome-plugins/no-ts-ignore.grit",
+    "./biome-plugins/no-double-cast.grit",
+    "./biome-plugins/no-throw-plain-error.grit"
+  ],
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

Adds 4 custom biome GritQL plugins as type safety guardrails:

| Plugin | Severity | What it catches |
|---|---|---|
| `no-internals-import` | warn | `import ... from '@vertz/core/internals'` outside `@vertz/testing` |
| `no-ts-ignore` | error | `@ts-ignore` — use `@ts-expect-error` instead |
| `no-double-cast` | warn | `as unknown as T` double casts that bypass type safety |
| `no-throw-plain-error` | warn | `throw new Error()` — prefer VertzException subclasses |

### Why warn instead of error?

GritQL plugins don't yet support `biome-ignore` suppressions or per-file overrides ([known issue](https://github.com/biomejs/biome/issues/8522)). Using `warn` severity means:
- Developers see the warning and decide if it's legitimate
- CI won't fail on known-legitimate uses (e.g., `@vertz/testing` importing internals, test mocks using double casts)
- New violations in unexpected places still surface immediately

`no-ts-ignore` is `error` since there are zero current violations — it's a pure guardrail.

## Test plan

- [x] `biome check ./packages` — 0 errors, 27 warnings (all legitimate)
- [x] All 482 tests pass across core, schema, testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)