### PR TITLE
fix(ci): add pull-requests write permission to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `pull-requests: write` permission to the Release workflow so the `changesets/action` can create the "Version Packages" PR
- Without this permission, the action fails with `Resource not accessible by integration`

Closes #448

## Test plan

- [ ] Verify the Release workflow passes on main after merge (creates the Version Packages PR successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)