### PR TITLE
fix(db): migrate postgres-integration tests to PGlite

### DIFF
--- a/.changeset/ui-canvas-phase1-cleanup.md
+++ b/.changeset/ui-canvas-phase1-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@vertz/ui-canvas": minor
+---
+
+Breaking changes to `@vertz/ui-canvas` to fix Phase 1 issues before Phase 2:
+
+- `render()` is now async (returns `Promise<CanvasState>`) — migrated to PixiJS v8 `app.init()` API
+- `render()` now returns `{ canvas, app, stage, dispose }` — exposes PixiJS Application and stage for scene building
+- `destroy()` removed from public API — use `dispose()` from `render()` return value instead
+- `@vertz/ui` moved from `devDependencies` to `peerDependencies`
+- `bindSignal` internal cleanup (redundant signal read removed)


### PR DESCRIPTION
## Summary

- Migrate `postgres-integration.test.ts` from requiring an external PostgreSQL instance to using PGlite (in-memory), removing the dependency that broke local `git push` via the pre-push hook
- Fix pre-existing bug in `seedTestData` where `unwrap` received a Promise instead of a resolved Result (`await unwrap(promise)` → `unwrap(await promise)`)
- Convert error scenario tests from try/catch to Result pattern to match the actual db API (methods return `err()`, they don't throw)

## Test plan

- [x] `bun run test` in `packages/db` — all 929 tests pass (no Postgres required)
- [x] `bun run typecheck` — no type errors
- [x] `bunx biome check` — lint clean
- [x] Pre-push hook passes across all 24 packages

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)