### PR TITLE
fix(ui): ensure test task depends on own build in turbo

### DIFF
--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The `subpath-exports.test.ts` checks for `dist/` files (e.g., `dist/router/public.d.ts`) via `existsSync`
- Turbo's root config only declares `"dependsOn": ["^build"]` for test tasks — upstream builds, not the package's own build
- This race condition caused `@vertz/ui:test` to start before `@vertz/ui:build` completed, resulting in `Missing DTS: ./dist/router/public.d.ts` failures on main
- Fix: add `packages/ui/turbo.json` so `@vertz/ui:test` depends on both `build` and `^build`

## Test plan

- [ ] CI passes — no more `@vertz/ui:test` race condition
- [ ] `bunx turbo run test --filter=@vertz/ui --dry-run` shows `@vertz/ui#build` as a dependency of `@vertz/ui#test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)