### PR TITLE
feat(ui,ui-compiler): redesign form() API — direct properties, per-field signals, compiler binding [#527]

### DIFF
--- a/.changeset/form-api-redesign.md
+++ b/.changeset/form-api-redesign.md
@@ -1,0 +1,33 @@
+---
+'@vertz/ui': patch
+'@vertz/ui-compiler': patch
+---
+
+**BREAKING:** Redesign `form()` API — direct properties, per-field signals, and compiler-assisted DOM binding.
+
+### Removed
+- `form().attrs()` — use direct properties: `form.action`, `form.method`, `form.onSubmit`
+- `form().error(field)` — use per-field signals: `form.title.error`
+- `form().handleSubmit(callbacks)` — use `form.submit(formData?)` and pass callbacks via `FormOptions`
+- `SubmitCallbacks` type — merged into `FormOptions` (`onSuccess`, `onError`, `resetOnSuccess`)
+
+### Added
+- Direct properties: `action`, `method`, `onSubmit`, `reset`, `setFieldError`, `submit`
+- Per-field reactive state via Proxy: `form.<field>.error`, `.dirty`, `.touched`, `.value`
+- Form-level computed signals: `form.dirty`, `form.valid`
+- `FieldState<T>` type and `createFieldState()` factory
+- `__bindElement(el)` for compiler-assisted DOM event delegation
+- 3-level signal auto-unwrap in compiler: `form.title.error` → `.value`
+- `__bindElement` transform in JSX compiler for `<form>` elements
+
+### Migration
+```diff
+- const { action, method, onSubmit } = todoForm.attrs({ onSuccess, resetOnSuccess: true });
++ const todoForm = form(sdk, { schema, onSuccess, resetOnSuccess: true });
+
+- effect(() => { titleError = todoForm.error('title') ?? ''; });
++ {todoForm.title.error}
+
+- formEl.addEventListener('submit', todoForm.handleSubmit({ onSuccess, onError }));
++ <form onSubmit={todoForm.onSubmit}>
+```

--- a/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
@@ -1,0 +1,465 @@
+// ===========================================================================
+// Form API Developer Walkthrough — Public API Validation Test
+//
+// This test validates that a developer can use the full form() API using
+// ONLY public imports from @vertz/ui and @vertz/schema. If anything is
+// missing from the public exports, this file will fail to compile.
+//
+// Covers: form creation, direct properties, per-field signals, submission
+// pipeline, form-level signals, reset, setFieldError, SDK meta extraction.
+//
+// Uses only public package imports — never relative imports.
+// ===========================================================================
+
+import { s } from '@vertz/schema';
+import type { FormOptions, SdkMethod, SdkMethodWithMeta } from '@vertz/ui/form';
+import { form, formDataToObject } from '@vertz/ui/form';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// 1. Mock SDK method — simulates generated SDK output
+// ---------------------------------------------------------------------------
+
+interface CreateUserBody {
+  name: string;
+  email: string;
+}
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+/** Mock SDK method with url/method metadata (no .meta). */
+function mockSdk(): SdkMethod<CreateUserBody, User> {
+  const fn = async (body: CreateUserBody): Promise<User> => ({
+    id: 'u-1',
+    ...body,
+  });
+  return Object.assign(fn, { url: '/api/users', method: 'POST' });
+}
+
+/** Mock SDK method WITH .meta.bodySchema (simulates codegen output). */
+function mockSdkWithMeta(): SdkMethodWithMeta<CreateUserBody, User> {
+  const schema = s.object({
+    name: s.string().min(1),
+    email: s.string().min(1),
+  });
+  const fn = async (body: CreateUserBody): Promise<User> => ({
+    id: 'u-1',
+    ...body,
+  });
+  return Object.assign(fn, {
+    url: '/api/users',
+    method: 'POST',
+    meta: { bodySchema: schema },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Validation schema — using public @vertz/schema API
+// ---------------------------------------------------------------------------
+
+const createUserSchema = s.object({
+  name: s.string().min(1),
+  email: s.string().min(1),
+});
+
+// ---------------------------------------------------------------------------
+// 3. Walkthrough Tests
+// ---------------------------------------------------------------------------
+
+describe('Form API Developer Walkthrough', () => {
+  // -------------------------------------------------------------------------
+  // 3a. Direct properties — action, method, onSubmit
+  // -------------------------------------------------------------------------
+
+  describe('Direct properties', () => {
+    it('form() exposes action from SDK url', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.action).toBe('/api/users');
+    });
+
+    it('form() exposes method from SDK method', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.method).toBe('POST');
+    });
+
+    it('form() exposes onSubmit as a function', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(typeof userForm.onSubmit).toBe('function');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3b. Submission — valid data flows through to SDK method
+  // -------------------------------------------------------------------------
+
+  describe('Submission pipeline', () => {
+    it('submit() calls SDK method with validated data and invokes onSuccess', async () => {
+      const onSuccess = vi.fn();
+      const userForm = form(mockSdk(), {
+        schema: createUserSchema,
+        onSuccess,
+      });
+
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@test.com');
+      await userForm.submit(fd);
+
+      expect(onSuccess).toHaveBeenCalledWith({
+        id: 'u-1',
+        name: 'Alice',
+        email: 'alice@test.com',
+      });
+      expect(userForm.submitting.peek()).toBe(false);
+    });
+
+    it('submit() validates and calls onError on invalid data', async () => {
+      const onError = vi.fn();
+      const userForm = form(mockSdk(), {
+        schema: createUserSchema,
+        onError,
+      });
+
+      const fd = new FormData();
+      fd.append('name', '');
+      fd.append('email', '');
+      await userForm.submit(fd);
+
+      expect(onError).toHaveBeenCalled();
+      // SDK method should NOT have been called
+      expect(userForm.submitting.peek()).toBe(false);
+    });
+
+    it('submit() calls onError when SDK method throws', async () => {
+      const failingSdk = Object.assign(
+        async () => {
+          throw new Error('Server error');
+        },
+        { url: '/api/users', method: 'POST' },
+      ) as SdkMethod<CreateUserBody, User>;
+
+      const onError = vi.fn();
+      const userForm = form(failingSdk, {
+        schema: createUserSchema,
+        onError,
+      });
+
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@test.com');
+      await userForm.submit(fd);
+
+      expect(onError).toHaveBeenCalled();
+      const errors = onError.mock.calls[0]?.[0] as Record<string, string>;
+      expect(errors._form).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3c. Per-field error signals — reactive error access
+  // -------------------------------------------------------------------------
+
+  describe('Per-field error signals', () => {
+    it('field.error starts as undefined', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.name.error.peek()).toBeUndefined();
+      expect(userForm.email.error.peek()).toBeUndefined();
+    });
+
+    it('field.error is populated after failed validation', async () => {
+      const onError = vi.fn();
+      const userForm = form(mockSdk(), {
+        schema: createUserSchema,
+        onError,
+      });
+
+      const fd = new FormData();
+      fd.append('name', '');
+      fd.append('email', '');
+      await userForm.submit(fd);
+
+      expect(userForm.name.error.peek()).toBeDefined();
+      expect(userForm.email.error.peek()).toBeDefined();
+    });
+
+    it('field.error is cleared after successful submission', async () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // First: trigger validation errors
+      const fd1 = new FormData();
+      fd1.append('name', '');
+      fd1.append('email', '');
+      await userForm.submit(fd1);
+      expect(userForm.name.error.peek()).toBeDefined();
+
+      // Then: submit valid data — errors should clear
+      const fd2 = new FormData();
+      fd2.append('name', 'Alice');
+      fd2.append('email', 'alice@test.com');
+      await userForm.submit(fd2);
+      expect(userForm.name.error.peek()).toBeUndefined();
+      expect(userForm.email.error.peek()).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3d. setFieldError — server-side validation errors
+  // -------------------------------------------------------------------------
+
+  describe('setFieldError', () => {
+    it('populates per-field error signal', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      userForm.setFieldError('email', 'Already taken');
+      expect(userForm.email.error.peek()).toBe('Already taken');
+    });
+
+    it('only accepts keyof TBody at compile time', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // Valid: 'name' and 'email' are fields
+      userForm.setFieldError('name', 'Too short');
+      userForm.setFieldError('email', 'Invalid');
+
+      // @ts-expect-error — 'nonExistent' is not a field on CreateUserBody
+      userForm.setFieldError('nonExistent', 'Nope');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3e. Form-level signals — dirty, valid, submitting
+  // -------------------------------------------------------------------------
+
+  describe('Form-level signals', () => {
+    it('submitting starts as false', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.submitting.peek()).toBe(false);
+    });
+
+    it('dirty starts as false', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.dirty.peek()).toBe(false);
+    });
+
+    it('valid starts as true (no errors)', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.valid.peek()).toBe(true);
+    });
+
+    it('dirty reacts to field changes (including fields added after first read)', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // Read dirty first — field cache is empty
+      expect(userForm.dirty.peek()).toBe(false);
+
+      // Simulate field becoming dirty
+      userForm.name.dirty.value = true;
+      expect(userForm.dirty.peek()).toBe(true);
+    });
+
+    it('valid reacts to field errors (including fields added after first read)', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // Read valid first — field cache is empty
+      expect(userForm.valid.peek()).toBe(true);
+
+      // Set a field error
+      userForm.setFieldError('email', 'Required');
+      expect(userForm.valid.peek()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3f. Reset
+  // -------------------------------------------------------------------------
+
+  describe('Reset', () => {
+    it('reset() clears all field errors, dirty, and touched', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      userForm.setFieldError('name', 'Required');
+      userForm.name.dirty.value = true;
+      userForm.name.touched.value = true;
+
+      userForm.setFieldError('email', 'Invalid');
+      userForm.email.dirty.value = true;
+
+      expect(userForm.valid.peek()).toBe(false);
+      expect(userForm.dirty.peek()).toBe(true);
+
+      userForm.reset();
+
+      expect(userForm.name.error.peek()).toBeUndefined();
+      expect(userForm.name.dirty.peek()).toBe(false);
+      expect(userForm.name.touched.peek()).toBe(false);
+      expect(userForm.email.error.peek()).toBeUndefined();
+      expect(userForm.valid.peek()).toBe(true);
+      expect(userForm.dirty.peek()).toBe(false);
+    });
+
+    it('resetOnSuccess resets after successful submission', async () => {
+      const onSuccess = vi.fn();
+      const userForm = form(mockSdk(), {
+        schema: createUserSchema,
+        onSuccess,
+        resetOnSuccess: true,
+      });
+
+      // Dirty a field first
+      userForm.name.dirty.value = true;
+      expect(userForm.dirty.peek()).toBe(true);
+
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@test.com');
+      await userForm.submit(fd);
+
+      expect(onSuccess).toHaveBeenCalled();
+      expect(userForm.dirty.peek()).toBe(false);
+      expect(userForm.name.error.peek()).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3g. SDK meta.bodySchema — auto-extraction
+  // -------------------------------------------------------------------------
+
+  describe('SDK meta.bodySchema auto-extraction', () => {
+    it('form() auto-validates from .meta.bodySchema (no explicit schema needed)', async () => {
+      const onError = vi.fn();
+      // No explicit schema — uses .meta.bodySchema
+      const userForm = form(mockSdkWithMeta(), { onError });
+
+      const fd = new FormData();
+      fd.append('name', '');
+      fd.append('email', '');
+      await userForm.submit(fd);
+
+      expect(onError).toHaveBeenCalled();
+      expect(userForm.name.error.peek()).toBeDefined();
+    });
+
+    it('explicit schema overrides .meta.bodySchema', async () => {
+      // Stricter schema: name must be >= 5 chars
+      const strictSchema = s.object({
+        name: s.string().min(5),
+        email: s.string().min(1),
+      });
+      const onError = vi.fn();
+      const userForm = form(mockSdkWithMeta(), { schema: strictSchema, onError });
+
+      const fd = new FormData();
+      fd.append('name', 'Al'); // valid for meta schema (min 1) but not for explicit (min 5)
+      fd.append('email', 'al@test.com');
+      await userForm.submit(fd);
+
+      expect(onError).toHaveBeenCalled();
+      expect(userForm.name.error.peek()).toBeDefined();
+    });
+
+    it('form() without .meta requires explicit schema (type error)', () => {
+      const plainSdk = mockSdk(); // no .meta
+
+      // @ts-expect-error — SDK without .meta requires explicit schema
+      form(plainSdk);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3h. Per-field signal state — dirty, touched, value
+  // -------------------------------------------------------------------------
+
+  describe('Per-field signal state', () => {
+    it('field.dirty starts as false', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.name.dirty.peek()).toBe(false);
+    });
+
+    it('field.touched starts as false', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.name.touched.peek()).toBe(false);
+    });
+
+    it('field.value starts as undefined (no initial)', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      expect(userForm.name.value.peek()).toBeUndefined();
+    });
+
+    it('field.value starts with initial value when provided', () => {
+      const userForm = form(mockSdk(), {
+        schema: createUserSchema,
+        initial: { name: 'Alice', email: 'alice@test.com' },
+      });
+      expect(userForm.name.value.peek()).toBe('Alice');
+      expect(userForm.email.value.peek()).toBe('alice@test.com');
+    });
+
+    it('field state is lazily created and cached (same reference)', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+      const first = userForm.name;
+      const second = userForm.name;
+      expect(first).toBe(second);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3i. formDataToObject — utility
+  // -------------------------------------------------------------------------
+
+  describe('formDataToObject utility', () => {
+    it('converts FormData to plain object', () => {
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@test.com');
+      const obj = formDataToObject(fd);
+      expect(obj).toEqual({ name: 'Alice', email: 'alice@test.com' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3j. Type safety — compile-time checks
+  // -------------------------------------------------------------------------
+
+  describe('Type safety', () => {
+    it('FormInstance type is accessible from public imports', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // These type assertions verify the public API types resolve correctly
+      const _action: string = userForm.action;
+      const _method: string = userForm.method;
+      const _onSubmit: (e: Event) => Promise<void> = userForm.onSubmit;
+      const _reset: () => void = userForm.reset;
+      const _submit: (formData?: FormData) => Promise<void> = userForm.submit;
+
+      // Suppress unused variable warnings
+      void [_action, _method, _onSubmit, _reset, _submit];
+    });
+
+    it('FormOptions type is accessible from public imports', () => {
+      const _opts: FormOptions<CreateUserBody, User> = {
+        schema: createUserSchema,
+        onSuccess: (_user) => {},
+        onError: (_errors) => {},
+        resetOnSuccess: true,
+      };
+      void _opts;
+    });
+
+    it('old API methods do not exist', () => {
+      const userForm = form(mockSdk(), { schema: createUserSchema });
+
+      // @ts-expect-error — attrs() was removed
+      userForm.attrs;
+
+      // @ts-expect-error — error() was removed
+      userForm.error;
+
+      // @ts-expect-error — handleSubmit() was removed
+      userForm.handleSubmit;
+    });
+  });
+});

--- a/packages/integration-tests/src/__tests__/sdk-schema-integration.test.ts
+++ b/packages/integration-tests/src/__tests__/sdk-schema-integration.test.ts
@@ -6,47 +6,49 @@
  *
  * Uses only public package imports — never relative imports.
  */
-import { form } from '@vertz/ui/form';
+
 import { s } from '@vertz/schema';
+import { form } from '@vertz/ui/form';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('SDK Schema Integration', () => {
   // Mock SDK method with .meta.bodySchema (simulates generated SDK)
   const schema = s.object({ title: s.string().min(1) });
-  const createTodo = Object.assign(
-    async (body: { title: string }) => ({ id: '1', ...body }),
-    { url: '/todos', method: 'POST', meta: { bodySchema: schema } },
-  );
+  const createTodo = Object.assign(async (body: { title: string }) => ({ id: '1', ...body }), {
+    url: '/todos',
+    method: 'POST',
+    meta: { bodySchema: schema },
+  });
 
   it('form() auto-validates from SDK meta.bodySchema', async () => {
-    const f = form(createTodo);
     const onError = vi.fn();
+    const f = form(createTodo, { onError });
 
     const fd = new FormData();
     fd.append('title', '');
-    await f.handleSubmit({ onError })(fd);
+    await f.submit(fd);
 
     expect(onError).toHaveBeenCalled();
-    expect(f.error('title')).toBeDefined();
+    expect(f.title.error.peek()).toBeDefined();
   });
 
   it('form() passes valid data through to SDK method', async () => {
-    const f = form(createTodo);
     const onSuccess = vi.fn();
+    const f = form(createTodo, { onSuccess });
 
     const fd = new FormData();
     fd.append('title', 'Buy milk');
-    await f.handleSubmit({ onSuccess })(fd);
+    await f.submit(fd);
 
     expect(onSuccess).toHaveBeenCalledWith({ id: '1', title: 'Buy milk' });
-    expect(f.error('title')).toBeUndefined();
+    expect(f.title.error.peek()).toBeUndefined();
   });
 
   it('form() requires explicit schema when SDK lacks meta', () => {
-    const plainSdk = Object.assign(
-      async (body: { title: string }) => ({ id: '1', ...body }),
-      { url: '/todos', method: 'POST' },
-    );
+    const plainSdk = Object.assign(async (body: { title: string }) => ({ id: '1', ...body }), {
+      url: '/todos',
+      method: 'POST',
+    });
 
     // @ts-expect-error — SDK without .meta requires explicit schema
     form(plainSdk);
@@ -55,14 +57,14 @@ describe('SDK Schema Integration', () => {
   it('form() allows explicit schema to override meta.bodySchema', async () => {
     // Custom schema that rejects titles shorter than 5 chars
     const strictSchema = s.object({ title: s.string().min(5) });
-    const f = form(createTodo, { schema: strictSchema });
     const onError = vi.fn();
+    const f = form(createTodo, { schema: strictSchema, onError });
 
     const fd = new FormData();
     fd.append('title', 'Hi'); // valid for meta schema (min 1) but not for explicit (min 5)
-    await f.handleSubmit({ onError })(fd);
+    await f.submit(fd);
 
     expect(onError).toHaveBeenCalled();
-    expect(f.error('title')).toBeDefined();
+    expect(f.title.error.peek()).toBeDefined();
   });
 });

--- a/packages/ui-compiler/src/__tests__/bind-element.test.ts
+++ b/packages/ui-compiler/src/__tests__/bind-element.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @file Tests for __bindElement transform on form elements
+ */
+import { describe, expect, it } from 'vitest';
+import { compile } from '../compiler';
+
+describe('__bindElement transform', () => {
+  it('should add __bindElement when form tag has onSubmit from form variable', () => {
+    const source = `
+      import { form } from '@vertz/ui';
+
+      function TaskForm() {
+        const taskForm = form({ title: '' });
+        return <form onSubmit={taskForm.onSubmit}><button>Submit</button></form>;
+      }
+    `;
+
+    const result = compile(source, 'test.tsx');
+
+    expect(result.code).toContain('taskForm.__bindElement(');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('should NOT add __bindElement when handler is a regular function', () => {
+    const source = `
+      import { form } from '@vertz/ui';
+
+      function TaskForm() {
+        const taskForm = form({ title: '' });
+        const handler = () => {};
+        return <form onSubmit={handler}><button>Submit</button></form>;
+      }
+    `;
+
+    const result = compile(source, 'test.tsx');
+
+    expect(result.code).not.toContain('__bindElement');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('should NOT add __bindElement when tag is not form', () => {
+    const source = `
+      import { form } from '@vertz/ui';
+
+      function TaskForm() {
+        const taskForm = form({ title: '' });
+        return <div onSubmit={taskForm.onSubmit}><button>Submit</button></div>;
+      }
+    `;
+
+    const result = compile(source, 'test.tsx');
+
+    expect(result.code).not.toContain('__bindElement');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('should add __bindElement for self-closing form tag', () => {
+    const source = `
+      import { form } from '@vertz/ui';
+
+      function TaskForm() {
+        const taskForm = form({ title: '' });
+        return <form onSubmit={taskForm.onSubmit} />;
+      }
+    `;
+
+    const result = compile(source, 'test.tsx');
+
+    expect(result.code).toContain('taskForm.__bindElement(');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/ui-compiler/src/__tests__/signal-api-registry.test.ts
+++ b/packages/ui-compiler/src/__tests__/signal-api-registry.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Tests for signal-api-registry configuration
+ */
+import { describe, expect, it } from 'vitest';
+import { getSignalApiConfig } from '../signal-api-registry';
+
+describe('signal-api-registry', () => {
+  it('should return updated form config with fieldSignalProperties', () => {
+    const config = getSignalApiConfig('form');
+    expect(config).toBeDefined();
+    expect(config?.signalProperties).toEqual(new Set(['submitting', 'dirty', 'valid']));
+    expect(config?.plainProperties).toEqual(
+      new Set(['action', 'method', 'onSubmit', 'reset', 'setFieldError', 'submit']),
+    );
+    expect(config?.fieldSignalProperties).toEqual(new Set(['error', 'dirty', 'touched', 'value']));
+  });
+});

--- a/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
@@ -106,6 +106,24 @@ describe('ReactivityAnalyzer', () => {
     expect(findVar(result?.variables, 'count')?.kind).toBe('signal');
   });
 
+  it('stores plainProperties and fieldSignalProperties from signal API config', () => {
+    const [result] = analyze(`
+      import { form } from '@vertz/ui';
+
+      function TaskForm() {
+        const taskForm = form({ name: '' });
+        return <div>{taskForm.submitting}</div>;
+      }
+    `);
+    const v = findVar(result?.variables, 'taskForm');
+    expect(v?.kind).toBe('static');
+    expect(v?.signalProperties).toEqual(new Set(['submitting', 'dirty', 'valid']));
+    expect(v?.plainProperties).toEqual(
+      new Set(['action', 'method', 'onSubmit', 'reset', 'setFieldError', 'submit']),
+    );
+    expect(v?.fieldSignalProperties).toEqual(new Set(['error', 'dirty', 'touched', 'value']));
+  });
+
   it('analyzes multiple components independently', () => {
     const results = analyze(`
       function Counter() {

--- a/packages/ui-compiler/src/signal-api-registry.ts
+++ b/packages/ui-compiler/src/signal-api-registry.ts
@@ -7,6 +7,8 @@ export interface SignalApiConfig {
   signalProperties: Set<string>;
   /** Properties that are plain values (no unwrapping needed). */
   plainProperties: Set<string>;
+  /** Per-field signal properties (e.g., form().title.error → .value). */
+  fieldSignalProperties?: Set<string>;
 }
 
 /**
@@ -18,8 +20,9 @@ export const SIGNAL_API_REGISTRY: Record<string, SignalApiConfig> = {
     plainProperties: new Set(['refetch']),
   },
   form: {
-    signalProperties: new Set(['submitting', 'errors', 'values']),
-    plainProperties: new Set(['reset', 'submit', 'handleSubmit']),
+    signalProperties: new Set(['submitting', 'dirty', 'valid']),
+    plainProperties: new Set(['action', 'method', 'onSubmit', 'reset', 'setFieldError', 'submit']),
+    fieldSignalProperties: new Set(['error', 'dirty', 'touched', 'value']),
   },
   createLoader: {
     signalProperties: new Set(['data', 'loading', 'error']),

--- a/packages/ui-compiler/src/transformers/signal-transformer.ts
+++ b/packages/ui-compiler/src/transformers/signal-transformer.ts
@@ -20,11 +20,19 @@ export class SignalTransformer {
   ): void {
     const signals = new Set(variables.filter((v) => v.kind === 'signal').map((v) => v.name));
 
-    // Build map of variables with signal properties (from signal APIs)
+    // Build maps of variables with signal API properties
     const signalApiVars = new Map<string, Set<string>>();
+    const plainPropVars = new Map<string, Set<string>>();
+    const fieldSignalPropVars = new Map<string, Set<string>>();
     for (const v of variables) {
       if (v.signalProperties && v.signalProperties.size > 0) {
         signalApiVars.set(v.name, v.signalProperties);
+      }
+      if (v.plainProperties && v.plainProperties.size > 0) {
+        plainPropVars.set(v.name, v.plainProperties);
+      }
+      if (v.fieldSignalProperties && v.fieldSignalProperties.size > 0) {
+        fieldSignalPropVars.set(v.name, v.fieldSignalProperties);
       }
     }
 
@@ -36,8 +44,14 @@ export class SignalTransformer {
       transformReferences(source, bodyNode, signals, mutationRanges);
     }
 
-    if (signalApiVars.size > 0) {
-      transformSignalApiProperties(source, bodyNode, signalApiVars);
+    if (signalApiVars.size > 0 || fieldSignalPropVars.size > 0) {
+      transformSignalApiProperties(
+        source,
+        bodyNode,
+        signalApiVars,
+        plainPropVars,
+        fieldSignalPropVars,
+      );
     }
   }
 }
@@ -119,17 +133,77 @@ function transformReferences(
 
 /**
  * Transform property accesses on signal API variables to auto-unwrap.
- * E.g., tasks.data → tasks.data.value
+ *
+ * Handles two patterns:
+ * - 2-level: `tasks.data` → `tasks.data.value` (root.signalProp)
+ * - 3-level: `taskForm.title.error` → `taskForm.title.error.value` (root.field.fieldSignalProp)
+ *
+ * 3-level chains are processed first to avoid the inner PropertyAccessExpression
+ * being matched as a 2-level check.
  */
 function transformSignalApiProperties(
   source: MagicString,
   bodyNode: Node,
   signalApiVars: Map<string, Set<string>>,
+  plainPropVars: Map<string, Set<string>>,
+  fieldSignalPropVars: Map<string, Set<string>>,
 ): void {
+  // Pass 1: Find and transform 3-level chains, track their ranges
+  const threeLevelRanges: Array<{ start: number; end: number }> = [];
+
+  bodyNode.forEachDescendant((node) => {
+    if (!node.isKind(SyntaxKind.PropertyAccessExpression)) return;
+
+    const outerExpr = node.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+    const middleExpr = outerExpr.getExpression();
+    const leafProp = outerExpr.getName();
+
+    // 3-level: outerExpr = middleExpr.leafProp, middleExpr = rootIdent.middleProp
+    if (!middleExpr.isKind(SyntaxKind.PropertyAccessExpression)) return;
+
+    const innerExpr = middleExpr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+    const rootExpr = innerExpr.getExpression();
+    const middleProp = innerExpr.getName();
+
+    if (!rootExpr.isKind(SyntaxKind.Identifier)) return;
+    const rootName = rootExpr.getText();
+
+    // Root must be a signal API var with fieldSignalProperties
+    const fieldSignalProps = fieldSignalPropVars.get(rootName);
+    if (!fieldSignalProps) return;
+
+    // Middle must NOT be a signal property or plain property (it's a field name)
+    const signalProps = signalApiVars.get(rootName);
+    const plainProps = plainPropVars.get(rootName);
+    if (signalProps?.has(middleProp) || plainProps?.has(middleProp)) return;
+
+    // Leaf must be a field signal property
+    if (!fieldSignalProps.has(leafProp)) return;
+
+    // Guard: Check if .value is already present (migration case)
+    const parent = outerExpr.getParent();
+    if (parent?.isKind(SyntaxKind.PropertyAccessExpression)) {
+      const parentProp = parent.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+      if (parentProp.getExpression() === outerExpr && parentProp.getName() === 'value') {
+        threeLevelRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
+        return; // Already has .value, skip transformation
+      }
+    }
+
+    source.appendLeft(outerExpr.getEnd(), '.value');
+    threeLevelRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
+  });
+
+  // Pass 2: Transform 2-level chains, skipping nodes inside 3-level ranges
   bodyNode.forEachDescendant((node) => {
     if (!node.isKind(SyntaxKind.PropertyAccessExpression)) return;
 
     const expr = node.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+
+    // Skip if this node is inside a 3-level chain range
+    const nodeStart = expr.getStart();
+    if (threeLevelRanges.some((r) => nodeStart >= r.start && nodeStart < r.end)) return;
+
     const objExpr = expr.getExpression();
     const propName = expr.getName();
 
@@ -149,8 +223,6 @@ function transformSignalApiProperties(
       }
     }
 
-    // Use appendLeft so source.slice(start, end) includes the .value transform
-    // (appendRight at `end` is NOT captured by slice(start, end), but appendLeft IS)
     source.appendLeft(expr.getEnd(), '.value');
   });
 }

--- a/packages/ui-compiler/src/types.ts
+++ b/packages/ui-compiler/src/types.ts
@@ -56,6 +56,10 @@ export interface VariableInfo {
    * the Set on deserialization.
    */
   signalProperties?: Set<string>;
+  /** Plain (non-signal) properties on this variable. */
+  plainProperties?: Set<string>;
+  /** Per-field signal properties (e.g., form().title.error). */
+  fieldSignalProperties?: Set<string>;
 }
 
 /** Information about a detected component function. */

--- a/packages/ui/docs/react-migration.md
+++ b/packages/ui/docs/react-migration.md
@@ -263,11 +263,11 @@ function LoginForm() {
   const f = form(login, { schema: loginSchema });
 
   return (
-    <form {...f.attrs()} onSubmit={f.handleSubmit()}>
+    <form action={f.action} method={f.method} onSubmit={f.onSubmit}>
       <input name="email" />
-      {f.error('email') && <span class="error">{f.error('email')}</span>}
+      {f.email.error && <span class="error">{f.email.error}</span>}
       <input type="password" name="password" />
-      {f.error('password') && <span class="error">{f.error('password')}</span>}
+      {f.password.error && <span class="error">{f.password.error}</span>}
       <button type="submit">{f.submitting.value ? 'Logging in...' : 'Login'}</button>
     </form>
   );
@@ -275,10 +275,10 @@ function LoginForm() {
 ```
 
 The `form()` helper takes an SDK method (with `.url` and `.method` properties) and a validation schema. It provides:
-- `attrs()` for progressive enhancement (returns action/method)
-- `handleSubmit()` extracts FormData, validates, and submits
-- `error(fieldName)` for field-level error messages
-- `submitting.value` for loading state
+- Direct properties: `action`, `method`, `onSubmit` for progressive enhancement
+- Per-field reactive signals: `form.<field>.error`, `.dirty`, `.touched`, `.value`
+- `submitting` signal for loading state
+- `submit(formData?)` for programmatic submission
 
 ---
 

--- a/packages/ui/src/__tests__/subpath-exports.test.ts
+++ b/packages/ui/src/__tests__/subpath-exports.test.ts
@@ -53,7 +53,7 @@ describe('Subpath Exports — @vertz/ui/router', () => {
 });
 
 describe('Subpath Exports — @vertz/ui/form', () => {
-  const expectedExports = ['form', 'formDataToObject', 'validate'];
+  const expectedExports = ['createFieldState', 'form', 'formDataToObject', 'validate'];
 
   test('exports exactly the public API (no internal leaks)', async () => {
     const mod = await import('../form/public');
@@ -71,6 +71,7 @@ describe('Subpath Exports — @vertz/ui/form', () => {
   test('same references as main barrel', async () => {
     const main = await import('../index');
     const subpath = await import('../form/public');
+    expect(subpath.createFieldState).toBe(main.createFieldState);
     expect(subpath.form).toBe(main.form);
     expect(subpath.formDataToObject).toBe(main.formDataToObject);
     expect(subpath.validate).toBe(main.validate);

--- a/packages/ui/src/dom/__tests__/conditional.test.ts
+++ b/packages/ui/src/dom/__tests__/conditional.test.ts
@@ -267,6 +267,55 @@ describe('__conditional', () => {
     expect(container.textContent).toBe('visible');
   });
 
+  it('handles string branch results by converting to text nodes', () => {
+    const loading = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => loading.value,
+      () => 'Loading...' as unknown as Node,
+      () => 'Done' as unknown as Node,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toContain('Loading...');
+
+    loading.value = false;
+    expect(container.textContent).toContain('Done');
+  });
+
+  it('handles number branch results by converting to text nodes', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () => 42 as unknown as Node,
+      () => 0 as unknown as Node,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toContain('42');
+
+    show.value = false;
+    // 0 is falsy but should still render as text
+    expect(container.textContent).toContain('0');
+  });
+
+  it('handles boolean branch results as empty (not rendered as text)', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () => false as unknown as Node,
+      () => true as unknown as Node,
+    );
+    container.appendChild(fragment);
+    // false should render as empty, not as "false" text
+    expect(container.textContent).not.toContain('false');
+    expect(container.textContent).not.toContain('true');
+
+    show.value = false;
+    expect(container.textContent).not.toContain('true');
+    expect(container.textContent).not.toContain('false');
+  });
+
   it('handles both branches returning null without crashing', () => {
     const show = signal(true);
     const container = document.createElement('div');

--- a/packages/ui/src/dom/conditional.ts
+++ b/packages/ui/src/dom/conditional.ts
@@ -43,7 +43,16 @@ export function __conditional(
 
     // Branch may return null (e.g. false-branch of {show && <el/>}).
     // Use a comment placeholder so replaceChild always has a valid Node.
-    const newNode = branchResult ?? document.createComment('empty');
+    // Branches may also return primitives (strings, numbers) from ternary
+    // expressions like {loading ? 'Loading...' : 'Done'} — convert to text nodes.
+    let newNode: Node;
+    if (branchResult == null || typeof branchResult === 'boolean') {
+      newNode = document.createComment('empty');
+    } else if (branchResult instanceof Node) {
+      newNode = branchResult;
+    } else {
+      newNode = document.createTextNode(String(branchResult));
+    }
 
     if (currentNode?.parentNode) {
       // Replace old node with new node

--- a/packages/ui/src/form/__tests__/field-state.test.ts
+++ b/packages/ui/src/form/__tests__/field-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createFieldState } from '../field-state';
+
+describe('createFieldState', () => {
+  it('returns object with 4 signals at default values', () => {
+    const field = createFieldState('title');
+
+    expect(field.error.peek()).toBeUndefined();
+    expect(field.dirty.peek()).toBe(false);
+    expect(field.touched.peek()).toBe(false);
+    expect(field.value.peek()).toBeUndefined();
+  });
+
+  it('accepts an initial value for the value signal', () => {
+    const field = createFieldState('title', 'Hello');
+
+    expect(field.value.peek()).toBe('Hello');
+  });
+
+  it('each property is a writable signal', () => {
+    const field = createFieldState<string>('title', 'initial');
+
+    field.error.value = 'Required';
+    expect(field.error.peek()).toBe('Required');
+
+    field.dirty.value = true;
+    expect(field.dirty.peek()).toBe(true);
+
+    field.touched.value = true;
+    expect(field.touched.peek()).toBe(true);
+
+    field.value.value = 'updated';
+    expect(field.value.peek()).toBe('updated');
+  });
+});

--- a/packages/ui/src/form/field-state.ts
+++ b/packages/ui/src/form/field-state.ts
@@ -1,0 +1,18 @@
+import { signal } from '../runtime/signal';
+import type { Signal } from '../runtime/signal-types';
+
+export interface FieldState<T = unknown> {
+  error: Signal<string | undefined>;
+  dirty: Signal<boolean>;
+  touched: Signal<boolean>;
+  value: Signal<T>;
+}
+
+export function createFieldState<T>(_name: string, initialValue?: T): FieldState<T> {
+  return {
+    error: signal<string | undefined>(undefined),
+    dirty: signal(false),
+    touched: signal(false),
+    value: signal(initialValue as T),
+  };
+}

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -1,9 +1,10 @@
+export type { FieldState } from './field-state';
+export { createFieldState } from './field-state';
 export type {
   FormInstance,
   FormOptions,
   SdkMethod,
   SdkMethodWithMeta,
-  SubmitCallbacks,
 } from './form';
 export { form } from './form';
 export type { FormDataOptions } from './form-data';

--- a/packages/ui/src/form/public.ts
+++ b/packages/ui/src/form/public.ts
@@ -5,12 +5,13 @@
  * the public surface. This file exists for consistency with other subpaths.
  */
 
+export type { FieldState } from './field-state';
+export { createFieldState } from './field-state';
 export type {
   FormInstance,
   FormOptions,
   SdkMethod,
   SdkMethodWithMeta,
-  SubmitCallbacks,
 } from './form';
 export { form } from './form';
 export type { FormDataOptions } from './form-data';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,12 +29,13 @@ export type {
 export { compileTheme, css, defineTheme, globalCss, s, ThemeProvider, variants } from './css';
 
 // Forms
+export type { FieldState } from './form/field-state';
+export { createFieldState } from './form/field-state';
 export type {
   FormInstance,
   FormOptions,
   SdkMethod,
   SdkMethodWithMeta,
-  SubmitCallbacks,
 } from './form/form';
 export { form } from './form/form';
 export type { FormDataOptions } from './form/form-data';

--- a/plans/form-attrs-api-improvement.md
+++ b/plans/form-attrs-api-improvement.md
@@ -77,7 +77,7 @@ const taskForm = form(taskApi.create, {
 });
 ```
 
-All configuration lives in `form()` options. No separate `attrs()` call. No separate `handleSubmit()` call. The `schema` option remains explicit until SDK `.meta` embeds schemas (Section 7).
+All configuration lives in `form()` options. No separate `attrs()` call. No separate `handleSubmit()` call. The `schema` option is auto-extracted from SDK `.meta.bodySchema` when present (see Section 7A — implemented).
 
 ### 2B. Form binding — direct properties, no `attrs()`
 
@@ -364,16 +364,16 @@ The JSX analyzer's `containsSignalApiPropertyAccess()` also needs to handle 3-le
 
 ## 7. Future Scope
 
-### 7A. SDK Schema Integration
+### 7A. SDK Schema Integration — **IMPLEMENTED**
 
-This section documents the planned evolution. **Not in current scope.**
+**Status: Implemented in Issue #527.** The `@vertz/codegen` already embeds `.meta.bodySchema` on generated SDK methods. The `form()` API now has overloads making `schema` optional when `.meta.bodySchema` exists on the SDK method (`SdkMethodWithMeta`).
 
 #### SDK methods carry `.meta` with `bodySchema`
 
-The `EntitySdkGenerator` will embed a `.meta` property on each SDK method:
+Generated SDK methods embed a `.meta` property with the validation schema:
 
 ```ts
-// Generated SDK output (future)
+// Generated SDK output (current)
 import { CreateTodoInputSchema } from '../schemas';
 
 const create = Object.assign(
@@ -392,11 +392,14 @@ const create = Object.assign(
 #### `form()` extracts schema automatically
 
 ```ts
-// Future — no schema option needed
+// SDK with .meta — no schema option needed
 const todoForm = form(api.todos.create);
+
+// SDK without .meta — schema REQUIRED (enforced by TypeScript overloads)
+const todoForm = form(plainSdk, { schema: mySchema });
 ```
 
-The `schema` option becomes optional — only needed for custom client-side validation that differs from the server schema.
+The `schema` option is optional when the SDK method has `.meta.bodySchema`. An explicit `schema` option overrides the embedded schema when both are present.
 
 #### Progressive enhancement without JS
 
@@ -531,7 +534,7 @@ Mirrors `HTMLFormElement` direct field access pattern. In native DOM, `form.titl
 
 ## 10. Non-Goals
 
-- **SDK `.meta` embedding** — requires codegen changes, separate design and issue
+- ~~**SDK `.meta` embedding**~~ — **DONE**: codegen already embeds `.meta.bodySchema`, `form()` auto-extracts it
 - **JSX spread support** — compiler change, separate effort
 - **Server-side error rendering** — progressive enhancement for error responses, future scope
 - **Multi-step forms / wizards** — out of scope for v1


### PR DESCRIPTION
## Summary

- **BREAKING:** Removes `form().attrs()`, `form().error()`, `form().handleSubmit()`, and `SubmitCallbacks` type
- Adds direct properties: `action`, `method`, `onSubmit`, `submit`, `reset`, `setFieldError`
- Adds Proxy-based per-field signal state: `form.<field>.error`, `.dirty`, `.touched`, `.value`
- Adds form-level computed signals: `form.dirty`, `form.valid`
- Adds compiler 3-level signal auto-unwrap: `form.title.error` → `.value`
- Adds `__bindElement` transform for `<form onSubmit={f.onSubmit}>` elements
- Adds `FieldState<T>` type and `createFieldState()` factory
- Merges callbacks (`onSuccess`, `onError`, `resetOnSuccess`) into `FormOptions`
- Fixes `__conditional` to handle primitive branch results (strings, numbers)

### Migration

```diff
- const { action, method, onSubmit } = todoForm.attrs({ onSuccess, resetOnSuccess: true });
+ const todoForm = form(sdk, { schema, onSuccess, resetOnSuccess: true });

- effect(() => { titleError = todoForm.error('title') ?? ''; });
+ {todoForm.title.error}

- formEl.addEventListener('submit', todoForm.handleSubmit({ onSuccess, onError }));
+ <form onSubmit={todoForm.onSubmit}>
```

### Packages changed

- `@vertz/ui` — runtime: new form types, field-state factory, Proxy-based form, __conditional fix, barrel exports
- `@vertz/ui-compiler` — signal-api-registry, reactivity-analyzer, signal-transformer (3-level chains), jsx-analyzer (3-level detection), jsx-transformer (__bindElement)
- `@vertz/integration-tests` — updated SDK schema integration tests
- `entity-todo` example — rewritten with new API
- `task-manager` example — rewritten with new API

## Test plan

- [x] 29 form runtime tests (direct properties, submission, Proxy, reset, meta.bodySchema)
- [x] 16 type tests (FieldState, FormInstance, reserved name conflicts, removed methods)
- [x] 3 field-state unit tests
- [x] 12 __conditional tests (including new primitive branch tests)
- [x] 6 signal-transformer 3-level chain tests
- [x] 4 jsx-analyzer 3-level reactive detection tests
- [x] 4 __bindElement transform tests
- [x] 4 SDK schema integration tests
- [x] 4 form integration tests
- [x] 24 subpath export tests (updated for createFieldState)
- [x] 24 task-manager tests pass
- [x] 22 entity-todo tests pass
- [x] Full monorepo: 65/65 turbo tasks pass (lint + typecheck + test + build)

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)