### PR TITLE
docs(server): export Result helpers for README examples

### DIFF
--- a/.changeset/server-docs-fix.md
+++ b/.changeset/server-docs-fix.md
@@ -1,0 +1,5 @@
+---
+'@vertz/server': patch
+---
+
+docs(server): export Result type helpers (ok, err, isOk, isErr) for README examples

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -43,6 +43,8 @@ export {
   BadRequestException,
   ConflictException,
   createEnv,
+  // Result helpers
+  err,
   // Immutability
   createImmutableProxy,
   createMiddleware,
@@ -52,8 +54,11 @@ export {
   deepFreeze,
   ForbiddenException,
   InternalServerErrorException,
+  isErr,
+  isOk,
   makeImmutable,
   NotFoundException,
+  ok,
   ServiceUnavailableException,
   UnauthorizedException,
   ValidationException,


### PR DESCRIPTION
Replaces #370. Fixes #352.

Reopened under bot identity per team policy.

## Summary

The README already contains accurate API documentation with correct builder patterns for `createServer()`, `createModule()`, and `createAuth()`. All examples have been verified against actual source code.

This PR adds missing exports (`ok`, `err`, `isOk`, `isErr`) so the Result type examples in the README work correctly.

## Changes

- ✅ Export `ok`, `err`, `isOk`, `isErr` from @vertz/server
- ✅ All API examples verified against actual source code in packages/server/src/

## Issues Fixed from Original PR #370

- ✅ createServer() API already correct in main (builder pattern with register, middlewares, listen)
- ✅ createAuth() API already correct in main (in-memory for Phase 1, matches implementation)
- ✅ Result type helpers now exported for README examples
- ✅ Removed tutorial with incorrect APIs (original PR had APIs that didn't match implementation)

The original PR #370 included a full-stack tutorial with incorrect API calls that don't match the actual implementation. That content has been removed. The README in main already has correct examples.