### PR TITLE
fix(compiler): close implementation gaps in IR assembly, incremental compilation, and typecheck watch

### DIFF
--- a/packages/compiler/src/__tests__/typecheck.test.ts
+++ b/packages/compiler/src/__tests__/typecheck.test.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import { parseTscOutput, typecheck } from '../typecheck';
+import { parseTscOutput, parseWatchBlock, typecheck, typecheckWatch } from '../typecheck';
 
 describe('typecheck', () => {
   it('returns success for valid project', async () => {
@@ -44,5 +45,78 @@ describe('parseTscOutput', () => {
     const diagnostics = parseTscOutput('');
 
     expect(diagnostics).toEqual([]);
+  });
+});
+
+describe('parseWatchBlock', () => {
+  it('parses a clean watch compilation', () => {
+    const block = [
+      '[12:00:00] Starting compilation in watch mode...',
+      '[12:00:01] Found 0 errors. Watching for file changes.',
+    ].join('\n');
+
+    const result = parseWatchBlock(block);
+
+    expect(result.success).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('parses a watch compilation with errors', () => {
+    const block = [
+      '[12:00:00] File change detected. Starting incremental compilation...',
+      "src/app.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.",
+      '[12:00:01] Found 1 error. Watching for file changes.',
+    ].join('\n');
+
+    const result = parseWatchBlock(block);
+
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].file).toBe('src/app.ts');
+  });
+});
+
+describe('typecheckWatch', () => {
+  it('yields a result for each compilation cycle', async () => {
+    const stdout = new EventEmitter();
+    const proc = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr: new EventEmitter(),
+      kill: () => true,
+    });
+    const spawner = () => proc as ReturnType<typeof import('node:child_process').spawn>;
+
+    const watcher = typecheckWatch({ spawner });
+    const results: Awaited<ReturnType<typeof parseWatchBlock>>[] = [];
+
+    const collecting = (async () => {
+      for await (const result of watcher) {
+        results.push(result);
+        if (results.length >= 2) break;
+      }
+    })();
+
+    // Simulate first compilation (clean)
+    stdout.emit(
+      'data',
+      Buffer.from(
+        '[12:00:00] Starting compilation in watch mode...\n[12:00:01] Found 0 errors. Watching for file changes.\n',
+      ),
+    );
+
+    // Simulate second compilation (with error)
+    stdout.emit(
+      'data',
+      Buffer.from(
+        "[12:00:02] File change detected. Starting incremental compilation...\nsrc/app.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n[12:00:03] Found 1 error. Watching for file changes.\n",
+      ),
+    );
+
+    await collecting;
+
+    expect(results).toHaveLength(2);
+    expect(results[0].success).toBe(true);
+    expect(results[1].success).toBe(false);
+    expect(results[1].diagnostics).toHaveLength(1);
   });
 });

--- a/packages/compiler/src/generators/__tests__/__snapshots__/openapi-generator.test.ts.snap
+++ b/packages/compiler/src/generators/__tests__/__snapshots__/openapi-generator.test.ts.snap
@@ -395,3 +395,399 @@ exports[`OpenAPIGenerator > snapshot tests > snapshot: multi-module CRUD API 1`]
   ],
 }
 `;
+
+exports[`OpenAPIGenerator snapshot tests snapshot: discriminated union response 1`] = `
+{
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+          },
+          "status": {
+            "const": "error",
+          },
+        },
+        "required": [
+          "status",
+        ],
+        "type": "object",
+      },
+      "SuccessResponse": {
+        "properties": {
+          "data": {
+            "type": "object",
+          },
+          "status": {
+            "const": "success",
+          },
+        },
+        "required": [
+          "status",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "Union API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/result": {
+      "get": {
+        "operationId": "getResult",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "discriminator": {
+                    "propertyName": "status",
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse",
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse",
+                    },
+                  ],
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "results",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "/api",
+    },
+  ],
+  "tags": [
+    {
+      "name": "results",
+    },
+  ],
+}
+`;
+
+exports[`OpenAPIGenerator snapshot tests snapshot: middleware headers in spec 1`] = `
+{
+  "components": {
+    "schemas": {},
+  },
+  "info": {
+    "title": "Auth API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "user_list",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "header",
+            "name": "x-request-id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "/api",
+    },
+  ],
+  "tags": [
+    {
+      "name": "users",
+    },
+  ],
+}
+`;
+
+exports[`OpenAPIGenerator snapshot tests snapshot: minimal single-route API 1`] = `
+{
+  "components": {
+    "schemas": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "operationId": "user_getById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "/api",
+    },
+  ],
+  "tags": [
+    {
+      "name": "users",
+    },
+  ],
+}
+`;
+
+exports[`OpenAPIGenerator snapshot tests snapshot: multi-module CRUD API 1`] = `
+{
+  "components": {
+    "schemas": {
+      "CreateUserBody": {
+        "properties": {
+          "email": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "email",
+        ],
+        "type": "object",
+      },
+      "ReadUserResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "CRUD API",
+    "version": "2.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "user_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadUserResponse",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+      "post": {
+        "operationId": "user_create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserBody",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadUserResponse",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+    },
+    "/users/{id}": {
+      "delete": {
+        "operationId": "user_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+      "get": {
+        "operationId": "user_getById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadUserResponse",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+      "put": {
+        "operationId": "user_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserBody",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadUserResponse",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+        "tags": [
+          "users",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "/api",
+    },
+  ],
+  "tags": [
+    {
+      "name": "users",
+    },
+  ],
+}
+`;

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from './analyzers/service-analyzer';
 // Compiler
 export type { CompileResult, CompilerDependencies, Validator } from './compiler';
-export { Compiler } from './compiler';
+export { Compiler, createCompiler } from './compiler';
 // Config
 export type {
   CompilerConfig,
@@ -136,7 +136,7 @@ export type {
   FileChange,
   IncrementalResult,
 } from './incremental';
-export { categorizeChanges, IncrementalCompiler } from './incremental';
+export { categorizeChanges, findAffectedModules, IncrementalCompiler } from './incremental';
 // IR builders
 export {
   addDiagnosticsToIR,
@@ -176,8 +176,13 @@ export type {
   SourceLocation,
 } from './ir/types';
 // Typecheck
-export type { TypecheckDiagnostic, TypecheckOptions, TypecheckResult } from './typecheck';
-export { parseTscOutput, typecheck } from './typecheck';
+export type {
+  TypecheckDiagnostic,
+  TypecheckOptions,
+  TypecheckResult,
+  TypecheckWatchOptions,
+} from './typecheck';
+export { parseTscOutput, parseWatchBlock, typecheck, typecheckWatch } from './typecheck';
 // AST helpers
 export {
   extractObjectLiteral,

--- a/packages/compiler/src/ir/merge.ts
+++ b/packages/compiler/src/ir/merge.ts
@@ -13,6 +13,7 @@ export function mergeIR(base: AppIR, partial: Partial<AppIR>): AppIR {
     modules: mergeByName(base.modules, partial.modules),
     schemas: mergeByName(base.schemas, partial.schemas),
     middleware: mergeByName(base.middleware, partial.middleware),
+    dependencyGraph: partial.dependencyGraph ?? base.dependencyGraph,
     diagnostics: [],
   };
 }

--- a/packages/compiler/src/typecheck.ts
+++ b/packages/compiler/src/typecheck.ts
@@ -1,4 +1,5 @@
-import { execFile } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 
 export interface TypecheckDiagnostic {
   file: string;
@@ -32,6 +33,74 @@ export function parseTscOutput(output: string): TypecheckDiagnostic[] {
     match = pattern.exec(output);
   }
   return diagnostics;
+}
+
+export function parseWatchBlock(block: string): TypecheckResult {
+  const diagnostics = parseTscOutput(block);
+  const foundMatch = /Found (\d+) error/.exec(block);
+  const errorCount = foundMatch ? Number.parseInt(foundMatch[1], 10) : diagnostics.length;
+  return {
+    success: errorCount === 0,
+    diagnostics,
+  };
+}
+
+export interface TypecheckWatchOptions extends TypecheckOptions {
+  spawner?: () => ChildProcess;
+}
+
+export async function* typecheckWatch(
+  options: TypecheckWatchOptions = {},
+): AsyncGenerator<TypecheckResult> {
+  const proc =
+    options.spawner?.() ??
+    spawn(
+      'tsc',
+      ['--noEmit', '--watch', ...(options.tsconfigPath ? ['--project', options.tsconfigPath] : [])],
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+  const completionMarker = /Found \d+ error/;
+  let buffer = '';
+
+  const results: TypecheckResult[] = [];
+  let resolve: (() => void) | null = null;
+  let done = false;
+
+  const onData = (chunk: Buffer) => {
+    buffer += chunk.toString();
+    if (completionMarker.test(buffer)) {
+      const result = parseWatchBlock(buffer);
+      buffer = '';
+      results.push(result);
+      resolve?.();
+    }
+  };
+
+  proc.stdout?.on('data', onData);
+  proc.stderr?.on('data', onData);
+
+  proc.on('close', () => {
+    done = true;
+    resolve?.();
+  });
+
+  try {
+    while (!done || results.length > 0) {
+      const next = results.shift();
+      if (next) {
+        yield next;
+      } else if (!done) {
+        await new Promise<void>((r) => {
+          resolve = r;
+        });
+      }
+    }
+  } finally {
+    proc.kill();
+  }
 }
 
 export async function typecheck(options: TypecheckOptions = {}): Promise<TypecheckResult> {


### PR DESCRIPTION
## Summary

Closes implementation gaps discovered after merging the compiler design plan (phases 1-12):

- **Typed analyzer results** — `CompilerDependencies` used `Analyzer<unknown>` for all analyzers. Now properly typed with `EnvAnalyzerResult`, `SchemaAnalyzerResult`, etc. The `analyze()` method was ignoring analyzer return values — now correctly assembles IR from results.
- **`createCompiler()` factory** — New convenience function that wires up all real analyzers, validators, and generators with a ts-morph `Project`.
- **`findAffectedModules()`** — Incremental compilation returned empty `affectedModules`. Now maps file changes to owning module names via sourceFile matching (module files, service files, router files, schema files by directory containment).
- **`mergeIR()` dependency graph** — Was silently dropping `dependencyGraph` on incremental merge. Fixed to preserve or replace graph data.
- **`typecheckWatch()` async generator** — New streaming interface for `tsc --watch` integration. Includes `parseWatchBlock()` for parsing individual watch compilation cycles.
- **Updated exports** — `createCompiler`, `typecheckWatch`, `parseWatchBlock`, `TypecheckWatchOptions` added to public API.

Design plan: [plans/vertz-compiler-design.md](./plans/vertz-compiler-design.md)

## Test plan

- [x] 582 tests pass, 0 failures
- [x] `bun run typecheck` — all 4 packages clean
- [x] `bunx biome check` — no lint/format issues
- [x] New tests cover: typed IR assembly, createCompiler instantiation, parseWatchBlock (clean + error), typecheckWatch async generator with simulated stdout, findAffectedModules (module/service/router/schema file changes + dedup), affectedModules in incremental handleChanges, mergeIR dependency graph replace + preserve
- [x] Pre-push CI (Dagger) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)