### PR TITLE
feat(ui): typed Link — generic LinkProps<T> with href validation [#589]

### DIFF
--- a/packages/ui/src/router/__tests__/type-safe-router.test-d.ts
+++ b/packages/ui/src/router/__tests__/type-safe-router.test-d.ts
@@ -154,8 +154,27 @@ void _e2eInfKey;
 const _e2eBadInfKey: E2EInferredKeys = '/nonexistent';
 void _e2eBadInfKey;
 
-// ─── Phase 5+ tests (commented out until types exist) ───────────────────────
-//
-// Phase 5: Typed Link — createLink<T>() with typed href
-// These tests will be uncommented as each phase is implemented.
-// See plans/type-safe-router-impl.md → E2E Acceptance Test for full spec.
+// ─── Phase 5: Typed Link ─────────────────────────────────────────────────────
+
+import type { LinkProps } from '../link';
+
+// Typed LinkProps validates href against route paths
+type E2ERouteMapForLink = (typeof _e2eRoutes)['__routes'];
+declare const _e2eTypedLink: (props: LinkProps<E2ERouteMapForLink>) => HTMLAnchorElement;
+
+// Valid hrefs compile
+_e2eTypedLink({ href: '/', children: 'Home' });
+_e2eTypedLink({ href: '/tasks/42', children: 'Task' });
+_e2eTypedLink({ href: '/users/1/posts/99', children: 'Post' });
+_e2eTypedLink({ href: '/settings', children: 'Settings' });
+_e2eTypedLink({ href: '/files/docs/readme.md', children: 'File' });
+
+// @ts-expect-error - invalid path
+_e2eTypedLink({ href: '/nonexistent', children: 'Bad' });
+
+// @ts-expect-error - partial param path
+_e2eTypedLink({ href: '/tasks', children: 'Bad' });
+
+// Untyped LinkProps accepts any string href (backward compat)
+declare const _e2eUntypedLink: (props: LinkProps) => HTMLAnchorElement;
+_e2eUntypedLink({ href: '/anything-goes', children: 'OK' });

--- a/packages/ui/src/router/link.ts
+++ b/packages/ui/src/router/link.ts
@@ -7,11 +7,19 @@
 
 import { effect } from '../runtime/signal';
 import type { ReadonlySignal } from '../runtime/signal-types';
+import type { RouteConfigLike, RouteDefinitionMap } from './define-routes';
+import type { RoutePaths } from './params';
 
-/** Props for the Link component. */
-export interface LinkProps {
+/**
+ * Props for the Link component.
+ *
+ * Generic over the route map `T`. Defaults to `RouteDefinitionMap` (string
+ * index signature) for backward compatibility — unparameterized `LinkProps`
+ * accepts any string href.
+ */
+export interface LinkProps<T extends Record<string, RouteConfigLike> = RouteDefinitionMap> {
   /** The target URL path. */
-  href: string;
+  href: RoutePaths<T>;
   /** Text or content for the link. */
   children: string;
   /** Class applied when the link's href matches the current path. */


### PR DESCRIPTION
## Summary

Phase 5 of the type-safe router feature (#572). Closes #589.

- **`LinkProps<T>`** — generic interface where `href: RoutePaths<T>`. When parameterized with a typed route map, TypeScript rejects invalid hrefs at compile time. Default `T = RouteDefinitionMap` preserves backward compatibility (unparameterized `LinkProps` accepts any string).
- No runtime changes — this is purely a type-level enhancement to `link.ts`.

## Changes

- `link.ts` — make `LinkProps` generic with `href: RoutePaths<T>`, add imports for `RouteConfigLike`, `RouteDefinitionMap`, `RoutePaths`
- `router.test-d.ts` — Phase 5 type tests (typed Link rejects invalid href, accepts valid, untyped backward compat)
- `type-safe-router.test-d.ts` — E2E acceptance test updated with Phase 5 section

## Type Flow

```
defineRoutes<const T>() → TypedRoutes<T>
                               ↓
                     InferRouteMap<typeof routes> → T
                               ↓
                     LinkProps<T>.href: RoutePaths<T>  ← typed href validation
```

## Test plan

- [x] Type: `Link({ href: '/nonexistent' })` — `@ts-expect-error` with typed routes
- [x] Type: `Link({ href: '/tasks/42' })` — compiles with typed routes
- [x] Type: Untyped `LinkProps` accepts any string href — backward compat
- [x] Runtime: All 8 existing link tests pass (no runtime changes)
- [x] E2E: `type-safe-router.test-d.ts` Phase 5 section passes
- [x] `bun run typecheck --filter @vertz/ui` — clean
- [x] `bunx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)