### PR TITLE
fix(bun-plugin): address PR review feedback

### DIFF
--- a/packages/bun-plugin/src/context-stable-ids.ts
+++ b/packages/bun-plugin/src/context-stable-ids.ts
@@ -1,6 +1,6 @@
 import type MagicString from 'magic-string';
-import { ts } from 'ts-morph';
 import type { SourceFile } from 'ts-morph';
+import { ts } from 'ts-morph';
 
 /**
  * Inject stable IDs into createContext() calls for HMR support.
@@ -24,7 +24,8 @@ export function injectContextStableIds(
       if (!ts.isIdentifier(decl.name)) continue;
 
       const varName = decl.name.text;
-      const stableId = `${relFilePath}::${varName}`;
+      const escapedPath = relFilePath.replace(/['\\]/g, '\\$&');
+      const stableId = `${escapedPath}::${varName}`;
       const callExpr = decl.initializer;
 
       // Insert the stable ID as the last argument

--- a/packages/bun-plugin/src/fast-refresh-codegen.ts
+++ b/packages/bun-plugin/src/fast-refresh-codegen.ts
@@ -9,6 +9,7 @@ import type { ComponentInfo } from '@vertz/ui-compiler';
  * HMR updates, triggering full page reloads.
  */
 export function generateRefreshPreamble(moduleId: string): string {
+  const escapedId = moduleId.replace(/['\\]/g, '\\$&');
   return (
     `const __$fr = globalThis[Symbol.for('vertz:fast-refresh')];\n` +
     `const { __$refreshReg, __$refreshTrack, __$refreshPerform, ` +
@@ -16,7 +17,7 @@ export function generateRefreshPreamble(moduleId: string): string {
     `_tryOnCleanup: __$tryCleanup, runCleanups: __$runCleanups, ` +
     `getContextScope: __$getCtx, setContextScope: __$setCtx, ` +
     `startSignalCollection: __$startSigCol, stopSignalCollection: __$stopSigCol } = __$fr;\n` +
-    `const __$moduleId = '${moduleId}';\n`
+    `const __$moduleId = '${escapedId}';\n`
   );
 }
 

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -14,14 +14,9 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
-import remapping from '@ampproject/remapping';
 import type { EncodedSourceMap } from '@ampproject/remapping';
-import {
-  CSSExtractor,
-  ComponentAnalyzer,
-  HydrationTransformer,
-  compile,
-} from '@vertz/ui-compiler';
+import remapping from '@ampproject/remapping';
+import { ComponentAnalyzer, CSSExtractor, compile, HydrationTransformer } from '@vertz/ui-compiler';
 import type { BunPlugin } from 'bun';
 import MagicString from 'magic-string';
 import { Project, ts } from 'ts-morph';
@@ -42,15 +37,12 @@ import type {
  * Returns the plugin along with maps for CSS extractions and sidecar paths,
  * which build scripts need for dead CSS elimination.
  */
-export function createVertzBunPlugin(
-  options?: VertzBunPluginOptions,
-): VertzBunPluginResult {
+export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunPluginResult {
   const filter = options?.filter ?? /\.tsx$/;
   const hmr = options?.hmr ?? true;
   const fastRefresh = options?.fastRefresh ?? hmr;
   const projectRoot = options?.projectRoot ?? process.cwd();
-  const cssOutDir =
-    options?.cssOutDir ?? resolve(projectRoot, '.vertz', 'css');
+  const cssOutDir = options?.cssOutDir ?? resolve(projectRoot, '.vertz', 'css');
   const cssExtractor = new CSSExtractor();
   const componentAnalyzer = new ComponentAnalyzer();
 
@@ -64,113 +56,114 @@ export function createVertzBunPlugin(
     name: 'vertz-bun-plugin',
     setup(build) {
       build.onLoad({ filter }, async (args) => {
-        const source = await Bun.file(args.path).text();
+        try {
+          const source = await Bun.file(args.path).text();
 
-        // ── 1. Hydration transform ─────────────────────────────
-        const hydrationS = new MagicString(source);
-        const hydrationProject = new Project({
-          useInMemoryFileSystem: true,
-          compilerOptions: {
-            jsx: ts.JsxEmit.Preserve,
-            strict: true,
-          },
-        });
-        const hydrationSourceFile = hydrationProject.createSourceFile(
-          args.path,
-          source,
-        );
-        const hydrationTransformer = new HydrationTransformer();
-        hydrationTransformer.transform(hydrationS, hydrationSourceFile);
+          // ── 1. Hydration transform ─────────────────────────────
+          const hydrationS = new MagicString(source);
+          const hydrationProject = new Project({
+            useInMemoryFileSystem: true,
+            compilerOptions: {
+              jsx: ts.JsxEmit.Preserve,
+              strict: true,
+            },
+          });
+          const hydrationSourceFile = hydrationProject.createSourceFile(args.path, source);
+          const hydrationTransformer = new HydrationTransformer();
+          hydrationTransformer.transform(hydrationS, hydrationSourceFile);
 
-        // ── 2. Context stable IDs (Fast Refresh only) ──────────
-        if (fastRefresh) {
-          const relFilePath = relative(projectRoot, args.path);
-          injectContextStableIds(hydrationS, hydrationSourceFile, relFilePath);
-        }
+          // ── 2. Context stable IDs (Fast Refresh only) ──────────
+          if (fastRefresh) {
+            const relFilePath = relative(projectRoot, args.path);
+            injectContextStableIds(hydrationS, hydrationSourceFile, relFilePath);
+          }
 
-        const hydratedCode = hydrationS.toString();
-        const hydrationMap = hydrationS.generateMap({
-          source: args.path,
-          includeContent: true,
-        });
+          const hydratedCode = hydrationS.toString();
+          const hydrationMap = hydrationS.generateMap({
+            source: args.path,
+            includeContent: true,
+          });
 
-        // ── 3. Compile (reactive + JSX transforms) ─────────────
-        const compileResult = compile(hydratedCode, {
-          filename: args.path,
-          target: options?.target,
-        });
+          // ── 3. Compile (reactive + JSX transforms) ─────────────
+          const compileResult = compile(hydratedCode, {
+            filename: args.path,
+            target: options?.target,
+          });
 
-        // ── 4. Source map chaining ──────────────────────────────
-        const remapped = remapping(
-          [
-            compileResult.map as EncodedSourceMap,
-            hydrationMap as EncodedSourceMap,
-          ],
-          () => null,
-        );
+          // ── 4. Source map chaining ──────────────────────────────
+          const remapped = remapping(
+            [compileResult.map as EncodedSourceMap, hydrationMap as EncodedSourceMap],
+            () => null,
+          );
 
-        // ── 5. CSS extraction → sidecar file ───────────────────
-        const extraction = cssExtractor.extract(source, args.path);
-        let cssImportLine = '';
+          // ── 5. CSS extraction → sidecar file ───────────────────
+          const extraction = cssExtractor.extract(source, args.path);
+          let cssImportLine = '';
 
-        if (extraction.css.length > 0) {
-          fileExtractions.set(args.path, extraction);
+          if (extraction.css.length > 0) {
+            fileExtractions.set(args.path, extraction);
+
+            if (hmr) {
+              // Write CSS to a sidecar file on disk for Bun's CSS HMR
+              const hash = filePathHash(args.path);
+              const cssFileName = `${hash}.css`;
+              const cssFilePath = resolve(cssOutDir, cssFileName);
+
+              writeFileSync(cssFilePath, extraction.css);
+              cssSidecarMap.set(args.path, cssFilePath);
+
+              // Compute relative import path from source file to CSS file
+              const relPath = relative(dirname(args.path), cssFilePath);
+              const importPath = relPath.startsWith('.') ? relPath : `./${relPath}`;
+              cssImportLine = `import '${importPath}';\n`;
+            }
+          }
+
+          // ── 6. Fast Refresh: detect components and inject wrappers ──
+          let refreshPreamble = '';
+          let refreshEpilogue = '';
+
+          if (fastRefresh) {
+            const components = componentAnalyzer.analyze(hydrationSourceFile);
+            const refreshCode = generateRefreshCode(args.path, components);
+            if (refreshCode) {
+              refreshPreamble = refreshCode.preamble;
+              refreshEpilogue = refreshCode.epilogue;
+            }
+          }
+
+          // ── 7. Assemble output ─────────────────────────────────
+          const mapBase64 = Buffer.from(remapped.toString()).toString('base64');
+          const sourceMapComment = `\n//# sourceMappingURL=data:application/json;base64,${mapBase64}`;
+
+          let contents = '';
+          if (cssImportLine) {
+            contents += cssImportLine;
+          }
+          if (refreshPreamble) {
+            contents += refreshPreamble;
+          }
+          contents += compileResult.code;
+
+          if (refreshEpilogue) {
+            contents += refreshEpilogue;
+          }
 
           if (hmr) {
-            // Write CSS to a sidecar file on disk for Bun's CSS HMR
-            const hash = filePathHash(args.path);
-            const cssFileName = `${hash}.css`;
-            const cssFilePath = resolve(cssOutDir, cssFileName);
-
-            writeFileSync(cssFilePath, extraction.css);
-            cssSidecarMap.set(args.path, cssFilePath);
-
-            // Compute relative import path from source file to CSS file
-            const relPath = relative(dirname(args.path), cssFilePath);
-            const importPath = relPath.startsWith('.') ? relPath : `./${relPath}`;
-            cssImportLine = `import '${importPath}';\n`;
+            // Bun statically analyzes import.meta.hot.accept() calls.
+            // It MUST be called directly (no optional chaining, no variable indirection).
+            contents += '\nimport.meta.hot.accept();\n';
           }
+
+          contents += sourceMapComment;
+
+          return { contents, loader: 'tsx' };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const relPath = relative(projectRoot, args.path);
+          console.error(`[vertz-bun-plugin] Failed to process ${relPath}:`, message);
+          throw err;
         }
-
-        // ── 6. Fast Refresh: detect components and inject wrappers ──
-        let refreshPreamble = '';
-        let refreshEpilogue = '';
-
-        if (fastRefresh) {
-          const components = componentAnalyzer.analyze(hydrationSourceFile);
-          const refreshCode = generateRefreshCode(args.path, components);
-          if (refreshCode) {
-            refreshPreamble = refreshCode.preamble;
-            refreshEpilogue = refreshCode.epilogue;
-          }
-        }
-
-        // ── 7. Assemble output ─────────────────────────────────
-        const mapBase64 = Buffer.from(remapped.toString()).toString('base64');
-        const sourceMapComment = `\n//# sourceMappingURL=data:application/json;base64,${mapBase64}`;
-
-        let contents = '';
-        if (cssImportLine) {
-          contents += cssImportLine;
-        }
-        if (refreshPreamble) {
-          contents += refreshPreamble;
-        }
-        contents += compileResult.code;
-
-        if (refreshEpilogue) {
-          contents += refreshEpilogue;
-        }
-
-        if (hmr) {
-          // Bun statically analyzes import.meta.hot.accept() calls.
-          // It MUST be called directly (no optional chaining, no variable indirection).
-          contents += '\nimport.meta.hot.accept();\n';
-        }
-
-        contents += sourceMapComment;
-
-        return { contents, loader: 'tsx' };
       });
     },
   };


### PR DESCRIPTION
## Summary

- Escape single quotes and backslashes in stable ID and module ID codegen to prevent code injection from file paths containing special characters
- Capture new context scope after factory re-execution instead of reusing stale old scope, fixing context drift across HMR cycles
- Run partial cleanups on factory error before popping scope, preventing leaked event listeners from failed re-mounts
- Add try/catch in plugin `build.onLoad` with descriptive error message including relative file path

## Issues addressed

From [PR #719 review](https://github.com/vertz-dev/vertz/pull/719):

| # | Issue | Severity | Fix |
|---|-------|----------|-----|
| 1 | Code injection in stable ID generation | Critical | Escape `'` and `\` in `relFilePath` |
| 3 | Stale context scope after re-mount | Major | Capture `getContextScope()` after factory execution |
| 4 | Lost cleanups on factory error | Major | `runCleanups(newCleanups)` in catch block |
| 6 | No plugin error handling | Minor | try/catch in `build.onLoad` with file path |
| 8 | Module ID not escaped in codegen | Minor | Escape `'` and `\` in `moduleId` |

### Not addressed (with rationale)

| # | Issue | Reason |
|---|-------|--------|
| 2 | Memory leak in registry | Registry is bounded by module count in a dev session; pruning happens in `__$refreshTrack`. Deferred. |
| 5 | Unbalanced signal collection stack | `stopSignalCollection()` returning `[]` on empty stack is intentional safe fallback, not a bug |
| 7 | Duplicate `import.meta.hot.accept()` | False positive — the two calls are in different files (runtime self-accepts vs plugin injects into component modules) |
| GLM#1 | ts-morph version mismatch | Must align `compiler`, `ui-compiler`, and `bun-plugin` together — separate PR |
| GLM#2 | Missing subpath exports | False positive — bun-plugin imports from main export `@vertz/ui-compiler`, not subpaths |

## Test plan

- [x] All 64/64 turbo quality gates pass (lint, typecheck, test, build)
- [x] 35 signal tests pass in `@vertz/ui`
- [x] Typecheck clean on `@vertz/bun-plugin`
- [x] Build succeeds on `@vertz/bun-plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)