### PR TITLE
feat(core): validate body, query, and headers schemas at runtime

### DIFF
--- a/packages/core/src/app/__tests__/schema-validation.test.ts
+++ b/packages/core/src/app/__tests__/schema-validation.test.ts
@@ -76,4 +76,195 @@ describe('Schema Validation', () => {
     expect(response.status).toBe(200);
     expect(receivedParams).toEqual({ id: 123 }); // Should be parsed to number
   });
+
+  it('validates body using schema when provided', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/users' });
+
+    const bodySchema = {
+      parse: (value: unknown) => {
+        const body = value as Record<string, unknown>;
+        if (typeof body.name !== 'string' || body.name.length === 0) {
+          throw new BadRequestException('name is required');
+        }
+        return { name: body.name };
+      },
+    };
+
+    let receivedBody: unknown;
+    router.post('/', {
+      body: bodySchema,
+      handler: (ctx: HandlerCtx) => {
+        receivedBody = ctx.body;
+        return { created: true };
+      },
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice' }),
+    });
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(200);
+    expect(receivedBody).toEqual({ name: 'Alice' });
+  });
+
+  it('rejects request when body fails schema validation', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/users' });
+
+    const bodySchema = {
+      parse: (value: unknown) => {
+        const body = value as Record<string, unknown>;
+        if (typeof body.name !== 'string' || body.name.length === 0) {
+          throw new BadRequestException('name is required');
+        }
+        return { name: body.name };
+      },
+    };
+
+    router.post('/', {
+      body: bodySchema,
+      handler: () => ({ created: true }),
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('validates query using schema when provided', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/users' });
+
+    const querySchema = {
+      parse: (value: unknown) => {
+        const query = value as Record<string, unknown>;
+        if (query.page !== undefined) {
+          const page = Number(query.page);
+          if (Number.isNaN(page)) {
+            throw new BadRequestException('page must be a number');
+          }
+          return { page };
+        }
+        return {};
+      },
+    };
+
+    router.get('/', {
+      query: querySchema,
+      handler: () => ({ users: [] }),
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/users?page=abc');
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('passes validated query to handler', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/users' });
+
+    const querySchema = {
+      parse: (value: unknown) => {
+        const query = value as Record<string, unknown>;
+        return { page: Number(query.page ?? 1) };
+      },
+    };
+
+    let receivedQuery: unknown;
+    router.get('/', {
+      query: querySchema,
+      handler: (ctx: HandlerCtx) => {
+        receivedQuery = ctx.query;
+        return { users: [] };
+      },
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/users?page=3');
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(200);
+    expect(receivedQuery).toEqual({ page: 3 });
+  });
+
+  it('validates headers using schema when provided', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/data' });
+
+    const headersSchema = {
+      parse: (value: unknown) => {
+        const headers = value as Record<string, unknown>;
+        if (!headers['x-api-key']) {
+          throw new BadRequestException('x-api-key is required');
+        }
+        return { 'x-api-key': headers['x-api-key'] };
+      },
+    };
+
+    router.get('/', {
+      headers: headersSchema,
+      handler: () => ({ data: [] }),
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/data');
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('passes validated headers to handler', async () => {
+    const moduleDef = createModuleDef({ name: 'test' });
+    const router = moduleDef.router({ prefix: '/data' });
+
+    const headersSchema = {
+      parse: (value: unknown) => {
+        const headers = value as Record<string, unknown>;
+        return { 'x-api-key': headers['x-api-key'] };
+      },
+    };
+
+    let receivedHeaders: unknown;
+    router.get('/', {
+      headers: headersSchema,
+      handler: (ctx: HandlerCtx) => {
+        receivedHeaders = ctx.headers;
+        return { data: [] };
+      },
+    });
+
+    const module = createModule(moduleDef, { services: [], routers: [router], exports: [] });
+    const app = createApp({}).register(module);
+
+    const request = new Request('http://localhost/data', {
+      headers: { 'x-api-key': 'secret123' },
+    });
+    const response = await app.handler(request);
+
+    expect(response.status).toBe(200);
+    expect(receivedHeaders).toEqual({ 'x-api-key': 'secret123' });
+  });
 });


### PR DESCRIPTION
## Summary

- **Body, query, and headers schemas are now validated at runtime** — previously only `params` was validated via `.parse()` before building the handler context. The other schemas were only used for TypeScript type inference.
- Schema validation errors are wrapped as `BadRequestException` (400) regardless of the error type thrown by the schema
- Applied the same fix to `@vertz/testing`'s `test-app.ts` for consistency

### Before

```typescript
router.post('/', {
  body: s.object({ name: s.string().min(1) }),
  handler: (ctx) => {
    // ctx.body had TypeScript types but NO runtime validation
    // Invalid body would reach the handler unchecked
  },
});
```

### After

```typescript
router.post('/', {
  body: s.object({ name: s.string().min(1) }),
  handler: (ctx) => {
    // ctx.body is validated AND typed
    // Invalid body → 400 BadRequestException before handler runs
  },
});
```

### Files changed

- `packages/core/src/app/app-runner.ts` — Added `bodySchema`, `querySchema`, `headersSchema` to `RouteEntry`. Added `validateSchema()` helper that wraps errors as `BadRequestException`.
- `packages/testing/src/test-app.ts` — Same changes for consistency with the core runtime.
- Test files with 14 new test cases covering valid/invalid body, query, and headers validation in both packages.

## Test plan

- [x] 1069 tests pass, 0 failures
- [x] `bun run typecheck` — all 4 packages clean
- [x] `bunx biome check` — no issues
- [x] Pre-push CI (Dagger) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)