### PR TITLE
feat(codegen): add CodegenIR types and IR adapter pipeline [VER-57]

### DIFF
--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -2,7 +2,9 @@
 
 ## Linear Ticket Reference
 
-When a commit is associated with a Linear ticket, include the ticket identifier in the commit subject line in brackets:
+Every commit MUST reference its Linear ticket. Before committing, ask the user for the ticket ID if you don't have it.
+
+Include the ticket identifier in the commit subject line in brackets:
 
 ```
 feat(compiler): add moduleName to SchemaIR [VER-55]
@@ -13,3 +15,16 @@ Format: `<type>(<scope>): <description> [<TICKET-ID>]`
 The ticket ID goes at the end of the subject line, inside square brackets. This makes tickets discoverable from `git log --oneline`.
 
 If the commit closes the ticket, also include `Closes <TICKET-ID>` in the commit body.
+
+## Never Use PR Numbers in Commits
+
+Do NOT put GitHub PR numbers (e.g., `#114`) in commit messages. PR numbers are assigned by GitHub after the commit exists — they don't belong in commit history. Use Linear ticket IDs instead.
+
+## Read Linear Ticket Before Starting Work
+
+Before starting implementation on any phase or task:
+
+1. **Ask the user for the Linear ticket ID** associated with the work
+2. **Read the ticket** using `linear-mcp` or ask the user for context from the ticket
+3. Use the ticket's description, acceptance criteria, and context to guide implementation
+4. Reference the ticket ID in all commits for that work

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,19 @@
         "vitest": "^4.0.18",
       },
     },
+    "packages/codegen": {
+      "name": "@vertz/codegen",
+      "version": "0.1.0",
+      "dependencies": {
+        "@vertz/compiler": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.2.1",
+        "bunup": "latest",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
     "packages/compiler": {
       "name": "@vertz/compiler",
       "version": "0.1.0",
@@ -419,6 +432,8 @@
     "@types/react": ["@types/react@19.2.13", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ=="],
 
     "@vertz/cli": ["@vertz/cli@workspace:packages/cli"],
+
+    "@vertz/codegen": ["@vertz/codegen@workspace:packages/codegen"],
 
     "@vertz/compiler": ["@vertz/compiler@workspace:packages/compiler"],
 
@@ -824,6 +839,8 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@vertz/codegen/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
     "@vertz/compiler/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "@vertz/core/@types/node": ["@types/node@22.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A=="],
@@ -859,6 +876,24 @@
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@vertz/codegen/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vertz/codegen/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vertz/codegen/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vertz/codegen/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vertz/codegen/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vertz/codegen/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vertz/codegen/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vertz/codegen/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "@vertz/codegen/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "@vertz/compiler/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@vertz/codegen",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "packages/codegen"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bunup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
+  },
+  "dependencies": {
+    "@vertz/compiler": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.1",
+    "bunup": "latest",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/codegen/src/__tests__/ir-adapter.test.ts
+++ b/packages/codegen/src/__tests__/ir-adapter.test.ts
@@ -1,0 +1,1030 @@
+import type { AppIR, ModuleIR, RouteIR, RouterIR, SchemaIR } from '@vertz/compiler';
+import { describe, expect, it } from 'vitest';
+import { adaptIR } from '../ir-adapter';
+
+// ── Fixture helpers ──────────────────────────────────────────────
+
+const loc = { sourceFile: 'test.ts', sourceLine: 1, sourceColumn: 1 };
+
+function makeRoute(overrides: Partial<RouteIR>): RouteIR {
+  return {
+    method: 'GET',
+    path: '/',
+    fullPath: '/',
+    operationId: 'test',
+    middleware: [],
+    tags: [],
+    ...loc,
+    ...overrides,
+  };
+}
+
+function makeRouter(overrides: Partial<RouterIR>): RouterIR {
+  return {
+    name: 'TestRouter',
+    moduleName: 'test',
+    prefix: '/',
+    inject: [],
+    routes: [],
+    ...loc,
+    ...overrides,
+  };
+}
+
+function makeModule(overrides: Partial<ModuleIR>): ModuleIR {
+  return {
+    name: 'test',
+    imports: [],
+    services: [],
+    routers: [],
+    exports: [],
+    ...loc,
+    ...overrides,
+  };
+}
+
+function makeSchema(overrides: Partial<SchemaIR>): SchemaIR {
+  return {
+    name: 'TestSchema',
+    moduleName: 'test',
+    namingConvention: {},
+    isNamed: true,
+    ...loc,
+    ...overrides,
+  };
+}
+
+function makeAppIR(overrides: Partial<AppIR>): AppIR {
+  return {
+    app: {
+      basePath: '/api',
+      globalMiddleware: [],
+      moduleRegistrations: [],
+      ...loc,
+    },
+    modules: [],
+    middleware: [],
+    schemas: [],
+    dependencyGraph: {
+      nodes: [],
+      edges: [],
+      initializationOrder: [],
+      circularDependencies: [],
+    },
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+describe('adaptIR', () => {
+  it('returns empty IR for an empty app', () => {
+    const appIR = makeAppIR({});
+    const result = adaptIR(appIR);
+
+    expect(result.modules).toEqual([]);
+    expect(result.schemas).toEqual([]);
+    expect(result.auth.schemes).toEqual([]);
+    expect(result.basePath).toBe('/api');
+  });
+
+  describe('Step 1: Flatten', () => {
+    it('flattens a single module with one route into one module with one operation', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                prefix: '/users',
+                routes: [
+                  makeRoute({
+                    method: 'GET',
+                    path: '/',
+                    fullPath: '/api/users',
+                    operationId: 'listUsers',
+                    tags: ['users'],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.modules).toHaveLength(1);
+      expect(result.modules[0]?.name).toBe('users');
+      expect(result.modules[0]?.operations).toHaveLength(1);
+      expect(result.modules[0]?.operations[0]?.operationId).toBe('listUsers');
+      expect(result.modules[0]?.operations[0]?.method).toBe('GET');
+      expect(result.modules[0]?.operations[0]?.path).toBe('/api/users');
+      expect(result.modules[0]?.operations[0]?.tags).toEqual(['users']);
+    });
+
+    it('flattens multiple modules with multiple routers', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [makeRoute({ operationId: 'listUsers', fullPath: '/api/users' })],
+              }),
+            ],
+          }),
+          makeModule({
+            name: 'orders',
+            routers: [
+              makeRouter({
+                moduleName: 'orders',
+                routes: [
+                  makeRoute({ operationId: 'listOrders', fullPath: '/api/orders' }),
+                  makeRoute({
+                    operationId: 'createOrder',
+                    method: 'POST',
+                    fullPath: '/api/orders',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.modules).toHaveLength(2);
+      // Sorted alphabetically
+      expect(result.modules[0]?.name).toBe('orders');
+      expect(result.modules[0]?.operations).toHaveLength(2);
+      expect(result.modules[1]?.name).toBe('users');
+      expect(result.modules[1]?.operations).toHaveLength(1);
+    });
+
+    it('carries all schema slots (params, query, body, headers, response) into operations', () => {
+      const paramsSchema = { type: 'object', properties: { id: { type: 'string' } } };
+      const querySchema = { type: 'object', properties: { verbose: { type: 'boolean' } } };
+      const bodySchema = { type: 'object', properties: { name: { type: 'string' } } };
+      const headersSchema = { type: 'object', properties: { 'x-tenant': { type: 'string' } } };
+      const responseSchema = { type: 'object', properties: { ok: { type: 'boolean' } } };
+
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'updateUser',
+                    method: 'PUT',
+                    fullPath: '/api/users/:id',
+                    params: { kind: 'inline', sourceFile: 'test.ts', jsonSchema: paramsSchema },
+                    query: { kind: 'inline', sourceFile: 'test.ts', jsonSchema: querySchema },
+                    body: { kind: 'inline', sourceFile: 'test.ts', jsonSchema: bodySchema },
+                    headers: { kind: 'inline', sourceFile: 'test.ts', jsonSchema: headersSchema },
+                    response: { kind: 'inline', sourceFile: 'test.ts', jsonSchema: responseSchema },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const op = result.modules[0]?.operations[0];
+
+      expect(op?.params).toEqual(paramsSchema);
+      expect(op?.query).toEqual(querySchema);
+      expect(op?.body).toEqual(bodySchema);
+      expect(op?.headers).toEqual(headersSchema);
+      expect(op?.response).toEqual(responseSchema);
+    });
+
+    it('passes description through to operations', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'listUsers',
+                    fullPath: '/api/users',
+                    description: 'List all users with pagination',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.modules[0]?.operations[0]?.description).toBe('List all users with pagination');
+    });
+
+    it('merges routes from multiple routers in the same module', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                name: 'UsersRouter',
+                routes: [makeRoute({ operationId: 'listUsers', fullPath: '/api/users' })],
+              }),
+              makeRouter({
+                moduleName: 'users',
+                name: 'AdminUsersRouter',
+                routes: [
+                  makeRoute({ operationId: 'deleteUser', fullPath: '/api/admin/users/:id' }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.modules).toHaveLength(1);
+      expect(result.modules[0]?.operations).toHaveLength(2);
+    });
+
+    it('carries inline schema JSON into operation fields', () => {
+      const querySchema = {
+        type: 'object',
+        properties: { page: { type: 'number' } },
+      };
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'listUsers',
+                    fullPath: '/api/users',
+                    query: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: querySchema,
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const op = result.modules[0]?.operations[0];
+
+      expect(op?.query).toEqual(querySchema);
+      expect(op?.schemaRefs.query).toBeUndefined();
+    });
+
+    it('tracks named schema refs and resolves JSON from AppIR schemas', () => {
+      const bodyJsonSchema = {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      };
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateUserBody',
+                      sourceFile: 'test.ts',
+                      jsonSchema: bodyJsonSchema,
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateUserBody',
+            moduleName: 'users',
+            jsonSchema: bodyJsonSchema,
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const op = result.modules[0]?.operations[0];
+
+      expect(op?.schemaRefs.body).toBe('CreateUserBody');
+      expect(op?.body).toEqual(bodyJsonSchema);
+    });
+  });
+
+  it('excludes schemas without jsonSchema', () => {
+    const appIR = makeAppIR({
+      schemas: [
+        makeSchema({ name: 'NoJson', moduleName: 'users' }),
+        makeSchema({
+          name: 'WithJson',
+          moduleName: 'users',
+          jsonSchema: { type: 'object' },
+        }),
+      ],
+    });
+
+    const result = adaptIR(appIR);
+
+    expect(result.schemas).toHaveLength(1);
+    expect(result.schemas[0]?.name).toBe('WithJson');
+  });
+
+  it('produces empty operations for a module with no routers', () => {
+    const appIR = makeAppIR({
+      modules: [makeModule({ name: 'empty', routers: [] })],
+    });
+
+    const result = adaptIR(appIR);
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.modules[0]?.operations).toEqual([]);
+  });
+
+  it('handles route with no schemas at all', () => {
+    const appIR = makeAppIR({
+      modules: [
+        makeModule({
+          name: 'health',
+          routers: [
+            makeRouter({
+              moduleName: 'health',
+              routes: [
+                makeRoute({
+                  operationId: 'healthCheck',
+                  method: 'GET',
+                  fullPath: '/health',
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = adaptIR(appIR);
+    const op = result.modules[0]?.operations[0];
+
+    expect(op?.params).toBeUndefined();
+    expect(op?.query).toBeUndefined();
+    expect(op?.body).toBeUndefined();
+    expect(op?.headers).toBeUndefined();
+    expect(op?.response).toBeUndefined();
+    expect(op?.schemaRefs.params).toBeUndefined();
+    expect(op?.schemaRefs.query).toBeUndefined();
+    expect(op?.schemaRefs.body).toBeUndefined();
+  });
+
+  describe('Step 2-3: Collect refs and detect shared schemas', () => {
+    it('collects named schemas into CodegenIR.schemas', () => {
+      const bodySchema = {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      };
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateUserBody',
+                      sourceFile: 'test.ts',
+                      jsonSchema: bodySchema,
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateUserBody',
+            moduleName: 'users',
+            namingConvention: { operation: 'create', entity: 'User', part: 'Body' },
+            jsonSchema: bodySchema,
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.schemas).toHaveLength(1);
+      expect(result.schemas[0]?.name).toBe('CreateUserBody');
+      expect(result.schemas[0]?.jsonSchema).toEqual(bodySchema);
+      expect(result.schemas[0]?.annotations.namingParts).toEqual({
+        operation: 'create',
+        entity: 'User',
+        part: 'Body',
+      });
+    });
+  });
+
+  describe('Step 4: Resolve name collisions', () => {
+    it('prefixes colliding schema names with module name', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateBody',
+                      sourceFile: 'users.ts',
+                      jsonSchema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          makeModule({
+            name: 'orders',
+            routers: [
+              makeRouter({
+                moduleName: 'orders',
+                routes: [
+                  makeRoute({
+                    operationId: 'createOrder',
+                    method: 'POST',
+                    fullPath: '/api/orders',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateBody',
+                      sourceFile: 'orders.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { productId: { type: 'string' } },
+                      },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateBody',
+            moduleName: 'users',
+            sourceFile: 'users.ts',
+            jsonSchema: { type: 'object', properties: { name: { type: 'string' } } },
+          }),
+          makeSchema({
+            name: 'CreateBody',
+            moduleName: 'orders',
+            sourceFile: 'orders.ts',
+            jsonSchema: { type: 'object', properties: { productId: { type: 'string' } } },
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const schemaNames = result.schemas.map((s) => s.name);
+
+      expect(schemaNames).toContain('UsersCreateBody');
+      expect(schemaNames).toContain('OrdersCreateBody');
+      expect(schemaNames).not.toContain('CreateBody');
+    });
+
+    it('updates operation schemaRefs when collisions are resolved', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateBody',
+                      sourceFile: 'users.ts',
+                      jsonSchema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          makeModule({
+            name: 'orders',
+            routers: [
+              makeRouter({
+                moduleName: 'orders',
+                routes: [
+                  makeRoute({
+                    operationId: 'createOrder',
+                    method: 'POST',
+                    fullPath: '/api/orders',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateBody',
+                      sourceFile: 'orders.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { productId: { type: 'string' } },
+                      },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateBody',
+            moduleName: 'users',
+            sourceFile: 'users.ts',
+            jsonSchema: { type: 'object', properties: { name: { type: 'string' } } },
+          }),
+          makeSchema({
+            name: 'CreateBody',
+            moduleName: 'orders',
+            sourceFile: 'orders.ts',
+            jsonSchema: { type: 'object', properties: { productId: { type: 'string' } } },
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const ordersModule = result.modules.find((m) => m.name === 'orders');
+      const usersModule = result.modules.find((m) => m.name === 'users');
+
+      expect(ordersModule?.operations[0]?.schemaRefs.body).toBe('OrdersCreateBody');
+      expect(usersModule?.operations[0]?.schemaRefs.body).toBe('UsersCreateBody');
+    });
+
+    it('does not prefix non-colliding schema names', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateUserBody',
+                      sourceFile: 'test.ts',
+                      jsonSchema: { type: 'object' },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateUserBody',
+            moduleName: 'users',
+            jsonSchema: { type: 'object' },
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.schemas[0]?.name).toBe('CreateUserBody');
+    });
+  });
+
+  describe('Step 5: Name inline schemas', () => {
+    it('derives names from operationId + slot for inline schemas', () => {
+      const querySchema = {
+        type: 'object',
+        properties: { page: { type: 'number' } },
+      };
+      const responseSchema = {
+        type: 'object',
+        properties: { items: { type: 'array', items: { type: 'string' } } },
+      };
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'listUsers',
+                    fullPath: '/api/users',
+                    query: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: querySchema,
+                    },
+                    response: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: responseSchema,
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const schemaNames = result.schemas.map((s) => s.name);
+
+      expect(schemaNames).toContain('ListUsersQuery');
+      expect(schemaNames).toContain('ListUsersResponse');
+    });
+
+    it('names inline params and body schemas correctly', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'getUser',
+                    fullPath: '/api/users/:id',
+                    params: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { id: { type: 'string' } },
+                        required: ['id'],
+                      },
+                    },
+                  }),
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { name: { type: 'string' } },
+                        required: ['name'],
+                      },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const schemaNames = result.schemas.map((s) => s.name);
+
+      expect(schemaNames).toContain('GetUserParams');
+      expect(schemaNames).toContain('CreateUserBody');
+    });
+
+    it('does not create schemas for named refs (only for inline)', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateUserBody',
+                      sourceFile: 'test.ts',
+                      jsonSchema: { type: 'object' },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'CreateUserBody',
+            moduleName: 'users',
+            jsonSchema: { type: 'object' },
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      // Should have exactly 1 schema (the named one), not 2
+      expect(result.schemas).toHaveLength(1);
+      expect(result.schemas[0]?.name).toBe('CreateUserBody');
+    });
+  });
+
+  describe('Step 5: Inline schema annotations', () => {
+    it('assigns empty namingParts to inline schemas', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'listUsers',
+                    fullPath: '/api/users',
+                    query: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: { type: 'object', properties: { page: { type: 'number' } } },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const inlineSchema = result.schemas.find((s) => s.name === 'ListUsersQuery');
+
+      expect(inlineSchema?.annotations.namingParts).toEqual({});
+    });
+  });
+
+  describe('Step 7: Extract metadata', () => {
+    it('extracts basePath and version from AppIR', () => {
+      const appIR = makeAppIR({
+        app: {
+          basePath: '/api/v1',
+          version: '1.0.0',
+          globalMiddleware: [],
+          moduleRegistrations: [],
+          ...loc,
+        },
+      });
+
+      const result = adaptIR(appIR);
+
+      expect(result.basePath).toBe('/api/v1');
+      expect(result.version).toBe('1.0.0');
+    });
+
+    it('leaves version undefined when AppIR has no version', () => {
+      const appIR = makeAppIR({});
+
+      const result = adaptIR(appIR);
+
+      expect(result.version).toBeUndefined();
+    });
+  });
+
+  describe('Step 8: Sort deterministically', () => {
+    it('sorts modules alphabetically by name', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({ name: 'orders', routers: [] }),
+          makeModule({ name: 'auth', routers: [] }),
+          makeModule({ name: 'users', routers: [] }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const names = result.modules.map((m) => m.name);
+
+      expect(names).toEqual(['auth', 'orders', 'users']);
+    });
+
+    it('sorts schemas alphabetically by name', () => {
+      const appIR = makeAppIR({
+        schemas: [
+          makeSchema({ name: 'UpdateUserBody', jsonSchema: { type: 'object' } }),
+          makeSchema({ name: 'CreateUserBody', jsonSchema: { type: 'object' } }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const names = result.schemas.map((s) => s.name);
+
+      expect(names).toEqual(['CreateUserBody', 'UpdateUserBody']);
+    });
+
+    it('sorts operations within a module by operationId', () => {
+      const appIR = makeAppIR({
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({ operationId: 'updateUser', fullPath: '/api/users/:id' }),
+                  makeRoute({ operationId: 'createUser', fullPath: '/api/users' }),
+                  makeRoute({ operationId: 'listUsers', fullPath: '/api/users' }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+      const opIds = result.modules[0]?.operations.map((o) => o.operationId);
+
+      expect(opIds).toEqual(['createUser', 'listUsers', 'updateUser']);
+    });
+  });
+
+  describe('Integration: full pipeline', () => {
+    it('adapts a realistic multi-module AppIR into a complete CodegenIR', () => {
+      const appIR = makeAppIR({
+        app: {
+          basePath: '/api/v1',
+          version: '2.0.0',
+          globalMiddleware: [],
+          moduleRegistrations: [],
+          ...loc,
+        },
+        modules: [
+          makeModule({
+            name: 'users',
+            routers: [
+              makeRouter({
+                moduleName: 'users',
+                routes: [
+                  makeRoute({
+                    operationId: 'listUsers',
+                    fullPath: '/api/v1/users',
+                    query: {
+                      kind: 'inline',
+                      sourceFile: 'test.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { page: { type: 'number' }, limit: { type: 'number' } },
+                      },
+                    },
+                    response: {
+                      kind: 'named',
+                      schemaName: 'ListUsersResponse',
+                      sourceFile: 'test.ts',
+                      jsonSchema: {
+                        type: 'array',
+                        items: { $ref: '#/$defs/User' },
+                      },
+                    },
+                  }),
+                  makeRoute({
+                    operationId: 'createUser',
+                    method: 'POST',
+                    fullPath: '/api/v1/users',
+                    body: {
+                      kind: 'named',
+                      schemaName: 'CreateUserBody',
+                      sourceFile: 'test.ts',
+                      jsonSchema: {
+                        type: 'object',
+                        properties: { name: { type: 'string' } },
+                        required: ['name'],
+                      },
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          makeModule({
+            name: 'orders',
+            routers: [
+              makeRouter({
+                moduleName: 'orders',
+                routes: [
+                  makeRoute({
+                    operationId: 'listOrders',
+                    fullPath: '/api/v1/orders',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        schemas: [
+          makeSchema({
+            name: 'ListUsersResponse',
+            moduleName: 'users',
+            namingConvention: { operation: 'list', entity: 'Users', part: 'Response' },
+            jsonSchema: { type: 'array', items: { $ref: '#/$defs/User' } },
+          }),
+          makeSchema({
+            name: 'CreateUserBody',
+            moduleName: 'users',
+            namingConvention: { operation: 'create', entity: 'User', part: 'Body' },
+            jsonSchema: {
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+          }),
+        ],
+      });
+
+      const result = adaptIR(appIR);
+
+      // Metadata
+      expect(result.basePath).toBe('/api/v1');
+      expect(result.version).toBe('2.0.0');
+
+      // Modules sorted
+      expect(result.modules.map((m) => m.name)).toEqual(['orders', 'users']);
+
+      // Operations sorted within modules
+      const usersModule = result.modules.find((m) => m.name === 'users');
+      expect(usersModule?.operations.map((o) => o.operationId)).toEqual([
+        'createUser',
+        'listUsers',
+      ]);
+
+      // Named schemas collected
+      expect(result.schemas.find((s) => s.name === 'CreateUserBody')).toBeDefined();
+      expect(result.schemas.find((s) => s.name === 'ListUsersResponse')).toBeDefined();
+
+      // Inline schemas named
+      expect(result.schemas.find((s) => s.name === 'ListUsersQuery')).toBeDefined();
+
+      // Schema refs on operations
+      const createOp = usersModule?.operations.find((o) => o.operationId === 'createUser');
+      expect(createOp?.schemaRefs.body).toBe('CreateUserBody');
+
+      const listOp = usersModule?.operations.find((o) => o.operationId === 'listUsers');
+      expect(listOp?.schemaRefs.response).toBe('ListUsersResponse');
+
+      // Auth defaults to empty
+      expect(result.auth.schemes).toEqual([]);
+    });
+  });
+});

--- a/packages/codegen/src/__tests__/utils/imports.test.ts
+++ b/packages/codegen/src/__tests__/utils/imports.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { mergeImports, renderImports } from '../../utils/imports';
+
+describe('mergeImports', () => {
+  it('deduplicates identical imports', () => {
+    const result = mergeImports([
+      { from: './types', name: 'User', isType: true },
+      { from: './types', name: 'User', isType: true },
+    ]);
+    expect(result).toEqual([{ from: './types', name: 'User', isType: true }]);
+  });
+
+  it('keeps different names from the same module', () => {
+    const result = mergeImports([
+      { from: './types', name: 'User', isType: true },
+      { from: './types', name: 'Post', isType: true },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('sorts by module path then by name', () => {
+    const result = mergeImports([
+      { from: './types', name: 'User', isType: true },
+      { from: './client', name: 'Client', isType: false },
+      { from: './types', name: 'Post', isType: true },
+    ]);
+    expect(result.map((i) => `${i.from}:${i.name}`)).toEqual([
+      './client:Client',
+      './types:Post',
+      './types:User',
+    ]);
+  });
+});
+
+describe('renderImports', () => {
+  it('renders type imports grouped by module', () => {
+    const result = renderImports([
+      { from: './types', name: 'Post', isType: true },
+      { from: './types', name: 'User', isType: true },
+    ]);
+    expect(result).toBe("import type { Post, User } from './types';");
+  });
+
+  it('renders value and type imports separately for same module', () => {
+    const result = renderImports([
+      { from: './client', name: 'createClient', isType: false },
+      { from: './client', name: 'SDKConfig', isType: true },
+    ]);
+    expect(result).toBe(
+      "import type { SDKConfig } from './client';\nimport { createClient } from './client';",
+    );
+  });
+
+  it('renders aliased imports', () => {
+    const result = renderImports([
+      { from: './types', name: 'User', isType: true, alias: 'UserType' },
+    ]);
+    expect(result).toBe("import type { User as UserType } from './types';");
+  });
+
+  it('returns empty string for empty imports', () => {
+    expect(renderImports([])).toBe('');
+  });
+
+  it('renders imports from multiple modules', () => {
+    const result = renderImports([
+      { from: './types', name: 'User', isType: true },
+      { from: '@vertz/fetch', name: 'FetchClient', isType: false },
+    ]);
+    expect(result).toContain("import type { User } from './types';");
+    expect(result).toContain("import { FetchClient } from '@vertz/fetch';");
+  });
+});

--- a/packages/codegen/src/__tests__/utils/naming.test.ts
+++ b/packages/codegen/src/__tests__/utils/naming.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { toCamelCase, toKebabCase, toPascalCase, toSnakeCase } from '../../utils/naming';
+
+describe('toPascalCase', () => {
+  it('capitalizes a single lowercase word', () => {
+    expect(toPascalCase('users')).toBe('Users');
+  });
+
+  it('converts kebab-case to PascalCase', () => {
+    expect(toPascalCase('create-user')).toBe('CreateUser');
+  });
+
+  it('converts snake_case to PascalCase', () => {
+    expect(toPascalCase('create_user')).toBe('CreateUser');
+  });
+
+  it('converts camelCase to PascalCase', () => {
+    expect(toPascalCase('createUser')).toBe('CreateUser');
+  });
+
+  it('handles already PascalCase input', () => {
+    expect(toPascalCase('CreateUser')).toBe('CreateUser');
+  });
+
+  it('handles empty string', () => {
+    expect(toPascalCase('')).toBe('');
+  });
+
+  it('handles multi-word kebab-case', () => {
+    expect(toPascalCase('get-user-by-id')).toBe('GetUserById');
+  });
+});
+
+describe('toCamelCase', () => {
+  it('converts kebab-case to camelCase', () => {
+    expect(toCamelCase('list-users')).toBe('listUsers');
+  });
+
+  it('converts PascalCase to camelCase', () => {
+    expect(toCamelCase('ListUsers')).toBe('listUsers');
+  });
+
+  it('converts snake_case to camelCase', () => {
+    expect(toCamelCase('list_users')).toBe('listUsers');
+  });
+
+  it('handles single word', () => {
+    expect(toCamelCase('users')).toBe('users');
+  });
+});
+
+describe('toKebabCase', () => {
+  it('converts PascalCase to kebab-case', () => {
+    expect(toKebabCase('CreateUser')).toBe('create-user');
+  });
+
+  it('converts camelCase to kebab-case', () => {
+    expect(toKebabCase('createUser')).toBe('create-user');
+  });
+
+  it('converts snake_case to kebab-case', () => {
+    expect(toKebabCase('create_user')).toBe('create-user');
+  });
+});
+
+describe('toSnakeCase', () => {
+  it('converts camelCase to snake_case', () => {
+    expect(toSnakeCase('createUser')).toBe('create_user');
+  });
+
+  it('converts PascalCase to snake_case', () => {
+    expect(toSnakeCase('CreateUser')).toBe('create_user');
+  });
+
+  it('converts kebab-case to snake_case', () => {
+    expect(toSnakeCase('create-user')).toBe('create_user');
+  });
+});

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,0 +1,24 @@
+export { adaptIR } from './ir-adapter';
+export type {
+  CodegenAuth,
+  CodegenAuthScheme,
+  CodegenIR,
+  CodegenModule,
+  CodegenOperation,
+  CodegenSchema,
+  FileFragment,
+  GeneratedFile,
+  Generator,
+  GeneratorConfig,
+  HttpMethod,
+  Import,
+  JsonSchema,
+  OAuthFlows,
+  OperationAuth,
+  OperationSchemaRefs,
+  SchemaAnnotations,
+  SchemaNamingParts,
+  StreamingConfig,
+} from './types';
+export { mergeImports, renderImports } from './utils/imports';
+export { toCamelCase, toKebabCase, toPascalCase, toSnakeCase } from './utils/naming';

--- a/packages/codegen/src/ir-adapter.ts
+++ b/packages/codegen/src/ir-adapter.ts
@@ -1,0 +1,123 @@
+import type { AppIR, SchemaRef } from '@vertz/compiler';
+import type { CodegenIR, CodegenModule, CodegenSchema, OperationSchemaRefs } from './types';
+import { toPascalCase } from './utils/naming';
+
+export function adaptIR(appIR: AppIR): CodegenIR {
+  // Step 2: Collect named schemas
+  const rawSchemas = appIR.schemas.filter((s) => s.isNamed && s.jsonSchema);
+
+  // Step 4: Detect collisions — same name from different modules
+  const nameCount = new Map<string, number>();
+  for (const s of rawSchemas) {
+    nameCount.set(s.name, (nameCount.get(s.name) ?? 0) + 1);
+  }
+
+  // Build rename map: moduleName:originalName -> resolvedName
+  const renameMap = new Map<string, string>();
+  const schemas: CodegenSchema[] = rawSchemas.map((s) => {
+    const isCollision = (nameCount.get(s.name) ?? 0) > 1;
+    const resolvedName = isCollision ? `${toPascalCase(s.moduleName)}${s.name}` : s.name;
+    renameMap.set(`${s.moduleName}:${s.name}`, resolvedName);
+
+    return {
+      name: resolvedName,
+      jsonSchema: s.jsonSchema as Record<string, unknown>,
+      annotations: {
+        namingParts: {
+          operation: s.namingConvention.operation,
+          entity: s.namingConvention.entity,
+          part: s.namingConvention.part,
+        },
+      },
+    };
+  });
+
+  // Step 1: Flatten module -> router -> route into module -> operation
+  const modules: CodegenModule[] = appIR.modules.map((mod) => ({
+    name: mod.name,
+    operations: mod.routers.flatMap((router) =>
+      router.routes.map((route) => {
+        const resolveRef = (ref: SchemaRef | undefined): string | undefined => {
+          if (!ref || ref.kind !== 'named') return undefined;
+          return renameMap.get(`${mod.name}:${ref.schemaName}`) ?? ref.schemaName;
+        };
+
+        const schemaRefs: OperationSchemaRefs = {
+          params: resolveRef(route.params),
+          query: resolveRef(route.query),
+          body: resolveRef(route.body),
+          headers: resolveRef(route.headers),
+          response: resolveRef(route.response),
+        };
+
+        return {
+          operationId: route.operationId,
+          method: route.method,
+          path: route.fullPath,
+          description: route.description,
+          tags: route.tags,
+          params: route.params?.jsonSchema,
+          query: route.query?.jsonSchema,
+          body: route.body?.jsonSchema,
+          headers: route.headers?.jsonSchema,
+          response: route.response?.jsonSchema,
+          schemaRefs,
+        };
+      }),
+    ),
+  }));
+
+  // Step 5: Name inline schemas (derive from operationId + slot)
+  const slotNames: Record<string, string> = {
+    params: 'Params',
+    query: 'Query',
+    body: 'Body',
+    headers: 'Headers',
+    response: 'Response',
+  };
+
+  const inlineSchemas: CodegenSchema[] = [];
+  for (const mod of appIR.modules) {
+    for (const router of mod.routers) {
+      for (const route of router.routes) {
+        for (const [slot, suffix] of Object.entries(slotNames)) {
+          const ref = route[slot as keyof typeof route] as
+            | { kind: string; jsonSchema?: Record<string, unknown> }
+            | undefined;
+          if (
+            ref &&
+            typeof ref === 'object' &&
+            'kind' in ref &&
+            ref.kind === 'inline' &&
+            ref.jsonSchema
+          ) {
+            const name = `${toPascalCase(route.operationId)}${suffix}`;
+            inlineSchemas.push({
+              name,
+              jsonSchema: ref.jsonSchema,
+              annotations: { namingParts: {} },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Step 8: Sort deterministically
+  const allSchemas = [...schemas, ...inlineSchemas].sort((a, b) => a.name.localeCompare(b.name));
+
+  const sortedModules = modules
+    .map((m) => ({
+      ...m,
+      operations: [...m.operations].sort((a, b) => a.operationId.localeCompare(b.operationId)),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    basePath: appIR.app.basePath,
+    version: appIR.app.version,
+    modules: sortedModules,
+    schemas: allSchemas,
+    auth: { schemes: [] },
+  };
+}

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -1,0 +1,139 @@
+// ── Codegen IR Types ────────────────────────────────────────────
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export type JsonSchema = Record<string, unknown>;
+
+export interface CodegenIR {
+  basePath: string;
+  version?: string;
+  modules: CodegenModule[];
+  schemas: CodegenSchema[];
+  auth: CodegenAuth;
+}
+
+export interface CodegenModule {
+  name: string;
+  operations: CodegenOperation[];
+}
+
+export interface CodegenOperation {
+  operationId: string;
+  method: HttpMethod;
+  path: string;
+  description?: string;
+  tags: string[];
+  params?: JsonSchema;
+  query?: JsonSchema;
+  body?: JsonSchema;
+  headers?: JsonSchema;
+  response?: JsonSchema;
+  streaming?: StreamingConfig;
+  schemaRefs: OperationSchemaRefs;
+  auth?: OperationAuth;
+}
+
+export interface StreamingConfig {
+  format: 'sse' | 'ndjson';
+  eventSchema?: JsonSchema;
+}
+
+export interface OperationAuth {
+  required: boolean;
+  schemes: string[];
+}
+
+export interface OperationSchemaRefs {
+  params?: string;
+  query?: string;
+  body?: string;
+  headers?: string;
+  response?: string;
+}
+
+// ── Auth ────────────────────────────────────────────────────────
+
+export interface CodegenAuth {
+  schemes: CodegenAuthScheme[];
+}
+
+export type CodegenAuthScheme =
+  | { type: 'bearer'; name: string; description?: string }
+  | { type: 'basic'; name: string; description?: string }
+  | {
+      type: 'apiKey';
+      name: string;
+      in: 'header' | 'query' | 'cookie';
+      paramName: string;
+      description?: string;
+    }
+  | { type: 'oauth2'; name: string; flows: OAuthFlows; description?: string };
+
+export interface OAuthFlows {
+  authorizationCode?: {
+    authorizationUrl: string;
+    tokenUrl: string;
+    scopes: Record<string, string>;
+  };
+  clientCredentials?: {
+    tokenUrl: string;
+    scopes: Record<string, string>;
+  };
+  deviceCode?: {
+    deviceAuthorizationUrl: string;
+    tokenUrl: string;
+    scopes: Record<string, string>;
+  };
+}
+
+// ── Schema ──────────────────────────────────────────────────────
+
+export interface CodegenSchema {
+  name: string;
+  jsonSchema: JsonSchema;
+  annotations: SchemaAnnotations;
+}
+
+export interface SchemaAnnotations {
+  description?: string;
+  deprecated?: boolean;
+  brand?: string;
+  namingParts: SchemaNamingParts;
+}
+
+export interface SchemaNamingParts {
+  operation?: string;
+  entity?: string;
+  part?: string;
+}
+
+// ── Generator ───────────────────────────────────────────────────
+
+export interface Generator {
+  readonly name: string;
+  generate(ir: CodegenIR, config: GeneratorConfig): GeneratedFile[];
+}
+
+export interface GeneratedFile {
+  path: string;
+  content: string;
+}
+
+export interface GeneratorConfig {
+  outputDir: string;
+  options: Record<string, unknown>;
+}
+
+// ── Template System ─────────────────────────────────────────────
+
+export interface Import {
+  from: string;
+  name: string;
+  isType: boolean;
+  alias?: string;
+}
+
+export interface FileFragment {
+  content: string;
+  imports: Import[];
+}

--- a/packages/codegen/src/utils/imports.ts
+++ b/packages/codegen/src/utils/imports.ts
@@ -1,0 +1,46 @@
+import type { Import } from '../types';
+
+export function mergeImports(imports: Import[]): Import[] {
+  const seen = new Map<string, Import>();
+  for (const imp of imports) {
+    const key = `${imp.from}::${imp.name}::${imp.isType}::${imp.alias ?? ''}`;
+    if (!seen.has(key)) {
+      seen.set(key, imp);
+    }
+  }
+  return [...seen.values()].sort((a, b) => {
+    const fromCmp = a.from.localeCompare(b.from);
+    if (fromCmp !== 0) return fromCmp;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function renderImports(imports: Import[]): string {
+  const grouped = new Map<string, { types: string[]; values: string[] }>();
+
+  for (const imp of imports) {
+    let group = grouped.get(imp.from);
+    if (!group) {
+      group = { types: [], values: [] };
+      grouped.set(imp.from, group);
+    }
+    const nameStr = imp.alias ? `${imp.name} as ${imp.alias}` : imp.name;
+    if (imp.isType) {
+      group.types.push(nameStr);
+    } else {
+      group.values.push(nameStr);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [from, group] of grouped) {
+    if (group.types.length > 0) {
+      lines.push(`import type { ${group.types.join(', ')} } from '${from}';`);
+    }
+    if (group.values.length > 0) {
+      lines.push(`import { ${group.values.join(', ')} } from '${from}';`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/codegen/src/utils/naming.ts
+++ b/packages/codegen/src/utils/naming.ts
@@ -1,0 +1,29 @@
+function splitWords(input: string): string[] {
+  return input
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[-_\s]+/)
+    .filter(Boolean);
+}
+
+export function toPascalCase(input: string): string {
+  return splitWords(input)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+}
+
+export function toCamelCase(input: string): string {
+  const pascal = toPascalCase(input);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+export function toKebabCase(input: string): string {
+  return splitWords(input)
+    .map((w) => w.toLowerCase())
+    .join('-');
+}
+
+export function toSnakeCase(input: string): string {
+  return splitWords(input)
+    .map((w) => w.toLowerCase())
+    .join('_');
+}

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "isolatedDeclarations": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/codegen/tsconfig.typecheck.json
+++ b/packages/codegen/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/codegen/vitest.config.ts
+++ b/packages/codegen/vitest.config.ts
@@ -1,0 +1,23 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test-d.ts'],
+    environment: 'node',
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.test-d.ts'],
+      ignoreSourceErrors: true,
+      tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
+    },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the codegen design plan — `@vertz/codegen` package scaffolding, CodegenIR type definitions, and the `adaptIR()` pipeline.

- **CodegenIR types** — `CodegenIR`, `CodegenModule`, `CodegenOperation`, `CodegenSchema`, `CodegenAuth`, `Generator`, `GeneratedFile`, `Import`, `FileFragment`
- **IR Adapter pipeline** (`adaptIR()`) — transforms `AppIR` → `CodegenIR`:
  - Flatten module → router → route into module → operations
  - Collect named schemas, resolve name collisions (module-prefixed)
  - Name inline schemas from operationId + slot
  - Extract metadata, sort deterministically
- **Naming utilities** — `toPascalCase`, `toCamelCase`, `toKebabCase`, `toSnakeCase`
- **Import utilities** — `mergeImports()`, `renderImports()`

50 tests across 3 test files, all passing.

## Test plan

- [x] All 50 tests pass (`bun run --filter @vertz/codegen test`)
- [x] Full workspace typecheck passes (`bun run typecheck`)
- [x] Biome lint/format clean
- [ ] CI passes on this PR

Closes VER-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)