### PR TITLE
fix: add repository.url to cloudflare package

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -36,5 +36,10 @@
     "@vertz/ui-server": {
       "optional": true
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "cloudflare"
   }
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -21,5 +21,10 @@
     "typescript": "^5.7.0",
     "vitest": "^4.0.18",
     "yaml": "^2.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "integration-tests"
   }
 }


### PR DESCRIPTION
npm provenance requires repository.url to match the GitHub repo. @vertz/cloudflare was missing it, causing E422 on publish. Also fixed integration-tests.