### PR TITLE
fix(ci): rewrite bun test lcov paths for Codecov flag matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,10 +248,14 @@ jobs:
           ./codecov create-report -t "$CODECOV_TOKEN" --git-service github
 
           # Upload each package's coverage with its own flag
-          # bun test produces lcov.info, vitest produces coverage-final.json
+          # bun test produces lcov.info (relative paths), vitest produces coverage-final.json (absolute paths)
           for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
             if [ -f "packages/$pkg/coverage/lcov.info" ]; then
               echo "Uploading coverage for $pkg (lcov)"
+              # bun test emits relative SF: paths (e.g. "src/foo.ts").
+              # Codecov flags match against repo-root-relative paths (e.g. "packages/pkg/src/foo.ts").
+              # Rewrite SF: lines to include the package prefix so flag matching works.
+              sed -i "s|^SF:src/|SF:packages/$pkg/src/|" "packages/$pkg/coverage/lcov.info"
               ./codecov do-upload \
                 -t "$CODECOV_TOKEN" \
                 --git-service github \


### PR DESCRIPTION
## Summary

- bun test emits `lcov.info` with relative `SF:` paths (e.g., `SF:src/foo.ts`), but Codecov flags expect repo-root-relative paths (e.g., `packages/errors/src/foo.ts`)
- This mismatch caused 12 bun-test packages to report 0% on their Codecov flags despite successful uploads — keeping the badge stuck at 86%
- Fix: `sed` rewrite of `SF:` lines to prepend `packages/<pkg>/` before uploading

Closes #632

## Test plan

- [ ] CI coverage job completes successfully
- [ ] Codecov flags for bun-test packages (core, schema, compiler, codegen, cli, db, errors, server, ui, ui-canvas, ui-compiler, ui-primitives) show non-zero coverage
- [ ] Overall Codecov badge reflects the true monorepo coverage (expected ~90%+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)