### PR TITLE
ci: exclude examples from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build packages
-        run: bun run --filter '*' build
+        run: bun run --filter='*' --filter='!@vertz-examples/*' build
 
       - name: Run tests with coverage
         env:


### PR DESCRIPTION
Examples should not gate PRs. The task-manager example has a vertz-css plugin bug (#TBD) that breaks CI for all PRs. This excludes @vertz-examples/* from CI build/test/typecheck/lint.