### PR TITLE
feat(ui): exports, example update, integration walkthrough [Phase 6]

### DIFF
--- a/.changeset/type-safe-router.md
+++ b/.changeset/type-safe-router.md
@@ -1,0 +1,9 @@
+---
+'@vertz/ui': patch
+---
+
+Add type-safe router: `navigate()`, `useParams()`, and Link `href` are validated
+against defined route paths at compile time. New exports: `useParams<TPath>()`,
+`useRouter<T>()`, `InferRouteMap<T>`, `TypedRoutes<T>`, `TypedRouter<T>`,
+`RoutePaths<T>`, `PathWithParams<T>`, `LinkProps<T>`. Fully backward-compatible —
+existing code compiles unchanged.

--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -223,10 +223,18 @@ RouterContext.Provider(appRouter, () => {
   // ... shell layout uses {view}
 });
 
-// Page component — access router via context
+// App-level typed router hook (recommended)
+// Create once in router.ts, use everywhere for typed navigate()
+import type { InferRouteMap } from '@vertz/ui';
+import { useRouter } from '@vertz/ui';
+export function useAppRouter() {
+  return useRouter<InferRouteMap<typeof routes>>();
+}
+
+// Page component — access typed router via useAppRouter()
 export function TaskListPage() {
-  const { navigate } = useRouter();
-  // navigate('/tasks/new')
+  const { navigate } = useAppRouter();
+  navigate('/tasks/new');   // typed — only valid paths accepted
 }
 
 // Page with typed route params — use useParams<TPath>()
@@ -235,9 +243,10 @@ export function TaskDetailPage() {
   // taskId: string — fully typed, throws if no route matched
 }
 
-// Alternative: untyped access via router.current (non-page contexts)
+// Alternative: untyped access via useRouter() (backward compat)
 export function SomeWidget() {
   const router = useRouter();
+  router.navigate('/anything'); // accepts any string
   const taskId = router.current.value?.params.id ?? '';
 }
 ```

--- a/examples/task-manager/src/pages/create-task.tsx
+++ b/examples/task-manager/src/pages/create-task.tsx
@@ -7,8 +7,9 @@
  * - Navigation after successful form submission
  */
 
-import { css, useRouter } from '@vertz/ui';
+import { css } from '@vertz/ui';
 import { TaskForm } from '../components/task-form';
+import { useAppRouter } from '../router';
 
 const pageStyles = css({
   page: ['max-w:lg', 'mx:auto'],
@@ -18,10 +19,10 @@ const pageStyles = css({
 /**
  * Render the create-task page.
  *
- * Navigation is accessed via useRouter() context.
+ * Navigation is accessed via useAppRouter() context.
  */
 export function CreateTaskPage() {
-  const { navigate } = useRouter();
+  const { navigate } = useAppRouter();
   return (
     <div class={pageStyles.classNames.page} data-testid="create-task-page">
       <h1 class={pageStyles.classNames.title}>Create New Task</h1>

--- a/examples/task-manager/src/pages/task-detail.tsx
+++ b/examples/task-manager/src/pages/task-detail.tsx
@@ -11,10 +11,11 @@
  * - Compiler conditional transform for loading/error/content visibility
  */
 
-import { css, onCleanup, onMount, query, useRouter } from '@vertz/ui';
+import { css, onCleanup, onMount, query, useParams } from '@vertz/ui';
 import { deleteTask, fetchTask, updateTask } from '../api/mock-data';
 import { ConfirmDialog } from '../components/confirm-dialog';
 import type { TaskStatus } from '../lib/types';
+import { useAppRouter } from '../router';
 import { badge, button } from '../styles/components';
 
 const detailStyles = css({
@@ -50,12 +51,12 @@ const detailStyles = css({
  * transitions) use const declarations — the compiler classifies them
  * as computed and wraps them automatically. No effect() needed.
  *
- * Task ID and navigation are accessed via useRouter() context.
+ * Task ID is accessed via useParams<TPath>() for typed params.
+ * Navigation is accessed via useAppRouter() for typed navigate().
  */
 export function TaskDetailPage() {
-  const router = useRouter();
-  const { navigate } = router;
-  const taskId = router.current.value?.params.id ?? '';
+  const { navigate } = useAppRouter();
+  const { id: taskId } = useParams<'/tasks/:id'>();
   // ── Data fetching ──────────────────────────────────
 
   const taskQuery = query(() => fetchTask(taskId), {

--- a/examples/task-manager/src/pages/task-list.tsx
+++ b/examples/task-manager/src/pages/task-list.tsx
@@ -12,10 +12,11 @@
  * - <TaskCard /> JSX component embedding
  */
 
-import { onCleanup, onMount, query, useRouter } from '@vertz/ui';
+import { onCleanup, onMount, query } from '@vertz/ui';
 import { fetchTasks } from '../api/mock-data';
 import { TaskCard } from '../components/task-card';
 import type { Task, TaskStatus } from '../lib/types';
+import { useAppRouter } from '../router';
 import { button, emptyStateStyles, layoutStyles } from '../styles/components';
 
 /**
@@ -27,10 +28,10 @@ import { button, emptyStateStyles, layoutStyles } from '../styles/components';
  * Derived values (errorMsg, filteredTasks) use const declarations —
  * the compiler classifies them as computed and wraps them automatically.
  *
- * Navigation is accessed via useRouter() context — no props needed.
+ * Navigation is accessed via useAppRouter() context — no props needed.
  */
 export function TaskListPage() {
-  const { navigate } = useRouter();
+  const { navigate } = useAppRouter();
   // ── Reactive state ─────────────────────────────────
 
   // Local state: compiler transforms `let` to signal()

--- a/examples/task-manager/src/router.ts
+++ b/examples/task-manager/src/router.ts
@@ -6,10 +6,10 @@
  * - createRouter() for navigation state
  * - createLink() for client-side navigation with active state
  * - createOutlet() for nested route rendering
- * - Pages access navigation via useRouter() context (no prop threading)
+ * - Pages access navigation via useAppRouter() context (no prop threading)
  */
 
-import type { OutletContext, Router } from '@vertz/ui';
+import type { InferRouteMap, OutletContext } from '@vertz/ui';
 import {
   createContext,
   createLink,
@@ -17,6 +17,7 @@ import {
   createRouter,
   defineRoutes,
   signal,
+  useRouter,
   watch,
 } from '@vertz/ui';
 import { fetchTask, fetchTasks } from './api/mock-data';
@@ -74,7 +75,17 @@ const initialPath =
     ? window.location.pathname
     : (globalThis as any).__SSR_URL__ || '/';
 
-export const appRouter: Router = createRouter(routes, initialPath);
+export const appRouter = createRouter(routes, initialPath);
+
+/**
+ * Typed useRouter hook for the app's route map.
+ *
+ * Use this instead of plain useRouter() to get typed navigate() that
+ * validates paths at compile time.
+ */
+export function useAppRouter() {
+  return useRouter<InferRouteMap<typeof routes>>();
+}
 
 /**
  * Create the Link component factory, bound to the router's current path.

--- a/packages/integration-tests/src/__tests__/type-safe-router-walkthrough.test-d.ts
+++ b/packages/integration-tests/src/__tests__/type-safe-router-walkthrough.test-d.ts
@@ -6,7 +6,7 @@
  * typechecks miss: bundler-inlined symbols, .d.ts generation
  * problems, and variance mismatches.
  *
- * Created in Phase 1 as a failing (RED) stub. Passes after Phase 6
+ * Created in Phase 1 as a failing (RED) stub. Activated in Phase 6
  * when all types are exported from the public API.
  *
  * @see plans/type-safe-router.md (design doc)
@@ -14,49 +14,87 @@
  * @see .claude/rules/public-api-validation.md
  */
 
-// Phase 1: These types are implemented but NOT yet exported from @vertz/ui.
-// This file will fail to typecheck until Phase 6 adds the public exports.
-//
-// Once exported, uncomment and validate:
-//
-// import type { PathWithParams, RoutePaths, InferRouteMap, Router } from '@vertz/ui';
-// import { createRouter, defineRoutes, useParams, useRouter } from '@vertz/ui';
-//
-// const routes = defineRoutes({
-//   '/': { component: () => document.createElement('div') },
-//   '/tasks/:id': { component: () => document.createElement('div') },
-//   '/users/:userId/posts/:postId': { component: () => document.createElement('div') },
-//   '/settings': { component: () => document.createElement('div') },
-//   '/files/*': { component: () => document.createElement('div') },
-// });
-//
-// const router = createRouter(routes);
-//
-// // Valid paths
-// router.navigate('/');
-// router.navigate('/tasks/42');
-// router.navigate('/users/1/posts/99');
-// router.navigate('/settings');
-// router.navigate('/files/docs/readme.md');
-//
-// // Invalid paths rejected
-// // @ts-expect-error - invalid path
-// // router.navigate('/nonexistent');
-//
-// // useParams typed
-// const params = useParams<'/tasks/:id'>();
-// const _id: string = params.id;
-//
-// // useRouter with InferRouteMap
-// const typedRouter = useRouter<InferRouteMap<typeof routes>>();
-// typedRouter.navigate('/tasks/42');
-//
-// // TypedRouter assignable to Router
-// const _asRouter: Router = router;
-//
-// // Backward compat
-// declare const untypedRouter: Router;
-// untypedRouter.navigate('/anything');
+import type { InferRouteMap, LinkProps, PathWithParams, Router, RoutePaths } from '@vertz/ui';
 
-// Placeholder to make the file valid TypeScript (empty export)
-export {};
+// Verify RoutePaths produces the expected union
+type AppPaths = RoutePaths<{
+  '/': { component: () => HTMLElement };
+  '/tasks/:id': { component: () => HTMLElement };
+}>;
+const _rpStatic: AppPaths = '/';
+const _rpParam: AppPaths = '/tasks/42';
+void _rpStatic;
+void _rpParam;
+import { createRouter, defineRoutes, useParams, useRouter } from '@vertz/ui';
+
+// ─── Phase 1: PathWithParams + RoutePaths ─────────────────────────────────────
+
+const _pwp: PathWithParams<'/tasks/:id'> = '/tasks/42';
+void _pwp;
+
+// ─── Phase 2: defineRoutes preserves literal keys ─────────────────────────────
+
+const routes = defineRoutes({
+  '/': { component: () => document.createElement('div') },
+  '/tasks/:id': { component: () => document.createElement('div') },
+  '/users/:userId/posts/:postId': { component: () => document.createElement('div') },
+  '/settings': { component: () => document.createElement('div') },
+  '/files/*': { component: () => document.createElement('div') },
+});
+
+// ─── Phase 3: createRouter<T> with typed navigate ─────────────────────────────
+
+const router = createRouter(routes);
+
+// Valid paths
+router.navigate('/');
+router.navigate('/tasks/42');
+router.navigate('/users/1/posts/99');
+router.navigate('/settings');
+router.navigate('/files/docs/readme.md');
+
+// @ts-expect-error - invalid path
+router.navigate('/nonexistent');
+
+// ─── Phase 4: useParams + useRouter<InferRouteMap> ────────────────────────────
+
+// useParams typed
+const params = useParams<'/tasks/:id'>();
+const _id: string = params.id;
+void _id;
+
+// @ts-expect-error - 'name' not on ExtractParams<'/tasks/:id'>
+const _badParam = params.name;
+void _badParam;
+
+// useRouter with InferRouteMap
+const typedRouter = useRouter<InferRouteMap<typeof routes>>();
+typedRouter.navigate('/tasks/42');
+
+// @ts-expect-error - invalid path via InferRouteMap
+typedRouter.navigate('/nonexistent');
+
+// TypedRouter assignable to Router (backward compat)
+const _asRouter: Router = router;
+void _asRouter;
+
+// Backward compat — untyped Router accepts any string
+declare const untypedRouter: Router;
+untypedRouter.navigate('/anything');
+
+// ─── Phase 5: Typed LinkProps ─────────────────────────────────────────────────
+
+type AppRouteMap = InferRouteMap<typeof routes>;
+declare const typedLink: (props: LinkProps<AppRouteMap>) => HTMLAnchorElement;
+
+// Valid hrefs
+typedLink({ href: '/', children: 'Home' });
+typedLink({ href: '/tasks/42', children: 'Task' });
+typedLink({ href: '/settings', children: 'Settings' });
+
+// @ts-expect-error - invalid href
+typedLink({ href: '/nonexistent', children: 'Bad' });
+
+// Untyped LinkProps backward compat
+declare const untypedLink: (props: LinkProps) => HTMLAnchorElement;
+untypedLink({ href: '/anything-goes', children: 'OK' });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -80,7 +80,7 @@ export type { NavigateOptions, Router, TypedRouter } from './router/navigate';
 export { createRouter } from './router/navigate';
 export type { OutletContext } from './router/outlet';
 export { createOutlet } from './router/outlet';
-export type { ExtractParams } from './router/params';
+export type { ExtractParams, PathWithParams, RoutePaths } from './router/params';
 export { RouterContext, useParams, useRouter } from './router/router-context';
 export type { RouterViewProps } from './router/router-view';
 export { RouterView } from './router/router-view';

--- a/packages/ui/src/router/index.ts
+++ b/packages/ui/src/router/index.ts
@@ -20,7 +20,7 @@ export type { NavigateOptions, Router, TypedRouter } from './navigate';
 export { createRouter } from './navigate';
 export type { OutletContext } from './outlet';
 export { createOutlet } from './outlet';
-export type { ExtractParams } from './params';
+export type { ExtractParams, PathWithParams, RoutePaths } from './params';
 export { RouterContext, useParams, useRouter } from './router-context';
 export type { RouterViewProps } from './router-view';
 export { RouterView } from './router-view';

--- a/packages/ui/src/router/public.ts
+++ b/packages/ui/src/router/public.ts
@@ -24,7 +24,7 @@ export type { NavigateOptions, Router, TypedRouter } from './navigate';
 export { createRouter } from './navigate';
 export type { OutletContext } from './outlet';
 export { createOutlet } from './outlet';
-export type { ExtractParams } from './params';
+export type { ExtractParams, PathWithParams, RoutePaths } from './params';
 export { RouterContext, useParams, useRouter } from './router-context';
 export type { RouterViewProps } from './router-view';
 export { RouterView } from './router-view';


### PR DESCRIPTION
## Summary

Closes #590 — Phase 6 of the type-safe router feature.

- **Export `PathWithParams` and `RoutePaths`** from all barrel files (`router/index.ts`, `router/public.ts`, `src/index.ts`) — these were implemented in Phase 1 but not publicly exported
- **Add `useAppRouter()` pattern** to the task-manager example — a typed wrapper around `useRouter<InferRouteMap<typeof routes>>()` that gives all pages compile-time validated `navigate()` calls
- **Update example pages**: `task-detail.tsx` uses `useParams<'/tasks/:id'>()`, all pages use `useAppRouter()` instead of untyped `useRouter()`
- **Activate integration walkthrough test** — the Phase 1 stub is now a full cross-package type test using public `@vertz/ui` imports, validating the complete type flow: `defineRoutes` → `createRouter` → typed `navigate()` → `useParams` → `useRouter<InferRouteMap>` → typed `LinkProps`
- **Add changeset** for the full type-safe router feature (`@vertz/ui` patch)
- **Update `ui-components.md`** with the recommended `useAppRouter()` pattern

This completes the type-safe router feature (Phases 1–6). All types flow end-to-end from route definitions to `navigate()`, `useParams()`, and `LinkProps`, with full backward compatibility.

## Test plan

- [x] All 112 router + subpath export tests pass
- [x] `@vertz/ui` typecheck clean
- [x] Integration walkthrough typechecks via public `@vertz/ui` imports
- [x] Example app compiles and uses typed `navigate()`/`useParams()`
- [x] Backward compat: untyped `useRouter()` and `LinkProps` still accept any string

🤖 Generated with [Claude Code](https://claude.com/claude-code)