### PR TITLE
chore: add CI, contributing guide, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in the details below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Describe the issue...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps or code to reproduce the issue.
+      placeholder: |
+        1. Create a schema with...
+        2. Call .parse() with...
+        3. Expected X, got Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      placeholder: "@vertz/schema, @vertz/core, etc."
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version are you using?
+      placeholder: "0.1.0"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Runtime, OS, or anything else relevant.

--- a/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,0 +1,24 @@
+name: Question / Discussion
+description: Ask a question or start a discussion about design decisions
+labels: ["discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want to discuss an API design, suggest a different approach, or ask why we made a particular decision? This is the place.
+
+        You can also comment directly on [open PRs](https://github.com/vertz-dev/vertz/pulls) — we plan in the open and welcome feedback on design docs and implementation plans.
+
+  - type: textarea
+    id: topic
+    attributes:
+      label: What's on your mind?
+      description: Your question, idea, or topic for discussion.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any relevant links, code examples, or references (e.g. a specific plan doc or PR).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for Vertz? We'd love to hear it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+      placeholder: "I'm trying to... but currently I have to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work? Code examples are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which package would this affect?
+      placeholder: "@vertz/schema, @vertz/core, etc."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What does this PR do? Keep it to 1-3 bullet points. -->
+
+## Test plan
+
+<!-- How was this tested? Checklist of what to verify. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Lint, typecheck, test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Vertz
+
+Thanks for your interest in Vertz! We're building this framework in public and value community input.
+
+## How to Contribute
+
+Right now, the best ways to contribute are:
+
+### Open an Issue
+
+- **Bug reports** — Found something broken? Open an issue with steps to reproduce.
+- **Feature requests** — Have an idea? We want to hear it.
+- **Questions & discussion** — Not sure about a design decision? Ask.
+
+### Join the Conversation
+
+We plan features in the open via PRs with design docs and implementation plans. Browse [open PRs](https://github.com/vertz-dev/vertz/pulls) and leave comments — your perspective on API design, tradeoffs, and developer experience is valuable.
+
+### Code Contributions
+
+We're not accepting code PRs at this stage. The codebase follows a strict workflow (design doc, implementation plan, TDD) and is actively being built by the core team. This will change as the framework matures.
+
+If you're interested in contributing code in the future, the best way to prepare is to follow the project and participate in design discussions.
+
+## Development Setup
+
+If you want to run the project locally:
+
+```bash
+# Requires Bun (https://bun.sh)
+git clone https://github.com/vertz-dev/vertz.git
+cd vertz
+bun install
+
+# Run tests
+bun test
+
+# Type check
+bun run typecheck
+
+# Lint
+bun run lint
+```
+
+## Project Structure
+
+```
+packages/
+  schema/      # @vertz/schema — validation and type inference
+  core/        # @vertz/core — HTTP framework, modules, middleware
+  compiler/    # @vertz/compiler — static analysis and code generation
+  testing/     # @vertz/testing — integration test utilities
+plans/         # Design docs and implementation plans
+```
+
+## Code Conventions
+
+- **TypeScript strict mode** — all strict flags enabled, no `any`
+- **Biome** for formatting and linting
+- **Strict TDD** — every behavior has a failing test before implementation
+- **One PR per feature/phase** — atomic, reviewable changes
+
+## Links
+
+- [README](./README.md) — Project overview
+- [Manifesto](./MANIFESTO.md) — Philosophy and design principles
+- [Design docs](./plans/) — Architecture and implementation plans


### PR DESCRIPTION
## Summary
- **CI workflow** — runs lint, typecheck, and tests on every PR and push to main (Bun + Biome)
- **CONTRIBUTING.md** — explains how to participate: issues and design discussion comments (no code PRs at this stage)
- **Issue templates** — bug report, feature request, and question/discussion (YAML forms)
- **PR template** — lightweight summary + test plan

## Test plan
- [ ] CI workflow triggers on this PR and passes (lint, typecheck, test)
- [ ] Issue templates render correctly on GitHub (New Issue → template picker)
- [ ] PR template renders correctly (this PR should use it on next PRs)
- [ ] CONTRIBUTING.md links resolve (README, MANIFESTO, plans/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)