### PR TITLE
refactor(examples): remove explicit return type annotations

### DIFF
--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -12,10 +12,22 @@ export function TaskCard(props: TaskCardProps): HTMLElement {
   const { task, onClick } = props;
 
 // RIGHT
-export function TaskCard({ task, onClick }: TaskCardProps): HTMLElement {
+export function TaskCard({ task, onClick }: TaskCardProps) {
 ```
 
 Never destructure props in the function body. The only exception is unused props, where `_props: PropsType` is acceptable to satisfy the type signature.
+
+### Don't annotate return types
+
+Let TypeScript infer component return types. The JSX factory already maps tag names to specific element types via `HTMLElementTagNameMap` (e.g., `<form>` returns `HTMLFormElement`, `<div>` returns `HTMLDivElement`). Explicit `: HTMLElement` annotations are a lossy upcast.
+
+```tsx
+// WRONG — loses type specificity
+export function TaskForm({ onSuccess }: TaskFormProps): HTMLElement {
+
+// RIGHT — TypeScript infers the correct element type
+export function TaskForm({ onSuccess }: TaskFormProps) {
+```
 
 ### Props interface naming
 

--- a/examples/entity-todo/src/app.tsx
+++ b/examples/entity-todo/src/app.tsx
@@ -10,14 +10,10 @@
 import { ThemeProvider } from '@vertz/ui';
 import { TodoListPage } from './pages/todo-list';
 
-export function App(): HTMLElement {
+export function App() {
   const content = TodoListPage();
 
-  const container = (
-    <div data-testid="app-root">
-      {content}
-    </div>
-  );
+  const container = <div data-testid="app-root">{content}</div>;
 
   const themeWrapper = ThemeProvider({
     theme: 'light',

--- a/examples/entity-todo/src/components/todo-form.tsx
+++ b/examples/entity-todo/src/components/todo-form.tsx
@@ -27,7 +27,7 @@ export interface TodoFormProps {
   onSuccess: (todo: Todo) => void;
 }
 
-export function TodoForm({ onSuccess }: TodoFormProps): HTMLFormElement {
+export function TodoForm({ onSuccess }: TodoFormProps) {
   const todoForm = form(todoApi.create, {
     schema: createTodoSchema,
     onSuccess,

--- a/examples/entity-todo/src/components/todo-item.tsx
+++ b/examples/entity-todo/src/components/todo-item.tsx
@@ -18,7 +18,7 @@ export interface TodoItemProps {
   onDelete: (id: string) => void;
 }
 
-export function TodoItem({ id, title, completed, onToggle, onDelete }: TodoItemProps): HTMLElement {
+export function TodoItem({ id, title, completed, onToggle, onDelete }: TodoItemProps) {
   let isCompleted = completed;
 
   const handleToggle = async () => {

--- a/examples/entity-todo/src/pages/todo-list.tsx
+++ b/examples/entity-todo/src/pages/todo-list.tsx
@@ -17,7 +17,7 @@ import { TodoForm } from '../components/todo-form';
 import { TodoItem } from '../components/todo-item';
 import { emptyStateStyles, layoutStyles } from '../styles/components';
 
-export function TodoListPage(): HTMLElement {
+export function TodoListPage() {
   // query() returns external signals
   const todosQuery = query(() => fetchTodos(), {
     key: 'todo-list',

--- a/examples/task-manager/src/app.tsx
+++ b/examples/task-manager/src/app.tsx
@@ -27,17 +27,15 @@ const navStyles = css({
  * 1. SettingsContext.Provider — for app-wide settings access
  * 2. ThemeProvider — for CSS custom property switching
  */
-export function App(): HTMLElement {
+export function App() {
   const settings = createSettingsValue();
 
-  const container = (<div data-testid="app-root" />);
+  const container = <div data-testid="app-root" />;
 
   // We wrap the render in the SettingsContext.Provider scope
   SettingsContext.Provider(settings, () => {
     // Main content area — updated by the route watch callback
-    const main = (
-      <main class={layoutStyles.classNames.main} data-testid="main-content" />
-    );
+    const main = <main class={layoutStyles.classNames.main} data-testid="main-content" />;
 
     // Shell layout: sidebar + main, composed with JSX
     const shell = (
@@ -89,7 +87,7 @@ export function App(): HTMLElement {
       () => appRouter.current.value,
       (match) => {
         if (!match) {
-          updateContent((<div data-testid="not-found">Page not found</div>));
+          updateContent(<div data-testid="not-found">Page not found</div>);
           return;
         }
 

--- a/examples/task-manager/src/components/confirm-dialog.tsx
+++ b/examples/task-manager/src/components/confirm-dialog.tsx
@@ -40,7 +40,7 @@ export function ConfirmDialog({
   description,
   confirmLabel = 'Confirm',
   onConfirm,
-}: ConfirmDialogProps): HTMLElement {
+}: ConfirmDialogProps) {
   let isOpen = false;
   const titleId = `dialog-title-${Math.random().toString(36).slice(2, 8)}`;
 

--- a/examples/task-manager/src/components/task-card.tsx
+++ b/examples/task-manager/src/components/task-card.tsx
@@ -51,7 +51,7 @@ export interface TaskCardProps {
  *
  * Returns an HTMLElement that acts as a clickable card linking to the task detail.
  */
-export function TaskCard({ task, onClick }: TaskCardProps): HTMLElement {
+export function TaskCard({ task, onClick }: TaskCardProps) {
   return (
     <article
       class={cardStyles.classNames.card}

--- a/examples/task-manager/src/components/task-form.tsx
+++ b/examples/task-manager/src/components/task-form.tsx
@@ -68,7 +68,7 @@ export interface TaskFormProps {
  * Callbacks (onSuccess, onError) are passed as form options.
  * Per-field error signals drive reactive error display directly in JSX.
  */
-export function TaskForm({ onSuccess, onCancel }: TaskFormProps): HTMLElement {
+export function TaskForm({ onSuccess, onCancel }: TaskFormProps) {
   const taskForm = form(taskApi.create, {
     schema: createTaskSchema,
     onSuccess,

--- a/examples/task-manager/src/pages/create-task.tsx
+++ b/examples/task-manager/src/pages/create-task.tsx
@@ -22,7 +22,7 @@ export interface CreateTaskPageProps {
 /**
  * Render the create-task page.
  */
-export function CreateTaskPage({ navigate }: CreateTaskPageProps): HTMLElement {
+export function CreateTaskPage({ navigate }: CreateTaskPageProps) {
   return (
     <div class={pageStyles.classNames.page} data-testid="create-task-page">
       <h1 class={pageStyles.classNames.title}>Create New Task</h1>

--- a/examples/task-manager/src/pages/settings.tsx
+++ b/examples/task-manager/src/pages/settings.tsx
@@ -35,7 +35,7 @@ export interface SettingsPageProps {
 /**
  * Render the settings page with theme switching.
  */
-export function SettingsPage(_props: SettingsPageProps): HTMLElement {
+export function SettingsPage(_props: SettingsPageProps) {
   const settings = useSettings();
 
   // Local state: compiler transforms `let` to signal()

--- a/examples/task-manager/src/pages/task-detail.tsx
+++ b/examples/task-manager/src/pages/task-detail.tsx
@@ -55,7 +55,7 @@ export interface TaskDetailPageProps {
  * transitions) use const declarations — the compiler classifies them
  * as computed and wraps them automatically. No effect() needed.
  */
-export function TaskDetailPage({ taskId, navigate }: TaskDetailPageProps): HTMLElement {
+export function TaskDetailPage({ taskId, navigate }: TaskDetailPageProps) {
   // ── Data fetching ──────────────────────────────────
 
   const taskQuery = query(() => fetchTask(taskId), {

--- a/examples/task-manager/src/pages/task-list.tsx
+++ b/examples/task-manager/src/pages/task-list.tsx
@@ -31,7 +31,7 @@ export interface TaskListPageProps {
  * Derived values (errorMsg, filteredTasks) use const declarations —
  * the compiler classifies them as computed and wraps them automatically.
  */
-export function TaskListPage({ navigate }: TaskListPageProps): HTMLElement {
+export function TaskListPage({ navigate }: TaskListPageProps) {
   // ── Reactive state ─────────────────────────────────
 
   // Local state: compiler transforms `let` to signal()


### PR DESCRIPTION
## Summary
- Remove explicit `: HTMLElement` / `: HTMLFormElement` return types from all 12 component functions across both example apps
- Let TypeScript infer the correct specific element type — the JSX factory already maps tag names via `HTMLElementTagNameMap` (e.g., `<form>` → `HTMLFormElement`)
- Update `ui-components.md` rules to document the convention

## Test plan
- [x] `bunx biome check` — no new lint errors
- [x] No remaining explicit return types in example source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)