### PR TITLE
fix(ci): use turbo for build in coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build packages
-        run: bun run --filter='*' --filter='!@vertz-examples/*' build
+        run: turbo run build --filter='!@vertz-examples/*'
 
       - name: Run tests with coverage
         env:


### PR DESCRIPTION
Coverage job build step used bun run --filter which doesn't exclude examples. task-manager example fails (#408 vertz-css bug), preventing coverage generation. Switched to turbo which properly excludes examples.