### PR TITLE
docs: rewrite quickstart with real verified API examples

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,62 +1,255 @@
 ---
 title: Quickstart
-description: Get up and running with Vertz in 5 minutes
+description: Build a working Vertz API in 5 minutes
 ---
 
 # Quickstart
 
-Get a Vertz project running in under 5 minutes.
+By the end of this guide you'll have a running HTTP server with type-safe routes, schema validation, and auto-generated CRUD endpoints. Total time: ~5 minutes.
 
 ## Prerequisites
 
-- **Node.js** 18+ 
-- **Bun** (recommended) or npm/pnpm
+- **Node.js** 22+ or **Bun** 1.0+
+- **TypeScript** 5.0+
 
-## Step 1: Create a New Project
+## Step 1: Create Your Project
 
-```bash
-# Using Bun (recommended)
-bun create vertz-app my-vertz-app
+<CodeGroup>
 
-# Or using npm
-npm create vertz-app my-vertz-app
+```bash Scaffold (recommended)
+npx @vertz/cli create my-app
+cd my-app
 ```
 
-## Step 2: Start the Dev Server
-
-```bash
-cd my-vertz-app
-bun dev
+```bash Manual setup
+mkdir my-app && cd my-app
+npm init -y
+npm install @vertz/server @vertz/schema @vertz/cli
+npx tsc --init
 ```
 
-Your app is now running at `http://localhost:3000`.
+</CodeGroup>
 
-## Step 3: Create Your First Component
+If you scaffolded, skip to [Step 4](#step-4-start-the-dev-server) — the template already has a working server.
 
-Edit `src/app.tsx`:
+## Step 2: Define a Schema
 
-```tsx
-import { component$, useSignal } from 'vertz/ui';
+Create `src/todo.schema.ts`. Schemas use `@vertz/schema` (a Zod-inspired library that ships with Vertz):
 
-export default component$(() => {
-  const count = useSignal(0);
-  
-  return (
-    <div class="p-8">
-      <h1 class="text-2xl font-bold mb-4">Hello Vertz!</h1>
-      <button 
-        onClick$={() => count.value++}
-        class="px-4 py-2 bg-primary text-white rounded"
-      >
-        Count: {count.value}
-      </button>
-    </div>
-  );
+```typescript src/todo.schema.ts
+import { s } from '@vertz/schema';
+
+export const CreateTodoSchema = s.object({
+  title: s.string().min(1),
+  done: s.boolean().default(false),
 });
+
+export const TodoParamsSchema = s.object({
+  id: s.string().uuid(),
+});
+
+// Infer TypeScript types from schemas — no duplication
+export type CreateTodo = typeof CreateTodoSchema._output;
+```
+
+## Step 3: Create Your Server
+
+Create `src/app.ts`. This is your entry point:
+
+```typescript src/app.ts
+import { createServer, createModuleDef, createModule } from '@vertz/server';
+import { CreateTodoSchema, TodoParamsSchema } from './todo.schema';
+
+// 1. Define a module (a logical group of routes + services)
+const todoDef = createModuleDef({ name: 'todos' });
+
+// 2. Create a router with a prefix
+const router = todoDef.router({ prefix: '/todos' });
+
+// In-memory store for this example
+const todos: { id: string; title: string; done: boolean }[] = [];
+
+// 3. Add routes — body/params schemas are validated automatically
+router.get('/', {
+  handler: () => ({ todos }),
+});
+
+router.post('/', {
+  body: CreateTodoSchema,
+  handler: (ctx) => {
+    // ctx.body is fully typed as { title: string; done: boolean }
+    const todo = { id: crypto.randomUUID(), ...ctx.body };
+    todos.push(todo);
+    return todo;
+  },
+});
+
+router.get('/:id', {
+  params: TodoParamsSchema,
+  handler: (ctx) => {
+    const todo = todos.find((t) => t.id === ctx.params.id);
+    if (!todo) throw new Error('Not found');
+    return todo;
+  },
+});
+
+// 4. Assemble the module
+const todoModule = createModule(todoDef, {
+  services: [],
+  routers: [router],
+  exports: [],
+});
+
+// 5. Create the server and register your module
+const app = createServer({});
+app.register(todoModule);
+
+// 6. Start listening
+app.listen(3000);
+```
+
+<Note>
+`createServer()` returns a builder. Call `.register()` to add modules, then `.listen()` to start.
+The handler is a standard `Request → Response` function — it works with Bun, Node, and any Web-compatible runtime.
+</Note>
+
+## Step 4: Start the Dev Server
+
+```bash
+npx vertz dev
+```
+
+This compiles your `src/` directory, starts the server on `http://localhost:3000`, watches for changes, and runs type-checking in the background.
+
+<Tip>
+Use `vertz dev --port 4000` to change the port, or `vertz dev --no-typecheck` to skip background type-checking.
+</Tip>
+
+## Step 5: Test Your API
+
+```bash
+# List todos (empty at first)
+curl http://localhost:3000/todos
+
+# Create a todo
+curl -X POST http://localhost:3000/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Learn Vertz"}'
+
+# Validation works — this fails because title is empty
+curl -X POST http://localhost:3000/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": ""}'
+
+# Get a specific todo (use the id from the create response)
+curl http://localhost:3000/todos/<id>
+```
+
+That's it. You have a type-safe API with automatic request validation.
+
+---
+
+## Going Further: Domains (Preview)
+
+<Warning>
+The domain API is in early development (TDD stub phase). The structure below is the target API — it compiles and passes contract tests, but CRUD generation isn't wired up yet. Use modules + routers (shown above) for production code today.
+</Warning>
+
+Domains are Vertz's answer to boilerplate CRUD. You declare a persisted entity and get endpoints generated automatically:
+
+```typescript src/domains/task.ts
+import { domain } from '@vertz/server';
+import { d } from '@vertz/db';
+import { s } from '@vertz/schema';
+
+// Define a database table
+const tasksTable = d.table('tasks', {
+  id: d.uuid().primaryKey().defaultValue('gen_random_uuid()'),
+  title: d.text().notNull(),
+  done: d.boolean().defaultValue('false').notNull(),
+  createdAt: d.timestamp().defaultValue('now()').notNull(),
+});
+
+// Create a domain — generates GET/POST/PUT/DELETE endpoints
+const Task = domain('tasks', {
+  type: 'persisted',
+  table: d.entry(tasksTable, {}),
+  access: {
+    read: () => true,           // everyone can read
+    create: (_row, ctx) => !!ctx.user, // must be logged in to create
+  },
+});
+```
+
+Register domains when creating your server:
+
+```typescript
+const app = createServer({
+  domains: [Task],
+  apiPrefix: '/api/',
+});
+
+// This will generate:
+//   GET    /api/tasks
+//   GET    /api/tasks/:id
+//   POST   /api/tasks
+//   PUT    /api/tasks/:id
+//   DELETE /api/tasks/:id
+```
+
+## Project Structure
+
+A typical Vertz project looks like this:
+
+```
+my-app/
+├── src/
+│   ├── app.ts              # Entry point — createServer + module registration
+│   ├── todo.schema.ts      # Schemas (validation + types)
+│   └── modules/
+│       └── todos/
+│           ├── router.ts   # Route definitions
+│           └── service.ts  # Business logic
+├── vertz.config.ts         # CLI configuration
+├── package.json
+└── tsconfig.json
+```
+
+## Configuration
+
+Create `vertz.config.ts` to customize the CLI:
+
+```typescript vertz.config.ts
+import type { CLIConfig } from '@vertz/cli';
+
+const config: CLIConfig = {
+  compiler: {
+    sourceDir: 'src',
+    entryFile: 'src/app.ts',
+  },
+  dev: {
+    port: 3000,
+    host: 'localhost',
+    typecheck: true,
+  },
+};
+
+export default config;
 ```
 
 ## What's Next?
 
-- **[Core Concepts](/concepts/domains)** — Learn about the domain system
-- **[UI Guide](/ui/overview)** — Deep dive into the UI framework
-- **[Schema](/schema/overview)** — Define your data model
+<CardGroup cols={2}>
+  <Card title="Core Concepts" icon="book" href="/concepts/server">
+    Understand servers, modules, and routers
+  </Card>
+  <Card title="Schema" icon="shield" href="/schema/overview">
+    Deep dive into validation with `@vertz/schema`
+  </Card>
+  <Card title="Database" icon="database" href="/concepts/domains">
+    Learn about domains and `@vertz/db`
+  </Card>
+  <Card title="UI Framework" icon="browser" href="/ui/overview">
+    Build reactive UIs with the Vertz compiler
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Rewrites the getting-started quickstart from scratch with real, verified API examples.

- Two setup paths (scaffold + manual)
- Schema definition with actual `@vertz/schema` API
- Server creation with real `createServer()` chain
- Route handlers with typed `ctx.body` and `ctx.params`
- `vertz dev` usage
- Domain API preview (honestly marked as upcoming)
- Mintlify MDX format with CodeGroup, Note, Warning components