### PR TITLE
test(schema): add type-level tests and fix type inference bugs

### DIFF
--- a/packages/schema/src/__tests__/schema-types.test-d.ts
+++ b/packages/schema/src/__tests__/schema-types.test-d.ts
@@ -1,0 +1,118 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { ReadonlySchema } from '../core/schema';
+import { s } from '../index';
+
+describe('optional', () => {
+  it('adds undefined to output', () => {
+    const schema = s.string().optional();
+    expectTypeOf(schema.parse(undefined)).toEqualTypeOf<string | undefined>();
+  });
+
+  it('rejects non-matching type', () => {
+    const schema = s.string().optional();
+    const result = schema.parse('hello');
+    // @ts-expect-error — string | undefined is not assignable to number
+    const _bad: number = result;
+    void _bad;
+  });
+});
+
+describe('nullable', () => {
+  it('adds null to output', () => {
+    const schema = s.string().nullable();
+    expectTypeOf(schema.parse(null)).toEqualTypeOf<string | null>();
+  });
+
+  it('rejects non-matching type', () => {
+    const schema = s.string().nullable();
+    const result = schema.parse('hello');
+    // @ts-expect-error — string | null is not assignable to number
+    const _bad: number = result;
+    void _bad;
+  });
+});
+
+describe('default', () => {
+  it('output excludes undefined', () => {
+    const schema = s.string().default('fallback');
+    expectTypeOf(schema.parse(undefined)).toEqualTypeOf<string>();
+
+    const result = schema.parse(undefined);
+    // @ts-expect-error — string is not assignable to undefined
+    const _bad: undefined = result;
+    void _bad;
+  });
+});
+
+describe('transform', () => {
+  it('changes output type', () => {
+    const schema = s.string().transform((v) => v.length);
+    expectTypeOf(schema.parse('hello')).toEqualTypeOf<number>();
+  });
+
+  it('rejects original type as output', () => {
+    const schema = s.string().transform((v) => v.length);
+    const result = schema.parse('hello');
+    // @ts-expect-error — number is not assignable to string
+    const _bad: string = result;
+    void _bad;
+  });
+});
+
+describe('pipe', () => {
+  it('changes output to second schema', () => {
+    const schema = s.string().transform(Number).pipe(s.number());
+    expectTypeOf(schema.parse('42')).toEqualTypeOf<number>();
+  });
+
+  it('rejects first schema output type', () => {
+    const schema = s.string().transform(Number).pipe(s.number());
+    const result = schema.parse('42');
+    // @ts-expect-error — number is not assignable to string
+    const _bad: string = result;
+    void _bad;
+  });
+});
+
+describe('brand', () => {
+  it('plain value not assignable to branded', () => {
+    const schema = s.string().brand<'UserId'>();
+    type UserId = ReturnType<typeof schema.parse>;
+    const plain = 'hello';
+    // @ts-expect-error — plain string is not assignable to branded string
+    const _bad: UserId = plain;
+    void _bad;
+  });
+});
+
+describe('readonly', () => {
+  it('makes output properties readonly', () => {
+    type Obj = { name: string };
+    type RO = ReadonlySchema<Readonly<Obj>, Obj>;
+    const result = {} as RO['_output'];
+    // @ts-expect-error — cannot assign to readonly property
+    result.name = 'changed';
+  });
+});
+
+describe('catch', () => {
+  it('preserves output type', () => {
+    const schema = s.string().catch('default');
+    expectTypeOf(schema.parse(undefined)).toEqualTypeOf<string>();
+  });
+});
+
+describe('refine', () => {
+  it('preserves schema output type', () => {
+    const schema = s.string().refine((v) => v.length > 0);
+    expectTypeOf(schema.parse('hello')).toEqualTypeOf<string>();
+  });
+
+  it('rejects wrong type', () => {
+    const schema = s.string().refine((v) => v.length > 0);
+    const result = schema.parse('hello');
+    // @ts-expect-error — string is not assignable to number
+    const _bad: number = result;
+    void _bad;
+  });
+});

--- a/packages/schema/src/core/schema.ts
+++ b/packages/schema/src/core/schema.ts
@@ -180,8 +180,8 @@ export abstract class Schema<O, I = O> {
     return new BrandedSchema(this);
   }
 
-  readonly(): ReadonlySchema<Readonly<O>, I> {
-    return new ReadonlySchema(this);
+  readonly(): ReadonlySchema<O extends object ? Readonly<O> : O, I> {
+    return new ReadonlySchema(this) as ReadonlySchema<O extends object ? Readonly<O> : O, I>;
   }
 
   _runPipeline(value: unknown, ctx: ParseContext): O {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -178,7 +178,8 @@ export const s = {
     new LiteralSchema(value),
   union: <T extends [SchemaAny, ...SchemaAny[]]>(options: [...T]): UnionSchema<T> =>
     new UnionSchema(options),
-  discriminatedUnion: <T extends [ObjectSchema, ...ObjectSchema[]]>(
+  // biome-ignore lint/suspicious/noExplicitAny: ObjectSchema<any> needed for covariant constraint on concrete shapes
+  discriminatedUnion: <T extends [ObjectSchema<any>, ...ObjectSchema<any>[]]>(
     discriminator: string,
     options: [...T],
   ): DiscriminatedUnionSchema<T> => new DiscriminatedUnionSchema(discriminator, options),

--- a/packages/schema/src/schemas/__tests__/composite-types.test-d.ts
+++ b/packages/schema/src/schemas/__tests__/composite-types.test-d.ts
@@ -1,0 +1,90 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { s } from '../../index';
+
+describe('tuple', () => {
+  it('infers positional types', () => {
+    const schema = s.tuple([s.string(), s.number()]);
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<[string, number]>();
+  });
+
+  it('rejects wrong positional type', () => {
+    const schema = s.tuple([s.string(), s.number()]);
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — [string, string] is not assignable to [string, number]
+    const _bad: Output = ['hello', 'world'];
+    void _bad;
+  });
+
+  it('requires at least one item', () => {
+    // @ts-expect-error — empty tuple is not assignable to [SchemaAny, ...SchemaAny[]]
+    s.tuple([]);
+  });
+});
+
+describe('union', () => {
+  it('infers union of option types', () => {
+    const schema = s.union([s.string(), s.number()]);
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<string | number>();
+  });
+
+  it('rejects types not in union', () => {
+    const schema = s.union([s.string(), s.number()]);
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — boolean is not assignable to string | number
+    const _bad: Output = true;
+    void _bad;
+  });
+
+  it('requires at least one option', () => {
+    // @ts-expect-error — empty array is not assignable to [SchemaAny, ...SchemaAny[]]
+    s.union([]);
+  });
+});
+
+describe('discriminatedUnion', () => {
+  it('infers discriminated output', () => {
+    const schema = s.discriminatedUnion('type', [
+      s.object({ type: s.literal('a'), value: s.string() }),
+      s.object({ type: s.literal('b'), count: s.number() }),
+    ]);
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<
+      { type: 'a'; value: string } | { type: 'b'; count: number }
+    >();
+  });
+
+  it('requires at least one option', () => {
+    // @ts-expect-error — empty array is not assignable to [ObjectSchema, ...ObjectSchema[]]
+    s.discriminatedUnion('type', []);
+  });
+});
+
+describe('intersection', () => {
+  it('infers intersection of both', () => {
+    const schema = s.intersection(s.object({ name: s.string() }), s.object({ age: s.number() }));
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string } & { age: number }>();
+  });
+
+  it('rejects missing properties', () => {
+    const schema = s.intersection(s.object({ name: s.string() }), s.object({ age: s.number() }));
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — missing 'age' from intersection
+    const _bad: Output = { name: 'hello' };
+    void _bad;
+  });
+});
+
+describe('enum', () => {
+  it('infers union of literal values', () => {
+    const schema = s.enum(['red', 'green', 'blue'] as const);
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<'red' | 'green' | 'blue'>();
+
+    // @ts-expect-error — 'yellow' is not in the enum
+    const _bad: Output = 'yellow';
+    void _bad;
+  });
+});

--- a/packages/schema/src/schemas/__tests__/object-types.test-d.ts
+++ b/packages/schema/src/schemas/__tests__/object-types.test-d.ts
@@ -1,0 +1,91 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { s } from '../../index';
+
+describe('shape inference', () => {
+  it('infers correct shape', () => {
+    const schema = s.object({ name: s.string(), age: s.number() });
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string; age: number }>();
+  });
+
+  it('rejects missing required properties', () => {
+    const schema = s.object({ name: s.string(), age: s.number() });
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — missing 'age' property
+    const _bad: Output = { name: 'hello' };
+    void _bad;
+  });
+
+  it('rejects extra properties', () => {
+    const schema = s.object({ name: s.string() });
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — 'extra' does not exist on type
+    const _bad: Output = { name: 'hello', extra: true };
+    void _bad;
+  });
+});
+
+describe('partial', () => {
+  it('makes all properties optional', () => {
+    const schema = s.object({ name: s.string(), age: s.number() }).partial();
+    type Output = ReturnType<typeof schema.parse>;
+    expectTypeOf<Output>().toMatchTypeOf<{
+      name: string | undefined;
+      age: number | undefined;
+    }>();
+  });
+
+  it('rejects wrong property types', () => {
+    const schema = s.object({ name: s.string() }).partial();
+    type Output = ReturnType<typeof schema.parse>;
+    // @ts-expect-error — boolean is not assignable to string | undefined
+    const _bad: Output = { name: true };
+    void _bad;
+  });
+});
+
+describe('pick', () => {
+  it('keeps only specified keys', () => {
+    const schema = s.object({ name: s.string(), age: s.number(), active: s.boolean() });
+    const picked = schema.pick('name', 'age');
+    type Output = ReturnType<typeof picked.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string; age: number }>();
+  });
+
+  it('rejects omitted keys', () => {
+    const schema = s.object({ name: s.string(), age: s.number(), active: s.boolean() });
+    const picked = schema.pick('name');
+    type Output = ReturnType<typeof picked.parse>;
+    // @ts-expect-error — 'age' does not exist on picked type
+    const _check: Output = { name: 'hello', age: 42 };
+    void _check;
+  });
+});
+
+describe('omit', () => {
+  it('removes specified keys', () => {
+    const schema = s.object({ name: s.string(), age: s.number(), active: s.boolean() });
+    const omitted = schema.omit('active');
+    type Output = ReturnType<typeof omitted.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string; age: number }>();
+  });
+});
+
+describe('extend', () => {
+  it('adds new properties', () => {
+    const base = s.object({ name: s.string() });
+    const extended = base.extend({ age: s.number() });
+    type Output = ReturnType<typeof extended.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string; age: number }>();
+  });
+});
+
+describe('merge', () => {
+  it('combines two object schemas', () => {
+    const a = s.object({ name: s.string() });
+    const b = s.object({ age: s.number() });
+    const merged = a.merge(b);
+    type Output = ReturnType<typeof merged.parse>;
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string; age: number }>();
+  });
+});

--- a/packages/schema/src/schemas/discriminated-union.ts
+++ b/packages/schema/src/schemas/discriminated-union.ts
@@ -6,9 +6,13 @@ import type { JSONSchemaObject, RefTracker } from '../introspection/json-schema'
 import { LiteralSchema } from './literal';
 import type { ObjectSchema } from './object';
 
-type DiscriminatedOptions = [ObjectSchema, ...ObjectSchema[]];
-type InferDiscriminatedUnion<T extends DiscriminatedOptions> =
-  T[number] extends Schema<infer O> ? O : never;
+// biome-ignore lint/suspicious/noExplicitAny: ObjectSchema<any> needed for covariant constraint on concrete shapes
+type DiscriminatedOptions = [ObjectSchema<any>, ...ObjectSchema<any>[]];
+type InferDiscriminatedUnion<T extends DiscriminatedOptions> = T[number] extends infer U
+  ? U extends Schema<infer O>
+    ? O
+    : never
+  : never;
 
 function receivedType(value: unknown): string {
   if (value === null) return 'null';
@@ -21,7 +25,8 @@ export class DiscriminatedUnionSchema<T extends DiscriminatedOptions> extends Sc
 > {
   private readonly _discriminator: string;
   private readonly _options: T;
-  private readonly _lookup: Map<unknown, ObjectSchema>;
+  // biome-ignore lint/suspicious/noExplicitAny: erased shape type for runtime lookup
+  private readonly _lookup: Map<unknown, ObjectSchema<any>>;
 
   constructor(discriminator: string, options: T) {
     super();

--- a/packages/schema/src/schemas/union.ts
+++ b/packages/schema/src/schemas/union.ts
@@ -5,7 +5,11 @@ import { SchemaType } from '../core/types';
 import type { JSONSchemaObject, RefTracker } from '../introspection/json-schema';
 
 type UnionOptions = [SchemaAny, ...SchemaAny[]];
-type InferUnion<T extends UnionOptions> = T[number] extends Schema<infer O> ? O : never;
+type InferUnion<T extends UnionOptions> = T[number] extends infer U
+  ? U extends Schema<infer O>
+    ? O
+    : never
+  : never;
 
 export class UnionSchema<T extends UnionOptions> extends Schema<InferUnion<T>> {
   private readonly _options: T;

--- a/packages/schema/src/utils/__tests__/infer-types.test-d.ts
+++ b/packages/schema/src/utils/__tests__/infer-types.test-d.ts
@@ -1,0 +1,35 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { s } from '../../index';
+import type { Infer, Input, Output } from '../type-inference';
+
+describe('Infer', () => {
+  it('extracts output type', () => {
+    const schema = s.string();
+    expectTypeOf<Infer<typeof schema>>().toEqualTypeOf<string>();
+  });
+
+  it('rejects non-schema types', () => {
+    // @ts-expect-error — string is not a schema type
+    type _Bad = Infer<string>;
+  });
+});
+
+describe('Input', () => {
+  it('differs from output on transform', () => {
+    const schema = s.string().transform((v) => v.length);
+    expectTypeOf<Input<typeof schema>>().toEqualTypeOf<string>();
+    expectTypeOf<Infer<typeof schema>>().toEqualTypeOf<number>();
+  });
+
+  it('rejects non-schema types', () => {
+    // @ts-expect-error — number is not a schema type
+    type _Bad = Input<number>;
+  });
+});
+
+describe('Output', () => {
+  it('equivalent to Infer', () => {
+    const schema = s.number();
+    expectTypeOf<Output<typeof schema>>().toEqualTypeOf<Infer<typeof schema>>();
+  });
+});

--- a/packages/schema/tsconfig.typecheck.json
+++ b/packages/schema/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "skipLibCheck": true
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -1,9 +1,19 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test-d.ts'],
     environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.test-d.ts'],
+      ignoreSourceErrors: true,
+      tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
+    },
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Add 40 type-level tests (`.test-d.ts`) across 4 files to lock down `@vertz/schema` type behavior, guarding PR #80 fixes
- Fix 4 pre-existing type bugs discovered during test authoring:
  - `ReadonlySchema` variance (`Readonly<any>` ≠ `any` in TS 5.9)
  - `InferUnion` / `InferDiscriminatedUnion` non-distributive conditional types (union output was `never`)
  - `DiscriminatedOptions` constraint too narrow for concrete `ObjectSchema` shapes

## Test plan
- [x] `bun run --filter '@vertz/schema' test` — 372 tests pass (292 runtime + 40 type × 2 runs)
- [x] `bun run typecheck` — 0 errors across all packages
- [x] `bunx biome check .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)