### PR TITLE
fix(ci): handle workflow_dispatch in coverage job + update Codecov token [#470]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
       - name: Detect changed packages
         id: changes
         run: |
-          # On push to main, mark all packages as changed so we get full coverage
-          if [ "${{ github.event_name }}" = "push" ]; then
+          # On push to main or workflow_dispatch, mark all packages as changed so we get full coverage
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors; do
               echo "${pkg//-/_}=true" >> "$GITHUB_OUTPUT"
             done
@@ -183,8 +183,8 @@ jobs:
         env:
           DATABASE_TEST_URL: postgres://postgres:postgres@localhost:5432/vertz_test
         run: |
-          # On push to main, run coverage for all packages
-          if [ "${{ github.event_name }}" = "push" ]; then
+          # On push to main or workflow_dispatch, run coverage for all packages
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors; do
               echo "::group::Coverage — $pkg"
               cd packages/$pkg


### PR DESCRIPTION
## Summary
- Fix coverage job to handle `workflow_dispatch` events (previously only `push` and `pull_request` were handled, causing no coverage files to be generated on manual triggers)
- Update `CODECOV_TOKEN` secret with correct repository token

## Context
The previous token returned `"Repository not found"` on upload. The coverage job also silently skipped all packages on `workflow_dispatch` because event-specific logic fell through to PR code paths with missing variables.

## Test plan
- [ ] Merge this PR (triggers push-to-main CI)
- [ ] Verify Codecov uploads succeed in the CI logs (no "Repository not found" error)
- [ ] Verify coverage appears on the Codecov dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)