### PR TITLE
fix(ci): add missing packages to coverage pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           # On push to main or workflow_dispatch, mark all packages as changed so we get full coverage
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
               echo "${pkg//-/_}=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -158,7 +158,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
 
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
             if echo "$CHANGED_FILES" | grep -q "^packages/$pkg/"; then
               echo "${pkg//-/_}=true" >> "$GITHUB_OUTPUT"
             else
@@ -205,7 +205,7 @@ jobs:
 
           # On push to main or workflow_dispatch, run coverage for all packages
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
               run_coverage "$pkg"
             done
             exit 0
@@ -215,7 +215,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
 
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
             if echo "$CHANGED_FILES" | grep -q "^packages/$pkg/"; then
               run_coverage "$pkg"
             else
@@ -225,7 +225,7 @@ jobs:
 
       - name: Verify coverage output
         run: |
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
             if [ -f "packages/$pkg/coverage/lcov.info" ]; then
               echo "OK: packages/$pkg/coverage/lcov.info (bun test)"
             elif [ -f "packages/$pkg/coverage/coverage-summary.json" ]; then
@@ -249,7 +249,7 @@ jobs:
 
           # Upload each package's coverage with its own flag
           # bun test produces lcov.info, vitest produces coverage-final.json
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
             if [ -f "packages/$pkg/coverage/lcov.info" ]; then
               echo "Uploading coverage for $pkg (lcov)"
               ./codecov do-upload \

--- a/codecov.yml
+++ b/codecov.yml
@@ -77,7 +77,35 @@ flags:
     paths:
       - packages/schema/src/
     carryforward: true
+  server:
+    paths:
+      - packages/server/src/
+    carryforward: true
   testing:
     paths:
       - packages/testing/src/
+    carryforward: true
+  tui:
+    paths:
+      - packages/tui/src/
+    carryforward: true
+  ui:
+    paths:
+      - packages/ui/src/
+    carryforward: true
+  ui-canvas:
+    paths:
+      - packages/ui-canvas/src/
+    carryforward: true
+  ui-compiler:
+    paths:
+      - packages/ui-compiler/src/
+    carryforward: true
+  ui-primitives:
+    paths:
+      - packages/ui-primitives/src/
+    carryforward: true
+  ui-server:
+    paths:
+      - packages/ui-server/src/
     carryforward: true


### PR DESCRIPTION
## Summary

- Add 6 missing packages to all coverage `for pkg in ...` loops in `ci.yml`: `tui`, `ui`, `ui-canvas`, `ui-compiler`, `ui-primitives`, `ui-server`
- Add 7 missing flag definitions to `codecov.yml`: `server`, `tui`, `ui`, `ui-canvas`, `ui-compiler`, `ui-primitives`, `ui-server`

The CI coverage job hard-coded 12 packages but missed 7 that have test scripts. This caused the Codecov badge to be stuck at 86% — coverage from these packages was never uploaded, so their code was treated as 0% covered.

## Test plan

- [x] Pre-push quality gates pass (lint, typecheck, test, build)
- [ ] After merge, verify Codecov badge updates on next push to main

Ref #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)