### PR TITLE
fix(ci): fix release workflow auth and CLI bin entry

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "changelog": ["@changesets/changelog-github", { "repo": "vertz-dev/vertz" }],
   "commit": false,
-  "fixed": [["@vertz/schema", "@vertz/core", "@vertz/compiler", "@vertz/testing"]],
+  "fixed": [["@vertz/schema", "@vertz/core", "@vertz/compiler", "@vertz/testing", "@vertz/cli"]],
   "ignore": [],
   "linked": [],
   "updateInternalDependencies": "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          NODE_AUTH_TOKEN: ""
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/bin/vertz.ts
+++ b/packages/cli/bin/vertz.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { createCLI } from '../src/cli';
 
 const program = createCLI();

--- a/packages/cli/bunup.config.ts
+++ b/packages/cli/bunup.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from 'bunup';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
-  dts: true,
-  clean: true,
-  external: ['@vertz/compiler', 'commander', 'jiti'],
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    external: ['@vertz/compiler', 'commander', 'jiti'],
+  },
+  {
+    entry: ['bin/vertz.ts'],
+    format: ['esm'],
+    dts: false,
+    clean: false,
+    external: ['@vertz/compiler', 'commander', 'jiti'],
+    banner: '#!/usr/bin/env node',
+  },
+]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "provenance": true
   },
   "bin": {
-    "vertz": "./bin/vertz.ts"
+    "vertz": "./dist/vertz.js"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,8 +24,7 @@
     }
   },
   "files": [
-    "dist",
-    "bin"
+    "dist"
   ],
   "scripts": {
     "build": "bunup",


### PR DESCRIPTION
## Summary

- **`NODE_AUTH_TOKEN`** was hardcoded to `""` in `release.yml` — every push to main failed with `ENEEDAUTH`. Now reads from `secrets.NPM_TOKEN`
- **CLI `bin` entry** pointed to `./bin/vertz.ts` — npm rejects `.ts` bin entries and silently removes them during publish. Now compiles via bunup to `dist/vertz.js`
- **`@vertz/cli` missing from changeset `fixed` group** — could version independently from other packages. Added to the fixed array

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, verify the release workflow creates a "Version Packages" PR (or publishes if no pending changesets)
- [ ] Verify `@vertz/cli` bin works: `bun run --filter @vertz/cli build && node packages/cli/dist/vertz.js --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)