### PR TITLE
fix(ci): enable file path fixing for Codecov uploads [#470]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
                 --file "packages/$pkg/coverage/coverage-final.json" \
                 --flag "$pkg" \
                 --disable-search \
-                --disable-file-fixes
+                --network-root-folder "$GITHUB_WORKSPACE"
             else
               echo "Skipping $pkg (no coverage file)"
             fi


### PR DESCRIPTION
## Summary
Replace `--disable-file-fixes` with `--network-root-folder $GITHUB_WORKSPACE` in Codecov upload.

## Problem
Coverage JSON files contain absolute paths from the CI runner (e.g., `/home/runner/work/vertz/vertz/packages/core/src/file.ts`). With `--disable-file-fixes`, Codecov couldn't normalize these paths to repo-relative paths, causing all uploads to remain stuck at `"started"` state without ever being processed.

## Fix
Use `--network-root-folder "$GITHUB_WORKSPACE"` to tell Codecov the workspace root. This enables proper path stripping so `/home/runner/work/vertz/vertz/packages/core/src/file.ts` becomes `packages/core/src/file.ts`, which Codecov can map to the repo.

## Test plan
- [ ] Codecov API shows uploads with state `"processed"` (not `"started"`)
- [ ] Codecov dashboard shows coverage percentage
- [ ] Badge shows a number instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)