### PR TITLE
feat(compiler): add IR types, diagnostic system, and compiler skeleton (Phase 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,19 @@
         "@biomejs/biome": "^2.3.14",
       },
     },
+    "packages/compiler": {
+      "name": "@vertz/compiler",
+      "version": "0.1.0",
+      "dependencies": {
+        "ts-morph": "^25.0.0",
+      },
+      "devDependencies": {
+        "@types/node": "^25.2.1",
+        "bunup": "latest",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
     "packages/core": {
       "name": "@vertz/core",
       "version": "0.1.0",
@@ -136,6 +149,12 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oxc-minify/binding-android-arm64": ["@oxc-minify/binding-android-arm64@0.93.0", "", { "os": "android", "cpu": "arm64" }, "sha512-N3j/JoK4hXwQbnyOJoEltM8MEkddWV3XtfYimO6jsMjr5R6QdauKaSVeQHO/lSezB7SFkrMPqr6X7tBfghHiXA=="],
 
@@ -287,6 +306,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
+    "@ts-morph/common": ["@ts-morph/common@0.26.1", "", { "dependencies": { "fast-glob": "^3.3.2", "minimatch": "^9.0.4", "path-browserify": "^1.0.1" } }, "sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -296,6 +317,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@25.2.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg=="],
+
+    "@vertz/compiler": ["@vertz/compiler@workspace:packages/compiler"],
 
     "@vertz/core": ["@vertz/core@workspace:packages/core"],
 
@@ -319,6 +342,12 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "bunup": ["bunup@0.16.22", "", { "dependencies": { "@bunup/dts": "^0.14.50", "@bunup/shared": "0.16.20", "chokidar": "^5.0.0", "coffi": "^0.1.37", "lightningcss": "^1.30.2", "picocolors": "^1.1.1", "tinyexec": "^1.0.2", "tree-kill": "^1.2.2", "zlye": "^0.4.4" }, "peerDependencies": { "typescript": "latest" }, "optionalPeers": ["typescript"], "bin": { "bunup": "dist/cli/index.js" } }, "sha512-R1ARiGA396bP/PYDA3dB6SwpB5zsypEt1KJtG34HvuoJBZJTP7NK2k9GUALXyhB/2V2v62GMh356IAJInCJ7vA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -328,6 +357,8 @@
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
     "coffi": ["coffi@0.1.37", "", { "dependencies": { "strip-json-comments": "^5.0.3" } }, "sha512-ewO5Xis7sw7g54yI/3lJ/nNV90Er4ZnENeDORZjrs58T70MmwKFLZgevraNCz+RmB4KDKsYT1ui1wDB36iPWqQ=="],
 
@@ -345,9 +376,23 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
@@ -379,6 +424,12 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -388,6 +439,8 @@
     "oxc-resolver": ["oxc-resolver@11.17.0", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.17.0", "@oxc-resolver/binding-android-arm64": "11.17.0", "@oxc-resolver/binding-darwin-arm64": "11.17.0", "@oxc-resolver/binding-darwin-x64": "11.17.0", "@oxc-resolver/binding-freebsd-x64": "11.17.0", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.17.0", "@oxc-resolver/binding-linux-arm-musleabihf": "11.17.0", "@oxc-resolver/binding-linux-arm64-gnu": "11.17.0", "@oxc-resolver/binding-linux-arm64-musl": "11.17.0", "@oxc-resolver/binding-linux-ppc64-gnu": "11.17.0", "@oxc-resolver/binding-linux-riscv64-gnu": "11.17.0", "@oxc-resolver/binding-linux-riscv64-musl": "11.17.0", "@oxc-resolver/binding-linux-s390x-gnu": "11.17.0", "@oxc-resolver/binding-linux-x64-gnu": "11.17.0", "@oxc-resolver/binding-linux-x64-musl": "11.17.0", "@oxc-resolver/binding-openharmony-arm64": "11.17.0", "@oxc-resolver/binding-wasm32-wasi": "11.17.0", "@oxc-resolver/binding-win32-arm64-msvc": "11.17.0", "@oxc-resolver/binding-win32-ia32-msvc": "11.17.0", "@oxc-resolver/binding-win32-x64-msvc": "11.17.0" } }, "sha512-R5P2Tw6th+nQJdNcZGfuppBS/sM0x1EukqYffmlfX2xXLgLGCCPwu4ruEr9Sx29mrpkHgITc130Qps2JR90NdQ=="],
 
     "oxc-transform": ["oxc-transform@0.93.0", "", { "optionalDependencies": { "@oxc-transform/binding-android-arm64": "0.93.0", "@oxc-transform/binding-darwin-arm64": "0.93.0", "@oxc-transform/binding-darwin-x64": "0.93.0", "@oxc-transform/binding-freebsd-x64": "0.93.0", "@oxc-transform/binding-linux-arm-gnueabihf": "0.93.0", "@oxc-transform/binding-linux-arm-musleabihf": "0.93.0", "@oxc-transform/binding-linux-arm64-gnu": "0.93.0", "@oxc-transform/binding-linux-arm64-musl": "0.93.0", "@oxc-transform/binding-linux-riscv64-gnu": "0.93.0", "@oxc-transform/binding-linux-s390x-gnu": "0.93.0", "@oxc-transform/binding-linux-x64-gnu": "0.93.0", "@oxc-transform/binding-linux-x64-musl": "0.93.0", "@oxc-transform/binding-wasm32-wasi": "0.93.0", "@oxc-transform/binding-win32-arm64-msvc": "0.93.0", "@oxc-transform/binding-win32-x64-msvc": "0.93.0" } }, "sha512-QCwM2nMAWf4hEBehLVA2apllxdmmWLb5M0in9HwC2boaaFbP0QntbLy4hfRZGur2KKyEBErZbH9S5NYX8eHslg=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -399,9 +452,15 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -427,9 +486,13 @@
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "ts-import-resolver": ["ts-import-resolver@0.1.23", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-282pgr6j6aOvP3P2I6XugDxdBobkpdMmdbWjRjGl5gjPI1p0+oTNGDh1t924t75kRlyIkF65DiwhSIUysmyHQA=="],
+
+    "ts-morph": ["ts-morph@25.0.1", "", { "dependencies": { "@ts-morph/common": "~0.26.0", "code-block-writer": "^13.0.3" } }, "sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -446,6 +509,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "zlye": ["zlye@0.4.4", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-fwpeC841X3ElOLYRMKXbwX29pitNrsm6nRNvEhDMrRXDl3BhR2i03Bkr0GNrpyYgZJuEzUsBylXAYzgGPXXOCQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
   }

--- a/packages/compiler/bunup.config.ts
+++ b/packages/compiler/bunup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'bunup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+});

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@vertz/compiler",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bunup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
+  },
+  "dependencies": {
+    "ts-morph": "^25.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.1",
+    "bunup": "latest",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/compiler/src/__tests__/base-analyzer.test.ts
+++ b/packages/compiler/src/__tests__/base-analyzer.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import { BaseAnalyzer } from '../analyzers/base-analyzer';
+import { createDiagnostic } from '../errors';
+import { resolveConfig } from '../config';
+
+class TestAnalyzer extends BaseAnalyzer<string> {
+  async analyze(): Promise<string> {
+    return 'test';
+  }
+
+  emitDiagnostic(): void {
+    this.addDiagnostic(
+      createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'test' }),
+    );
+  }
+}
+
+function createTestAnalyzer(): TestAnalyzer {
+  const project = new Project({ useInMemoryFileSystem: true });
+  return new TestAnalyzer(project, resolveConfig());
+}
+
+describe('BaseAnalyzer', () => {
+  it('stores project and config', () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const config = resolveConfig({ strict: true });
+    const analyzer = new TestAnalyzer(project, config);
+    expect(analyzer['project']).toBe(project);
+    expect(analyzer['config']).toBe(config);
+  });
+
+  it('accumulates diagnostics via addDiagnostic', () => {
+    const analyzer = createTestAnalyzer();
+    analyzer.emitDiagnostic();
+    analyzer.emitDiagnostic();
+    expect(analyzer.getDiagnostics()).toHaveLength(2);
+  });
+
+  it('getDiagnostics returns a copy (not the internal array)', () => {
+    const analyzer = createTestAnalyzer();
+    analyzer.emitDiagnostic();
+    const copy = analyzer.getDiagnostics();
+    copy.push(createDiagnostic({ severity: 'info', code: 'VERTZ_DEAD_CODE', message: 'extra' }));
+    expect(analyzer.getDiagnostics()).toHaveLength(1);
+  });
+
+  it('starts with empty diagnostics', () => {
+    const analyzer = createTestAnalyzer();
+    expect(analyzer.getDiagnostics()).toEqual([]);
+  });
+});

--- a/packages/compiler/src/__tests__/base-generator.test.ts
+++ b/packages/compiler/src/__tests__/base-generator.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { BaseGenerator } from '../generators/base-generator';
+import { resolveConfig } from '../config';
+import type { AppIR } from '../ir/types';
+
+class TestGenerator extends BaseGenerator {
+  async generate(_ir: AppIR, _outputDir: string): Promise<void> {
+    // no-op
+  }
+
+  testResolveOutputPath(outputDir: string, fileName: string): string {
+    return this.resolveOutputPath(outputDir, fileName);
+  }
+}
+
+describe('BaseGenerator', () => {
+  it('resolveOutputPath joins outputDir and fileName', () => {
+    const gen = new TestGenerator(resolveConfig());
+    expect(gen.testResolveOutputPath('/project/.vertz/generated', 'openapi.json')).toBe(
+      '/project/.vertz/generated/openapi.json',
+    );
+  });
+
+  it('resolveOutputPath handles nested fileName', () => {
+    const gen = new TestGenerator(resolveConfig());
+    expect(gen.testResolveOutputPath('/project/out', 'schemas/registry.ts')).toBe(
+      '/project/out/schemas/registry.ts',
+    );
+  });
+
+  it('stores config', () => {
+    const config = resolveConfig({ strict: true });
+    const gen = new TestGenerator(config);
+    expect(gen['config']).toBe(config);
+  });
+});

--- a/packages/compiler/src/__tests__/compiler.test.ts
+++ b/packages/compiler/src/__tests__/compiler.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { Compiler } from '../compiler';
+import { resolveConfig } from '../config';
+import { createDiagnostic } from '../errors';
+import type { CompilerDependencies, Validator } from '../compiler';
+
+function stubAnalyzer(name: string, calls: string[]) {
+  return {
+    analyze: async () => {
+      calls.push(`analyze:${name}`);
+      return {};
+    },
+  };
+}
+
+function stubDependencies(calls: string[]): CompilerDependencies {
+  return {
+    analyzers: {
+      env: stubAnalyzer('env', calls),
+      schema: stubAnalyzer('schema', calls),
+      middleware: stubAnalyzer('middleware', calls),
+      module: stubAnalyzer('module', calls),
+      app: stubAnalyzer('app', calls),
+      dependencyGraph: stubAnalyzer('dependencyGraph', calls),
+    },
+    validators: [],
+    generators: [],
+  };
+}
+
+describe('Compiler', () => {
+  it('runs all analyzers', async () => {
+    const calls: string[] = [];
+    const deps = stubDependencies(calls);
+    const compiler = new Compiler(resolveConfig(), deps);
+    await compiler.compile();
+    expect(calls).toContain('analyze:env');
+    expect(calls).toContain('analyze:schema');
+    expect(calls).toContain('analyze:middleware');
+    expect(calls).toContain('analyze:module');
+    expect(calls).toContain('analyze:app');
+    expect(calls).toContain('analyze:dependencyGraph');
+  });
+
+  it('runs validators after analyzers', async () => {
+    const calls: string[] = [];
+    const deps = stubDependencies(calls);
+    const validator: Validator = {
+      validate: async () => {
+        calls.push('validate');
+        return [];
+      },
+    };
+    deps.validators.push(validator);
+    const compiler = new Compiler(resolveConfig(), deps);
+    await compiler.compile();
+    const analyzeIndices = calls
+      .filter((c) => c.startsWith('analyze:'))
+      .map((c) => calls.indexOf(c));
+    const validateIndex = calls.indexOf('validate');
+    for (const idx of analyzeIndices) {
+      expect(idx).toBeLessThan(validateIndex);
+    }
+  });
+
+  it('runs generators when no errors', async () => {
+    const calls: string[] = [];
+    const deps = stubDependencies(calls);
+    deps.generators.push({
+      generate: async () => {
+        calls.push('generate');
+      },
+    });
+    const compiler = new Compiler(resolveConfig(), deps);
+    await compiler.compile();
+    expect(calls).toContain('generate');
+  });
+
+  it('skips generators when errors exist', async () => {
+    const calls: string[] = [];
+    const deps = stubDependencies(calls);
+    deps.validators.push({
+      validate: async () => [
+        createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'err' }),
+      ],
+    });
+    deps.generators.push({
+      generate: async () => {
+        calls.push('generate');
+      },
+    });
+    const compiler = new Compiler(resolveConfig(), deps);
+    await compiler.compile();
+    expect(calls).not.toContain('generate');
+  });
+
+  it('returns success: true when no errors', async () => {
+    const deps = stubDependencies([]);
+    const compiler = new Compiler(resolveConfig(), deps);
+    const result = await compiler.compile();
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success: false when errors exist', async () => {
+    const deps = stubDependencies([]);
+    deps.validators.push({
+      validate: async () => [
+        createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'err' }),
+      ],
+    });
+    const compiler = new Compiler(resolveConfig(), deps);
+    const result = await compiler.compile();
+    expect(result.success).toBe(false);
+  });
+
+  it('collects diagnostics from all validators', async () => {
+    const deps = stubDependencies([]);
+    deps.validators.push({
+      validate: async () => [
+        createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'w1' }),
+      ],
+    });
+    deps.validators.push({
+      validate: async () => [
+        createDiagnostic({ severity: 'info', code: 'VERTZ_DEAD_CODE', message: 'i1' }),
+      ],
+    });
+    const compiler = new Compiler(resolveConfig(), deps);
+    const result = await compiler.compile();
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it('returns the assembled IR', async () => {
+    const deps = stubDependencies([]);
+    const compiler = new Compiler(resolveConfig(), deps);
+    const result = await compiler.compile();
+    expect(result.ir).toBeDefined();
+    expect(result.ir.app).toBeDefined();
+    expect(result.ir.modules).toBeDefined();
+    expect(result.ir.middleware).toBeDefined();
+    expect(result.ir.schemas).toBeDefined();
+  });
+});

--- a/packages/compiler/src/__tests__/config.test.ts
+++ b/packages/compiler/src/__tests__/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { defineConfig, resolveConfig } from '../config';
+
+describe('defineConfig', () => {
+  it('returns the same config object (identity function)', () => {
+    const input = { strict: true };
+    expect(defineConfig(input)).toBe(input);
+  });
+});
+
+describe('resolveConfig', () => {
+  it('with no arguments returns all defaults', () => {
+    const config = resolveConfig();
+    expect(config.strict).toBe(false);
+    expect(config.forceGenerate).toBe(false);
+    expect(config.compiler.sourceDir).toBe('src');
+    expect(config.compiler.outputDir).toBe('.vertz/generated');
+    expect(config.compiler.entryFile).toBe('src/app.ts');
+    expect(config.compiler.schemas.enforceNaming).toBe(true);
+    expect(config.compiler.schemas.enforcePlacement).toBe(true);
+    expect(config.compiler.openapi.output).toBe('.vertz/generated/openapi.json');
+    expect(config.compiler.openapi.info.title).toBe('Vertz API');
+    expect(config.compiler.openapi.info.version).toBe('1.0.0');
+    expect(config.compiler.validation.requireResponseSchema).toBe(true);
+    expect(config.compiler.validation.detectDeadCode).toBe(true);
+  });
+
+  it('merges user overrides with defaults', () => {
+    const config = resolveConfig({ strict: true, compiler: { sourceDir: 'app' } });
+    expect(config.strict).toBe(true);
+    expect(config.compiler.sourceDir).toBe('app');
+    expect(config.compiler.outputDir).toBe('.vertz/generated');
+  });
+
+  it('merges nested partial objects', () => {
+    const config = resolveConfig({ compiler: { schemas: { enforceNaming: false } } });
+    expect(config.compiler.schemas.enforceNaming).toBe(false);
+    expect(config.compiler.schemas.enforcePlacement).toBe(true);
+  });
+
+  it('with undefined input returns defaults', () => {
+    const config = resolveConfig(undefined);
+    expect(config.strict).toBe(false);
+    expect(config.compiler.sourceDir).toBe('src');
+  });
+
+  it('with empty object returns defaults', () => {
+    const config = resolveConfig({});
+    expect(config.strict).toBe(false);
+    expect(config.compiler.sourceDir).toBe('src');
+  });
+});

--- a/packages/compiler/src/__tests__/errors.test.ts
+++ b/packages/compiler/src/__tests__/errors.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDiagnostic,
+  createDiagnosticFromLocation,
+  filterBySeverity,
+  hasErrors,
+  mergeDiagnostics,
+} from '../errors';
+
+describe('createDiagnostic', () => {
+  it('returns a Diagnostic with all provided fields', () => {
+    const result = createDiagnostic({
+      severity: 'error',
+      code: 'VERTZ_APP_MISSING',
+      message: 'No vertz.app() found',
+    });
+
+    expect(result.severity).toBe('error');
+    expect(result.code).toBe('VERTZ_APP_MISSING');
+    expect(result.message).toBe('No vertz.app() found');
+    expect(result.file).toBeUndefined();
+    expect(result.line).toBeUndefined();
+    expect(result.column).toBeUndefined();
+  });
+
+  it('includes optional fields when provided', () => {
+    const result = createDiagnostic({
+      severity: 'warning',
+      code: 'VERTZ_SERVICE_UNUSED',
+      message: 'Unused service',
+      file: 'src/user.ts',
+      line: 10,
+      column: 3,
+      suggestion: 'Remove or export the service',
+    });
+
+    expect(result.severity).toBe('warning');
+    expect(result.code).toBe('VERTZ_SERVICE_UNUSED');
+    expect(result.message).toBe('Unused service');
+    expect(result.file).toBe('src/user.ts');
+    expect(result.line).toBe(10);
+    expect(result.column).toBe(3);
+    expect(result.suggestion).toBe('Remove or export the service');
+  });
+});
+
+describe('createDiagnosticFromLocation', () => {
+  it('maps SourceLocation fields to Diagnostic', () => {
+    const result = createDiagnosticFromLocation(
+      { sourceFile: 'src/mod.ts', sourceLine: 5, sourceColumn: 1 },
+      { severity: 'error', code: 'VERTZ_MODULE_CIRCULAR', message: 'Circular' },
+    );
+
+    expect(result.file).toBe('src/mod.ts');
+    expect(result.line).toBe(5);
+    expect(result.column).toBe(1);
+    expect(result.severity).toBe('error');
+    expect(result.code).toBe('VERTZ_MODULE_CIRCULAR');
+    expect(result.message).toBe('Circular');
+  });
+});
+
+describe('hasErrors', () => {
+  it('returns false for empty array', () => {
+    expect(hasErrors([])).toBe(false);
+  });
+
+  it('returns false for warnings-only array', () => {
+    const diagnostics = [
+      createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'unused' }),
+    ];
+    expect(hasErrors(diagnostics)).toBe(false);
+  });
+
+  it('returns true when at least one error exists', () => {
+    const diagnostics = [
+      createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'unused' }),
+      createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'missing' }),
+    ];
+    expect(hasErrors(diagnostics)).toBe(true);
+  });
+});
+
+describe('filterBySeverity', () => {
+  it('returns only matching diagnostics', () => {
+    const diagnostics = [
+      createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'err' }),
+      createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'warn' }),
+      createDiagnostic({ severity: 'info', code: 'VERTZ_DEAD_CODE', message: 'info' }),
+    ];
+    const result = filterBySeverity(diagnostics, 'warning');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.severity).toBe('warning');
+  });
+});
+
+describe('mergeDiagnostics', () => {
+  it('concatenates two arrays without mutating originals', () => {
+    const a = [
+      createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'a1' }),
+      createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'a2' }),
+    ];
+    const b = [
+      createDiagnostic({ severity: 'info', code: 'VERTZ_DEAD_CODE', message: 'b1' }),
+      createDiagnostic({ severity: 'error', code: 'VERTZ_DEP_CYCLE', message: 'b2' }),
+    ];
+    const merged = mergeDiagnostics(a, b);
+    expect(merged).toHaveLength(4);
+    expect(a).toHaveLength(2);
+    expect(b).toHaveLength(2);
+  });
+});
+
+describe('createDiagnostic sourceContext', () => {
+  it('includes sourceContext when provided', () => {
+    const result = createDiagnostic({
+      severity: 'error',
+      code: 'VERTZ_APP_MISSING',
+      message: 'missing',
+      sourceContext: {
+        lines: [{ number: 10, text: 'const x = 1;' }],
+        highlightStart: 6,
+        highlightLength: 1,
+      },
+    });
+    expect(result.sourceContext).toBeDefined();
+    expect(result.sourceContext!.lines).toHaveLength(1);
+    expect(result.sourceContext!.highlightStart).toBe(6);
+    expect(result.sourceContext!.highlightLength).toBe(1);
+  });
+});

--- a/packages/compiler/src/__tests__/ir-types.test-d.ts
+++ b/packages/compiler/src/__tests__/ir-types.test-d.ts
@@ -1,0 +1,100 @@
+import { describe, it } from 'vitest';
+import type {
+  AppIR,
+  DependencyEdge,
+  DependencyNode,
+  ModuleDefContext,
+  RouteIR,
+  SchemaRef,
+} from '../ir/types';
+import { createEmptyDependencyGraph } from '../ir/builder';
+import type { Diagnostic } from '../errors';
+import type { ResolvedConfig, VertzConfig } from '../config';
+
+describe('type-level: IR types', () => {
+  it('AppIR requires app field', () => {
+    // @ts-expect-error — AppIR without 'app' field should be rejected
+    const _bad: AppIR = {
+      modules: [],
+      middleware: [],
+      schemas: [],
+      dependencyGraph: createEmptyDependencyGraph(),
+      diagnostics: [],
+    };
+  });
+
+  it('RouteIR.method only accepts valid HttpMethod', () => {
+    const _bad: RouteIR = {
+      // @ts-expect-error — 'INVALID' is not a valid HttpMethod
+      method: 'INVALID',
+      path: '/',
+      fullPath: '/',
+      operationId: 'test',
+      middleware: [],
+      tags: [],
+      sourceFile: '',
+      sourceLine: 0,
+      sourceColumn: 0,
+    };
+    void _bad;
+  });
+
+  it('DependencyNodeKind only accepts valid kinds', () => {
+    // @ts-expect-error — 'unknown' is not a valid DependencyNodeKind
+    const _bad: DependencyNode = { id: '1', kind: 'unknown', name: 'test' };
+    void _bad;
+  });
+
+  it('DependencyEdgeKind only accepts valid kinds', () => {
+    // @ts-expect-error — 'unknown' is not a valid DependencyEdgeKind
+    const _bad: DependencyEdge = { from: '1', to: '2', kind: 'unknown' };
+    void _bad;
+  });
+});
+
+describe('type-level: Diagnostic types', () => {
+  it('DiagnosticCode only accepts known codes', () => {
+    // @ts-expect-error — 'VERTZ_FAKE_CODE' is not a valid DiagnosticCode
+    const _bad: Diagnostic = { severity: 'error', code: 'VERTZ_FAKE_CODE', message: 'bad' };
+    void _bad;
+  });
+
+  it('Diagnostic severity only accepts valid values', () => {
+    // @ts-expect-error — 'critical' is not a valid DiagnosticSeverity
+    const _bad: Diagnostic = { severity: 'critical', code: 'VERTZ_APP_MISSING', message: 'bad' };
+    void _bad;
+  });
+});
+
+describe('type-level: Config types', () => {
+  it('VertzConfig accepts partial compiler config', () => {
+    const config: VertzConfig = { strict: true, compiler: { sourceDir: 'app' } };
+    void config;
+  });
+
+  it('ResolvedConfig requires all fields (no optionals)', () => {
+    // @ts-expect-error — ResolvedConfig with missing compiler field should be rejected
+    const _bad: ResolvedConfig = { strict: true, forceGenerate: false };
+    void _bad;
+  });
+});
+
+describe('type-level: SchemaRef discriminated union', () => {
+  it('narrows via kind field', () => {
+    const ref: SchemaRef = {} as SchemaRef;
+    if (ref.kind === 'named') {
+      const name: string = ref.schemaName;
+      void name;
+    }
+    // @ts-expect-error — schemaName not accessible without narrowing
+    const _bad: string = ref.schemaName;
+  });
+});
+
+describe('type-level: ModuleDefContext', () => {
+  it('moduleDefVariables is Map<string, string>', () => {
+    // @ts-expect-error — Map<string, number> is not assignable to Map<string, string>
+    const _bad: ModuleDefContext = { moduleDefVariables: new Map<string, number>() };
+    void _bad;
+  });
+});

--- a/packages/compiler/src/__tests__/ir-types.test.ts
+++ b/packages/compiler/src/__tests__/ir-types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { addDiagnosticsToIR, createEmptyAppIR, createEmptyDependencyGraph } from '../ir/builder';
+import { createDiagnostic } from '../errors';
+
+describe('createEmptyAppIR', () => {
+  it('returns an AppIR with empty collections', () => {
+    const ir = createEmptyAppIR();
+    expect(ir.app.basePath).toBe('');
+    expect(ir.app.globalMiddleware).toEqual([]);
+    expect(ir.app.moduleRegistrations).toEqual([]);
+    expect(ir.modules).toEqual([]);
+    expect(ir.middleware).toEqual([]);
+    expect(ir.schemas).toEqual([]);
+    expect(ir.diagnostics).toEqual([]);
+    expect(ir.env).toBeUndefined();
+    expect(ir.dependencyGraph.nodes).toEqual([]);
+    expect(ir.dependencyGraph.edges).toEqual([]);
+    expect(ir.dependencyGraph.initializationOrder).toEqual([]);
+    expect(ir.dependencyGraph.circularDependencies).toEqual([]);
+  });
+
+  it('returns a fresh object each call (no shared state)', () => {
+    const a = createEmptyAppIR();
+    const b = createEmptyAppIR();
+    expect(a).not.toBe(b);
+    a.modules.push({} as never);
+    expect(b.modules).toHaveLength(0);
+  });
+});
+
+describe('createEmptyDependencyGraph', () => {
+  it('returns empty graph', () => {
+    const graph = createEmptyDependencyGraph();
+    expect(graph.nodes).toEqual([]);
+    expect(graph.edges).toEqual([]);
+    expect(graph.initializationOrder).toEqual([]);
+    expect(graph.circularDependencies).toEqual([]);
+  });
+});
+
+describe('addDiagnosticsToIR', () => {
+  it('returns new AppIR with merged diagnostics', () => {
+    const ir = createEmptyAppIR();
+    const d1 = createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'a' });
+    const d2 = createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'b' });
+    const result = addDiagnosticsToIR(ir, [d1, d2]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(ir.diagnostics).toHaveLength(0);
+  });
+
+  it('preserves existing diagnostics', () => {
+    const d1 = createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'a' });
+    const ir = addDiagnosticsToIR(createEmptyAppIR(), [d1]);
+    const d2 = createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'b' });
+    const result = addDiagnosticsToIR(ir, [d2]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]).toBe(d1);
+    expect(result.diagnostics[1]).toBe(d2);
+  });
+});

--- a/packages/compiler/src/analyzers/base-analyzer.ts
+++ b/packages/compiler/src/analyzers/base-analyzer.ts
@@ -1,0 +1,28 @@
+import type { Project } from 'ts-morph';
+import type { ResolvedConfig } from '../config';
+import type { Diagnostic } from '../errors';
+
+export interface Analyzer<T> {
+  analyze(): Promise<T>;
+}
+
+export abstract class BaseAnalyzer<T> implements Analyzer<T> {
+  protected readonly project: Project;
+  protected readonly config: ResolvedConfig;
+  private readonly _diagnostics: Diagnostic[] = [];
+
+  constructor(project: Project, config: ResolvedConfig) {
+    this.project = project;
+    this.config = config;
+  }
+
+  abstract analyze(): Promise<T>;
+
+  protected addDiagnostic(diagnostic: Diagnostic): void {
+    this._diagnostics.push(diagnostic);
+  }
+
+  getDiagnostics(): Diagnostic[] {
+    return [...this._diagnostics];
+  }
+}

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,0 +1,74 @@
+import type { ResolvedConfig } from './config';
+import type { Diagnostic } from './errors';
+import { hasErrors } from './errors';
+import type { Analyzer } from './analyzers/base-analyzer';
+import type { Generator } from './generators/base-generator';
+import type { AppIR } from './ir/types';
+import { createEmptyAppIR } from './ir/builder';
+
+export interface Validator {
+  validate(ir: AppIR): Promise<Diagnostic[]>;
+}
+
+export interface CompileResult {
+  success: boolean;
+  ir: AppIR;
+  diagnostics: Diagnostic[];
+}
+
+export interface CompilerDependencies {
+  analyzers: {
+    env: Analyzer<unknown>;
+    schema: Analyzer<unknown>;
+    middleware: Analyzer<unknown>;
+    module: Analyzer<unknown>;
+    app: Analyzer<unknown>;
+    dependencyGraph: Analyzer<unknown>;
+  };
+  validators: Validator[];
+  generators: Generator[];
+}
+
+export class Compiler {
+  private readonly config: ResolvedConfig;
+  private readonly deps: CompilerDependencies;
+
+  constructor(config: ResolvedConfig, dependencies: CompilerDependencies) {
+    this.config = config;
+    this.deps = dependencies;
+  }
+
+  async compile(): Promise<CompileResult> {
+    const ir = createEmptyAppIR();
+
+    // 1. Run all analyzers
+    const { analyzers } = this.deps;
+    await analyzers.env.analyze();
+    await analyzers.schema.analyze();
+    await analyzers.module.analyze();
+    await analyzers.middleware.analyze();
+    await analyzers.app.analyze();
+    await analyzers.dependencyGraph.analyze();
+
+    // 2. Run all validators
+    const allDiagnostics: Diagnostic[] = [];
+    for (const validator of this.deps.validators) {
+      const diagnostics = await validator.validate(ir);
+      allDiagnostics.push(...diagnostics);
+    }
+
+    // 3. If errors and not forcing generation, skip generators
+    const hasErrorDiags = hasErrors(allDiagnostics);
+    if (!hasErrorDiags || this.config.forceGenerate) {
+      // 4. Run all generators in parallel
+      const outputDir = this.config.compiler.outputDir;
+      await Promise.all(this.deps.generators.map((g) => g.generate(ir, outputDir)));
+    }
+
+    return {
+      success: !hasErrorDiags,
+      ir: { ...ir, diagnostics: allDiagnostics },
+      diagnostics: allDiagnostics,
+    };
+  }
+}

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -1,0 +1,71 @@
+export interface SchemaConfig {
+  enforceNaming: boolean;
+  enforcePlacement: boolean;
+}
+
+export interface OpenAPIConfig {
+  output: string;
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+  };
+}
+
+export interface ValidationConfig {
+  requireResponseSchema: boolean;
+  detectDeadCode: boolean;
+}
+
+export interface CompilerConfig {
+  sourceDir: string;
+  outputDir: string;
+  entryFile: string;
+  schemas: SchemaConfig;
+  openapi: OpenAPIConfig;
+  validation: ValidationConfig;
+}
+
+export interface VertzConfig {
+  strict?: boolean;
+  forceGenerate?: boolean;
+  compiler?: Partial<CompilerConfig>;
+}
+
+export interface ResolvedConfig {
+  strict: boolean;
+  forceGenerate: boolean;
+  compiler: CompilerConfig;
+}
+
+export function defineConfig(config: VertzConfig): VertzConfig {
+  return config;
+}
+
+export function resolveConfig(config?: VertzConfig): ResolvedConfig {
+  return {
+    strict: config?.strict ?? false,
+    forceGenerate: config?.forceGenerate ?? false,
+    compiler: {
+      sourceDir: config?.compiler?.sourceDir ?? 'src',
+      outputDir: config?.compiler?.outputDir ?? '.vertz/generated',
+      entryFile: config?.compiler?.entryFile ?? 'src/app.ts',
+      schemas: {
+        enforceNaming: config?.compiler?.schemas?.enforceNaming ?? true,
+        enforcePlacement: config?.compiler?.schemas?.enforcePlacement ?? true,
+      },
+      openapi: {
+        output: config?.compiler?.openapi?.output ?? '.vertz/generated/openapi.json',
+        info: {
+          title: config?.compiler?.openapi?.info?.title ?? 'Vertz API',
+          version: config?.compiler?.openapi?.info?.version ?? '1.0.0',
+          description: config?.compiler?.openapi?.info?.description,
+        },
+      },
+      validation: {
+        requireResponseSchema: config?.compiler?.validation?.requireResponseSchema ?? true,
+        detectDeadCode: config?.compiler?.validation?.detectDeadCode ?? true,
+      },
+    },
+  };
+}

--- a/packages/compiler/src/errors.ts
+++ b/packages/compiler/src/errors.ts
@@ -1,0 +1,110 @@
+import type { SourceLocation } from './ir/types';
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export type DiagnosticCode =
+  | 'VERTZ_SCHEMA_NAMING'
+  | 'VERTZ_SCHEMA_PLACEMENT'
+  | 'VERTZ_SCHEMA_EXECUTION'
+  | 'VERTZ_SCHEMA_MISSING_ID'
+  | 'VERTZ_SCHEMA_DYNAMIC_NAME'
+  | 'VERTZ_MODULE_CIRCULAR'
+  | 'VERTZ_MODULE_EXPORT_INVALID'
+  | 'VERTZ_MODULE_IMPORT_MISSING'
+  | 'VERTZ_MODULE_DUPLICATE_NAME'
+  | 'VERTZ_MODULE_DYNAMIC_NAME'
+  | 'VERTZ_MODULE_OPTIONS_INVALID'
+  | 'VERTZ_SERVICE_INJECT_MISSING'
+  | 'VERTZ_SERVICE_UNUSED'
+  | 'VERTZ_SERVICE_DYNAMIC_NAME'
+  | 'VERTZ_ENV_MISSING_DEFAULT'
+  | 'VERTZ_ENV_DUPLICATE'
+  | 'VERTZ_ENV_DYNAMIC_CONFIG'
+  | 'VERTZ_MW_MISSING_NAME'
+  | 'VERTZ_MW_MISSING_HANDLER'
+  | 'VERTZ_MW_DYNAMIC_NAME'
+  | 'VERTZ_MW_NON_OBJECT_CONFIG'
+  | 'VERTZ_MW_REQUIRES_UNSATISFIED'
+  | 'VERTZ_MW_PROVIDES_COLLISION'
+  | 'VERTZ_MW_ORDER_INVALID'
+  | 'VERTZ_RT_UNKNOWN_MODULE_DEF'
+  | 'VERTZ_RT_DYNAMIC_PATH'
+  | 'VERTZ_RT_MISSING_HANDLER'
+  | 'VERTZ_RT_MISSING_PREFIX'
+  | 'VERTZ_RT_DYNAMIC_CONFIG'
+  | 'VERTZ_ROUTE_DUPLICATE'
+  | 'VERTZ_ROUTE_PARAM_MISMATCH'
+  | 'VERTZ_ROUTE_MISSING_RESPONSE'
+  | 'VERTZ_APP_MISSING'
+  | 'VERTZ_APP_DUPLICATE'
+  | 'VERTZ_APP_BASEPATH_FORMAT'
+  | 'VERTZ_APP_INLINE_MODULE'
+  | 'VERTZ_DEP_CYCLE'
+  | 'VERTZ_CTX_COLLISION'
+  | 'VERTZ_DEAD_CODE';
+
+export interface SourceContext {
+  lines: { number: number; text: string }[];
+  highlightStart: number;
+  highlightLength: number;
+}
+
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  code: DiagnosticCode;
+  message: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  suggestion?: string;
+  sourceContext?: SourceContext;
+}
+
+export interface CreateDiagnosticOptions {
+  severity: DiagnosticSeverity;
+  code: DiagnosticCode;
+  message: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  suggestion?: string;
+  sourceContext?: SourceContext;
+}
+
+export function createDiagnostic(options: CreateDiagnosticOptions): Diagnostic {
+  return { ...options };
+}
+
+export function createDiagnosticFromLocation(
+  location: SourceLocation,
+  options: Omit<CreateDiagnosticOptions, 'file' | 'line' | 'column'>,
+): Diagnostic {
+  return {
+    ...options,
+    file: location.sourceFile,
+    line: location.sourceLine,
+    column: location.sourceColumn,
+  };
+}
+
+export function hasErrors(diagnostics: readonly Diagnostic[]): boolean {
+  return diagnostics.some((d) => d.severity === 'error');
+}
+
+export function filterBySeverity(
+  diagnostics: readonly Diagnostic[],
+  severity: DiagnosticSeverity,
+): Diagnostic[] {
+  return diagnostics.filter((d) => d.severity === severity);
+}
+
+export function mergeDiagnostics(
+  a: readonly Diagnostic[],
+  b: readonly Diagnostic[],
+): Diagnostic[] {
+  return [...a, ...b];
+}

--- a/packages/compiler/src/generators/base-generator.ts
+++ b/packages/compiler/src/generators/base-generator.ts
@@ -1,0 +1,21 @@
+import { join } from 'node:path';
+import type { ResolvedConfig } from '../config';
+import type { AppIR } from '../ir/types';
+
+export interface Generator {
+  generate(ir: AppIR, outputDir: string): Promise<void>;
+}
+
+export abstract class BaseGenerator implements Generator {
+  protected readonly config: ResolvedConfig;
+
+  constructor(config: ResolvedConfig) {
+    this.config = config;
+  }
+
+  abstract generate(ir: AppIR, outputDir: string): Promise<void>;
+
+  protected resolveOutputPath(outputDir: string, fileName: string): string {
+    return join(outputDir, fileName);
+  }
+}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,0 +1,75 @@
+// IR types
+export type {
+  AppDefinition,
+  AppIR,
+  DependencyEdge,
+  DependencyEdgeKind,
+  DependencyGraphIR,
+  DependencyNode,
+  DependencyNodeKind,
+  EnvIR,
+  EnvVariableIR,
+  HttpMethod,
+  ImportRef,
+  InjectRef,
+  InlineSchemaRef,
+  MiddlewareIR,
+  MiddlewareRef,
+  ModuleDefContext,
+  ModuleIR,
+  ModuleRegistration,
+  NamedSchemaRef,
+  RouteIR,
+  RouterIR,
+  SchemaIR,
+  SchemaNameParts,
+  SchemaRef,
+  ServiceIR,
+  ServiceMethodIR,
+  ServiceMethodParam,
+  SourceLocation,
+} from './ir/types';
+
+// IR builders
+export {
+  addDiagnosticsToIR,
+  createEmptyAppIR,
+  createEmptyDependencyGraph,
+} from './ir/builder';
+
+// Diagnostics
+export type {
+  CreateDiagnosticOptions,
+  Diagnostic,
+  DiagnosticCode,
+  DiagnosticSeverity,
+  SourceContext,
+} from './errors';
+export {
+  createDiagnostic,
+  createDiagnosticFromLocation,
+  filterBySeverity,
+  hasErrors,
+  mergeDiagnostics,
+} from './errors';
+
+// Config
+export type {
+  CompilerConfig,
+  OpenAPIConfig,
+  ResolvedConfig,
+  SchemaConfig,
+  ValidationConfig,
+  VertzConfig,
+} from './config';
+export { defineConfig, resolveConfig } from './config';
+
+// Base classes
+export type { Analyzer } from './analyzers/base-analyzer';
+export { BaseAnalyzer } from './analyzers/base-analyzer';
+export type { Generator } from './generators/base-generator';
+export { BaseGenerator } from './generators/base-generator';
+
+// Compiler
+export type { CompileResult, CompilerDependencies, Validator } from './compiler';
+export { Compiler } from './compiler';

--- a/packages/compiler/src/ir/builder.ts
+++ b/packages/compiler/src/ir/builder.ts
@@ -1,0 +1,39 @@
+import type { Diagnostic } from '../errors';
+import type { AppIR, DependencyGraphIR } from './types';
+
+export function createEmptyDependencyGraph(): DependencyGraphIR {
+  return {
+    nodes: [],
+    edges: [],
+    initializationOrder: [],
+    circularDependencies: [],
+  };
+}
+
+export function createEmptyAppIR(): AppIR {
+  return {
+    app: {
+      basePath: '',
+      globalMiddleware: [],
+      moduleRegistrations: [],
+      sourceFile: '',
+      sourceLine: 0,
+      sourceColumn: 0,
+    },
+    modules: [],
+    middleware: [],
+    schemas: [],
+    dependencyGraph: createEmptyDependencyGraph(),
+    diagnostics: [],
+  };
+}
+
+export function addDiagnosticsToIR(
+  ir: AppIR,
+  diagnostics: readonly Diagnostic[],
+): AppIR {
+  return {
+    ...ir,
+    diagnostics: [...ir.diagnostics, ...diagnostics],
+  };
+}

--- a/packages/compiler/src/ir/types.ts
+++ b/packages/compiler/src/ir/types.ts
@@ -1,0 +1,201 @@
+import type { Diagnostic } from '../errors';
+
+// ── Source location mixin ──────────────────────────────────────────
+
+export interface SourceLocation {
+  sourceFile: string;
+  sourceLine: number;
+  sourceColumn: number;
+}
+
+// ── Top-level IR ───────────────────────────────────────────────────
+
+export interface AppIR {
+  app: AppDefinition;
+  env?: EnvIR;
+  modules: ModuleIR[];
+  middleware: MiddlewareIR[];
+  schemas: SchemaIR[];
+  dependencyGraph: DependencyGraphIR;
+  diagnostics: Diagnostic[];
+}
+
+// ── App ────────────────────────────────────────────────────────────
+
+export interface AppDefinition extends SourceLocation {
+  basePath: string;
+  version?: string;
+  globalMiddleware: MiddlewareRef[];
+  moduleRegistrations: ModuleRegistration[];
+}
+
+export interface ModuleRegistration {
+  moduleName: string;
+  options?: Record<string, unknown>;
+}
+
+// ── Env ────────────────────────────────────────────────────────────
+
+export interface EnvIR extends SourceLocation {
+  loadFiles: string[];
+  schema?: SchemaRef;
+  variables: EnvVariableIR[];
+}
+
+export interface EnvVariableIR {
+  name: string;
+  type: string;
+  hasDefault: boolean;
+  required: boolean;
+}
+
+// ── Module ─────────────────────────────────────────────────────────
+
+export interface ModuleIR extends SourceLocation {
+  name: string;
+  imports: ImportRef[];
+  options?: SchemaRef;
+  services: ServiceIR[];
+  routers: RouterIR[];
+  exports: string[];
+}
+
+export interface ImportRef {
+  localName: string;
+  sourceModule?: string;
+  sourceExport?: string;
+  isEnvImport: boolean;
+}
+
+// ── Service ────────────────────────────────────────────────────────
+
+export interface ServiceIR extends SourceLocation {
+  name: string;
+  moduleName: string;
+  inject: InjectRef[];
+  methods: ServiceMethodIR[];
+}
+
+export interface InjectRef {
+  localName: string;
+  resolvedToken: string;
+}
+
+export interface ServiceMethodIR {
+  name: string;
+  parameters: ServiceMethodParam[];
+  returnType: string;
+}
+
+export interface ServiceMethodParam {
+  name: string;
+  type: string;
+}
+
+// ── Router ─────────────────────────────────────────────────────────
+
+export interface RouterIR extends SourceLocation {
+  name: string;
+  moduleName: string;
+  prefix: string;
+  inject: InjectRef[];
+  routes: RouteIR[];
+}
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export interface RouteIR extends SourceLocation {
+  method: HttpMethod;
+  path: string;
+  fullPath: string;
+  operationId: string;
+  params?: SchemaRef;
+  query?: SchemaRef;
+  body?: SchemaRef;
+  headers?: SchemaRef;
+  response?: SchemaRef;
+  middleware: MiddlewareRef[];
+  description?: string;
+  tags: string[];
+}
+
+// ── Middleware ──────────────────────────────────────────────────────
+
+export interface MiddlewareIR extends SourceLocation {
+  name: string;
+  inject: InjectRef[];
+  headers?: SchemaRef;
+  params?: SchemaRef;
+  query?: SchemaRef;
+  body?: SchemaRef;
+  requires?: SchemaRef;
+  provides?: SchemaRef;
+}
+
+export interface MiddlewareRef {
+  name: string;
+  sourceFile: string;
+}
+
+// ── Schema ─────────────────────────────────────────────────────────
+
+export interface SchemaIR extends SourceLocation {
+  name: string;
+  id?: string;
+  namingConvention: SchemaNameParts;
+  jsonSchema?: Record<string, unknown>;
+  isNamed: boolean;
+}
+
+export interface SchemaNameParts {
+  operation?: string;
+  entity?: string;
+  part?: string;
+}
+
+export type SchemaRef = NamedSchemaRef | InlineSchemaRef;
+
+export interface NamedSchemaRef {
+  kind: 'named';
+  schemaName: string;
+  sourceFile: string;
+  jsonSchema?: Record<string, unknown>;
+}
+
+export interface InlineSchemaRef {
+  kind: 'inline';
+  sourceFile: string;
+  jsonSchema?: Record<string, unknown>;
+}
+
+// ── Shared context types ──────────────────────────────────────────
+
+export interface ModuleDefContext {
+  moduleDefVariables: Map<string, string>;
+}
+
+// ── Dependency Graph ───────────────────────────────────────────────
+
+export interface DependencyGraphIR {
+  nodes: DependencyNode[];
+  edges: DependencyEdge[];
+  initializationOrder: string[];
+  circularDependencies: string[][];
+}
+
+export type DependencyNodeKind = 'module' | 'service' | 'router' | 'middleware';
+
+export interface DependencyNode {
+  id: string;
+  kind: DependencyNodeKind;
+  name: string;
+  moduleName?: string;
+}
+
+export type DependencyEdgeKind = 'imports' | 'inject' | 'uses-middleware' | 'exports';
+
+export interface DependencyEdge {
+  from: string;
+  to: string;
+  kind: DependencyEdgeKind;
+}

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "isolatedDeclarations": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/compiler/tsconfig.typecheck.json
+++ b/packages/compiler/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/compiler/vitest.config.ts
+++ b/packages/compiler/vitest.config.ts
@@ -1,0 +1,23 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test-d.ts'],
+    environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.test-d.ts'],
+      ignoreSourceErrors: true,
+      tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
+    },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Scaffold `@vertz/compiler` package with foundational types and pipeline for the mandatory compilation step
- Define 20+ IR type interfaces (AppIR, ModuleIR, RouteIR, SchemaRef discriminated union, DependencyGraphIR, etc.)
- Implement diagnostic system with 39 codes across 9 categories (schema, module, service, env, middleware, route, app, dependency, cross-cutting)
- Add config system with `VertzConfig` (user-facing), `ResolvedConfig` (fully resolved with defaults), `defineConfig()`, `resolveConfig()`
- Create `BaseAnalyzer` class with ts-morph `Project` access + diagnostic collector
- Create `BaseGenerator` class with output path resolution
- Add IR builder utilities (`createEmptyAppIR`, `createEmptyDependencyGraph`, `addDiagnosticsToIR`)
- Wire `Compiler` pipeline skeleton orchestrating analyze → validate → generate
- 55 tests (35 runtime + 10 type-level + 10 type-d)

## Test plan
- [x] `bun test` — 55 tests pass (8 test files)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — builds successfully (4.1KB JS + 8.7KB DTS)
- [x] No regressions in core (158 tests), schema (292 tests), testing (32 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)