### PR TITLE
docs: design doc for unified form API

### DIFF
--- a/tickets/vertz-ui/ui-008-forms.md
+++ b/tickets/vertz-ui/ui-008-forms.md
@@ -16,7 +16,7 @@ Implement the `form()` API for SDK-aware form handling with per-field signal sta
 
 The v1.0 approach is explicit schema — `form(api.users.create, { schema, onSuccess, ... })`. Auto-extraction via `.meta` is deferred to a post-v1.0 codegen enhancement.
 
-The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, replaces `error()` method with per-field signal properties, and moves all callbacks into `form()` options.
+The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, replaces `error()` method with per-field signal properties, moves all callbacks into `form()` options, and adds compiler-assisted DOM binding for field state tracking.
 
 ### What to implement
 
@@ -25,29 +25,38 @@ The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, 
 - `form(sdkMethod, opts?)` core — starts with explicit schema
 - Direct properties: `action`, `method`, `onSubmit` (no `attrs()` method)
 - `reset()` — clears all fields, errors, dirty, and touched state
-- Per-field signal states: `form.<field>.error`, `form.<field>.dirty`, `form.<field>.touched`, `form.<field>.value`
+- `setFieldError(field, msg)` — programmatically set per-field error (server-side validation)
+- `submit(formData?)` — programmatic submit using same callbacks as `onSubmit`
+- Per-field signal states via lazy Proxy: `form.<field>.error`, `form.<field>.dirty`, `form.<field>.touched`, `form.<field>.value`
 - Form-level signal states: `submitting`, `dirty`, `valid`
 - `formDataToObject(formData)` converter with type coercion
-- `FormOptions` with `schema`, `initial`, `onSuccess`, `onError`, `resetOnSuccess`
-- Initial values: static object or reactive signal (from `query()`)
+- `FormOptions` with `schema`, `initial` (static object only for v1), `onSuccess`, `onError`, `resetOnSuccess`
+- `__bindElement(el)` internal method — receives form element from compiler for event delegation
 - Progressive enhancement (works without JS)
 - Integration with `@vertz/schema` validation
 
 #### Compiler (`packages/ui-compiler/`)
 
 - Extend `signal-api-registry.ts` with `fieldSignalProperties` for 3-level chain support
-- Extend signal transformer to handle 3-level property chains (`taskForm.title.error` → `.value` insertion)
+- Reconcile form registry entry (remove old `errors`/`values`, add new properties)
+- Extend signal transformer to handle 3-level property chains (`taskForm.title.error` → `.value` insertion), top-down processing
 - Extend JSX analyzer `containsSignalApiPropertyAccess()` for 3-level chains
-- Reserved name validation: compiler error when schema field name conflicts with form-level property
+- Compiler-assisted DOM binding: `onSubmit={taskForm.onSubmit}` on `<form>` generates `__bindElement` call
+
+#### Types (`packages/ui/src/form/`)
+
+- Reserved name enforcement via TypeScript conditional types (not compiler diagnostic)
+- `FormInstance<TBody, TResult>` conditional type that errors when `keyof TBody & ReservedFormNames` is non-empty
 
 ### Files to create/modify
 
-- `packages/ui/src/form/form.ts` — rewrite with new API surface
+- `packages/ui/src/form/form.ts` — rewrite with new API surface, Proxy-based field access
 - `packages/ui/src/form/field-state.ts` — per-field signal state
 - `packages/ui/src/form/form-data.ts` — existing, may need updates
 - `packages/ui/src/form/validation.ts` — existing, may need updates
-- `packages/ui-compiler/src/signal-api-registry.ts` — add `fieldSignalProperties`
+- `packages/ui-compiler/src/signal-api-registry.ts` — add `fieldSignalProperties`, reconcile form entry
 - `packages/ui-compiler/src/transformers/signal-transformer.ts` — 3-level chain support
+- `packages/ui-compiler/src/transformers/jsx-transformer.ts` — `__bindElement` transform for form elements
 - `packages/ui-compiler/src/analyzers/jsx-analyzer.ts` — 3-level reactive detection
 - All corresponding `__tests__/` files
 
@@ -71,6 +80,8 @@ The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, 
 - [ ] `form().method` returns HTTP method (string)
 - [ ] `form().onSubmit` returns submit event handler that validates, calls SDK, invokes callbacks
 - [ ] `form().reset()` clears all fields, errors, dirty, and touched state
+- [ ] `form().setFieldError(field, msg)` sets per-field error signal (server-side validation)
+- [ ] `form().submit(formData?)` triggers submission using same callbacks as `onSubmit`
 - [ ] `form().submitting` is a `Signal<boolean>` reflecting submission in progress
 - [ ] `form().dirty` is a `Signal<boolean>` reflecting any-field-modified state
 - [ ] `form().valid` is a `Signal<boolean>` reflecting all-fields-valid state
@@ -82,6 +93,7 @@ The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, 
 - [ ] `form().<field>.touched` is a `Signal<boolean>` tracking focus/blur
 - [ ] `form().<field>.value` is a `Signal<T>` with current field value
 - [ ] Field names are type-safe (`keyof TBody`)
+- [ ] Field state objects are lazily created via Proxy (only when accessed)
 
 ### Compiler
 
@@ -90,17 +102,27 @@ The API redesign (discussed in PR #526, captured in #527) eliminates `attrs()`, 
 - [ ] JSX analyzer marks `{taskForm.title.error && <el/>}` as reactive
 - [ ] Middle accessor `taskForm.title` alone does NOT insert `.value`
 - [ ] 2-level chain `taskForm.submitting` still works (no regression)
-- [ ] Reserved name validation: compiler errors on schema fields conflicting with form properties
+- [ ] `onSubmit={taskForm.onSubmit}` on `<form>` generates `__bindElement` call
+- [ ] Signal API registry reconciled with new form API surface
+
+### Types
+
+- [ ] Reserved name conflict produces TypeScript type error (conditional type, not compiler diagnostic)
+- [ ] `setFieldError()` only accepts `keyof TBody` as field name
+- [ ] `form().<field>` only allows fields from `keyof TBody` (negative test: unknown field name)
 
 ### Other
 
 - [ ] Form works without JavaScript (progressive enhancement)
 - [ ] `resetOnSuccess: true` resets form after successful submission
-- [ ] `initial` accepts static object or reactive signal
+- [ ] `initial` accepts static object (v1 — reactive signals deferred)
 - [ ] `@vertz/schema` validation integration works
 - [ ] No `attrs()` method on the public API
 - [ ] No `error()` method on the public API
-- [ ] Zero `effect()` needed in form components for field state
+- [ ] No `handleSubmit()` on the public API (replaced by `submit()`)
+- [ ] Zero `effect()` needed in form components for field state (common case)
+- [ ] Flat schemas only (nested objects are non-goal for v1)
+- [ ] Bracket notation `taskForm[dynamicField].error` is non-goal for v1
 
 ### Integration Tests
 
@@ -164,7 +186,6 @@ test('form() has action, method, onSubmit as direct properties', () => {
 
 // IT-3-5: 3-level compiler transform
 test('compiler transforms taskForm.title.error in JSX', () => {
-  // Compiler test: verify .value insertion on 3-level chain
   const source = `
     const taskForm = form(taskApi.create, { schema });
     return <span>{taskForm.title.error}</span>;
@@ -172,9 +193,41 @@ test('compiler transforms taskForm.title.error in JSX', () => {
   const result = transform(source);
   expect(result).toContain('taskForm.title.error.value');
 });
+
+// IT-3-6: setFieldError maps server errors to per-field signals
+test('setFieldError populates per-field error signal', () => {
+  const userForm = form(api.users.create, { schema: createUserBodySchema });
+  userForm.setFieldError('email', 'Already taken');
+  expect(userForm.email.error.value).toBe('Already taken');
+});
+
+// IT-3-7: submit() uses same callbacks as onSubmit
+test('submit() triggers submission with configured callbacks', async () => {
+  let result: User | null = null;
+  const userForm = form(api.users.create, {
+    schema: createUserBodySchema,
+    onSuccess: (u) => { result = u; },
+  });
+  const fd = new FormData();
+  fd.set('name', 'Alice');
+  fd.set('email', 'alice@test.com');
+  await userForm.submit(fd);
+  expect(result).not.toBeNull();
+});
+
+// IT-3-8: compiler generates __bindElement for form elements
+test('compiler generates __bindElement for form with onSubmit', () => {
+  const source = `
+    const taskForm = form(taskApi.create, { schema });
+    return <form onSubmit={taskForm.onSubmit}></form>;
+  `;
+  const result = transform(source);
+  expect(result).toContain('__bindElement');
+});
 ```
 
 ## Progress
 
 - 2026-02-10: Ticket created from implementation plan.
 - 2026-02-21: Updated to reflect form API redesign (#527). `attrs()` eliminated, per-field signal states added, callbacks moved to `form()` options. Compiler changes added for 3-level chain support.
+- 2026-02-21: Addressed review findings. Reserved names → TypeScript conditional types. Static-only initial values for v1. Added `setFieldError()`, `submit()`. Compiler-assisted DOM binding. Lazy Proxy for field states. Explicit non-goals for nested schemas, bracket notation, reactive initial.


### PR DESCRIPTION
## Summary

- Adds design doc at `plans/form-unified-api.md` for a unified `form()` API that handles both create and edit scenarios
- Covers async initial value loading (`load` option), schema auto-inference from SDK method metadata, unified `loading`/`submitting`/`disabled` state, and zero-config create forms
- Includes all required design doc sections: API Surface, Manifesto Alignment, Non-Goals, Unknowns, Type Flow Map, E2E Acceptance Test

## Key design decisions

- **`load` option** for async initial values — reactive, re-fetches when dependencies change
- **Schema auto-inference** from `SdkMethodWithMeta.meta.bodySchema` — zero-config for codegen SDKs
- **`initialValues` + `load` mutually exclusive** at the type level (compile-time error)
- **Callbacks (`onSuccess`/`onError`) at form instantiation**, overridable per-submission
- **No "rules of hooks"** — forms can be instantiated after conditional returns, enabling clean loading patterns

## Open unknowns (3)

1. How `load` interacts with reactive dependencies (proposed: reactive, like `query()`)
2. Controlled vs uncontrolled inputs (proposed: controlled via `values` signal)
3. Whether `transform` should be required when load type differs (proposed: auto-strip via schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)