### PR TITLE
docs: fix hallucinations in db and server READMEs

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -32,7 +32,7 @@ const todosModel = d.model(todosTable);
 // 3. Create database client
 const db = createDb({
   url: process.env.DATABASE_URL!,
-  tables: { todos: todosModel },
+  models: { todos: todosModel },
 });
 
 // 4. Query with full type inference and Result-based errors
@@ -274,7 +274,7 @@ d.ref.many(() => coursesTable).through(() => enrollmentsTable, 'studentId', 'cou
 ```typescript
 const db = createDb({
   url: 'postgresql://user:pass@localhost:5432/mydb',
-  tables: { users: usersModel, posts: postsModel },
+  models: { users: usersModel, posts: postsModel },
   dialect: 'postgres',           // 'postgres' (default) or 'sqlite'
   pool: {
     max: 20,
@@ -500,11 +500,11 @@ const settings = d.table('settings', { /* ... */ }).shared();
 import { createDb, defaultPostgresDialect, defaultSqliteDialect } from '@vertz/db';
 
 // PostgreSQL (default)
-const pgDb = createDb({ url: 'postgresql://...', tables });
+const pgDb = createDb({ url: 'postgresql://...', models });
 
 // SQLite
 const sqliteDb = createDb({
-  tables,
+  models,
   dialect: 'sqlite',
   d1: d1Database,  // Cloudflare D1 or compatible
 });

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -292,7 +292,7 @@ Validation errors include details:
 ## Full Example
 
 ```typescript
-import { d, createRegistry } from '@vertz/db';
+import { d } from '@vertz/db';
 import { createServer, entity } from '@vertz/server';
 import { s } from '@vertz/schema';
 


### PR DESCRIPTION
## Summary

- **@vertz/db**: `tables` → `models` in `createDb` config (4 occurrences) — the property was renamed in #518 but the README still used the old name
- **@vertz/server**: Remove stale `createRegistry` import in Full Example — `createRegistry` was replaced by `d.model()` but this import was missed

## Test plan

- [x] Verified `CreateDbOptions.models` is the correct property name (source: `packages/db/src/client/database.ts`)
- [x] Verified `createRegistry` is not used elsewhere in the server README


🤖 Generated with [Claude Code](https://claude.com/claude-code)