### PR TITLE
feat(fetch): add @vertz/fetch shared HTTP client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,16 @@
         "vitest": "^3.0.0",
       },
     },
+    "packages/fetch": {
+      "name": "@vertz/fetch",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "bunup": "latest",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
     "packages/integration-tests": {
       "name": "@vertz/integration-tests",
       "version": "0.0.0",
@@ -413,6 +423,8 @@
     "@vertz/compiler": ["@vertz/compiler@workspace:packages/compiler"],
 
     "@vertz/core": ["@vertz/core@workspace:packages/core"],
+
+    "@vertz/fetch": ["@vertz/fetch@workspace:packages/fetch"],
 
     "@vertz/integration-tests": ["@vertz/integration-tests@workspace:packages/integration-tests"],
 
@@ -818,6 +830,10 @@
 
     "@vertz/core/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
+    "@vertz/fetch/@types/node": ["@types/node@22.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A=="],
+
+    "@vertz/fetch/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
     "@vertz/integration-tests/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "@vertz/schema/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
@@ -881,6 +897,26 @@
     "@vertz/core/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "@vertz/core/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@vertz/fetch/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@vertz/fetch/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vertz/fetch/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vertz/fetch/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vertz/fetch/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vertz/fetch/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vertz/fetch/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vertz/fetch/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vertz/fetch/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "@vertz/fetch/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "@vertz/integration-tests/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@vertz/fetch",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "packages/fetch"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bunup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "bunup": "latest",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/fetch/src/client.test.ts
+++ b/packages/fetch/src/client.test.ts
@@ -1,0 +1,577 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FetchClient } from './client';
+import { FetchError, NotFoundError } from './errors';
+
+describe('FetchClient', () => {
+  it('can be instantiated with minimal config', () => {
+    const client = new FetchClient({ baseURL: 'http://localhost:3000' });
+
+    expect(client).toBeInstanceOf(FetchClient);
+  });
+});
+
+describe('FetchClient.request', () => {
+  it('makes a GET request to the correct URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const result = await client.request('GET', '/api/users');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('http://localhost:3000/api/users');
+    expect(result.data).toEqual({ id: 1 });
+    expect(result.status).toBe(200);
+  });
+
+  it('sends JSON body with POST request', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, name: 'Alice' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const result = await client.request('POST', '/api/users', {
+      body: { name: 'Alice' },
+    });
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.method).toBe('POST');
+    const sentBody = await request.json();
+    expect(sentBody).toEqual({ name: 'Alice' });
+    expect(request.headers.get('Content-Type')).toBe('application/json');
+    expect(result.data).toEqual({ id: 1, name: 'Alice' });
+    expect(result.status).toBe(201);
+  });
+
+  it('appends query parameters to the URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users', {
+      query: { page: 1, limit: 10, search: 'alice' },
+    });
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    const url = new URL(request.url);
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.get('limit')).toBe('10');
+    expect(url.searchParams.get('search')).toBe('alice');
+  });
+
+  it('throws NotFoundError for 404 response', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/users/999')).rejects.toThrow(NotFoundError);
+
+    try {
+      await client.request('GET', '/api/users/999');
+    } catch (error) {
+      expect(error).toBeInstanceOf(FetchError);
+      expect((error as NotFoundError).status).toBe(404);
+      expect((error as NotFoundError).body).toEqual({ error: 'not_found' });
+    }
+  });
+
+  it('merges config headers with per-request headers', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      headers: { 'X-Api-Version': '2', Accept: 'application/json' },
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users', {
+      headers: { 'X-Request-Id': 'abc-123' },
+    });
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('X-Api-Version')).toBe('2');
+    expect(request.headers.get('Accept')).toBe('application/json');
+    expect(request.headers.get('X-Request-Id')).toBe('abc-123');
+  });
+
+  it('applies bearer auth strategy with static token', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [{ type: 'bearer', token: 'my-token-123' }],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Authorization')).toBe('Bearer my-token-123');
+  });
+
+  it('applies bearer auth with dynamic token function', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const tokenFn = vi.fn().mockResolvedValue('dynamic-token');
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [{ type: 'bearer', token: tokenFn }],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    expect(tokenFn).toHaveBeenCalledOnce();
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Authorization')).toBe('Bearer dynamic-token');
+  });
+
+  it('applies basic auth strategy', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [{ type: 'basic', username: 'admin', password: 'secret' }],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    const expected = `Basic ${btoa('admin:secret')}`;
+    expect(request.headers.get('Authorization')).toBe(expected);
+  });
+
+  it('applies apiKey strategy to header', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [
+        { type: 'apiKey', key: 'my-api-key', location: 'header', name: 'X-API-Key' },
+      ],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('X-API-Key')).toBe('my-api-key');
+  });
+
+  it('applies apiKey strategy to query', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [{ type: 'apiKey', key: 'my-api-key', location: 'query', name: 'api_key' }],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    const url = new URL(request.url);
+    expect(url.searchParams.get('api_key')).toBe('my-api-key');
+  });
+
+  it('applies custom auth strategy', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [
+        {
+          type: 'custom',
+          apply: (request) => {
+            request.headers.set('X-Custom-Auth', 'custom-value');
+            return request;
+          },
+        },
+      ],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('X-Custom-Auth')).toBe('custom-value');
+  });
+
+  it('retries on 503 with exponential backoff', async () => {
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) {
+        return Promise.resolve(
+          new Response('Service Unavailable', { status: 503, statusText: 'Service Unavailable' }),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      retry: {
+        retries: 3,
+        strategy: 'exponential',
+        backoffMs: 10,
+        retryOn: [503],
+      },
+      fetch: mockFetch,
+    });
+
+    const result = await client.request('GET', '/api/health');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(result.data).toEqual({ ok: true });
+  });
+
+  it('throws after exhausting all retries', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Response('Service Unavailable', { status: 503, statusText: 'Service Unavailable' }),
+        ),
+      );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      retry: { retries: 2, strategy: 'linear', backoffMs: 1, retryOn: [503] },
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/health')).rejects.toThrow('Service Unavailable');
+    expect(mockFetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+
+  it('does not retry non-retryable status codes', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'bad request' }), {
+          status: 400,
+          statusText: 'Bad Request',
+        }),
+      ),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      retry: { retries: 3, strategy: 'exponential', backoffMs: 10 },
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/users')).rejects.toThrow('Bad Request');
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
+  });
+
+  it('uses custom backoff function', async () => {
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 2) {
+        return Promise.resolve(
+          new Response('Error', { status: 500, statusText: 'Internal Server Error' }),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+
+    const customBackoff = vi.fn().mockReturnValue(1);
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      retry: { retries: 3, strategy: customBackoff, backoffMs: 100, retryOn: [500] },
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/health');
+
+    expect(customBackoff).toHaveBeenCalledWith(1, 100);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('FetchClient hooks', () => {
+  it('calls beforeRequest hook before making the request', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const beforeRequest = vi.fn();
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      hooks: { beforeRequest },
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    expect(beforeRequest).toHaveBeenCalledOnce();
+    expect(beforeRequest).toHaveBeenCalledBefore(mockFetch);
+    const [request] = beforeRequest.mock.calls[0] as [Request];
+    expect(request.url).toBe('http://localhost:3000/api/users');
+  });
+
+  it('calls afterResponse hook after successful response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const afterResponse = vi.fn();
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      hooks: { afterResponse },
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    expect(afterResponse).toHaveBeenCalledOnce();
+    const [response] = afterResponse.mock.calls[0] as [Response];
+    expect(response.status).toBe(200);
+  });
+
+  it('calls onError hook when request fails', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('Not Found', { status: 404, statusText: 'Not Found' })),
+      );
+    const onError = vi.fn();
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      hooks: { onError },
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/users/999')).rejects.toThrow();
+
+    expect(onError).toHaveBeenCalledOnce();
+    const [error] = onError.mock.calls[0] as [Error];
+    expect(error).toBeInstanceOf(NotFoundError);
+  });
+
+  it('calls beforeRetry hook before each retry attempt', async () => {
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) {
+        return Promise.resolve(new Response('Error', { status: 500, statusText: 'Error' }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+    const beforeRetry = vi.fn();
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      retry: { retries: 3, strategy: 'linear', backoffMs: 1, retryOn: [500] },
+      hooks: { beforeRetry },
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/health');
+
+    expect(beforeRetry).toHaveBeenCalledTimes(2);
+    expect(beforeRetry.mock.calls[0]?.[0]).toBe(1); // first retry attempt
+    expect(beforeRetry.mock.calls[1]?.[0]).toBe(2); // second retry attempt
+  });
+});
+
+describe('FetchClient timeout', () => {
+  it('aborts request after configured timeout', async () => {
+    const mockFetch = vi.fn().mockImplementation(
+      (request: Request) =>
+        new Promise((_resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error('should not resolve')), 5000);
+          request.signal.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(request.signal.reason);
+          });
+        }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      timeoutMs: 50,
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/slow')).rejects.toThrow();
+  });
+});
+
+describe('FetchClient edge cases', () => {
+  it('skips null and undefined query values', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users', {
+      query: { page: 1, search: undefined, filter: null },
+    });
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    const url = new URL(request.url);
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.has('search')).toBe(false);
+    expect(url.searchParams.has('filter')).toBe(false);
+  });
+
+  it('does not set Content-Type when body is not provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Content-Type')).toBeNull();
+  });
+
+  it('applies apiKey strategy with dynamic key function', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const keyFn = vi.fn().mockResolvedValue('dynamic-key');
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [{ type: 'apiKey', key: keyFn, location: 'header', name: 'X-API-Key' }],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    expect(keyFn).toHaveBeenCalledOnce();
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('X-API-Key')).toBe('dynamic-key');
+  });
+
+  it('applies multiple auth strategies in order', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      authStrategies: [
+        { type: 'bearer', token: 'my-token' },
+        { type: 'apiKey', key: 'my-key', location: 'header', name: 'X-API-Key' },
+      ],
+      fetch: mockFetch,
+    });
+
+    await client.request('GET', '/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Authorization')).toBe('Bearer my-token');
+    expect(request.headers.get('X-API-Key')).toBe('my-key');
+  });
+
+  it('handles non-JSON error responses gracefully', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+      ),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    try {
+      await client.request('GET', '/api/users');
+    } catch (error) {
+      expect(error).toBeInstanceOf(FetchError);
+      expect((error as FetchError).status).toBe(500);
+      expect((error as FetchError).body).toBeUndefined();
+    }
+  });
+
+  it('works without baseURL when full URL is provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = new FetchClient({ fetch: mockFetch });
+
+    await client.request('GET', 'http://example.com/api/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.url).toBe('http://example.com/api/users');
+  });
+
+  it('does not retry when retries is 0', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('Error', { status: 500, statusText: 'Error' })),
+      );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    await expect(client.request('GET', '/api/users')).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes response headers in the result', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'X-Request-Id': 'req-123', 'X-RateLimit-Remaining': '99' },
+      }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const result = await client.request('GET', '/api/users');
+
+    expect(result.headers.get('X-Request-Id')).toBe('req-123');
+    expect(result.headers.get('X-RateLimit-Remaining')).toBe('99');
+  });
+});

--- a/packages/fetch/src/client.ts
+++ b/packages/fetch/src/client.ts
@@ -1,0 +1,319 @@
+import { createErrorFromStatus, type FetchError } from './errors';
+import type {
+  AuthStrategy,
+  FetchClientConfig,
+  FetchResponse,
+  RequestOptions,
+  RetryConfig,
+  StreamingRequestOptions,
+} from './types';
+
+const DEFAULT_RETRY_ON = [429, 500, 502, 503, 504];
+
+export class FetchClient {
+  private readonly config: FetchClientConfig;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(config: FetchClientConfig) {
+    this.config = config;
+    this.fetchFn = config.fetch ?? globalThis.fetch;
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<FetchResponse<T>> {
+    const retryConfig = this.resolveRetryConfig();
+    let lastError: FetchError | undefined;
+
+    for (let attempt = 0; attempt <= retryConfig.retries; attempt++) {
+      if (attempt > 0) {
+        const delay = this.calculateBackoff(attempt, retryConfig);
+        await this.sleep(delay);
+      }
+
+      const url = this.buildURL(path, options?.query);
+      const headers = new Headers(this.config.headers);
+
+      if (options?.headers) {
+        for (const [key, value] of Object.entries(options.headers)) {
+          headers.set(key, value);
+        }
+      }
+
+      const signal = this.buildSignal(options?.signal);
+
+      const request = new Request(url, {
+        method,
+        headers,
+        body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
+        signal,
+      });
+
+      if (options?.body !== undefined) {
+        request.headers.set('Content-Type', 'application/json');
+      }
+
+      const authedRequest = await this.applyAuth(request);
+
+      await this.config.hooks?.beforeRequest?.(authedRequest);
+
+      const response = await this.fetchFn(authedRequest);
+
+      if (!response.ok) {
+        const body = await this.safeParseJSON(response);
+        const error = createErrorFromStatus(response.status, response.statusText, body);
+
+        if (attempt < retryConfig.retries && retryConfig.retryOn.includes(response.status)) {
+          lastError = error;
+          await this.config.hooks?.beforeRetry?.(attempt + 1, error);
+          continue;
+        }
+
+        await this.config.hooks?.onError?.(error);
+        throw error;
+      }
+
+      await this.config.hooks?.afterResponse?.(response);
+
+      const data = (await response.json()) as T;
+
+      return {
+        data,
+        status: response.status,
+        headers: response.headers,
+      };
+    }
+
+    // This is unreachable: the loop always either returns or throws.
+    // If retries are exhausted, the last iteration throws on the non-retryable path.
+    throw lastError;
+  }
+
+  async *requestStream<T>(
+    options: StreamingRequestOptions & { method: string; path: string },
+  ): AsyncGenerator<T> {
+    const url = this.buildURL(options.path, options.query);
+    const headers = new Headers(this.config.headers);
+
+    if (options.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers.set(key, value);
+      }
+    }
+
+    if (options.format === 'sse') {
+      headers.set('Accept', 'text/event-stream');
+    } else {
+      headers.set('Accept', 'application/x-ndjson');
+    }
+
+    const signal = this.buildSignal(options.signal);
+
+    const request = new Request(url, {
+      method: options.method,
+      headers,
+      body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+      signal,
+    });
+
+    const authedRequest = await this.applyAuth(request);
+
+    await this.config.hooks?.beforeRequest?.(authedRequest);
+
+    const response = await this.fetchFn(authedRequest);
+
+    if (!response.ok) {
+      const body = await this.safeParseJSON(response);
+      const error = createErrorFromStatus(response.status, response.statusText, body);
+      await this.config.hooks?.onError?.(error);
+      throw error;
+    }
+
+    if (!response.body) {
+      return;
+    }
+
+    this.config.hooks?.onStreamStart?.();
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        if (options.format === 'sse') {
+          yield* this.parseSSEBuffer<T>(buffer, (remaining) => {
+            buffer = remaining;
+          });
+        } else {
+          yield* this.parseNDJSONBuffer<T>(buffer, (remaining) => {
+            buffer = remaining;
+          });
+        }
+      }
+    } finally {
+      reader.releaseLock();
+      this.config.hooks?.onStreamEnd?.();
+    }
+  }
+
+  private *parseSSEBuffer<T>(
+    buffer: string,
+    setRemaining: (remaining: string) => void,
+  ): Generator<T> {
+    const events = buffer.split('\n\n');
+    const remaining = events.pop() ?? '';
+    setRemaining(remaining);
+
+    for (const event of events) {
+      if (!event.trim()) continue;
+
+      const lines = event.split('\n');
+      let data = '';
+
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          data += line.slice(6);
+        } else if (line.startsWith('data:')) {
+          data += line.slice(5);
+        }
+      }
+
+      if (data) {
+        const parsed = JSON.parse(data) as T;
+        this.config.hooks?.onStreamChunk?.(parsed);
+        yield parsed;
+      }
+    }
+  }
+
+  private *parseNDJSONBuffer<T>(
+    buffer: string,
+    setRemaining: (remaining: string) => void,
+  ): Generator<T> {
+    const lines = buffer.split('\n');
+    const remaining = lines.pop() ?? '';
+    setRemaining(remaining);
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      const parsed = JSON.parse(line) as T;
+      this.config.hooks?.onStreamChunk?.(parsed);
+      yield parsed;
+    }
+  }
+
+  private buildSignal(userSignal?: AbortSignal): AbortSignal | undefined {
+    const timeoutMs = this.config.timeoutMs;
+
+    if (!timeoutMs && !userSignal) return undefined;
+    if (!timeoutMs) return userSignal;
+
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    if (!userSignal) return timeoutSignal;
+
+    return AbortSignal.any([userSignal, timeoutSignal]);
+  }
+
+  private resolveRetryConfig(): RetryConfig {
+    const userConfig = this.config.retry;
+    return {
+      retries: userConfig?.retries ?? 0,
+      strategy: userConfig?.strategy ?? 'exponential',
+      backoffMs: userConfig?.backoffMs ?? 100,
+      retryOn: userConfig?.retryOn ?? DEFAULT_RETRY_ON,
+      retryOnError: userConfig?.retryOnError,
+    };
+  }
+
+  private calculateBackoff(attempt: number, config: RetryConfig): number {
+    const { strategy, backoffMs } = config;
+
+    if (typeof strategy === 'function') {
+      return strategy(attempt, backoffMs);
+    }
+
+    if (strategy === 'linear') {
+      return backoffMs * attempt;
+    }
+
+    // exponential
+    return backoffMs * 2 ** (attempt - 1);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private buildURL(path: string, query?: Record<string, unknown>): string {
+    const base = this.config.baseURL;
+    const url = base ? new URL(path, base) : new URL(path);
+
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    return url.toString();
+  }
+
+  private async applyAuth(request: Request): Promise<Request> {
+    const strategies = this.config.authStrategies;
+    if (!strategies) return request;
+
+    let current = request;
+    for (const strategy of strategies) {
+      current = await this.applyStrategy(current, strategy);
+    }
+    return current;
+  }
+
+  private async applyStrategy(request: Request, strategy: AuthStrategy): Promise<Request> {
+    switch (strategy.type) {
+      case 'bearer': {
+        const token =
+          typeof strategy.token === 'function' ? await strategy.token() : strategy.token;
+        request.headers.set('Authorization', `Bearer ${token}`);
+        return request;
+      }
+      case 'basic': {
+        const encoded = btoa(`${strategy.username}:${strategy.password}`);
+        request.headers.set('Authorization', `Basic ${encoded}`);
+        return request;
+      }
+      case 'apiKey': {
+        const key = typeof strategy.key === 'function' ? await strategy.key() : strategy.key;
+        if (strategy.location === 'header') {
+          request.headers.set(strategy.name, key);
+        } else if (strategy.location === 'query') {
+          const url = new URL(request.url);
+          url.searchParams.set(strategy.name, key);
+          return new Request(url, request);
+        }
+        return request;
+      }
+      case 'custom': {
+        return await strategy.apply(request);
+      }
+    }
+  }
+
+  private async safeParseJSON(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/packages/fetch/src/errors.test.ts
+++ b/packages/fetch/src/errors.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BadRequestError,
+  ConflictError,
+  createErrorFromStatus,
+  FetchError,
+  ForbiddenError,
+  GoneError,
+  InternalServerError,
+  NotFoundError,
+  RateLimitError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from './errors';
+
+describe('FetchError', () => {
+  it('stores status and message', () => {
+    const error = new FetchError('Something went wrong', 500);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.message).toBe('Something went wrong');
+    expect(error.status).toBe(500);
+    expect(error.name).toBe('FetchError');
+  });
+
+  it('stores optional response body', () => {
+    const body = { error: 'validation_failed', details: ['name is required'] };
+    const error = new FetchError('Bad Request', 400, body);
+
+    expect(error.body).toEqual(body);
+  });
+});
+
+describe('status-specific error classes', () => {
+  it('BadRequestError has status 400', () => {
+    const error = new BadRequestError('Validation failed');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(400);
+    expect(error.name).toBe('BadRequestError');
+  });
+
+  it('UnauthorizedError has status 401', () => {
+    const error = new UnauthorizedError('Invalid token');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(401);
+    expect(error.name).toBe('UnauthorizedError');
+  });
+
+  it('ForbiddenError has status 403', () => {
+    const error = new ForbiddenError('Access denied');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(403);
+    expect(error.name).toBe('ForbiddenError');
+  });
+
+  it('NotFoundError has status 404', () => {
+    const error = new NotFoundError('Resource not found');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(404);
+    expect(error.name).toBe('NotFoundError');
+  });
+
+  it('ConflictError has status 409', () => {
+    const error = new ConflictError('Resource conflict');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(409);
+    expect(error.name).toBe('ConflictError');
+  });
+
+  it('GoneError has status 410', () => {
+    const error = new GoneError('Resource gone');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(410);
+    expect(error.name).toBe('GoneError');
+  });
+
+  it('UnprocessableEntityError has status 422', () => {
+    const error = new UnprocessableEntityError('Unprocessable');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(422);
+    expect(error.name).toBe('UnprocessableEntityError');
+  });
+
+  it('RateLimitError has status 429', () => {
+    const error = new RateLimitError('Too many requests');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(429);
+    expect(error.name).toBe('RateLimitError');
+  });
+
+  it('InternalServerError has status 500', () => {
+    const error = new InternalServerError('Server error');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(500);
+    expect(error.name).toBe('InternalServerError');
+  });
+
+  it('ServiceUnavailableError has status 503', () => {
+    const error = new ServiceUnavailableError('Service down');
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(503);
+    expect(error.name).toBe('ServiceUnavailableError');
+  });
+});
+
+describe('createErrorFromStatus', () => {
+  it('returns specific error class for known status codes', () => {
+    expect(createErrorFromStatus(400, 'Bad')).toBeInstanceOf(BadRequestError);
+    expect(createErrorFromStatus(401, 'Unauth')).toBeInstanceOf(UnauthorizedError);
+    expect(createErrorFromStatus(403, 'Forbidden')).toBeInstanceOf(ForbiddenError);
+    expect(createErrorFromStatus(404, 'Not found')).toBeInstanceOf(NotFoundError);
+    expect(createErrorFromStatus(409, 'Conflict')).toBeInstanceOf(ConflictError);
+    expect(createErrorFromStatus(410, 'Gone')).toBeInstanceOf(GoneError);
+    expect(createErrorFromStatus(422, 'Unprocessable')).toBeInstanceOf(UnprocessableEntityError);
+    expect(createErrorFromStatus(429, 'Rate limit')).toBeInstanceOf(RateLimitError);
+    expect(createErrorFromStatus(500, 'Server')).toBeInstanceOf(InternalServerError);
+    expect(createErrorFromStatus(503, 'Unavailable')).toBeInstanceOf(ServiceUnavailableError);
+  });
+
+  it('returns generic FetchError for unknown status codes', () => {
+    const error = createErrorFromStatus(418, "I'm a teapot");
+
+    expect(error).toBeInstanceOf(FetchError);
+    expect(error.status).toBe(418);
+    expect(error.message).toBe("I'm a teapot");
+  });
+});

--- a/packages/fetch/src/errors.ts
+++ b/packages/fetch/src/errors.ts
@@ -1,0 +1,102 @@
+export class FetchError extends Error {
+  readonly status: number;
+  readonly body?: unknown;
+
+  constructor(message: string, status: number, body?: unknown) {
+    super(message);
+    this.name = 'FetchError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class BadRequestError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 400, body);
+    this.name = 'BadRequestError';
+  }
+}
+
+export class UnauthorizedError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 401, body);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 403, body);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class NotFoundError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 404, body);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ConflictError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 409, body);
+    this.name = 'ConflictError';
+  }
+}
+
+export class GoneError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 410, body);
+    this.name = 'GoneError';
+  }
+}
+
+export class UnprocessableEntityError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 422, body);
+    this.name = 'UnprocessableEntityError';
+  }
+}
+
+export class RateLimitError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 429, body);
+    this.name = 'RateLimitError';
+  }
+}
+
+export class InternalServerError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 500, body);
+    this.name = 'InternalServerError';
+  }
+}
+
+export class ServiceUnavailableError extends FetchError {
+  constructor(message: string, body?: unknown) {
+    super(message, 503, body);
+    this.name = 'ServiceUnavailableError';
+  }
+}
+
+const errorMap: Record<number, new (message: string, body?: unknown) => FetchError> = {
+  400: BadRequestError,
+  401: UnauthorizedError,
+  403: ForbiddenError,
+  404: NotFoundError,
+  409: ConflictError,
+  410: GoneError,
+  422: UnprocessableEntityError,
+  429: RateLimitError,
+  500: InternalServerError,
+  503: ServiceUnavailableError,
+};
+
+export function createErrorFromStatus(status: number, message: string, body?: unknown): FetchError {
+  const ErrorClass = errorMap[status];
+  if (ErrorClass) {
+    return new ErrorClass(message, body);
+  }
+  return new FetchError(message, status, body);
+}

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -1,0 +1,25 @@
+export { FetchClient } from './client';
+export {
+  BadRequestError,
+  ConflictError,
+  createErrorFromStatus,
+  FetchError,
+  ForbiddenError,
+  GoneError,
+  InternalServerError,
+  NotFoundError,
+  RateLimitError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from './errors';
+export type {
+  AuthStrategy,
+  FetchClientConfig,
+  FetchResponse,
+  HooksConfig,
+  RequestOptions,
+  RetryConfig,
+  StreamingFormat,
+  StreamingRequestOptions,
+} from './types';

--- a/packages/fetch/src/streaming.test.ts
+++ b/packages/fetch/src/streaming.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FetchClient } from './client';
+import { FetchError } from './errors';
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('FetchClient.requestStream (SSE)', () => {
+  it('yields parsed SSE data events', async () => {
+    const sseBody = 'data: {"id":1,"message":"hello"}\n\ndata: {"id":2,"message":"world"}\n\n';
+    const stream = createStream([sseBody]);
+
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const events: unknown[] = [];
+    for await (const event of client.requestStream({
+      method: 'GET',
+      path: '/api/events',
+      format: 'sse',
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { id: 1, message: 'hello' },
+      { id: 2, message: 'world' },
+    ]);
+  });
+
+  it('handles SSE events split across chunks', async () => {
+    const stream = createStream(['data: {"id":1}\n', '\ndata: {"id":2}\n\n']);
+
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const events: unknown[] = [];
+    for await (const event of client.requestStream({
+      method: 'GET',
+      path: '/api/events',
+      format: 'sse',
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('ignores non-data SSE fields (event, id, retry)', async () => {
+    const sseBody = 'event: update\nid: 42\nretry: 3000\ndata: {"type":"update"}\n\n';
+    const stream = createStream([sseBody]);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const events: unknown[] = [];
+    for await (const event of client.requestStream({
+      method: 'GET',
+      path: '/api/events',
+      format: 'sse',
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{ type: 'update' }]);
+  });
+
+  it('throws on non-OK response', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const events: unknown[] = [];
+    await expect(async () => {
+      for await (const event of client.requestStream({
+        method: 'GET',
+        path: '/api/events',
+        format: 'sse',
+      })) {
+        events.push(event);
+      }
+    }).rejects.toThrow(FetchError);
+
+    expect(events).toEqual([]);
+  });
+
+  it('sets Accept header for SSE', async () => {
+    const stream = createStream([]);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    for await (const _ of client.requestStream({
+      method: 'GET',
+      path: '/api/events',
+      format: 'sse',
+    })) {
+      // consume
+    }
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Accept')).toBe('text/event-stream');
+  });
+});
+
+describe('FetchClient.requestStream (NDJSON)', () => {
+  it('yields parsed NDJSON lines', async () => {
+    const ndjsonBody = '{"id":1,"name":"alice"}\n{"id":2,"name":"bob"}\n';
+    const stream = createStream([ndjsonBody]);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const items: unknown[] = [];
+    for await (const item of client.requestStream({
+      method: 'GET',
+      path: '/api/stream',
+      format: 'ndjson',
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([
+      { id: 1, name: 'alice' },
+      { id: 2, name: 'bob' },
+    ]);
+  });
+
+  it('handles NDJSON split across chunks', async () => {
+    const stream = createStream(['{"id":1}\n{"id', '":2}\n']);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const items: unknown[] = [];
+    for await (const item of client.requestStream({
+      method: 'GET',
+      path: '/api/stream',
+      format: 'ndjson',
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('skips blank lines in NDJSON', async () => {
+    const ndjsonBody = '{"id":1}\n\n{"id":2}\n';
+    const stream = createStream([ndjsonBody]);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    const items: unknown[] = [];
+    for await (const item of client.requestStream({
+      method: 'GET',
+      path: '/api/stream',
+      format: 'ndjson',
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('sets Accept header for NDJSON', async () => {
+    const stream = createStream([]);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      fetch: mockFetch,
+    });
+
+    for await (const _ of client.requestStream({
+      method: 'GET',
+      path: '/api/stream',
+      format: 'ndjson',
+    })) {
+      // consume
+    }
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.headers.get('Accept')).toBe('application/x-ndjson');
+  });
+});
+
+describe('FetchClient.requestStream hooks', () => {
+  it('calls onStreamStart, onStreamChunk, and onStreamEnd hooks', async () => {
+    const stream = createStream(['data: {"id":1}\n\ndata: {"id":2}\n\n']);
+    const mockFetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const onStreamStart = vi.fn();
+    const onStreamChunk = vi.fn();
+    const onStreamEnd = vi.fn();
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      hooks: { onStreamStart, onStreamChunk, onStreamEnd },
+      fetch: mockFetch,
+    });
+
+    const events: unknown[] = [];
+    for await (const event of client.requestStream({
+      method: 'GET',
+      path: '/api/events',
+      format: 'sse',
+    })) {
+      events.push(event);
+    }
+
+    expect(onStreamStart).toHaveBeenCalledOnce();
+    expect(onStreamChunk).toHaveBeenCalledTimes(2);
+    expect(onStreamChunk).toHaveBeenCalledWith({ id: 1 });
+    expect(onStreamChunk).toHaveBeenCalledWith({ id: 2 });
+    expect(onStreamEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/fetch/src/types.ts
+++ b/packages/fetch/src/types.ts
@@ -1,0 +1,58 @@
+export type AuthStrategy =
+  | { type: 'bearer'; token: string | (() => string | Promise<string>) }
+  | { type: 'basic'; username: string; password: string }
+  | {
+      type: 'apiKey';
+      key: string | (() => string | Promise<string>);
+      location: 'header' | 'query' | 'cookie';
+      name: string;
+    }
+  | { type: 'custom'; apply: (request: Request) => Request | Promise<Request> };
+
+export interface RetryConfig {
+  retries: number;
+  strategy: 'exponential' | 'linear' | ((attempt: number, baseBackoff: number) => number);
+  backoffMs: number;
+  retryOn: number[];
+  retryOnError?: (error: Error) => boolean;
+}
+
+export type StreamingFormat = 'sse' | 'ndjson';
+
+export interface HooksConfig {
+  beforeRequest?: (request: Request) => void | Promise<void>;
+  afterResponse?: (response: Response) => void | Promise<void>;
+  onError?: (error: Error) => void | Promise<void>;
+  beforeRetry?: (attempt: number, error: Error) => void | Promise<void>;
+  onStreamStart?: () => void;
+  onStreamChunk?: (chunk: unknown) => void;
+  onStreamEnd?: () => void;
+}
+
+export interface FetchClientConfig {
+  baseURL?: string;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  retry?: Partial<RetryConfig>;
+  hooks?: HooksConfig;
+  authStrategies?: AuthStrategy[];
+  fetch?: typeof fetch;
+  credentials?: RequestCredentials;
+}
+
+export interface RequestOptions {
+  headers?: Record<string, string>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+export interface FetchResponse<T> {
+  data: T;
+  status: number;
+  headers: Headers;
+}
+
+export interface StreamingRequestOptions extends RequestOptions {
+  format: StreamingFormat;
+}

--- a/packages/fetch/tsconfig.json
+++ b/packages/fetch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/fetch/vitest.config.ts
+++ b/packages/fetch/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the codegen design plan — `@vertz/fetch`, a standalone, zero-dependency HTTP client that generated SDKs will build on.

- **`FetchClient.request()`** — typed fetch wrapper with JSON error handling
- **Auth strategies** — bearer (static/dynamic token), basic, apiKey (header/query, static/dynamic), custom
- **Retry logic** — exponential, linear, and custom backoff functions
- **`FetchClient.requestStream()`** — SSE and NDJSON parsers via async generators
- **Typed error classes** — `FetchError` base + 10 status-specific subclasses (`BadRequestError`, `UnauthorizedError`, etc.)
- **Lifecycle hooks** — `beforeRequest`, `afterResponse`, `onError`, `beforeRetry`, `onStreamStart`, `onStreamChunk`, `onStreamEnd`
- **Timeout support** via `AbortSignal`

53 tests across 3 test files, all passing. Zero runtime dependencies.

## Test plan

- [x] All 53 tests pass (`bun run --filter @vertz/fetch test`)
- [x] Full workspace typecheck passes (`bun run typecheck`)
- [x] Biome lint/format clean
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)