### PR TITLE
fix(cli): add timeout to build test that times out in CI [#688]

### DIFF
--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -16,13 +16,13 @@ describe('buildAction', () => {
     vi.restoreAllMocks();
   });
 
-  it('should export buildAction function', async () => {
+  it('should export buildAction function', { timeout: 15_000 }, async () => {
     const { buildAction } = await import('../build');
     expect(buildAction).toBeDefined();
     expect(typeof buildAction).toBe('function');
   });
 
-  it('should be an async function that returns a number', async () => {
+  it('should be an async function that returns a number', { timeout: 15_000 }, async () => {
     const { buildAction } = await import('../build');
     const result = buildAction({ noTypecheck: true });
 


### PR DESCRIPTION
## Summary

- The `buildAction` export test does `await import('../build')` which dynamically loads `BuildOrchestrator` and all dependencies
- In CI with parallel turbo tasks, this import exceeds the default 5s vitest timeout
- Added `{ timeout: 15_000 }` to both tests in `build.test.ts`
- This has been the root cause of CI failures on main since #694 was merged

## Test plan

- [x] All 280 CLI tests pass locally (34 files)
- [x] Full monorepo quality gates pass (60/60 turbo tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)