### PR TITLE
feat(ui): type-safe router Phase 1 — PathWithParams + RoutePaths [#585]

### DIFF
--- a/packages/integration-tests/src/__tests__/type-safe-router-walkthrough.test-d.ts
+++ b/packages/integration-tests/src/__tests__/type-safe-router-walkthrough.test-d.ts
@@ -40,7 +40,7 @@
 // router.navigate('/files/docs/readme.md');
 //
 // // Invalid paths rejected
-// // [ts-expect-error] - invalid path
+// // @ts-expect-error - invalid path
 // // router.navigate('/nonexistent');
 //
 // // useParams typed

--- a/packages/ui/src/router/__tests__/router.test-d.ts
+++ b/packages/ui/src/router/__tests__/router.test-d.ts
@@ -151,6 +151,14 @@ void _pwp5;
 const _pwp6: PathWithParams<'/'> = '/';
 void _pwp6;
 
+// Param + wildcard: '/users/:id/*' → `/users/${string}/${string}`
+const _pwp7: PathWithParams<'/users/:id/*'> = `/users/${'a'}/${'any/path'}`;
+void _pwp7;
+
+// @ts-expect-error - '/tasks' missing param segment, not assignable to `/tasks/${string}`
+const _pwpNeg: PathWithParams<'/tasks/:id'> = '/tasks';
+void _pwpNeg;
+
 // ─── RoutePaths type tests ──────────────────────────────────────────────────
 
 type TestRouteMap = {

--- a/packages/ui/src/router/__tests__/type-safe-router.test-d.ts
+++ b/packages/ui/src/router/__tests__/type-safe-router.test-d.ts
@@ -59,9 +59,9 @@ void _bad2;
 
 // Phase 2: defineRoutes<const T>() preserves literal keys
 // Phase 3: createRouter returns TypedRouter, navigate validates paths
+// Phase 3: TypedRouter assignable to Router, backward compat
 // Phase 4: useParams<TPath> returns ExtractParams<TPath>
 // Phase 4: useRouter<InferRouteMap<typeof routes>> typed navigate
-// Phase 3: TypedRouter assignable to Router, backward compat
 //
 // These tests will be uncommented as each phase is implemented.
 // See plans/type-safe-router-impl.md → E2E Acceptance Test for full spec.


### PR DESCRIPTION
## Summary

Closes #585

Phase 1 of the type-safe router feature (#572). Implements type utilities that convert route patterns to accepted URL shapes at the type level.

- **`PathWithParams<T>`** — converts route patterns to template literal types:
  - `'/tasks/:id'` → `` `/tasks/${string}` ``
  - `'/users/:id/posts/:postId'` → `` `/users/${string}/posts/${string}` ``
  - `'/files/*'` → `` `/files/${string}` ``
  - `string` → `string` (backward compat)
- **`RoutePaths<T>`** — maps a route definition map to a union of all valid URL shapes
- **E2E acceptance test stub** (RED state) — will be completed across Phases 2-5
- **Developer Walkthrough stub** in `packages/integration-tests/` using `@vertz/ui` imports (RED state, per `public-api-validation.md`)
- **POC verified** — `const T extends RouteConfigLike` constraint works with concrete loaders (with and without params access)

## Test plan

- [x] 7 TDD cycles — PathWithParams (single, multi, wildcard, string, trailing slash) + RoutePaths (union, negative, backward compat, empty map)
- [x] `bun run typecheck` on `@vertz/ui` — clean
- [x] `bunx biome check` on all modified files — clean
- [x] All existing router tests pass (62/64 test files, 2 pre-existing form failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)