### PR TITLE
chore: scaffold Mintlify docs package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -230,6 +230,10 @@
         "bun:sqlite",
       ],
     },
+    "packages/docs": {
+      "name": "@vertz/docs",
+      "version": "0.0.0",
+    },
     "packages/errors": {
       "name": "@vertz/errors",
       "version": "0.1.0",
@@ -879,6 +883,8 @@
     "@vertz/create-vertz-app": ["@vertz/create-vertz-app@workspace:packages/create-vertz-app"],
 
     "@vertz/db": ["@vertz/db@workspace:packages/db"],
+
+    "@vertz/docs": ["@vertz/docs@workspace:packages/docs"],
 
     "@vertz/errors": ["@vertz/errors@workspace:packages/errors"],
 

--- a/packages/docs/.mintignore
+++ b/packages/docs/.mintignore
@@ -1,0 +1,2 @@
+node_modules
+.turbo

--- a/packages/docs/api-reference/ui/compiler-plugin.mdx
+++ b/packages/docs/api-reference/ui/compiler-plugin.mdx
@@ -1,0 +1,4 @@
+---
+title: Compiler Plugin
+description: "API reference for the @vertz/ui-compiler Vite/Bun plugin"
+---

--- a/packages/docs/api-reference/ui/context.mdx
+++ b/packages/docs/api-reference/ui/context.mdx
@@ -1,0 +1,4 @@
+---
+title: Context
+description: "API reference for createContext(), useContext(), and Provider"
+---

--- a/packages/docs/api-reference/ui/css.mdx
+++ b/packages/docs/api-reference/ui/css.mdx
@@ -1,0 +1,4 @@
+---
+title: CSS
+description: "API reference for css(), variants(), and the design token system"
+---

--- a/packages/docs/api-reference/ui/form.mdx
+++ b/packages/docs/api-reference/ui/form.mdx
@@ -1,0 +1,4 @@
+---
+title: Form
+description: "API reference for form() — type-safe form handling with validation"
+---

--- a/packages/docs/api-reference/ui/jsx-runtime.mdx
+++ b/packages/docs/api-reference/ui/jsx-runtime.mdx
@@ -1,0 +1,4 @@
+---
+title: JSX Runtime
+description: "API reference for the @vertz/ui JSX runtime"
+---

--- a/packages/docs/api-reference/ui/mount.mdx
+++ b/packages/docs/api-reference/ui/mount.mdx
@@ -1,0 +1,4 @@
+---
+title: Mount
+description: "API reference for mount() — rendering your app to the DOM"
+---

--- a/packages/docs/api-reference/ui/query.mdx
+++ b/packages/docs/api-reference/ui/query.mdx
@@ -1,0 +1,4 @@
+---
+title: Query
+description: "API reference for query() — data fetching and caching"
+---

--- a/packages/docs/api-reference/ui/router.mdx
+++ b/packages/docs/api-reference/ui/router.mdx
@@ -1,0 +1,4 @@
+---
+title: Router
+description: "API reference for defineRoutes(), createRouter(), RouterView, and Link"
+---

--- a/packages/docs/api-reference/ui/signals.mdx
+++ b/packages/docs/api-reference/ui/signals.mdx
@@ -1,0 +1,4 @@
+---
+title: Signals
+description: "API reference for signal(), computed(), effect(), and watch()"
+---

--- a/packages/docs/api-reference/ui/ssr-handler.mdx
+++ b/packages/docs/api-reference/ui/ssr-handler.mdx
@@ -1,0 +1,4 @@
+---
+title: SSR Handler
+description: "API reference for createSSRHandler() from @vertz/ui-server"
+---

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "colors": {
+    "background": {
+      "dark": "#0F0F12",
+      "light": "#FFFFFF"
+    },
+    "dark": "#2563eb",
+    "light": "#60a5fa",
+    "primary": "#3b82f6"
+  },
+  "favicon": "/favicon.svg",
+  "footer": {
+    "socials": {
+      "github": "https://github.com/vertz-dev/vertz",
+      "x": "https://x.com/veraborgesv"
+    }
+  },
+  "logo": {
+    "dark": "/logo/dark.svg",
+    "light": "/logo/light.svg"
+  },
+  "name": "Vertz",
+  "navbar": {
+    "primary": {
+      "href": "/quickstart",
+      "label": "Get Started",
+      "type": "button"
+    }
+  },
+  "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/vertz-dev/vertz",
+          "icon": "github"
+        }
+      ]
+    },
+    "tabs": [
+      {
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": ["index", "quickstart", "installation"]
+          },
+          {
+            "group": "@vertz/ui",
+            "pages": [
+              "guides/ui/overview",
+              "guides/ui/components",
+              "guides/ui/reactivity",
+              "guides/ui/styling",
+              "guides/ui/routing",
+              "guides/ui/data-fetching",
+              "guides/ui/forms",
+              "guides/ui/ssr"
+            ]
+          },
+          {
+            "group": "@vertz/ui-compiler",
+            "pages": ["guides/ui/compiler"]
+          }
+        ],
+        "tab": "Guides"
+      },
+      {
+        "groups": [
+          {
+            "group": "@vertz/ui",
+            "pages": [
+              "api-reference/ui/jsx-runtime",
+              "api-reference/ui/signals",
+              "api-reference/ui/css",
+              "api-reference/ui/router",
+              "api-reference/ui/query",
+              "api-reference/ui/form",
+              "api-reference/ui/context",
+              "api-reference/ui/mount"
+            ]
+          },
+          {
+            "group": "@vertz/ui-server",
+            "pages": ["api-reference/ui/ssr-handler"]
+          },
+          {
+            "group": "@vertz/ui-compiler",
+            "pages": ["api-reference/ui/compiler-plugin"]
+          }
+        ],
+        "tab": "API Reference"
+      },
+      {
+        "groups": [
+          {
+            "group": "Examples",
+            "pages": ["examples/task-manager"]
+          }
+        ],
+        "tab": "Examples"
+      }
+    ]
+  },
+  "theme": "mint"
+}

--- a/packages/docs/examples/task-manager.mdx
+++ b/packages/docs/examples/task-manager.mdx
@@ -1,0 +1,4 @@
+---
+title: Task Manager
+description: "Full-stack example app with routing, data fetching, forms, and SSR"
+---

--- a/packages/docs/favicon.svg
+++ b/packages/docs/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#3b82f6"/>
+  <g transform="translate(2.5,2) scale(0.0906)">
+    <path d="M120.277 77H26L106.5 185.5L151.365 124.67L120.277 77Z" fill="white"/>
+    <path d="M147.986 243L127 214L195.467 124.67L165.731 77H272L147.986 243Z" fill="white"/>
+  </g>
+</svg>

--- a/packages/docs/guides/ui/compiler.mdx
+++ b/packages/docs/guides/ui/compiler.mdx
@@ -1,0 +1,4 @@
+---
+title: Compiler Plugin
+description: "@vertz/ui-compiler — the build plugin that transforms JSX and signals"
+---

--- a/packages/docs/guides/ui/components.mdx
+++ b/packages/docs/guides/ui/components.mdx
@@ -1,0 +1,4 @@
+---
+title: Components
+description: "Writing components with JSX and TypeScript"
+---

--- a/packages/docs/guides/ui/data-fetching.mdx
+++ b/packages/docs/guides/ui/data-fetching.mdx
@@ -1,0 +1,4 @@
+---
+title: Data Fetching
+description: "Fetch and cache data with query()"
+---

--- a/packages/docs/guides/ui/forms.mdx
+++ b/packages/docs/guides/ui/forms.mdx
@@ -1,0 +1,4 @@
+---
+title: Forms
+description: "Type-safe form handling with schema validation"
+---

--- a/packages/docs/guides/ui/overview.mdx
+++ b/packages/docs/guides/ui/overview.mdx
@@ -1,0 +1,4 @@
+---
+title: Overview
+description: "@vertz/ui — a compiled TypeScript UI framework with fine-grained reactivity"
+---

--- a/packages/docs/guides/ui/reactivity.mdx
+++ b/packages/docs/guides/ui/reactivity.mdx
@@ -1,0 +1,4 @@
+---
+title: Reactivity
+description: "Fine-grained reactivity with let, const, and signals"
+---

--- a/packages/docs/guides/ui/routing.mdx
+++ b/packages/docs/guides/ui/routing.mdx
@@ -1,0 +1,4 @@
+---
+title: Routing
+description: "Type-safe client-side routing with defineRoutes and createRouter"
+---

--- a/packages/docs/guides/ui/ssr.mdx
+++ b/packages/docs/guides/ui/ssr.mdx
@@ -1,0 +1,4 @@
+---
+title: Server-Side Rendering
+description: "SSR with @vertz/ui-server — two-pass rendering, query pre-fetch, and hydration"
+---

--- a/packages/docs/guides/ui/styling.mdx
+++ b/packages/docs/guides/ui/styling.mdx
@@ -1,0 +1,4 @@
+---
+title: Styling
+description: "Scoped styles with css() and parameterized styles with variants()"
+---

--- a/packages/docs/index.mdx
+++ b/packages/docs/index.mdx
@@ -1,0 +1,4 @@
+---
+title: Introduction
+description: "Vertz — a TypeScript UI framework with a compiler, fine-grained reactivity, and SSR"
+---

--- a/packages/docs/installation.mdx
+++ b/packages/docs/installation.mdx
@@ -1,0 +1,4 @@
+---
+title: Installation
+description: "Install @vertz/ui and configure the compiler"
+---

--- a/packages/docs/logo/dark.svg
+++ b/packages/docs/logo/dark.svg
@@ -1,0 +1,4 @@
+<svg width="298" height="298" viewBox="0 0 298 298" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M120.277 77H26L106.5 185.5L151.365 124.67L120.277 77Z" fill="white"/>
+  <path d="M147.986 243L125.5 210.5L190.467 124.67L160.731 77H272L147.986 243Z" fill="white"/>
+</svg>

--- a/packages/docs/logo/light.svg
+++ b/packages/docs/logo/light.svg
@@ -1,0 +1,4 @@
+<svg width="298" height="298" viewBox="0 0 298 298" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M120.277 77H26L106.5 185.5L151.365 124.67L120.277 77Z" fill="#1a1a2e"/>
+  <path d="M147.986 243L125.5 210.5L190.467 124.67L160.731 77H272L147.986 243Z" fill="#1a1a2e"/>
+</svg>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vertz/docs",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "mint dev",
+    "validate": "mint validate",
+    "broken-links": "mint broken-links"
+  }
+}

--- a/packages/docs/quickstart.mdx
+++ b/packages/docs/quickstart.mdx
@@ -1,0 +1,4 @@
+---
+title: Quickstart
+description: "Get up and running with @vertz/ui in under 5 minutes"
+---


### PR DESCRIPTION
## Summary
- Move documentation infrastructure from the backstage repo into `packages/docs/`
- Migrate from legacy `mint.json` to new `docs.json` format
- Set up directory structure with placeholder `.mdx` stubs (frontmatter only, no content)
- Navigation scoped to UI-first launch: `@vertz/ui`, `@vertz/ui-compiler`, `@vertz/ui-server`
- Logo assets (light/dark) and favicon with Vertz logo
- Package excluded from turbo build pipeline (no `build` script)

## Structure
```
packages/docs/
├── docs.json              # Mintlify config (new format)
├── package.json           # dev/validate scripts only
├── favicon.svg
├── logo/{light,dark}.svg
├── index.mdx              # Introduction
├── quickstart.mdx
├── installation.mdx
├── guides/ui/             # 9 guide stubs
├── api-reference/ui/      # 10 API ref stubs
└── examples/              # 1 example stub
```

## Notes
- No content written yet — waiting on Vite → Bun migration POC results before writing install/config docs
- Server/DB/ORM sections intentionally omitted for now (week 2 launch)
- Run locally with `cd packages/docs && mint dev` (requires `npm i -g mint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)