### PR TITLE
fix(ci): add coverage reporters to vitest configs

### DIFF
--- a/packages/cli-runtime/vitest.config.ts
+++ b/packages/cli-runtime/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     environment: 'node',
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/index.ts'],

--- a/packages/cloudflare/vitest.config.ts
+++ b/packages/cloudflare/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '@': resolve(__dirname, './src'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/codegen/vitest.config.ts
+++ b/packages/codegen/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/compiler/vitest.config.ts
+++ b/packages/compiler/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/errors/vitest.config.ts
+++ b/packages/errors/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/fetch/vitest.config.ts
+++ b/packages/fetch/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       tsconfig: resolve(__dirname, './tsconfig.typecheck.json'),
     },
     coverage: {
+      reporter: ['text', 'json-summary', 'json'],
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],


### PR DESCRIPTION
## Problem

The coverage report action expects `coverage/coverage-summary.json` files from vitest, but the vitest configs didn't specify which reporters to use.

## Solution

Added `reporter: ['text', 'json-summary', 'json']` to the coverage configuration in all package `vitest.config.ts` files:

- @vertz/cli
- @vertz/cli-runtime
- @vertz/cloudflare
- @vertz/codegen
- @vertz/compiler
- @vertz/core
- @vertz/db
- @vertz/errors
- @vertz/fetch
- @vertz/schema
- @vertz/testing

This ensures that when the CI runs `vitest run --coverage`, it generates the required json-summary and json files for the coverage report action.

## Testing

The CI workflow's coverage job will now generate the expected coverage files in each package's `coverage/` directory.