### PR TITLE
feat(landing): deploy to Cloudflare Workers and update content

### DIFF
--- a/sites/landing/.assetsignore
+++ b/sites/landing/.assetsignore
@@ -1,0 +1,4 @@
+wrangler.toml
+package.json
+node_modules
+.wrangler

--- a/sites/landing/index.html
+++ b/sites/landing/index.html
@@ -140,11 +140,14 @@
   <!-- ===================== FIXED NAV ===================== -->
   <nav class="fixed top-0 inset-x-0 z-50 flex items-center justify-between px-6 py-4 bg-[#0a0a0b]/80 backdrop-blur-md border-b-2 border-white/[0.04]">
     <div class="flex items-center gap-2">
-      <svg class="h-7" viewBox="0 0 298 298" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M120.277 77H26L106.5 185.5L151.365 124.67L120.277 77Z" fill="#3D94FF"/>
-        <path d="M147.986 243L127 214L195.467 124.67L165.731 77H272L147.986 243Z" fill="white"/>
+      <svg class="h-7" viewBox="0 0 689 272" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M137.986 232L117 203L185.467 113.67L155.731 66H262L137.986 232Z" fill="white"/>
+        <path d="M110.277 66H16L96.5 174.5L141.365 113.67L110.277 66Z" fill="#3D94FF"/>
+        <path d="M310.395 113.48C321.012 113.48 330.077 115.685 337.59 120.095C345.103 124.342 350.82 130.222 354.74 137.735C358.823 145.085 360.865 153.497 360.865 162.97C360.865 164.767 360.783 166.645 360.62 168.605C360.457 170.402 360.13 172.035 359.64 173.505H286.63C286.793 191.145 289.897 203.885 295.94 211.725C302.147 219.402 311.293 223.24 323.38 223.24C331.547 223.24 338.162 221.933 343.225 219.32C348.288 216.707 353.025 212.868 357.435 207.805L359.885 210.01C354.822 218.993 348.043 226.017 339.55 231.08C331.22 236.143 321.175 238.675 309.415 238.675C297.818 238.675 287.528 236.225 278.545 231.325C269.562 226.262 262.538 219.075 257.475 209.765C252.412 200.455 249.88 189.348 249.88 176.445C249.88 163.052 252.82 151.7 258.7 142.39C264.58 132.917 272.093 125.73 281.24 120.83C290.55 115.93 300.268 113.48 310.395 113.48ZM309.66 118.38C304.923 118.38 300.84 119.85 297.41 122.79C294.143 125.567 291.53 130.63 289.57 137.98C287.773 145.167 286.793 155.375 286.63 168.605H328.525C330.158 150.802 329.505 137.98 326.565 130.14C323.625 122.3 317.99 118.38 309.66 118.38Z" fill="white"/>
+        <path d="M373.075 235V232.55L376.75 231.57C380.016 230.59 382.221 229.12 383.365 227.16C384.671 225.2 385.325 222.668 385.325 219.565V142.88C385.325 139.287 384.671 136.673 383.365 135.04C382.221 133.243 380.016 132.018 376.75 131.365L373.075 130.385V127.935L415.215 113.725L417.665 116.175L419.87 137.245V139.205C422.156 134.632 425.096 130.467 428.69 126.71C432.446 122.79 436.53 119.605 440.94 117.155C445.513 114.705 450.005 113.48 454.415 113.48C460.621 113.48 465.358 115.195 468.625 118.625C471.891 122.055 473.525 126.383 473.525 131.61C473.525 137.163 471.891 141.492 468.625 144.595C465.521 147.535 461.765 149.005 457.355 149.005C450.495 149.005 444.451 145.575 439.225 138.715L438.735 138.225C437.101 135.938 435.223 134.713 433.1 134.55C430.976 134.223 429.016 135.203 427.22 137.49C425.586 138.96 424.198 140.757 423.055 142.88C422.075 144.84 421.095 147.127 420.115 149.74V218.095C420.115 224.628 422.973 228.712 428.69 230.345L436.53 232.55V235H373.075Z" fill="white"/>
+        <path d="M529.923 238.675C519.469 238.675 511.303 236.062 505.423 230.835C499.706 225.608 496.848 217.278 496.848 205.845V122.055H479.943V119.605L485.823 118.625C490.886 117.482 495.214 115.848 498.808 113.725C502.564 111.602 506.239 108.743 509.833 105.15L529.923 82.855H532.373L531.638 117.155H559.078V122.055H531.393V210.255C531.393 215.972 532.618 220.3 535.068 223.24C537.681 226.18 540.948 227.65 544.868 227.65C548.298 227.65 551.319 226.833 553.933 225.2C556.546 223.403 559.159 221.035 561.773 218.095L564.223 220.545C560.956 226.098 556.464 230.508 550.748 233.775C545.031 237.042 538.089 238.675 529.923 238.675Z" fill="white"/>
+        <path d="M574.068 235V231.08L640.953 122.055H603.958C599.712 122.055 596.363 123.198 593.913 125.485C591.463 127.772 589.177 130.793 587.053 134.55L578.233 150.965H575.783L577.498 117.155H675.498V120.585L610.083 230.1H648.548C653.775 230.1 657.613 228.875 660.063 226.425C662.513 223.975 664.8 220.627 666.923 216.38L675.498 198.25H677.948L675.743 235H574.068Z" fill="white"/>
       </svg>
-      <!-- logo -->
     </div>
     <div class="flex items-center gap-6">
       <a href="https://github.com/vertz-dev/vertz" target="_blank" rel="noopener" class="font-mono text-xs uppercase tracking-wider text-zinc-500 hover:text-zinc-300 transition-colors">GitHub</a>
@@ -196,7 +199,7 @@
     <!-- ===================== CODE EXAMPLES ===================== -->
     <section class="py-24 px-6">
       <div class="max-w-4xl mx-auto">
-        <p class="font-mono text-xs tracking-widest uppercase text-zinc-500 mb-8 text-center">@vertz/ui</p>
+        <p class="font-mono text-xs tracking-widest uppercase text-zinc-500 mb-8 text-center">vertz/ui</p>
         
         <!-- Code Window with Tabs -->
         <div class="bg-[#0a0a0b] border border-border overflow-hidden rounded-lg shadow-2xl">
@@ -208,7 +211,7 @@
           
           <!-- Counter Code -->
           <div id="code-counter">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> css <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> css <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">const</span> styles <span class="syn-punct">=</span> <span class="syn-fn">css</span><span class="syn-punct">({</span>
   <span class="syn-prop">button</span><span class="syn-punct">:</span> <span class="syn-punct">[</span><span class="syn-str">'px:4'</span><span class="syn-punct">,</span> <span class="syn-str">'py:2'</span><span class="syn-punct">,</span> <span class="syn-str">'rounded:md'</span><span class="syn-punct">,</span> <span class="syn-str">'bg:blue-600'</span><span class="syn-punct">,</span> <span class="syn-str">'text:white'</span><span class="syn-punct">]</span>
@@ -227,7 +230,7 @@
           
           <!-- Fetch Code -->
           <div id="code-fetch" class="hidden">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> query <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> query <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 <span class="syn-kw">import</span> <span class="syn-punct">{</span> api <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'./sdk'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">export</span> <span class="syn-kw">function</span> <span class="syn-fn">UserProfile</span><span class="syn-punct">({</span> <span class="syn-prop">userId</span> <span class="syn-punct">}:</span> <span class="syn-punct">{</span> <span class="syn-prop">userId</span><span class="syn-punct">:</span> <span class="syn-kw">string</span> <span class="syn-punct">})</span> <span class="syn-punct">{</span>
@@ -250,7 +253,7 @@
           
           <!-- Form Code -->
           <div id="code-form" class="hidden">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> form <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> form <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 <span class="syn-kw">import</span> <span class="syn-punct">{</span> api <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'./sdk'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">const</span> loginForm <span class="syn-punct">=</span> <span class="syn-fn">form</span><span class="syn-punct">(</span>api<span class="syn-punct">.</span>users<span class="syn-punct">.</span><span class="syn-fn">login</span><span class="syn-punct">,</span> <span class="syn-punct">{</span>
@@ -290,7 +293,7 @@
 
           <!-- Counter Code -->
           <div id="code-counter">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> css <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> css <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">const</span> styles <span class="syn-punct">=</span> <span class="syn-fn">css</span><span class="syn-punct">({</span>
   <span class="syn-prop">button</span><span class="syn-punct">:</span> <span class="syn-punct">[</span><span class="syn-str">'px:4'</span><span class="syn-punct">,</span> <span class="syn-str">'py:2'</span><span class="syn-punct">,</span> <span class="syn-str">'rounded:md'</span><span class="syn-punct">,</span> <span class="syn-str">'bg:blue-600'</span><span class="syn-punct">,</span> <span class="syn-str">'text:white'</span><span class="syn-punct">]</span>
@@ -309,7 +312,7 @@
 
           <!-- Fetch Code -->
           <div id="code-fetch" class="hidden">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> query <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> query <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 <span class="syn-kw">import</span> <span class="syn-punct">{</span> api <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'./sdk'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">export</span> <span class="syn-kw">function</span> <span class="syn-fn">UserProfile</span><span class="syn-punct">({</span> <span class="syn-prop">userId</span> <span class="syn-punct">}:</span> <span class="syn-punct">{</span> <span class="syn-prop">userId</span><span class="syn-punct">:</span> <span class="syn-kw">string</span> <span class="syn-punct">})</span> <span class="syn-punct">{</span>
@@ -332,7 +335,7 @@
 
           <!-- Form Code -->
           <div id="code-form" class="hidden">
-            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> form <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+            <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> form <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 <span class="syn-kw">import</span> <span class="syn-punct">{</span> api <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'./sdk'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">const</span> loginForm <span class="syn-punct">=</span> <span class="syn-fn">form</span><span class="syn-punct">(</span>api<span class="syn-punct">.</span>users<span class="syn-punct">.</span><span class="syn-fn">login</span><span class="syn-punct">,</span> <span class="syn-punct">{</span>
@@ -401,7 +404,7 @@
 
           <div>
             <div class="flex justify-between font-mono text-sm mb-2">
-              <span class="text-zinc-200">@vertz/ui</span>
+              <span class="text-zinc-200">vertz/ui</span>
               <span class="text-blue-400">~15KB gzipped</span>
             </div>
             <div class="h-8 bg-surface border border-border w-full relative">
@@ -454,7 +457,7 @@
           <div class="flex items-center gap-2 px-4 py-3 border-b border-border bg-[#0d0d0f]">
             <span class="font-mono text-xs text-zinc-500">Button.ts</span>
           </div>
-          <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> variants <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'@vertz/ui'</span><span class="syn-punct">;</span>
+          <pre class="p-6 text-sm font-mono leading-relaxed overflow-x-auto"><code><span class="syn-kw">import</span> <span class="syn-punct">{</span> variants <span class="syn-punct">}</span> <span class="syn-kw">from</span> <span class="syn-str">'vertz/ui'</span><span class="syn-punct">;</span>
 
 <span class="syn-kw">const</span> button <span class="syn-punct">=</span> <span class="syn-fn">variants</span><span class="syn-punct">({</span>
   <span class="syn-prop">base</span><span class="syn-punct">:</span> <span class="syn-punct">[</span><span class="syn-str">'rounded:md'</span><span class="syn-punct">,</span> <span class="syn-str">'font:semibold'</span><span class="syn-punct">],</span>
@@ -483,7 +486,7 @@
       <div class="max-w-xl mx-auto text-center">
         <h2 class="font-display text-4xl mb-6">This is just the beginning.</h2>
         <p class="text-zinc-400 mb-12 leading-relaxed">
-          We're building the full TypeScript stack — schema, database, API, client, UI. One type system, zero seams. <span class="text-zinc-200">@vertz/ui</span> is the first piece.
+          We're building the full TypeScript stack — schema, database, API, client, UI. One type system, zero seams. <span class="text-zinc-200">vertz/ui</span> is the first piece.
         </p>
 
         <!-- Email form -->
@@ -518,7 +521,7 @@
             <img src="./viniciusdacal.jpg" alt="Vinicius Dacal" class="w-20 h-20 mx-auto mb-4 object-cover ring-2 ring-zinc-800" />
             <p class="font-semibold text-lg">Vinicius Dacal</p>
             <p class="font-mono text-xs uppercase tracking-wider text-zinc-500 mt-1">CTO &amp; co-founder</p>
-            <p class="text-xs text-zinc-400 mt-2 leading-relaxed max-w-xs mx-auto">12+ years building at scale. Senior Engineer at Scrunch. Previously Staff Engineer at Voiceflow. Led Angular-to-React migrations, built GraphQL servers, shipped NestJS backends — and got tired of fighting the frameworks.</p>
+            <p class="text-xs text-zinc-400 mt-2 leading-relaxed max-w-xs mx-auto">15+ years building at scale. Senior Engineer at Scrunch. Previously Staff Engineer at Voiceflow. Led Angular-to-React migrations, built GraphQL servers, shipped NestJS backends — and got tired of fighting the frameworks.</p>
             <a href="https://x.com/viniciusdacal" target="_blank" rel="noopener"
                class="inline-flex items-center gap-1.5 mt-3 font-mono text-xs uppercase tracking-wider text-zinc-500 hover:text-blue-400 transition-colors">
               <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>

--- a/sites/landing/wrangler.toml
+++ b/sites/landing/wrangler.toml
@@ -1,0 +1,11 @@
+name = "vertz-landing"
+compatibility_date = "2025-01-01"
+workers_dev = true
+
+[assets]
+directory = "./"
+not_found_handling = "single-page-application"
+
+[[routes]]
+pattern = "vertz.dev"
+custom_domain = true


### PR DESCRIPTION
## Summary
- Add Cloudflare Workers deployment config (`wrangler.toml` + `.assetsignore`) for `vertz.dev`
- Update nav logo to full wordmark SVG (symbol + smaller serif "ertz" text)
- Replace all `@vertz/ui` references with `vertz/ui` (meta-package name)
- Fix founder bio from 12+ to 15+ years experience

## Test plan
- [x] Deployed and verified at https://vertz.dev
- [x] Verified at https://vertz-landing.viniciusldacal.workers.dev
- [ ] Visual check of logo in nav bar
- [ ] Confirm no `@vertz/ui` references remain on page

🤖 Generated with [Claude Code](https://claude.com/claude-code)