### PR TITLE
chore(compiler): fix biome lint violations and enforce quality gates

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -28,3 +28,10 @@ Type-only changes (generics, constraints, narrowing) follow the same red-green-r
 Positive type tests ("correct shape compiles") are NOT valid RED tests — loose signatures like `unknown` already accept them. Write negative tests first to drive the type constraints.
 
 **Important:** `@ts-expect-error` tests only verify **interface signatures** (the public API). They do NOT catch type errors in the **implementation body**. After GREEN, run `bun run typecheck` to ensure the implementation types are also correct. Type tests + typecheck together cover the full picture.
+
+## Never Skip Quality Gates
+
+- **Never skip or disable linting rules.** Fix the code to comply, don't suppress or weaken the rule. If a rule flags your code, your code is wrong — not the rule. This includes `biome`, `eslint`, or any other configured linter.
+- **Never skip or disable type checking.** No `@ts-ignore`, no `as any` casts, no loosening `tsconfig` strictness. If types don't pass, fix the types.
+- **Never skip or disable tests.** No `.skip`, no `xit`, no commenting out. If a test fails, fix the code or fix the test — don't silence it.
+- **Never skip pre-commit hooks or CI checks.** No `--no-verify`, no `--force`. These gates exist for a reason.

--- a/packages/compiler/src/__tests__/base-analyzer.test.ts
+++ b/packages/compiler/src/__tests__/base-analyzer.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
 import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { BaseAnalyzer } from '../analyzers/base-analyzer';
-import { createDiagnostic } from '../errors';
 import { resolveConfig } from '../config';
+import { createDiagnostic } from '../errors';
 
 class TestAnalyzer extends BaseAnalyzer<string> {
   async analyze(): Promise<string> {

--- a/packages/compiler/src/__tests__/base-generator.test.ts
+++ b/packages/compiler/src/__tests__/base-generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { BaseGenerator } from '../generators/base-generator';
 import { resolveConfig } from '../config';
+import { BaseGenerator } from '../generators/base-generator';
 import type { AppIR } from '../ir/types';
 
 class TestGenerator extends BaseGenerator {

--- a/packages/compiler/src/__tests__/compiler.test.ts
+++ b/packages/compiler/src/__tests__/compiler.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import type { CompilerDependencies, Validator } from '../compiler';
 import { Compiler } from '../compiler';
 import { resolveConfig } from '../config';
 import { createDiagnostic } from '../errors';
-import type { CompilerDependencies, Validator } from '../compiler';
 
 function stubAnalyzer(name: string, calls: string[]) {
   return {

--- a/packages/compiler/src/__tests__/errors.test.ts
+++ b/packages/compiler/src/__tests__/errors.test.ts
@@ -90,7 +90,7 @@ describe('filterBySeverity', () => {
     ];
     const result = filterBySeverity(diagnostics, 'warning');
     expect(result).toHaveLength(1);
-    expect(result[0]!.severity).toBe('warning');
+    expect(result.at(0)?.severity).toBe('warning');
   });
 });
 
@@ -124,8 +124,8 @@ describe('createDiagnostic sourceContext', () => {
       },
     });
     expect(result.sourceContext).toBeDefined();
-    expect(result.sourceContext!.lines).toHaveLength(1);
-    expect(result.sourceContext!.highlightStart).toBe(6);
-    expect(result.sourceContext!.highlightLength).toBe(1);
+    expect(result.sourceContext?.lines).toHaveLength(1);
+    expect(result.sourceContext?.highlightStart).toBe(6);
+    expect(result.sourceContext?.highlightLength).toBe(1);
   });
 });

--- a/packages/compiler/src/__tests__/ir-types.test-d.ts
+++ b/packages/compiler/src/__tests__/ir-types.test-d.ts
@@ -1,4 +1,7 @@
 import { describe, it } from 'vitest';
+import type { ResolvedConfig, VertzConfig } from '../config';
+import type { Diagnostic } from '../errors';
+import { createEmptyDependencyGraph } from '../ir/builder';
 import type {
   AppIR,
   DependencyEdge,
@@ -7,9 +10,6 @@ import type {
   RouteIR,
   SchemaRef,
 } from '../ir/types';
-import { createEmptyDependencyGraph } from '../ir/builder';
-import type { Diagnostic } from '../errors';
-import type { ResolvedConfig, VertzConfig } from '../config';
 
 describe('type-level: IR types', () => {
   it('AppIR requires app field', () => {

--- a/packages/compiler/src/__tests__/ir-types.test.ts
+++ b/packages/compiler/src/__tests__/ir-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { addDiagnosticsToIR, createEmptyAppIR, createEmptyDependencyGraph } from '../ir/builder';
 import { createDiagnostic } from '../errors';
+import { addDiagnosticsToIR, createEmptyAppIR, createEmptyDependencyGraph } from '../ir/builder';
 
 describe('createEmptyAppIR', () => {
   it('returns an AppIR with empty collections', () => {
@@ -42,7 +42,11 @@ describe('addDiagnosticsToIR', () => {
   it('returns new AppIR with merged diagnostics', () => {
     const ir = createEmptyAppIR();
     const d1 = createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'a' });
-    const d2 = createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'b' });
+    const d2 = createDiagnostic({
+      severity: 'warning',
+      code: 'VERTZ_SERVICE_UNUSED',
+      message: 'b',
+    });
     const result = addDiagnosticsToIR(ir, [d1, d2]);
     expect(result.diagnostics).toHaveLength(2);
     expect(ir.diagnostics).toHaveLength(0);
@@ -51,7 +55,11 @@ describe('addDiagnosticsToIR', () => {
   it('preserves existing diagnostics', () => {
     const d1 = createDiagnostic({ severity: 'error', code: 'VERTZ_APP_MISSING', message: 'a' });
     const ir = addDiagnosticsToIR(createEmptyAppIR(), [d1]);
-    const d2 = createDiagnostic({ severity: 'warning', code: 'VERTZ_SERVICE_UNUSED', message: 'b' });
+    const d2 = createDiagnostic({
+      severity: 'warning',
+      code: 'VERTZ_SERVICE_UNUSED',
+      message: 'b',
+    });
     const result = addDiagnosticsToIR(ir, [d2]);
     expect(result.diagnostics).toHaveLength(2);
     expect(result.diagnostics[0]).toBe(d1);

--- a/packages/compiler/src/analyzers/__tests__/env-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/env-analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../../config';
 import type { EnvIR, EnvVariableIR } from '../../ir/types';
 import { EnvAnalyzer } from '../env-analyzer';
@@ -20,7 +20,7 @@ export const env = vertz.env({ load: ['.env', '.env.local'], schema: envSchema }
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.env).toBeDefined();
-    expect(result.env!.loadFiles).toEqual(['.env', '.env.local']);
+    expect(result.env?.loadFiles).toEqual(['.env', '.env.local']);
   });
 
   it('returns undefined env when no vertz.env() call exists', async () => {
@@ -41,7 +41,7 @@ export const env = vertz.env({ load: [], schema: envSchema });`,
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.sourceLine).toBe(3);
+    expect(result.env?.sourceLine).toBe(3);
   });
 
   it('extracts empty load array', async () => {
@@ -54,7 +54,7 @@ export const env = vertz.env({ load: [], schema: envSchema });`,
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.loadFiles).toEqual([]);
+    expect(result.env?.loadFiles).toEqual([]);
   });
 
   it('extracts multiple load file paths', async () => {
@@ -67,7 +67,7 @@ export const env = vertz.env({ load: ['.env', '.env.local', '.env.production'], 
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.loadFiles).toEqual(['.env', '.env.local', '.env.production']);
+    expect(result.env?.loadFiles).toEqual(['.env', '.env.local', '.env.production']);
   });
 
   it('defaults to empty load array when load property is absent', async () => {
@@ -80,15 +80,12 @@ export const env = vertz.env({ schema: envSchema });`,
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.loadFiles).toEqual([]);
+    expect(result.env?.loadFiles).toEqual([]);
   });
 
   it('extracts schema reference from named identifier', async () => {
     const project = createProject();
-    project.createSourceFile(
-      'src/env.schema.ts',
-      `export const envSchema = {};`,
-    );
+    project.createSourceFile('src/env.schema.ts', `export const envSchema = {};`);
     project.createSourceFile(
       'src/env.ts',
       `import { vertz } from '@vertz/core';
@@ -97,10 +94,10 @@ export const env = vertz.env({ load: ['.env'], schema: envSchema });`,
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.schema).toBeDefined();
-    expect(result.env!.schema!.kind).toBe('named');
-    if (result.env!.schema!.kind === 'named') {
-      expect(result.env!.schema!.schemaName).toBe('envSchema');
+    expect(result.env?.schema).toBeDefined();
+    expect(result.env?.schema?.kind).toBe('named');
+    if (result.env?.schema?.kind === 'named') {
+      expect(result.env?.schema?.schemaName).toBe('envSchema');
     }
   });
 
@@ -113,7 +110,7 @@ export const env = vertz.env({ load: ['.env'] });`,
     );
     const analyzer = new EnvAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.env!.schema).toBeUndefined();
+    expect(result.env?.schema).toBeUndefined();
   });
 
   it('emits error when multiple vertz.env() calls exist', async () => {
@@ -128,8 +125,8 @@ export const env2 = vertz.env({ load: ['.env.local'] });`,
     await analyzer.analyze();
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('error');
-    expect(diags[0]!.code).toBe('VERTZ_ENV_DUPLICATE');
+    expect(diags.at(0)?.severity).toBe('error');
+    expect(diags.at(0)?.code).toBe('VERTZ_ENV_DUPLICATE');
   });
 
   it('emits no diagnostics for valid single env definition', async () => {

--- a/packages/compiler/src/analyzers/__tests__/middleware-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/middleware-analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../../config';
 import type { Diagnostic } from '../../errors';
 import type { MiddlewareIR } from '../../ir/types';
@@ -21,7 +21,7 @@ const auth = vertz.middleware({ name: 'auth', handler: async (ctx: any) => ({}) 
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.middleware).toHaveLength(1);
-    expect(result.middleware[0]!.name).toBe('auth');
+    expect(result.middleware.at(0)?.name).toBe('auth');
   });
 
   it('extracts source location', async () => {
@@ -34,8 +34,8 @@ const auth = vertz.middleware({ name: 'auth', handler: async (ctx: any) => ({}) 
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.sourceLine).toBe(3);
-    expect(result.middleware[0]!.sourceFile).toContain('auth.ts');
+    expect(result.middleware.at(0)?.sourceLine).toBe(3);
+    expect(result.middleware.at(0)?.sourceFile).toContain('auth.ts');
   });
 
   it('extracts inject references', async () => {
@@ -47,9 +47,15 @@ const auth = vertz.middleware({ name: 'auth', inject: { tokenService, userServic
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.inject).toHaveLength(2);
-    expect(result.middleware[0]!.inject[0]).toEqual({ localName: 'tokenService', resolvedToken: 'tokenService' });
-    expect(result.middleware[0]!.inject[1]).toEqual({ localName: 'userService', resolvedToken: 'userService' });
+    expect(result.middleware.at(0)?.inject).toHaveLength(2);
+    expect(result.middleware.at(0)?.inject[0]).toEqual({
+      localName: 'tokenService',
+      resolvedToken: 'tokenService',
+    });
+    expect(result.middleware.at(0)?.inject[1]).toEqual({
+      localName: 'userService',
+      resolvedToken: 'userService',
+    });
   });
 
   it('extracts headers schema reference', async () => {
@@ -62,10 +68,10 @@ const auth = vertz.middleware({ name: 'auth', headers: authHeaders, handler: asy
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.headers).toBeDefined();
-    expect(result.middleware[0]!.headers!.kind).toBe('named');
-    if (result.middleware[0]!.headers!.kind === 'named') {
-      expect(result.middleware[0]!.headers!.schemaName).toBe('authHeaders');
+    expect(result.middleware.at(0)?.headers).toBeDefined();
+    expect(result.middleware.at(0)?.headers?.kind).toBe('named');
+    if (result.middleware.at(0)?.headers?.kind === 'named') {
+      expect(result.middleware.at(0)?.headers?.schemaName).toBe('authHeaders');
     }
   });
 
@@ -79,10 +85,10 @@ const validate = vertz.middleware({ name: 'validate', params: validateParams, ha
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.params).toBeDefined();
-    expect(result.middleware[0]!.params!.kind).toBe('named');
-    if (result.middleware[0]!.params!.kind === 'named') {
-      expect(result.middleware[0]!.params!.schemaName).toBe('validateParams');
+    expect(result.middleware.at(0)?.params).toBeDefined();
+    expect(result.middleware.at(0)?.params?.kind).toBe('named');
+    if (result.middleware.at(0)?.params?.kind === 'named') {
+      expect(result.middleware.at(0)?.params?.schemaName).toBe('validateParams');
     }
   });
 
@@ -96,10 +102,10 @@ const paginate = vertz.middleware({ name: 'paginate', query: paginationQuery, ha
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.query).toBeDefined();
-    expect(result.middleware[0]!.query!.kind).toBe('named');
-    if (result.middleware[0]!.query!.kind === 'named') {
-      expect(result.middleware[0]!.query!.schemaName).toBe('paginationQuery');
+    expect(result.middleware.at(0)?.query).toBeDefined();
+    expect(result.middleware.at(0)?.query?.kind).toBe('named');
+    if (result.middleware.at(0)?.query?.kind === 'named') {
+      expect(result.middleware.at(0)?.query?.schemaName).toBe('paginationQuery');
     }
   });
 
@@ -113,10 +119,10 @@ const validate = vertz.middleware({ name: 'validate', body: requestBody, handler
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.body).toBeDefined();
-    expect(result.middleware[0]!.body!.kind).toBe('named');
-    if (result.middleware[0]!.body!.kind === 'named') {
-      expect(result.middleware[0]!.body!.schemaName).toBe('requestBody');
+    expect(result.middleware.at(0)?.body).toBeDefined();
+    expect(result.middleware.at(0)?.body?.kind).toBe('named');
+    if (result.middleware.at(0)?.body?.kind === 'named') {
+      expect(result.middleware.at(0)?.body?.schemaName).toBe('requestBody');
     }
   });
 
@@ -130,10 +136,10 @@ const auth = vertz.middleware({ name: 'auth', requires: requestIdState, handler:
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.requires).toBeDefined();
-    expect(result.middleware[0]!.requires!.kind).toBe('named');
-    if (result.middleware[0]!.requires!.kind === 'named') {
-      expect(result.middleware[0]!.requires!.schemaName).toBe('requestIdState');
+    expect(result.middleware.at(0)?.requires).toBeDefined();
+    expect(result.middleware.at(0)?.requires?.kind).toBe('named');
+    if (result.middleware.at(0)?.requires?.kind === 'named') {
+      expect(result.middleware.at(0)?.requires?.schemaName).toBe('requestIdState');
     }
   });
 
@@ -147,10 +153,10 @@ const auth = vertz.middleware({ name: 'auth', provides: authState, handler: asyn
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.provides).toBeDefined();
-    expect(result.middleware[0]!.provides!.kind).toBe('named');
-    if (result.middleware[0]!.provides!.kind === 'named') {
-      expect(result.middleware[0]!.provides!.schemaName).toBe('authState');
+    expect(result.middleware.at(0)?.provides).toBeDefined();
+    expect(result.middleware.at(0)?.provides?.kind).toBe('named');
+    if (result.middleware.at(0)?.provides?.kind === 'named') {
+      expect(result.middleware.at(0)?.provides?.schemaName).toBe('authState');
     }
   });
 
@@ -163,14 +169,14 @@ const logger = vertz.middleware({ name: 'logger', handler: async (ctx: any) => (
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.name).toBe('logger');
-    expect(result.middleware[0]!.inject).toEqual([]);
-    expect(result.middleware[0]!.headers).toBeUndefined();
-    expect(result.middleware[0]!.params).toBeUndefined();
-    expect(result.middleware[0]!.query).toBeUndefined();
-    expect(result.middleware[0]!.body).toBeUndefined();
-    expect(result.middleware[0]!.requires).toBeUndefined();
-    expect(result.middleware[0]!.provides).toBeUndefined();
+    expect(result.middleware.at(0)?.name).toBe('logger');
+    expect(result.middleware.at(0)?.inject).toEqual([]);
+    expect(result.middleware.at(0)?.headers).toBeUndefined();
+    expect(result.middleware.at(0)?.params).toBeUndefined();
+    expect(result.middleware.at(0)?.query).toBeUndefined();
+    expect(result.middleware.at(0)?.body).toBeUndefined();
+    expect(result.middleware.at(0)?.requires).toBeUndefined();
+    expect(result.middleware.at(0)?.provides).toBeUndefined();
   });
 
   it('handles middleware with all config properties', async () => {
@@ -198,14 +204,14 @@ const full = vertz.middleware({
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.name).toBe('full');
-    expect(result.middleware[0]!.inject).toHaveLength(1);
-    expect(result.middleware[0]!.headers!.kind).toBe('named');
-    expect(result.middleware[0]!.params!.kind).toBe('named');
-    expect(result.middleware[0]!.query!.kind).toBe('named');
-    expect(result.middleware[0]!.body!.kind).toBe('named');
-    expect(result.middleware[0]!.requires!.kind).toBe('named');
-    expect(result.middleware[0]!.provides!.kind).toBe('named');
+    expect(result.middleware.at(0)?.name).toBe('full');
+    expect(result.middleware.at(0)?.inject).toHaveLength(1);
+    expect(result.middleware.at(0)?.headers?.kind).toBe('named');
+    expect(result.middleware.at(0)?.params?.kind).toBe('named');
+    expect(result.middleware.at(0)?.query?.kind).toBe('named');
+    expect(result.middleware.at(0)?.body?.kind).toBe('named');
+    expect(result.middleware.at(0)?.requires?.kind).toBe('named');
+    expect(result.middleware.at(0)?.provides?.kind).toBe('named');
   });
 
   it('handles empty inject object', async () => {
@@ -217,7 +223,7 @@ const logger = vertz.middleware({ name: 'logger', inject: {}, handler: async (ct
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.inject).toEqual([]);
+    expect(result.middleware.at(0)?.inject).toEqual([]);
   });
 
   it('finds multiple middleware in one file', async () => {
@@ -231,8 +237,8 @@ const logger = vertz.middleware({ name: 'logger', handler: async (ctx: any) => (
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.middleware).toHaveLength(2);
-    expect(result.middleware[0]!.name).toBe('auth');
-    expect(result.middleware[1]!.name).toBe('logger');
+    expect(result.middleware.at(0)?.name).toBe('auth');
+    expect(result.middleware.at(1)?.name).toBe('logger');
   });
 
   it('finds middleware across multiple files', async () => {
@@ -268,9 +274,9 @@ const auth = vertz.middleware({ name: 'auth', headers: authHeaders, handler: asy
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.headers!.kind).toBe('named');
-    if (result.middleware[0]!.headers!.kind === 'named') {
-      expect(result.middleware[0]!.headers!.sourceFile).toContain('auth-headers.schema.ts');
+    expect(result.middleware.at(0)?.headers?.kind).toBe('named');
+    if (result.middleware.at(0)?.headers?.kind === 'named') {
+      expect(result.middleware.at(0)?.headers?.sourceFile).toContain('auth-headers.schema.ts');
     }
   });
 
@@ -284,9 +290,9 @@ const auth = vertz.middleware({ name: 'auth', headers: s.object({ authorization:
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.headers).toBeDefined();
-    expect(result.middleware[0]!.headers!.kind).toBe('inline');
-    expect(result.middleware[0]!.headers!.sourceFile).toContain('auth.ts');
+    expect(result.middleware.at(0)?.headers).toBeDefined();
+    expect(result.middleware.at(0)?.headers?.kind).toBe('inline');
+    expect(result.middleware.at(0)?.headers?.sourceFile).toContain('auth.ts');
   });
 
   it('resolves re-exported schemas', async () => {
@@ -307,9 +313,9 @@ const auth = vertz.middleware({ name: 'auth', headers: authHeaders, handler: asy
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.headers!.kind).toBe('named');
-    if (result.middleware[0]!.headers!.kind === 'named') {
-      expect(result.middleware[0]!.headers!.sourceFile).toContain('auth-headers.schema.ts');
+    expect(result.middleware.at(0)?.headers?.kind).toBe('named');
+    if (result.middleware.at(0)?.headers?.kind === 'named') {
+      expect(result.middleware.at(0)?.headers?.sourceFile).toContain('auth-headers.schema.ts');
     }
   });
 
@@ -323,7 +329,10 @@ const auth = vertz.middleware({ name: 'auth', inject: { tokenService }, handler:
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.inject[0]).toEqual({ localName: 'tokenService', resolvedToken: 'tokenService' });
+    expect(result.middleware.at(0)?.inject[0]).toEqual({
+      localName: 'tokenService',
+      resolvedToken: 'tokenService',
+    });
   });
 
   it('handles inject with explicit property values', async () => {
@@ -336,7 +345,10 @@ const auth = vertz.middleware({ name: 'auth', inject: { ts: tokenService }, hand
     );
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.middleware[0]!.inject[0]).toEqual({ localName: 'ts', resolvedToken: 'tokenService' });
+    expect(result.middleware.at(0)?.inject[0]).toEqual({
+      localName: 'ts',
+      resolvedToken: 'tokenService',
+    });
   });
 
   it('emits error diagnostic when name property is missing', async () => {
@@ -351,8 +363,8 @@ const broken = vertz.middleware({ handler: async (ctx: any) => ({}) });`,
     expect(result.middleware).toHaveLength(0);
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('error');
-    expect(diags[0]!.code).toBe('VERTZ_MW_MISSING_NAME');
+    expect(diags.at(0)?.severity).toBe('error');
+    expect(diags.at(0)?.code).toBe('VERTZ_MW_MISSING_NAME');
   });
 
   it('emits error diagnostic when handler is missing', async () => {
@@ -367,8 +379,8 @@ const broken = vertz.middleware({ name: 'broken' });`,
     expect(result.middleware).toHaveLength(0);
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('error');
-    expect(diags[0]!.code).toBe('VERTZ_MW_MISSING_HANDLER');
+    expect(diags.at(0)?.severity).toBe('error');
+    expect(diags.at(0)?.code).toBe('VERTZ_MW_MISSING_HANDLER');
   });
 
   it('emits warning when name is not a string literal', async () => {
@@ -383,8 +395,8 @@ const broken = vertz.middleware({ name: n, handler: async (ctx: any) => ({}) });
     await analyzer.analyze();
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('warning');
-    expect(diags[0]!.code).toBe('VERTZ_MW_DYNAMIC_NAME');
+    expect(diags.at(0)?.severity).toBe('warning');
+    expect(diags.at(0)?.code).toBe('VERTZ_MW_DYNAMIC_NAME');
   });
 
   it('emits warning when config argument is not an object literal', async () => {
@@ -399,8 +411,8 @@ const broken = vertz.middleware(config);`,
     await analyzer.analyze();
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('warning');
-    expect(diags[0]!.code).toBe('VERTZ_MW_NON_OBJECT_CONFIG');
+    expect(diags.at(0)?.severity).toBe('warning');
+    expect(diags.at(0)?.code).toBe('VERTZ_MW_NON_OBJECT_CONFIG');
   });
 
   it('ignores non-vertz.middleware calls', async () => {
@@ -440,7 +452,7 @@ export const auth = vertz.middleware({ name: 'auth', handler: async (ctx: any) =
     const analyzer = new MiddlewareAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.middleware).toHaveLength(1);
-    expect(result.middleware[0]!.name).toBe('auth');
+    expect(result.middleware.at(0)?.name).toBe('auth');
   });
 
   it('emits no diagnostics for valid middleware', async () => {

--- a/packages/compiler/src/analyzers/__tests__/module-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/module-analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project, SyntaxKind } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../../config';
 import type { ImportRef, ModuleIR } from '../../ir/types';
 import { extractIdentifierNames, ModuleAnalyzer, parseImports } from '../module-analyzer';
@@ -23,7 +23,7 @@ export const userModuleDef = vertz.moduleDef({ name: 'user' });`,
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
     expect(result.modules).toHaveLength(1);
-    expect(result.modules[0]!.name).toBe('user');
+    expect(result.modules.at(0)?.name).toBe('user');
   });
 
   it('discovers multiple module definitions', async () => {
@@ -48,16 +48,13 @@ export const userModuleDef = vertz.moduleDef({ name: 'user' });`,
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.sourceLine).toBe(2);
-    expect(result.modules[0]!.sourceFile).toContain('user.module.ts');
+    expect(result.modules.at(0)?.sourceLine).toBe(2);
+    expect(result.modules.at(0)?.sourceFile).toContain('user.module.ts');
   });
 
   it('extracts imports from moduleDef', async () => {
     const project = createProject();
-    project.createSourceFile(
-      'src/core/index.ts',
-      `export const dbService = {};`,
-    );
+    project.createSourceFile('src/core/index.ts', `export const dbService = {};`);
     project.createSourceFile(
       'src/user/user.module.ts',
       `import { vertz } from '@vertz/core';
@@ -66,8 +63,8 @@ const userModuleDef = vertz.moduleDef({ name: 'user', imports: { dbService } });
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.imports).toHaveLength(1);
-    expect(result.modules[0]!.imports[0]!.localName).toBe('dbService');
+    expect(result.modules.at(0)?.imports).toHaveLength(1);
+    expect(result.modules.at(0)?.imports.at(0)?.localName).toBe('dbService');
   });
 
   it('extracts multiple imports', async () => {
@@ -79,7 +76,7 @@ const userModuleDef = vertz.moduleDef({ name: 'user', imports: { dbService, conf
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.imports).toHaveLength(2);
+    expect(result.modules.at(0)?.imports).toHaveLength(2);
   });
 
   it('imports is empty array when not specified', async () => {
@@ -91,7 +88,7 @@ const userModuleDef = vertz.moduleDef({ name: 'user' });`,
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.imports).toEqual([]);
+    expect(result.modules.at(0)?.imports).toEqual([]);
   });
 
   it('extracts options schema reference', async () => {
@@ -108,10 +105,10 @@ const userModuleDef = vertz.moduleDef({ name: 'user', options: userOptionsSchema
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.options).toBeDefined();
-    expect(result.modules[0]!.options!.kind).toBe('named');
-    if (result.modules[0]!.options!.kind === 'named') {
-      expect(result.modules[0]!.options!.schemaName).toBe('userOptionsSchema');
+    expect(result.modules.at(0)?.options).toBeDefined();
+    expect(result.modules.at(0)?.options?.kind).toBe('named');
+    if (result.modules.at(0)?.options?.kind === 'named') {
+      expect(result.modules.at(0)?.options?.schemaName).toBe('userOptionsSchema');
     }
   });
 
@@ -124,7 +121,7 @@ const userModuleDef = vertz.moduleDef({ name: 'user' });`,
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.options).toBeUndefined();
+    expect(result.modules.at(0)?.options).toBeUndefined();
   });
 
   it('links vertz.module() to its moduleDef and extracts exports', async () => {
@@ -143,7 +140,7 @@ export const userModule = vertz.module(userModuleDef, {
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.exports).toEqual(['userService']);
+    expect(result.modules.at(0)?.exports).toEqual(['userService']);
   });
 
   it('extracts service names from module assembly', async () => {
@@ -160,7 +157,7 @@ export const userModule = vertz.module(userModuleDef, {
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.name).toBe('user');
+    expect(result.modules.at(0)?.name).toBe('user');
     // Services are stored as ServiceIR[] — populated later by ServiceAnalyzer integration
     // For now we verify module was found
     expect(result.modules).toHaveLength(1);
@@ -198,7 +195,7 @@ export const userModule = vertz.module(userModuleDef, {
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.exports).toEqual(['userService', 'authService']);
+    expect(result.modules.at(0)?.exports).toEqual(['userService', 'authService']);
   });
 
   it('handles module with no exports', async () => {
@@ -213,7 +210,7 @@ export const userModule = vertz.module(userModuleDef, {
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.exports).toEqual([]);
+    expect(result.modules.at(0)?.exports).toEqual([]);
   });
 
   it('handles module with no routers', async () => {
@@ -229,7 +226,7 @@ export const userModule = vertz.module(userModuleDef, {
     );
     const analyzer = createAnalyzer(project);
     const result = await analyzer.analyze();
-    expect(result.modules[0]!.routers).toEqual([]);
+    expect(result.modules.at(0)?.routers).toEqual([]);
   });
 
   it('emits error for moduleDef without name property', async () => {
@@ -243,8 +240,8 @@ const userModuleDef = vertz.moduleDef({});`,
     await analyzer.analyze();
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.severity).toBe('error');
-    expect(diags[0]!.code).toBe('VERTZ_MODULE_DYNAMIC_NAME');
+    expect(diags.at(0)?.severity).toBe('error');
+    expect(diags.at(0)?.code).toBe('VERTZ_MODULE_DYNAMIC_NAME');
   });
 
   it('emits no diagnostics for valid module', async () => {
@@ -264,16 +261,13 @@ export const userModule = vertz.module(userModuleDef, { exports: [] });`,
 describe('parseImports', () => {
   it('parses shorthand imports', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const obj = { dbService, configService };`,
-    );
+    const file = project.createSourceFile('test.ts', `const obj = { dbService, configService };`);
     const decl = file.getVariableDeclarationOrThrow('obj');
     const obj = decl.getInitializerIfKindOrThrow(SyntaxKind.ObjectLiteralExpression);
     const result = parseImports(obj);
     expect(result).toHaveLength(2);
-    expect(result[0]!.localName).toBe('dbService');
-    expect(result[1]!.localName).toBe('configService');
+    expect(result.at(0)?.localName).toBe('dbService');
+    expect(result.at(1)?.localName).toBe('configService');
   });
 
   it('handles empty imports object', () => {
@@ -288,10 +282,7 @@ describe('parseImports', () => {
 describe('extractIdentifierNames', () => {
   it('extracts names from identifier array', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const arr = [userService, authService];`,
-    );
+    const file = project.createSourceFile('test.ts', `const arr = [userService, authService];`);
     const decl = file.getVariableDeclarationOrThrow('arr');
     const expr = decl.getInitializerOrThrow();
     expect(extractIdentifierNames(expr)).toEqual(['userService', 'authService']);

--- a/packages/compiler/src/analyzers/__tests__/route-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/route-analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../../config';
 import type { ModuleDefContext, RouteIR, RouterIR } from '../../ir/types';
 import type { RouteAnalyzerResult } from '../route-analyzer';
@@ -25,7 +25,7 @@ const userRouter = userModuleDef.router({ prefix: '/users' });`,
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
     expect(result.routers).toHaveLength(1);
-    expect(result.routers[0]!.name).toBe('userRouter');
+    expect(result.routers[0]?.name).toBe('userRouter');
   });
 
   it('extracts router module name from context', async () => {
@@ -38,7 +38,7 @@ const userRouter = userModuleDef.router({ prefix: '/users' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.moduleName).toBe('user');
+    expect(result.routers[0]?.moduleName).toBe('user');
   });
 
   it('extracts router prefix', async () => {
@@ -51,7 +51,7 @@ const userRouter = userModuleDef.router({ prefix: '/users' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.prefix).toBe('/users');
+    expect(result.routers[0]?.prefix).toBe('/users');
   });
 
   it('extracts router inject references', async () => {
@@ -64,9 +64,15 @@ const userRouter = userModuleDef.router({ prefix: '/users', inject: { userServic
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.inject).toHaveLength(2);
-    expect(result.routers[0]!.inject[0]).toEqual({ localName: 'userService', resolvedToken: 'userService' });
-    expect(result.routers[0]!.inject[1]).toEqual({ localName: 'authService', resolvedToken: 'authService' });
+    expect(result.routers[0]?.inject).toHaveLength(2);
+    expect(result.routers[0]?.inject[0]).toEqual({
+      localName: 'userService',
+      resolvedToken: 'userService',
+    });
+    expect(result.routers[0]?.inject[1]).toEqual({
+      localName: 'authService',
+      resolvedToken: 'authService',
+    });
   });
 
   it('handles router with no inject', async () => {
@@ -79,7 +85,7 @@ const userRouter = userModuleDef.router({ prefix: '/users' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.inject).toEqual([]);
+    expect(result.routers[0]?.inject).toEqual([]);
   });
 
   it('extracts router source location', async () => {
@@ -94,8 +100,8 @@ const userRouter = userModuleDef.router({ prefix: '/users' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.sourceLine).toBe(5);
-    expect(result.routers[0]!.sourceFile).toContain('user.router.ts');
+    expect(result.routers[0]?.sourceLine).toBe(5);
+    expect(result.routers[0]?.sourceFile).toContain('user.router.ts');
   });
 
   it('extracts GET route', async () => {
@@ -109,9 +115,9 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(1);
-    expect(result.routers[0]!.routes[0]!.method).toBe('GET');
-    expect(result.routers[0]!.routes[0]!.path).toBe('/:id');
+    expect(result.routers[0]?.routes).toHaveLength(1);
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('GET');
+    expect(result.routers[0]?.routes.at(0)?.path).toBe('/:id');
   });
 
   it('extracts POST route', async () => {
@@ -125,7 +131,7 @@ userRouter.post('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.method).toBe('POST');
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('POST');
   });
 
   it('extracts PUT route', async () => {
@@ -139,7 +145,7 @@ userRouter.put('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.method).toBe('PUT');
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('PUT');
   });
 
   it('extracts PATCH route', async () => {
@@ -153,7 +159,7 @@ userRouter.patch('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.method).toBe('PATCH');
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('PATCH');
   });
 
   it('extracts DELETE route', async () => {
@@ -167,7 +173,7 @@ userRouter.delete('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.method).toBe('DELETE');
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('DELETE');
   });
 
   it('extracts HEAD route', async () => {
@@ -181,7 +187,7 @@ userRouter.head('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.method).toBe('HEAD');
+    expect(result.routers[0]?.routes.at(0)?.method).toBe('HEAD');
   });
 
   it('extracts params schema reference', async () => {
@@ -196,10 +202,10 @@ userRouter.get('/:id', { params: readUserParams, handler: async (ctx: any) => ({
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.params!.kind).toBe('named');
-    if (route.params!.kind === 'named') {
-      expect(route.params!.schemaName).toBe('readUserParams');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.params?.kind).toBe('named');
+    if (route?.params?.kind === 'named') {
+      expect(route.params.schemaName).toBe('readUserParams');
     }
   });
 
@@ -215,10 +221,10 @@ userRouter.get('/', { query: listUsersQuery, handler: async (ctx: any) => ({}) }
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.query!.kind).toBe('named');
-    if (route.query!.kind === 'named') {
-      expect(route.query!.schemaName).toBe('listUsersQuery');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.query?.kind).toBe('named');
+    if (route?.query?.kind === 'named') {
+      expect(route.query.schemaName).toBe('listUsersQuery');
     }
   });
 
@@ -234,10 +240,10 @@ userRouter.post('/', { body: createUserBody, handler: async (ctx: any) => ({}) }
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.body!.kind).toBe('named');
-    if (route.body!.kind === 'named') {
-      expect(route.body!.schemaName).toBe('createUserBody');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.body?.kind).toBe('named');
+    if (route?.body?.kind === 'named') {
+      expect(route.body.schemaName).toBe('createUserBody');
     }
   });
 
@@ -253,10 +259,10 @@ userRouter.get('/', { headers: customHeaders, handler: async (ctx: any) => ({}) 
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.headers!.kind).toBe('named');
-    if (route.headers!.kind === 'named') {
-      expect(route.headers!.schemaName).toBe('customHeaders');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.headers?.kind).toBe('named');
+    if (route?.headers?.kind === 'named') {
+      expect(route.headers.schemaName).toBe('customHeaders');
     }
   });
 
@@ -272,19 +278,16 @@ userRouter.get('/:id', { response: readUserResponse, handler: async (ctx: any) =
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.response!.kind).toBe('named');
-    if (route.response!.kind === 'named') {
-      expect(route.response!.schemaName).toBe('readUserResponse');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.response?.kind).toBe('named');
+    if (route?.response?.kind === 'named') {
+      expect(route.response.schemaName).toBe('readUserResponse');
     }
   });
 
   it('extracts middleware references', async () => {
     const project = createProject();
-    project.createSourceFile(
-      'src/middleware/auth.ts',
-      `export const authMiddleware = {};`,
-    );
+    project.createSourceFile('src/middleware/auth.ts', `export const authMiddleware = {};`);
     project.createSourceFile(
       'src/user/user.router.ts',
       `import { vertz } from '@vertz/core';
@@ -296,11 +299,11 @@ userRouter.get('/:id', { middlewares: [authMiddleware, rateLimitMiddleware], han
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.middleware).toHaveLength(2);
-    expect(route.middleware[0]!.name).toBe('authMiddleware');
-    expect(route.middleware[0]!.sourceFile).toContain('auth.ts');
-    expect(route.middleware[1]!.name).toBe('rateLimitMiddleware');
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.middleware).toHaveLength(2);
+    expect(route?.middleware.at(0)?.name).toBe('authMiddleware');
+    expect(route?.middleware.at(0)?.sourceFile).toContain('auth.ts');
+    expect(route?.middleware.at(1)?.name).toBe('rateLimitMiddleware');
   });
 
   it('extracts description', async () => {
@@ -314,7 +317,7 @@ userRouter.get('/:id', { description: 'Get user by ID', handler: async (ctx: any
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.description).toBe('Get user by ID');
+    expect(result.routers[0]?.routes.at(0)?.description).toBe('Get user by ID');
   });
 
   it('extracts tags', async () => {
@@ -328,7 +331,7 @@ userRouter.get('/:id', { tags: ['users', 'admin'], handler: async (ctx: any) => 
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.tags).toEqual(['users', 'admin']);
+    expect(result.routers[0]?.routes.at(0)?.tags).toEqual(['users', 'admin']);
   });
 
   it('defaults tags to empty array', async () => {
@@ -342,7 +345,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.tags).toEqual([]);
+    expect(result.routers[0]?.routes.at(0)?.tags).toEqual([]);
   });
 
   it('defaults description to undefined', async () => {
@@ -356,7 +359,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.description).toBeUndefined();
+    expect(result.routers[0]?.routes.at(0)?.description).toBeUndefined();
   });
 
   it('computes fullPath by joining prefix and path', async () => {
@@ -370,7 +373,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.fullPath).toBe('/users/:id');
+    expect(result.routers[0]?.routes.at(0)?.fullPath).toBe('/users/:id');
   });
 
   it('handles root route path', async () => {
@@ -384,7 +387,7 @@ userRouter.get('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.fullPath).toBe('/users');
+    expect(result.routers[0]?.routes.at(0)?.fullPath).toBe('/users');
   });
 
   it('handles nested prefix', async () => {
@@ -398,7 +401,7 @@ userRouter.get('/:id/posts', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.fullPath).toBe('/api/v1/users/:id/posts');
+    expect(result.routers[0]?.routes.at(0)?.fullPath).toBe('/api/v1/users/:id/posts');
   });
 
   it('handles prefix with trailing slash', async () => {
@@ -412,7 +415,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.fullPath).toBe('/users/:id');
+    expect(result.routers[0]?.routes.at(0)?.fullPath).toBe('/users/:id');
   });
 
   it('generates operationId from handler function name', async () => {
@@ -427,7 +430,7 @@ userRouter.get('/:id', { handler: getUserById });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.operationId).toBe('user_getUserById');
+    expect(result.routers[0]?.routes.at(0)?.operationId).toBe('user_getUserById');
   });
 
   it('generates operationId from arrow function fallback', async () => {
@@ -441,7 +444,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.operationId).toBe('user_get_id');
+    expect(result.routers[0]?.routes.at(0)?.operationId).toBe('user_get_id');
   });
 
   it('generates operationId from property access handler', async () => {
@@ -456,7 +459,7 @@ userRouter.get('/:id', { handler: handlers.getUserById });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.operationId).toBe('user_getUserById');
+    expect(result.routers[0]?.routes.at(0)?.operationId).toBe('user_getUserById');
   });
 
   it('handles operationId collision avoidance', async () => {
@@ -471,7 +474,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const ids = result.routers[0]!.routes.map((r) => r.operationId);
+    const ids = result.routers[0]?.routes.map((r) => r.operationId);
     expect(ids[0]).toBe('user_get_id');
     expect(ids[1]).toBe('user_get_id_2');
   });
@@ -491,8 +494,8 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.sourceLine).toBe(8);
-    expect(result.routers[0]!.routes[0]!.sourceFile).toContain('user.router.ts');
+    expect(result.routers[0]?.routes.at(0)?.sourceLine).toBe(8);
+    expect(result.routers[0]?.routes.at(0)?.sourceFile).toContain('user.router.ts');
   });
 
   it('extracts multiple routes on one router', async () => {
@@ -507,7 +510,7 @@ userRouter.post('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(2);
+    expect(result.routers[0]?.routes).toHaveLength(2);
   });
 
   it('extracts multiple routers in one file', async () => {
@@ -521,7 +524,9 @@ const userRouter = userModuleDef.router({ prefix: '/users' });
 const adminRouter = adminModuleDef.router({ prefix: '/admin' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
-    const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user', adminModuleDef: 'admin' }));
+    const result = await analyzer.analyzeForModules(
+      createContext({ userModuleDef: 'user', adminModuleDef: 'admin' }),
+    );
     expect(result.routers).toHaveLength(2);
   });
 
@@ -540,7 +545,9 @@ const todoModuleDef = vertz.moduleDef({ name: 'todo' });
 const todoRouter = todoModuleDef.router({ prefix: '/todos' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
-    const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user', todoModuleDef: 'todo' }));
+    const result = await analyzer.analyzeForModules(
+      createContext({ userModuleDef: 'user', todoModuleDef: 'todo' }),
+    );
     expect(result.routers).toHaveLength(2);
   });
 
@@ -558,8 +565,8 @@ userRouter
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(3);
-    const methods = result.routers[0]!.routes.map((r) => r.method);
+    expect(result.routers[0]?.routes).toHaveLength(3);
+    const methods = result.routers[0]?.routes.map((r) => r.method);
     expect(methods).toContain('GET');
     expect(methods).toContain('POST');
     expect(methods).toContain('DELETE');
@@ -577,7 +584,7 @@ userRouter.post('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(2);
+    expect(result.routers[0]?.routes).toHaveLength(2);
   });
 
   it('handles inline schema expressions', async () => {
@@ -592,7 +599,7 @@ userRouter.get('/:id', { params: s.object({ id: s.uuid() }), handler: async (ctx
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.params!.kind).toBe('inline');
+    expect(result.routers[0]?.routes.at(0)?.params?.kind).toBe('inline');
   });
 
   it('handles missing schema properties', async () => {
@@ -606,12 +613,12 @@ userRouter.get('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    const route = result.routers[0]!.routes[0]!;
-    expect(route.params).toBeUndefined();
-    expect(route.query).toBeUndefined();
-    expect(route.body).toBeUndefined();
-    expect(route.headers).toBeUndefined();
-    expect(route.response).toBeUndefined();
+    const route = result.routers[0]?.routes.at(0);
+    expect(route?.params).toBeUndefined();
+    expect(route?.query).toBeUndefined();
+    expect(route?.body).toBeUndefined();
+    expect(route?.headers).toBeUndefined();
+    expect(route?.response).toBeUndefined();
   });
 
   it('handles empty middlewares array', async () => {
@@ -625,7 +632,7 @@ userRouter.get('/', { middlewares: [], handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.middleware).toEqual([]);
+    expect(result.routers[0]?.routes.at(0)?.middleware).toEqual([]);
   });
 
   it('handles missing middlewares property', async () => {
@@ -639,7 +646,7 @@ userRouter.get('/', { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes[0]!.middleware).toEqual([]);
+    expect(result.routers[0]?.routes.at(0)?.middleware).toEqual([]);
   });
 
   it('emits error when router variable is not declared with a moduleDef call', async () => {
@@ -654,7 +661,7 @@ userRouter.get('/:id', { handler: async (ctx: any) => ({}) });`,
     await analyzer.analyzeForModules(createContext({}));
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.code).toBe('VERTZ_RT_UNKNOWN_MODULE_DEF');
+    expect(diags.at(0)?.code).toBe('VERTZ_RT_UNKNOWN_MODULE_DEF');
   });
 
   it('emits error when route path is not a string literal', async () => {
@@ -669,10 +676,10 @@ userRouter.get(dynamicPath, { handler: async (ctx: any) => ({}) });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(0);
+    expect(result.routers[0]?.routes).toHaveLength(0);
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.code).toBe('VERTZ_RT_DYNAMIC_PATH');
+    expect(diags.at(0)?.code).toBe('VERTZ_RT_DYNAMIC_PATH');
   });
 
   it('emits error when handler is missing', async () => {
@@ -687,10 +694,10 @@ userRouter.get('/:id', { params: readUserParams });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(0);
+    expect(result.routers[0]?.routes).toHaveLength(0);
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.code).toBe('VERTZ_RT_MISSING_HANDLER');
+    expect(diags.at(0)?.code).toBe('VERTZ_RT_MISSING_HANDLER');
   });
 
   it('emits warning when prefix is missing', async () => {
@@ -703,10 +710,10 @@ const userRouter = userModuleDef.router({ inject: { userService } });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.prefix).toBe('/');
+    expect(result.routers[0]?.prefix).toBe('/');
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.code).toBe('VERTZ_RT_MISSING_PREFIX');
+    expect(diags.at(0)?.code).toBe('VERTZ_RT_MISSING_PREFIX');
   });
 
   it('emits warning when route config is not an object literal', async () => {
@@ -723,7 +730,7 @@ userRouter.get('/:id', config);`,
     await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
     const diags = analyzer.getDiagnostics();
     expect(diags).toHaveLength(1);
-    expect(diags[0]!.code).toBe('VERTZ_RT_DYNAMIC_CONFIG');
+    expect(diags.at(0)?.code).toBe('VERTZ_RT_DYNAMIC_CONFIG');
   });
 
   it('ignores method calls that are not HTTP methods', async () => {
@@ -738,7 +745,7 @@ userRouter.toString();`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toHaveLength(0);
+    expect(result.routers[0]?.routes).toHaveLength(0);
   });
 
   it('handles exported router', async () => {
@@ -752,7 +759,7 @@ export const userRouter = userModuleDef.router({ prefix: '/users' });`,
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
     expect(result.routers).toHaveLength(1);
-    expect(result.routers[0]!.name).toBe('userRouter');
+    expect(result.routers[0]?.name).toBe('userRouter');
   });
 
   it('does not emit unknown module def error for unrelated .router() calls', async () => {
@@ -779,7 +786,7 @@ const emptyRouter = userModuleDef.router({ prefix: '/empty' });`,
     );
     const analyzer = new RouteAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModules(createContext({ userModuleDef: 'user' }));
-    expect(result.routers[0]!.routes).toEqual([]);
+    expect(result.routers[0]?.routes).toEqual([]);
   });
 });
 

--- a/packages/compiler/src/analyzers/__tests__/schema-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/schema-analyzer.test.ts
@@ -1,5 +1,5 @@
+import { Project } from 'ts-morph';
 import { describe, expect, it } from 'vitest';
-import { Project, SyntaxKind } from 'ts-morph';
 import { resolveConfig } from '../../config';
 import type { SchemaIR, SchemaNameParts, SchemaRef } from '../../ir/types';
 import {
@@ -30,23 +30,43 @@ describe('parseSchemaName', () => {
   });
 
   it('parses readUserResponse correctly', () => {
-    expect(parseSchemaName('readUserResponse')).toEqual({ operation: 'read', entity: 'User', part: 'Response' });
+    expect(parseSchemaName('readUserResponse')).toEqual({
+      operation: 'read',
+      entity: 'User',
+      part: 'Response',
+    });
   });
 
   it('parses updateTodoItemBody correctly', () => {
-    expect(parseSchemaName('updateTodoItemBody')).toEqual({ operation: 'update', entity: 'TodoItem', part: 'Body' });
+    expect(parseSchemaName('updateTodoItemBody')).toEqual({
+      operation: 'update',
+      entity: 'TodoItem',
+      part: 'Body',
+    });
   });
 
   it('parses listTodoQuery correctly', () => {
-    expect(parseSchemaName('listTodoQuery')).toEqual({ operation: 'list', entity: 'Todo', part: 'Query' });
+    expect(parseSchemaName('listTodoQuery')).toEqual({
+      operation: 'list',
+      entity: 'Todo',
+      part: 'Query',
+    });
   });
 
   it('parses deleteUserParams correctly', () => {
-    expect(parseSchemaName('deleteUserParams')).toEqual({ operation: 'delete', entity: 'User', part: 'Params' });
+    expect(parseSchemaName('deleteUserParams')).toEqual({
+      operation: 'delete',
+      entity: 'User',
+      part: 'Params',
+    });
   });
 
   it('parses readUserHeaders correctly', () => {
-    expect(parseSchemaName('readUserHeaders')).toEqual({ operation: 'read', entity: 'User', part: 'Headers' });
+    expect(parseSchemaName('readUserHeaders')).toEqual({
+      operation: 'read',
+      entity: 'User',
+      part: 'Headers',
+    });
   });
 
   it('returns all undefined for non-convention name', () => {
@@ -122,19 +142,13 @@ describe('isSchemaExpression', () => {
 
   it('does not detect unrelated function call', () => {
     const project = createProject();
-    const { file, expr } = getExpr(
-      project,
-      `const x = console.log('hello');`,
-    );
+    const { file, expr } = getExpr(project, `const x = console.log('hello');`);
     expect(isSchemaExpression(file, expr)).toBe(false);
   });
 
   it('does not detect non-schema identifier', () => {
     const project = createProject();
-    const { file, expr } = getExpr(
-      project,
-      `const someVariable = 1;\nconst x = someVariable;`,
-    );
+    const { file, expr } = getExpr(project, `const someVariable = 1;\nconst x = someVariable;`);
     expect(isSchemaExpression(file, expr)).toBe(false);
   });
 });
@@ -180,7 +194,11 @@ describe('extractSchemaId', () => {
 describe('createNamedSchemaRef', () => {
   it('creates named SchemaRef with correct fields', () => {
     const ref = createNamedSchemaRef('createUserBody', 'src/schemas/user.ts');
-    expect(ref).toEqual({ kind: 'named', schemaName: 'createUserBody', sourceFile: 'src/schemas/user.ts' });
+    expect(ref).toEqual({
+      kind: 'named',
+      schemaName: 'createUserBody',
+      sourceFile: 'src/schemas/user.ts',
+    });
   });
 });
 
@@ -203,10 +221,7 @@ describe('isSchemaFile', () => {
 
   it('returns false for file not importing @vertz/schema', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'src/utils/helpers.ts',
-      `export const foo = 'bar';`,
-    );
+    const file = project.createSourceFile('src/utils/helpers.ts', `export const foo = 'bar';`);
     expect(isSchemaFile(file)).toBe(false);
   });
 });
@@ -221,8 +236,8 @@ describe('SchemaAnalyzer', () => {
     const analyzer = new SchemaAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.schemas).toHaveLength(1);
-    expect(result.schemas[0]!.name).toBe('createUserBody');
-    expect(result.schemas[0]!.sourceFile).toContain('user.ts');
+    expect(result.schemas.at(0)?.name).toBe('createUserBody');
+    expect(result.schemas.at(0)?.sourceFile).toContain('user.ts');
   });
 
   it('discovers multiple schemas from one file', async () => {
@@ -251,10 +266,7 @@ export const createUserResponse = s.object({ id: s.string() });`,
 
   it('ignores files that do not import @vertz/schema', async () => {
     const project = createProject();
-    project.createSourceFile(
-      'src/utils/helpers.ts',
-      `export const foo = 'bar';`,
-    );
+    project.createSourceFile('src/utils/helpers.ts', `export const foo = 'bar';`);
     const analyzer = new SchemaAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
     expect(result.schemas).toHaveLength(0);
@@ -290,8 +302,8 @@ export const createUserResponse = s.object({ id: s.string() });`,
     );
     const analyzer = new SchemaAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.schemas[0]!.id).toBe('CreateUser');
-    expect(result.schemas[0]!.isNamed).toBe(true);
+    expect(result.schemas.at(0)?.id).toBe('CreateUser');
+    expect(result.schemas.at(0)?.isNamed).toBe(true);
   });
 
   it('marks schemas without .id() as not named', async () => {
@@ -302,8 +314,8 @@ export const createUserResponse = s.object({ id: s.string() });`,
     );
     const analyzer = new SchemaAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.schemas[0]!.isNamed).toBe(false);
-    expect(result.schemas[0]!.id).toBeUndefined();
+    expect(result.schemas.at(0)?.isNamed).toBe(false);
+    expect(result.schemas.at(0)?.id).toBeUndefined();
   });
 
   it('includes correct source location for discovered schema', async () => {
@@ -314,7 +326,7 @@ export const createUserResponse = s.object({ id: s.string() });`,
     );
     const analyzer = new SchemaAnalyzer(project, resolveConfig());
     const result = await analyzer.analyze();
-    expect(result.schemas[0]!.sourceLine).toBe(2);
+    expect(result.schemas.at(0)?.sourceLine).toBe(2);
   });
 
   it('emits no diagnostics for valid schema file', async () => {

--- a/packages/compiler/src/analyzers/__tests__/service-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/service-analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project, SyntaxKind } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../../config';
 import type { InjectRef, ServiceIR, ServiceMethodIR, ServiceMethodParam } from '../../ir/types';
 import { extractMethodSignatures, parseInjectRefs, ServiceAnalyzer } from '../service-analyzer';
@@ -25,8 +25,8 @@ const userService = userModuleDef.service({
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
     expect(result).toHaveLength(1);
-    expect(result[0]!.name).toBe('userService');
-    expect(result[0]!.moduleName).toBe('user');
+    expect(result.at(0)?.name).toBe('userService');
+    expect(result.at(0)?.moduleName).toBe('user');
   });
 
   it('discovers multiple services on same moduleDef', async () => {
@@ -59,8 +59,8 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.sourceLine).toBe(3);
-    expect(result[0]!.sourceFile).toContain('user.service.ts');
+    expect(result.at(0)?.sourceLine).toBe(3);
+    expect(result.at(0)?.sourceFile).toContain('user.service.ts');
   });
 
   it('extracts inject references with shorthand', async () => {
@@ -76,9 +76,12 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.inject).toHaveLength(2);
-    expect(result[0]!.inject[0]).toEqual({ localName: 'dbService', resolvedToken: 'dbService' });
-    expect(result[0]!.inject[1]).toEqual({ localName: 'configService', resolvedToken: 'configService' });
+    expect(result.at(0)?.inject).toHaveLength(2);
+    expect(result.at(0)?.inject[0]).toEqual({ localName: 'dbService', resolvedToken: 'dbService' });
+    expect(result.at(0)?.inject[1]).toEqual({
+      localName: 'configService',
+      resolvedToken: 'configService',
+    });
   });
 
   it('extracts inject with explicit key', async () => {
@@ -95,7 +98,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.inject[0]).toEqual({ localName: 'db', resolvedToken: 'dbService' });
+    expect(result.at(0)?.inject[0]).toEqual({ localName: 'db', resolvedToken: 'dbService' });
   });
 
   it('empty inject when not specified', async () => {
@@ -110,7 +113,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.inject).toEqual([]);
+    expect(result.at(0)?.inject).toEqual([]);
   });
 
   it('empty inject for empty object', async () => {
@@ -126,7 +129,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.inject).toEqual([]);
+    expect(result.at(0)?.inject).toEqual([]);
   });
 
   it('extracts method names from arrow function return', async () => {
@@ -144,9 +147,9 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods).toHaveLength(2);
-    expect(result[0]!.methods[0]!.name).toBe('findById');
-    expect(result[0]!.methods[1]!.name).toBe('create');
+    expect(result.at(0)?.methods).toHaveLength(2);
+    expect(result.at(0)?.methods.at(0)?.name).toBe('findById');
+    expect(result.at(0)?.methods.at(1)?.name).toBe('create');
   });
 
   it('extracts method parameter names and types', async () => {
@@ -163,9 +166,9 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods[0]!.parameters).toHaveLength(1);
-    expect(result[0]!.methods[0]!.parameters[0]!.name).toBe('id');
-    expect(result[0]!.methods[0]!.parameters[0]!.type).toBe('string');
+    expect(result.at(0)?.methods.at(0)?.parameters).toHaveLength(1);
+    expect(result.at(0)?.methods.at(0)?.parameters.at(0)?.name).toBe('id');
+    expect(result.at(0)?.methods.at(0)?.parameters.at(0)?.type).toBe('string');
   });
 
   it('extracts method with multiple parameters', async () => {
@@ -183,7 +186,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods[0]!.parameters).toHaveLength(2);
+    expect(result.at(0)?.methods.at(0)?.parameters).toHaveLength(2);
   });
 
   it('extracts method return type', async () => {
@@ -200,7 +203,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods[0]!.returnType).toContain('Promise');
+    expect(result.at(0)?.methods.at(0)?.returnType).toContain('Promise');
   });
 
   it('handles methods factory with block body', async () => {
@@ -219,8 +222,8 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods).toHaveLength(1);
-    expect(result[0]!.methods[0]!.name).toBe('findById');
+    expect(result.at(0)?.methods).toHaveLength(1);
+    expect(result.at(0)?.methods.at(0)?.name).toBe('findById');
   });
 
   it('returns empty methods for methods without recognizable return', async () => {
@@ -235,7 +238,7 @@ const userService = userModuleDef.service({
     );
     const analyzer = new ServiceAnalyzer(project, resolveConfig());
     const result = await analyzer.analyzeForModule('userModuleDef', 'user');
-    expect(result[0]!.methods).toEqual([]);
+    expect(result.at(0)?.methods).toEqual([]);
   });
 
   it('emits no diagnostics for valid service', async () => {
@@ -297,7 +300,7 @@ describe('extractMethodSignatures', () => {
     const expr = decl.getInitializerOrThrow();
     const methods = extractMethodSignatures(expr);
     expect(methods).toHaveLength(1);
-    expect(methods[0]!.name).toBe('findById');
+    expect(methods.at(0)?.name).toBe('findById');
   });
 
   it('extracts from arrow function with block body and return statement', () => {
@@ -310,7 +313,7 @@ describe('extractMethodSignatures', () => {
     const expr = decl.getInitializerOrThrow();
     const methods = extractMethodSignatures(expr);
     expect(methods).toHaveLength(1);
-    expect(methods[0]!.name).toBe('findById');
+    expect(methods.at(0)?.name).toBe('findById');
   });
 
   it('returns empty array when expression is not a function', () => {

--- a/packages/compiler/src/analyzers/env-analyzer.ts
+++ b/packages/compiler/src/analyzers/env-analyzer.ts
@@ -1,7 +1,14 @@
 import { SyntaxKind } from 'ts-morph';
-import type { EnvIR, SchemaRef } from '../ir/types';
 import { createDiagnosticFromLocation } from '../errors';
-import { extractObjectLiteral, findCallExpressions, getArrayElements, getPropertyValue, getSourceLocation, getStringValue } from '../utils/ast-helpers';
+import type { EnvIR, SchemaRef } from '../ir/types';
+import {
+  extractObjectLiteral,
+  findCallExpressions,
+  getArrayElements,
+  getPropertyValue,
+  getSourceLocation,
+  getStringValue,
+} from '../utils/ast-helpers';
 import { BaseAnalyzer } from './base-analyzer';
 import { createNamedSchemaRef } from './schema-analyzer';
 
@@ -22,17 +29,21 @@ export class EnvAnalyzer extends BaseAnalyzer<EnvAnalyzerResult> {
         const loc = getSourceLocation(call);
 
         if (env) {
-          this.addDiagnostic(createDiagnosticFromLocation(loc, {
-            severity: 'error',
-            code: 'VERTZ_ENV_DUPLICATE',
-            message: 'Multiple vertz.env() calls found. Only one is allowed.',
-          }));
+          this.addDiagnostic(
+            createDiagnosticFromLocation(loc, {
+              severity: 'error',
+              code: 'VERTZ_ENV_DUPLICATE',
+              message: 'Multiple vertz.env() calls found. Only one is allowed.',
+            }),
+          );
           continue;
         }
 
         const loadExpr = getPropertyValue(obj, 'load');
         const loadFiles = loadExpr
-          ? getArrayElements(loadExpr).map((e) => getStringValue(e)).filter((v): v is string => v !== null)
+          ? getArrayElements(loadExpr)
+              .map((e) => getStringValue(e))
+              .filter((v): v is string => v !== null)
           : [];
 
         const schemaExpr = getPropertyValue(obj, 'schema');

--- a/packages/compiler/src/analyzers/middleware-analyzer.ts
+++ b/packages/compiler/src/analyzers/middleware-analyzer.ts
@@ -1,8 +1,14 @@
 import type { ObjectLiteralExpression } from 'ts-morph';
 import { SyntaxKind } from 'ts-morph';
-import type { MiddlewareIR, SchemaRef } from '../ir/types';
 import { createDiagnosticFromLocation } from '../errors';
-import { extractObjectLiteral, findCallExpressions, getPropertyValue, getSourceLocation, getStringValue } from '../utils/ast-helpers';
+import type { MiddlewareIR, SchemaRef } from '../ir/types';
+import {
+  extractObjectLiteral,
+  findCallExpressions,
+  getPropertyValue,
+  getSourceLocation,
+  getStringValue,
+} from '../utils/ast-helpers';
 import { resolveIdentifier } from '../utils/import-resolver';
 import { BaseAnalyzer } from './base-analyzer';
 import { createInlineSchemaRef, createNamedSchemaRef, isSchemaExpression } from './schema-analyzer';
@@ -22,45 +28,53 @@ export class MiddlewareAnalyzer extends BaseAnalyzer<MiddlewareAnalyzerResult> {
         const obj = extractObjectLiteral(call, 0);
         if (!obj) {
           const callLoc = getSourceLocation(call);
-          this.addDiagnostic(createDiagnosticFromLocation(callLoc, {
-            severity: 'warning',
-            code: 'VERTZ_MW_NON_OBJECT_CONFIG',
-            message: 'Middleware config must be an object literal for static analysis.',
-            suggestion: 'Pass an inline object literal to vertz.middleware().',
-          }));
+          this.addDiagnostic(
+            createDiagnosticFromLocation(callLoc, {
+              severity: 'warning',
+              code: 'VERTZ_MW_NON_OBJECT_CONFIG',
+              message: 'Middleware config must be an object literal for static analysis.',
+              suggestion: 'Pass an inline object literal to vertz.middleware().',
+            }),
+          );
           continue;
         }
 
         const loc = getSourceLocation(call);
         const nameExpr = getPropertyValue(obj, 'name');
         if (!nameExpr) {
-          this.addDiagnostic(createDiagnosticFromLocation(loc, {
-            severity: 'error',
-            code: 'VERTZ_MW_MISSING_NAME',
-            message: "Middleware must have a 'name' property.",
-            suggestion: "Add a 'name' property to the middleware config.",
-          }));
+          this.addDiagnostic(
+            createDiagnosticFromLocation(loc, {
+              severity: 'error',
+              code: 'VERTZ_MW_MISSING_NAME',
+              message: "Middleware must have a 'name' property.",
+              suggestion: "Add a 'name' property to the middleware config.",
+            }),
+          );
           continue;
         }
         const name = getStringValue(nameExpr);
         if (!name) {
-          this.addDiagnostic(createDiagnosticFromLocation(loc, {
-            severity: 'warning',
-            code: 'VERTZ_MW_DYNAMIC_NAME',
-            message: 'Middleware name should be a string literal for static analysis.',
-            suggestion: 'Use a string literal for the middleware name.',
-          }));
+          this.addDiagnostic(
+            createDiagnosticFromLocation(loc, {
+              severity: 'warning',
+              code: 'VERTZ_MW_DYNAMIC_NAME',
+              message: 'Middleware name should be a string literal for static analysis.',
+              suggestion: 'Use a string literal for the middleware name.',
+            }),
+          );
           continue;
         }
 
         const handlerExpr = getPropertyValue(obj, 'handler');
         if (!handlerExpr) {
-          this.addDiagnostic(createDiagnosticFromLocation(loc, {
-            severity: 'error',
-            code: 'VERTZ_MW_MISSING_HANDLER',
-            message: "Middleware must have a 'handler' property.",
-            suggestion: "Add a 'handler' property to the middleware config.",
-          }));
+          this.addDiagnostic(
+            createDiagnosticFromLocation(loc, {
+              severity: 'error',
+              code: 'VERTZ_MW_MISSING_HANDLER',
+              message: "Middleware must have a 'handler' property.",
+              suggestion: "Add a 'handler' property to the middleware config.",
+            }),
+          );
           continue;
         }
 

--- a/packages/compiler/src/analyzers/route-analyzer.ts
+++ b/packages/compiler/src/analyzers/route-analyzer.ts
@@ -1,8 +1,22 @@
-import type { CallExpression, Expression, Identifier, ObjectLiteralExpression, SourceFile } from 'ts-morph';
+import type {
+  CallExpression,
+  Expression,
+  Identifier,
+  ObjectLiteralExpression,
+  SourceFile,
+} from 'ts-morph';
 import { SyntaxKind } from 'ts-morph';
-import type { HttpMethod, ModuleDefContext, RouteIR, RouterIR, SchemaRef } from '../ir/types';
 import { createDiagnosticFromLocation } from '../errors';
-import { extractObjectLiteral, findMethodCallsOnVariable, getArrayElements, getPropertyValue, getSourceLocation, getStringValue, getVariableNameForCall } from '../utils/ast-helpers';
+import type { HttpMethod, ModuleDefContext, RouteIR, RouterIR, SchemaRef } from '../ir/types';
+import {
+  extractObjectLiteral,
+  findMethodCallsOnVariable,
+  getArrayElements,
+  getPropertyValue,
+  getSourceLocation,
+  getStringValue,
+  getVariableNameForCall,
+} from '../utils/ast-helpers';
 import { resolveIdentifier } from '../utils/import-resolver';
 import { BaseAnalyzer } from './base-analyzer';
 import { createInlineSchemaRef, createNamedSchemaRef, isSchemaExpression } from './schema-analyzer';
@@ -40,14 +54,16 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
 
           const obj = extractObjectLiteral(call, 0);
           const prefixExpr = obj ? getPropertyValue(obj, 'prefix') : null;
-          const prefix = prefixExpr ? getStringValue(prefixExpr) ?? '/' : '/';
+          const prefix = prefixExpr ? (getStringValue(prefixExpr) ?? '/') : '/';
           if (!prefixExpr) {
-            this.addDiagnostic(createDiagnosticFromLocation(getSourceLocation(call), {
-              severity: 'warning',
-              code: 'VERTZ_RT_MISSING_PREFIX',
-              message: "Router should have a 'prefix' property.",
-              suggestion: "Add a 'prefix' property to the router config.",
-            }));
+            this.addDiagnostic(
+              createDiagnosticFromLocation(getSourceLocation(call), {
+                severity: 'warning',
+                code: 'VERTZ_RT_MISSING_PREFIX',
+                message: "Router should have a 'prefix' property.",
+                suggestion: "Add a 'prefix' property to the router config.",
+              }),
+            );
           }
 
           const loc = getSourceLocation(call);
@@ -76,10 +92,7 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
     return { routers };
   }
 
-  private detectUnknownRouterCalls(
-    file: SourceFile,
-    knownModuleDefVars: Set<string>,
-  ): void {
+  private detectUnknownRouterCalls(file: SourceFile, knownModuleDefVars: Set<string>): void {
     const allCalls = file.getDescendantsOfKind(SyntaxKind.CallExpression);
     for (const call of allCalls) {
       const expr = call.getExpression();
@@ -98,12 +111,15 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
       );
       if (!hasHttpMethodCalls) continue;
 
-      this.addDiagnostic(createDiagnosticFromLocation(getSourceLocation(call), {
-        severity: 'error',
-        code: 'VERTZ_RT_UNKNOWN_MODULE_DEF',
-        message: `'${obj.getText()}' is not a known moduleDef variable.`,
-        suggestion: 'Ensure the variable is declared with vertz.moduleDef() and is included in the module context.',
-      }));
+      this.addDiagnostic(
+        createDiagnosticFromLocation(getSourceLocation(call), {
+          severity: 'error',
+          code: 'VERTZ_RT_UNKNOWN_MODULE_DEF',
+          message: `'${obj.getText()}' is not a known moduleDef variable.`,
+          suggestion:
+            'Ensure the variable is declared with vertz.moduleDef() and is included in the module context.',
+        }),
+      );
     }
   }
 
@@ -121,7 +137,14 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
       const chainedCalls = this.findChainedHttpCalls(file, routerVarName, methodName);
       const allCalls = [...directCalls, ...chainedCalls];
       for (const call of allCalls) {
-        const route = this.extractRoute(call, httpMethod, prefix, moduleName, file, usedOperationIds);
+        const route = this.extractRoute(
+          call,
+          httpMethod,
+          prefix,
+          moduleName,
+          file,
+          usedOperationIds,
+        );
         if (route) routes.push(route);
       }
     }
@@ -145,10 +168,7 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
     });
   }
 
-  private chainResolvesToVariable(
-    expr: Expression,
-    varName: string,
-  ): boolean {
+  private chainResolvesToVariable(expr: Expression, varName: string): boolean {
     if (expr.isKind(SyntaxKind.Identifier)) {
       return expr.getText() === varName;
     }
@@ -175,12 +195,14 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
 
     const path = getStringValue(pathArg as Expression);
     if (path === null) {
-      this.addDiagnostic(createDiagnosticFromLocation(getSourceLocation(call), {
-        severity: 'error',
-        code: 'VERTZ_RT_DYNAMIC_PATH',
-        message: 'Route paths must be string literals for static analysis.',
-        suggestion: 'Use a string literal for the route path.',
-      }));
+      this.addDiagnostic(
+        createDiagnosticFromLocation(getSourceLocation(call), {
+          severity: 'error',
+          code: 'VERTZ_RT_DYNAMIC_PATH',
+          message: 'Route paths must be string literals for static analysis.',
+          suggestion: 'Use a string literal for the route path.',
+        }),
+      );
       return null;
     }
 
@@ -190,12 +212,14 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
 
     const obj = extractObjectLiteral(call, 1);
     if (!obj && args.length > 1) {
-      this.addDiagnostic(createDiagnosticFromLocation(loc, {
-        severity: 'warning',
-        code: 'VERTZ_RT_DYNAMIC_CONFIG',
-        message: 'Route config must be an object literal for static analysis.',
-        suggestion: 'Pass an inline object literal as the second argument.',
-      }));
+      this.addDiagnostic(
+        createDiagnosticFromLocation(loc, {
+          severity: 'warning',
+          code: 'VERTZ_RT_DYNAMIC_CONFIG',
+          message: 'Route config must be an object literal for static analysis.',
+          suggestion: 'Pass an inline object literal as the second argument.',
+        }),
+      );
     }
 
     const params = obj ? this.resolveSchemaRef(obj, 'params', filePath) : undefined;
@@ -213,19 +237,29 @@ export class RouteAnalyzer extends BaseAnalyzer<RouteAnalyzerResult> {
 
     const tagsExpr = obj ? getPropertyValue(obj, 'tags') : null;
     const tags = tagsExpr
-      ? getArrayElements(tagsExpr).map((e) => getStringValue(e)).filter((v): v is string => v !== null)
+      ? getArrayElements(tagsExpr)
+          .map((e) => getStringValue(e))
+          .filter((v): v is string => v !== null)
       : [];
 
     const handlerExpr = obj ? getPropertyValue(obj, 'handler') : null;
-    const operationId = this.generateOperationId(moduleName, method, path, handlerExpr, usedOperationIds);
+    const operationId = this.generateOperationId(
+      moduleName,
+      method,
+      path,
+      handlerExpr,
+      usedOperationIds,
+    );
 
     if (obj && !handlerExpr) {
-      this.addDiagnostic(createDiagnosticFromLocation(loc, {
-        severity: 'error',
-        code: 'VERTZ_RT_MISSING_HANDLER',
-        message: "Route must have a 'handler' property.",
-        suggestion: "Add a 'handler' property to the route config.",
-      }));
+      this.addDiagnostic(
+        createDiagnosticFromLocation(loc, {
+          severity: 'error',
+          code: 'VERTZ_RT_MISSING_HANDLER',
+          message: "Route must have a 'handler' property.",
+          suggestion: "Add a 'handler' property to the route config.",
+        }),
+      );
       return null;
     }
 
@@ -324,10 +358,8 @@ function joinPaths(prefix: string, path: string): string {
 }
 
 function sanitizePath(path: string): string {
-  return path
-    .replace(/^\//, '')
-    .replace(/[/:.]/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_|_$/g, '')
-    || 'root';
+  return (
+    path.replace(/^\//, '').replace(/[/:.]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '') ||
+    'root'
+  );
 }

--- a/packages/compiler/src/analyzers/schema-analyzer.ts
+++ b/packages/compiler/src/analyzers/schema-analyzer.ts
@@ -53,7 +53,8 @@ export function parseSchemaName(name: string): SchemaNameParts {
       const entity = rest.slice(0, -part.length);
       if (entity.length === 0) continue;
       // Entity must start with uppercase
-      if (entity[0] !== entity[0]!.toUpperCase()) continue;
+      const firstChar = entity.at(0);
+      if (!firstChar || firstChar !== firstChar.toUpperCase()) continue;
       return { operation: op, entity, part };
     }
   }
@@ -74,7 +75,8 @@ export function extractSchemaId(expr: Expression): string | null {
     if (access.isKind(SyntaxKind.PropertyAccessExpression) && access.getName() === 'id') {
       const args = current.getArguments();
       if (args.length === 1) {
-        const value = getStringValue(args[0]! as Expression);
+        const firstArg = args.at(0);
+        const value = firstArg ? getStringValue(firstArg as Expression) : null;
         if (value !== null) return value;
       }
     }
@@ -89,9 +91,9 @@ export function extractSchemaId(expr: Expression): string | null {
 }
 
 export function isSchemaFile(file: SourceFile): boolean {
-  return file.getImportDeclarations().some(
-    (decl) => decl.getModuleSpecifierValue() === '@vertz/schema',
-  );
+  return file
+    .getImportDeclarations()
+    .some((decl) => decl.getModuleSpecifierValue() === '@vertz/schema');
 }
 
 export function createNamedSchemaRef(schemaName: string, sourceFile: string): NamedSchemaRef {

--- a/packages/compiler/src/analyzers/service-analyzer.ts
+++ b/packages/compiler/src/analyzers/service-analyzer.ts
@@ -1,7 +1,14 @@
 import type { Expression, ObjectLiteralExpression } from 'ts-morph';
 import { SyntaxKind } from 'ts-morph';
 import type { InjectRef, ServiceIR, ServiceMethodIR, ServiceMethodParam } from '../ir/types';
-import { extractObjectLiteral, findMethodCallsOnVariable, getProperties, getPropertyValue, getSourceLocation, getVariableNameForCall } from '../utils/ast-helpers';
+import {
+  extractObjectLiteral,
+  findMethodCallsOnVariable,
+  getProperties,
+  getPropertyValue,
+  getSourceLocation,
+  getVariableNameForCall,
+} from '../utils/ast-helpers';
 import { BaseAnalyzer } from './base-analyzer';
 
 export interface ServiceAnalyzerResult {
@@ -13,10 +20,7 @@ export class ServiceAnalyzer extends BaseAnalyzer<ServiceAnalyzerResult> {
     return { services: [] };
   }
 
-  async analyzeForModule(
-    moduleDefVarName: string,
-    moduleName: string,
-  ): Promise<ServiceIR[]> {
+  async analyzeForModule(moduleDefVarName: string, moduleName: string): Promise<ServiceIR[]> {
     const services: ServiceIR[] = [];
 
     for (const file of this.project.getSourceFiles()) {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,10 +1,10 @@
+import type { Analyzer } from './analyzers/base-analyzer';
 import type { ResolvedConfig } from './config';
 import type { Diagnostic } from './errors';
 import { hasErrors } from './errors';
-import type { Analyzer } from './analyzers/base-analyzer';
 import type { Generator } from './generators/base-generator';
-import type { AppIR } from './ir/types';
 import { createEmptyAppIR } from './ir/builder';
+import type { AppIR } from './ir/types';
 
 export interface Validator {
   validate(ir: AppIR): Promise<Diagnostic[]>;

--- a/packages/compiler/src/errors.ts
+++ b/packages/compiler/src/errors.ts
@@ -102,9 +102,6 @@ export function filterBySeverity(
   return diagnostics.filter((d) => d.severity === severity);
 }
 
-export function mergeDiagnostics(
-  a: readonly Diagnostic[],
-  b: readonly Diagnostic[],
-): Diagnostic[] {
+export function mergeDiagnostics(a: readonly Diagnostic[], b: readonly Diagnostic[]): Diagnostic[] {
   return [...a, ...b];
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,4 +1,74 @@
 // IR types
+
+// Base classes
+export type { Analyzer } from './analyzers/base-analyzer';
+export { BaseAnalyzer } from './analyzers/base-analyzer';
+// Env analyzer
+export type { EnvAnalyzerResult } from './analyzers/env-analyzer';
+export { EnvAnalyzer } from './analyzers/env-analyzer';
+// Middleware analyzer
+export type { MiddlewareAnalyzerResult } from './analyzers/middleware-analyzer';
+export { MiddlewareAnalyzer } from './analyzers/middleware-analyzer';
+// Module analyzer
+export type { ModuleAnalyzerResult } from './analyzers/module-analyzer';
+export { extractIdentifierNames, ModuleAnalyzer, parseImports } from './analyzers/module-analyzer';
+// Route analyzer
+export type { RouteAnalyzerResult } from './analyzers/route-analyzer';
+export { RouteAnalyzer } from './analyzers/route-analyzer';
+// Schema analyzer
+export type { SchemaAnalyzerResult } from './analyzers/schema-analyzer';
+export {
+  createInlineSchemaRef,
+  createNamedSchemaRef,
+  extractSchemaId,
+  isSchemaExpression,
+  isSchemaFile,
+  parseSchemaName,
+  SchemaAnalyzer,
+} from './analyzers/schema-analyzer';
+// Service analyzer
+export type { ServiceAnalyzerResult } from './analyzers/service-analyzer';
+export {
+  extractMethodSignatures,
+  parseInjectRefs,
+  ServiceAnalyzer,
+} from './analyzers/service-analyzer';
+// Compiler
+export type { CompileResult, CompilerDependencies, Validator } from './compiler';
+export { Compiler } from './compiler';
+// Config
+export type {
+  CompilerConfig,
+  OpenAPIConfig,
+  ResolvedConfig,
+  SchemaConfig,
+  ValidationConfig,
+  VertzConfig,
+} from './config';
+export { defineConfig, resolveConfig } from './config';
+// Diagnostics
+export type {
+  CreateDiagnosticOptions,
+  Diagnostic,
+  DiagnosticCode,
+  DiagnosticSeverity,
+  SourceContext,
+} from './errors';
+export {
+  createDiagnostic,
+  createDiagnosticFromLocation,
+  filterBySeverity,
+  hasErrors,
+  mergeDiagnostics,
+} from './errors';
+export type { Generator } from './generators/base-generator';
+export { BaseGenerator } from './generators/base-generator';
+// IR builders
+export {
+  addDiagnosticsToIR,
+  createEmptyAppIR,
+  createEmptyDependencyGraph,
+} from './ir/builder';
 export type {
   AppDefinition,
   AppIR,
@@ -29,51 +99,6 @@ export type {
   ServiceMethodParam,
   SourceLocation,
 } from './ir/types';
-
-// IR builders
-export {
-  addDiagnosticsToIR,
-  createEmptyAppIR,
-  createEmptyDependencyGraph,
-} from './ir/builder';
-
-// Diagnostics
-export type {
-  CreateDiagnosticOptions,
-  Diagnostic,
-  DiagnosticCode,
-  DiagnosticSeverity,
-  SourceContext,
-} from './errors';
-export {
-  createDiagnostic,
-  createDiagnosticFromLocation,
-  filterBySeverity,
-  hasErrors,
-  mergeDiagnostics,
-} from './errors';
-
-// Config
-export type {
-  CompilerConfig,
-  OpenAPIConfig,
-  ResolvedConfig,
-  SchemaConfig,
-  ValidationConfig,
-  VertzConfig,
-} from './config';
-export { defineConfig, resolveConfig } from './config';
-
-// Base classes
-export type { Analyzer } from './analyzers/base-analyzer';
-export { BaseAnalyzer } from './analyzers/base-analyzer';
-export type { Generator } from './generators/base-generator';
-export { BaseGenerator } from './generators/base-generator';
-
-// Compiler
-export type { CompileResult, CompilerDependencies, Validator } from './compiler';
-export { Compiler } from './compiler';
-
 // AST helpers
 export {
   extractObjectLiteral,
@@ -88,42 +113,9 @@ export {
   getStringValue,
   getVariableNameForCall,
 } from './utils/ast-helpers';
-
 // Import resolver
 export type { ResolvedImport } from './utils/import-resolver';
 export { isFromImport, resolveExport, resolveIdentifier } from './utils/import-resolver';
-
-// Schema analyzer
-export type { SchemaAnalyzerResult } from './analyzers/schema-analyzer';
-export {
-  createInlineSchemaRef,
-  createNamedSchemaRef,
-  extractSchemaId,
-  isSchemaExpression,
-  isSchemaFile,
-  parseSchemaName,
-  SchemaAnalyzer,
-} from './analyzers/schema-analyzer';
-
-// Env analyzer
-export type { EnvAnalyzerResult } from './analyzers/env-analyzer';
-export { EnvAnalyzer } from './analyzers/env-analyzer';
-
-// Module analyzer
-export type { ModuleAnalyzerResult } from './analyzers/module-analyzer';
-export { extractIdentifierNames, ModuleAnalyzer, parseImports } from './analyzers/module-analyzer';
-
-// Service analyzer
-export type { ServiceAnalyzerResult } from './analyzers/service-analyzer';
-export { extractMethodSignatures, parseInjectRefs, ServiceAnalyzer } from './analyzers/service-analyzer';
-
-// Middleware analyzer
-export type { MiddlewareAnalyzerResult } from './analyzers/middleware-analyzer';
-export { MiddlewareAnalyzer } from './analyzers/middleware-analyzer';
-
-// Route analyzer
-export type { RouteAnalyzerResult } from './analyzers/route-analyzer';
-export { RouteAnalyzer } from './analyzers/route-analyzer';
 
 // Schema executor
 export type { SchemaExecutionResult, SchemaExecutor } from './utils/schema-executor';

--- a/packages/compiler/src/ir/builder.ts
+++ b/packages/compiler/src/ir/builder.ts
@@ -28,10 +28,7 @@ export function createEmptyAppIR(): AppIR {
   };
 }
 
-export function addDiagnosticsToIR(
-  ir: AppIR,
-  diagnostics: readonly Diagnostic[],
-): AppIR {
+export function addDiagnosticsToIR(ir: AppIR, diagnostics: readonly Diagnostic[]): AppIR {
   return {
     ...ir,
     diagnostics: [...ir.diagnostics, ...diagnostics],

--- a/packages/compiler/src/utils/__tests__/ast-helpers.test.ts
+++ b/packages/compiler/src/utils/__tests__/ast-helpers.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project, SyntaxKind } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import {
   extractObjectLiteral,
   findCallExpressions,
@@ -44,10 +44,7 @@ describe('findCallExpressions', () => {
 
   it('returns empty array when no match', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const app = vertz.app({ basePath: '/' });`,
-    );
+    const file = project.createSourceFile('test.ts', `const app = vertz.app({ basePath: '/' });`);
     const results = findCallExpressions(file, 'vertz', 'middleware');
     expect(results).toHaveLength(0);
   });
@@ -64,10 +61,7 @@ describe('findCallExpressions', () => {
 
   it('does not match different method name', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const app = vertz.app({ basePath: '/' });`,
-    );
+    const file = project.createSourceFile('test.ts', `const app = vertz.app({ basePath: '/' });`);
     const results = findCallExpressions(file, 'vertz', 'middleware');
     expect(results).toHaveLength(0);
   });
@@ -145,55 +139,40 @@ describe('findMethodCallsOnVariable', () => {
 describe('extractObjectLiteral', () => {
   it('extracts object literal at index 0', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `fn({ name: 'test' });`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `fn({ name: 'test' });`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     const result = extractObjectLiteral(call, 0);
     expect(result).not.toBeNull();
   });
 
   it('extracts object literal at index 1', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `fn('path', { params: 'schema' });`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `fn('path', { params: 'schema' });`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     const result = extractObjectLiteral(call, 1);
     expect(result).not.toBeNull();
   });
 
   it('returns null when argument is not object literal', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `fn('string');`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `fn('string');`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     const result = extractObjectLiteral(call, 0);
     expect(result).toBeNull();
   });
 
   it('returns null when argument index is out of bounds', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `fn({ a: 1 });`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `fn({ a: 1 });`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     const result = extractObjectLiteral(call, 5);
     expect(result).toBeNull();
   });
 
   it('returns null for no-argument call', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `fn();`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `fn();`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     const result = extractObjectLiteral(call, 0);
     expect(result).toBeNull();
   });
@@ -202,7 +181,7 @@ describe('extractObjectLiteral', () => {
 describe('getPropertyValue', () => {
   function getObj(project: Project, source: string) {
     const file = project.createSourceFile('test.ts', source);
-    return file.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression)[0]!;
+    return file.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression).at(0);
   }
 
   it('gets property value from object literal', () => {
@@ -230,7 +209,7 @@ describe('getPropertyValue', () => {
 describe('getProperties', () => {
   function getObj(project: Project, source: string) {
     const file = project.createSourceFile('test.ts', source);
-    return file.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression)[0]!;
+    return file.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression).at(0);
   }
 
   it('extracts all property assignments', () => {
@@ -238,8 +217,8 @@ describe('getProperties', () => {
     const obj = getObj(project, `const o = { name: 'user', count: 3 };`);
     const props = getProperties(obj);
     expect(props).toHaveLength(2);
-    expect(props[0]!.name).toBe('name');
-    expect(props[1]!.name).toBe('count');
+    expect(props.at(0)?.name).toBe('name');
+    expect(props.at(1)?.name).toBe('count');
   });
 
   it('handles shorthand properties', () => {
@@ -247,7 +226,7 @@ describe('getProperties', () => {
     const obj = getObj(project, `const name = 'user'; const o = { name, count: 3 };`);
     const props = getProperties(obj);
     expect(props).toHaveLength(2);
-    expect(props[0]!.name).toBe('name');
+    expect(props.at(0)?.name).toBe('name');
   });
 
   it('returns empty array for empty object', () => {
@@ -389,31 +368,22 @@ describe('getArrayElements', () => {
 describe('getVariableNameForCall', () => {
   it('extracts variable name from const declaration', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const userRouter = createRouter();`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `const userRouter = createRouter();`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     expect(getVariableNameForCall(call)).toBe('userRouter');
   });
 
   it('extracts variable name from let declaration', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `let mw = vertz.middleware({});`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `let mw = vertz.middleware({});`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     expect(getVariableNameForCall(call)).toBe('mw');
   });
 
   it('returns null for bare call (no assignment)', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `doSomething();`,
-    );
-    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression)[0]!;
+    const file = project.createSourceFile('test.ts', `doSomething();`);
+    const call = file.getDescendantsOfKind(SyntaxKind.CallExpression).at(0);
     expect(getVariableNameForCall(call)).toBeNull();
   });
 });
@@ -421,10 +391,7 @@ describe('getVariableNameForCall', () => {
 describe('getSourceLocation', () => {
   it('returns correct file, line, column', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'src/test.ts',
-      `const a = 1;\nconst b = 2;`,
-    );
+    const file = project.createSourceFile('src/test.ts', `const a = 1;\nconst b = 2;`);
     const decl = file.getVariableDeclarationOrThrow('b');
     const loc = getSourceLocation(decl);
     expect(loc.sourceFile).toContain('src/test.ts');

--- a/packages/compiler/src/utils/__tests__/import-resolver.test.ts
+++ b/packages/compiler/src/utils/__tests__/import-resolver.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Project, SyntaxKind } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
 import { isFromImport, resolveExport, resolveIdentifier } from '../import-resolver';
 
 function createProject() {
@@ -22,8 +22,8 @@ describe('resolveIdentifier', () => {
     const id = getIdentifierUsage(routerFile, 'x');
     const result = resolveIdentifier(id, project);
     expect(result).not.toBeNull();
-    expect(result!.sourceFile.getFilePath()).toContain('user.ts');
-    expect(result!.exportName).toBe('userService');
+    expect(result?.sourceFile.getFilePath()).toContain('user.ts');
+    expect(result?.exportName).toBe('userService');
   });
 
   it('resolves renamed import', () => {
@@ -36,8 +36,8 @@ describe('resolveIdentifier', () => {
     const id = getIdentifierUsage(routerFile, 'x');
     const result = resolveIdentifier(id, project);
     expect(result).not.toBeNull();
-    expect(result!.exportName).toBe('userService');
-    expect(result!.sourceFile.getFilePath()).toContain('user.ts');
+    expect(result?.exportName).toBe('userService');
+    expect(result?.sourceFile.getFilePath()).toContain('user.ts');
   });
 
   it('resolves re-export chain', () => {
@@ -51,16 +51,13 @@ describe('resolveIdentifier', () => {
     const id = getIdentifierUsage(routerFile, 'x');
     const result = resolveIdentifier(id, project);
     expect(result).not.toBeNull();
-    expect(result!.sourceFile.getFilePath()).toContain('user.ts');
-    expect(result!.exportName).toBe('userService');
+    expect(result?.sourceFile.getFilePath()).toContain('user.ts');
+    expect(result?.exportName).toBe('userService');
   });
 
   it('returns null for local variable (not imported)', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const local = 1;\nconst x = local;`,
-    );
+    const file = project.createSourceFile('test.ts', `const local = 1;\nconst x = local;`);
     const id = getIdentifierUsage(file, 'x');
     const result = resolveIdentifier(id, project);
     expect(result).toBeNull();
@@ -84,7 +81,7 @@ describe('resolveExport', () => {
     const file = project.createSourceFile('test.ts', `export const foo = 1;`);
     const result = resolveExport(file, 'foo', project);
     expect(result).not.toBeNull();
-    expect(result!.exportName).toBe('foo');
+    expect(result?.exportName).toBe('foo');
   });
 
   it('follows re-export to source', () => {
@@ -93,8 +90,8 @@ describe('resolveExport', () => {
     const fileA = project.createSourceFile('a.ts', `export { bar } from './b';`);
     const result = resolveExport(fileA, 'bar', project);
     expect(result).not.toBeNull();
-    expect(result!.sourceFile.getFilePath()).toContain('b.ts');
-    expect(result!.exportName).toBe('bar');
+    expect(result?.sourceFile.getFilePath()).toContain('b.ts');
+    expect(result?.exportName).toBe('bar');
   });
 });
 
@@ -121,10 +118,7 @@ describe('isFromImport', () => {
 
   it('returns false for local variable', () => {
     const project = createProject();
-    const file = project.createSourceFile(
-      'test.ts',
-      `const s = 1;\nconst x = s;`,
-    );
+    const file = project.createSourceFile('test.ts', `const s = 1;\nconst x = s;`);
     const id = getIdentifierUsage(file, 'x');
     expect(isFromImport(id, '@vertz/schema')).toBe(false);
   });

--- a/packages/compiler/src/utils/__tests__/schema-executor.test.ts
+++ b/packages/compiler/src/utils/__tests__/schema-executor.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createSchemaExecutor } from '../schema-executor';
 
 let tmpDir: string;
@@ -35,7 +35,7 @@ describe('createSchemaExecutor', () => {
     const executor = createSchemaExecutor(tmpDir);
     const result = await executor.execute('testSchema', filePath);
     expect(result).not.toBeNull();
-    expect(result!.jsonSchema).toHaveProperty('type', 'object');
+    expect(result?.jsonSchema).toHaveProperty('type', 'object');
   });
 
   it('execute returns null when file does not exist', async () => {
@@ -44,7 +44,7 @@ describe('createSchemaExecutor', () => {
     const result = await executor.execute('testSchema', path.join(tmpDir, 'nonexistent.js'));
     expect(result).toBeNull();
     expect(executor.getDiagnostics()).toHaveLength(1);
-    expect(executor.getDiagnostics()[0]!.code).toBe('VERTZ_SCHEMA_EXECUTION');
+    expect(executor.getDiagnostics().at(0)?.code).toBe('VERTZ_SCHEMA_EXECUTION');
   });
 
   it('execute returns null when export does not exist', async () => {
@@ -61,10 +61,7 @@ describe('createSchemaExecutor', () => {
 
   it('execute returns null when export has no toJSONSchema', async () => {
     setup();
-    const filePath = writeFile(
-      'user.js',
-      `export const testSchema = { name: 'not a schema' };`,
-    );
+    const filePath = writeFile('user.js', `export const testSchema = { name: 'not a schema' };`);
     const executor = createSchemaExecutor(tmpDir);
     const result = await executor.execute('testSchema', filePath);
     expect(result).toBeNull();
@@ -80,7 +77,7 @@ describe('createSchemaExecutor', () => {
     const executor = createSchemaExecutor(tmpDir);
     const result = await executor.execute('testSchema', filePath);
     expect(result).not.toBeNull();
-    expect(result!.jsonSchema).toHaveProperty('$defs');
+    expect(result?.jsonSchema).toHaveProperty('$defs');
   });
 
   it('getDiagnostics returns all accumulated errors', async () => {

--- a/packages/compiler/src/utils/ast-helpers.ts
+++ b/packages/compiler/src/utils/ast-helpers.ts
@@ -18,7 +18,11 @@ function matchPropertyAccess(
   const expr = call.getExpression();
   if (!expr.isKind(SyntaxKind.PropertyAccessExpression)) return null;
   const obj = expr.getExpression();
-  if (!obj.isKind(SyntaxKind.Identifier) || obj.getText() !== objectName || expr.getName() !== methodName) {
+  if (
+    !obj.isKind(SyntaxKind.Identifier) ||
+    obj.getText() !== objectName ||
+    expr.getName() !== methodName
+  ) {
     return null;
   }
   return expr;
@@ -29,9 +33,9 @@ export function findCallExpressions(
   objectName: string,
   methodName: string,
 ): CallExpression[] {
-  return file.getDescendantsOfKind(SyntaxKind.CallExpression).filter((call) =>
-    matchPropertyAccess(call, objectName, methodName) !== null,
-  );
+  return file
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((call) => matchPropertyAccess(call, objectName, methodName) !== null);
 }
 
 export function findMethodCallsOnVariable(
@@ -56,10 +60,7 @@ export function extractObjectLiteral(
   return null;
 }
 
-export function getPropertyValue(
-  obj: ObjectLiteralExpression,
-  key: string,
-): Expression | null {
+export function getPropertyValue(obj: ObjectLiteralExpression, key: string): Expression | null {
   for (const prop of obj.getProperties()) {
     if (prop.isKind(SyntaxKind.PropertyAssignment) && prop.getName() === key) {
       return prop.getInitializerOrThrow();
@@ -71,9 +72,7 @@ export function getPropertyValue(
   return null;
 }
 
-export function getProperties(
-  obj: ObjectLiteralExpression,
-): { name: string; value: Expression }[] {
+export function getProperties(obj: ObjectLiteralExpression): { name: string; value: Expression }[] {
   const result: { name: string; value: Expression }[] = [];
   for (const prop of obj.getProperties()) {
     if (prop.isKind(SyntaxKind.PropertyAssignment)) {
@@ -86,7 +85,10 @@ export function getProperties(
 }
 
 export function getStringValue(expr: Expression): string | null {
-  if (expr.isKind(SyntaxKind.StringLiteral) || expr.isKind(SyntaxKind.NoSubstitutionTemplateLiteral)) {
+  if (
+    expr.isKind(SyntaxKind.StringLiteral) ||
+    expr.isKind(SyntaxKind.NoSubstitutionTemplateLiteral)
+  ) {
     return expr.getLiteralValue();
   }
   return null;

--- a/packages/compiler/src/utils/import-resolver.ts
+++ b/packages/compiler/src/utils/import-resolver.ts
@@ -6,10 +6,7 @@ export interface ResolvedImport {
   exportName: string;
 }
 
-export function resolveIdentifier(
-  identifier: Identifier,
-  project: Project,
-): ResolvedImport | null {
+export function resolveIdentifier(identifier: Identifier, project: Project): ResolvedImport | null {
   const importInfo = findImportForIdentifier(identifier);
   if (!importInfo) return null;
 
@@ -38,7 +35,8 @@ export function resolveExport(
 
   const exportedDecls = file.getExportedDeclarations().get(exportName);
   if (exportedDecls && exportedDecls.length > 0) {
-    const decl = exportedDecls[0]!;
+    const decl = exportedDecls.at(0);
+    if (!decl) return null;
     return {
       declaration: decl,
       sourceFile: decl.getSourceFile(),
@@ -49,10 +47,7 @@ export function resolveExport(
   return null;
 }
 
-export function isFromImport(
-  identifier: Identifier,
-  moduleSpecifier: string,
-): boolean {
+export function isFromImport(identifier: Identifier, moduleSpecifier: string): boolean {
   const importInfo = findImportForIdentifier(identifier);
   if (!importInfo) return false;
   return importInfo.importDecl.getModuleSpecifierValue() === moduleSpecifier;

--- a/packages/compiler/src/utils/schema-executor.ts
+++ b/packages/compiler/src/utils/schema-executor.ts
@@ -6,10 +6,7 @@ export interface SchemaExecutionResult {
 }
 
 export interface SchemaExecutor {
-  execute(
-    schemaName: string,
-    sourceFile: string,
-  ): Promise<SchemaExecutionResult | null>;
+  execute(schemaName: string, sourceFile: string): Promise<SchemaExecutionResult | null>;
 
   getDiagnostics(): Diagnostic[];
 }
@@ -18,12 +15,14 @@ export function createSchemaExecutor(_rootDir: string): SchemaExecutor {
   const diagnostics: Diagnostic[] = [];
 
   function addError(message: string, file: string): null {
-    diagnostics.push(createDiagnostic({
-      severity: 'error',
-      code: 'VERTZ_SCHEMA_EXECUTION',
-      message,
-      file,
-    }));
+    diagnostics.push(
+      createDiagnostic({
+        severity: 'error',
+        code: 'VERTZ_SCHEMA_EXECUTION',
+        message,
+        file,
+      }),
+    );
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Replace all 269 `noNonNullAssertion` warnings and 30 `noNonNullAssertedOptionalChain` errors across 13 source and test files
- Pattern: `array[N]!.prop` → `array.at(N)?.prop` (safe in tests because `expect(undefined).toBe(x)` fails properly)
- Fix 3 source files (module-analyzer, schema-analyzer, import-resolver) with proper null guards using `.at()` + early returns
- Remove unused `SyntaxKind` import from schema-analyzer tests
- Apply biome auto-formatting across all compiler files
- Add "Never Skip Quality Gates" section to `.claude/rules/tdd.md`

## Test plan
- [x] All 277 compiler tests pass
- [x] Typecheck clean (`bun run typecheck`)
- [x] Biome lint: 0 errors, 1 warning (intentional test data), 3 infos (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)