### PR TITLE
test(contacts-api): add OpenAPI spec and SDK codegen output tests

### DIFF
--- a/examples/contacts-api/test/codegen.test.ts
+++ b/examples/contacts-api/test/codegen.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { existsSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const EXAMPLE_DIR = resolve(import.meta.dir, '..');
+const GENERATED_DIR = resolve(EXAMPLE_DIR, 'src/generated');
+const OPENAPI_PATH = resolve(EXAMPLE_DIR, '.vertz/generated/openapi.json');
+
+describe('codegen', () => {
+  beforeAll(async () => {
+    // Clean previous output to ensure a fresh run
+    if (existsSync(GENERATED_DIR)) {
+      rmSync(GENERATED_DIR, { recursive: true });
+    }
+
+    const proc = Bun.spawn(['bun', 'run', 'codegen'], {
+      cwd: EXAMPLE_DIR,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`codegen failed (exit ${exitCode}): ${stderr}`);
+    }
+  }, 30_000);
+
+  afterAll(() => {
+    // Clean up generated files after tests
+    if (existsSync(GENERATED_DIR)) {
+      rmSync(GENERATED_DIR, { recursive: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // SDK file structure
+  // ---------------------------------------------------------------------------
+
+  describe('SDK output', () => {
+    it('generates the barrel index', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'index.ts'))).toBe(true);
+    });
+
+    it('generates the client factory', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'client.ts'))).toBe(true);
+    });
+
+    it('generates entity SDK for contacts', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'entities/contacts.ts'))).toBe(true);
+    });
+
+    it('generates entity schema for contacts', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'schemas/contacts.ts'))).toBe(true);
+    });
+
+    it('generates shared types', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'types/shared.ts'))).toBe(true);
+    });
+
+    it('generates entity types', () => {
+      expect(existsSync(resolve(GENERATED_DIR, 'types/__entities.ts'))).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SDK content
+  // ---------------------------------------------------------------------------
+
+  describe('SDK content', () => {
+    it('client.ts exports createClient function', async () => {
+      const content = await Bun.file(resolve(GENERATED_DIR, 'client.ts')).text();
+      expect(content).toContain('export function createClient');
+    });
+
+    it('entities/contacts.ts exports CRUD methods', async () => {
+      const content = await Bun.file(resolve(GENERATED_DIR, 'entities/contacts.ts')).text();
+      expect(content).toContain('list');
+      expect(content).toContain('get');
+      expect(content).toContain('create');
+      expect(content).toContain('update');
+      expect(content).toContain('delete');
+    });
+
+    it('schemas/contacts.ts exports create and update input schemas', async () => {
+      const content = await Bun.file(resolve(GENERATED_DIR, 'schemas/contacts.ts')).text();
+      expect(content).toContain('createContactsInputSchema');
+      expect(content).toContain('updateContactsInputSchema');
+    });
+
+    it('types/__entities.ts exports response and input types for all CRUD operations', async () => {
+      const content = await Bun.file(resolve(GENERATED_DIR, 'types/__entities.ts')).text();
+      expect(content).toContain('CreateContactsInput');
+      expect(content).toContain('UpdateContactsInput');
+      expect(content).toContain('CreateContactsResponse');
+      expect(content).toContain('GetContactsResponse');
+      expect(content).toContain('ListContactsResponse');
+      expect(content).toContain('UpdateContactsResponse');
+      expect(content).toContain('DeleteContactsResponse');
+    });
+
+    it('response types include all contact fields', async () => {
+      const content = await Bun.file(resolve(GENERATED_DIR, 'types/__entities.ts')).text();
+      // At least one response type should have all model fields
+      expect(content).toContain('id: string');
+      expect(content).toContain('name: string');
+      expect(content).toContain('createdAt: string');
+      expect(content).toContain('updatedAt: string');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // OpenAPI spec
+  // ---------------------------------------------------------------------------
+
+  describe('OpenAPI spec', () => {
+    it('generates an openapi.json file', () => {
+      expect(existsSync(OPENAPI_PATH)).toBe(true);
+    });
+
+    it('produces a valid OpenAPI 3.1.0 document', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      expect(spec.openapi).toBe('3.1.0');
+      expect(spec.info).toBeDefined();
+      expect(spec.paths).toBeDefined();
+    });
+
+    it('defines /contacts and /contacts/{id} paths', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      expect(spec.paths['/contacts']).toBeDefined();
+      expect(spec.paths['/contacts/{id}']).toBeDefined();
+    });
+
+    it('defines all CRUD operations with correct HTTP methods', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+
+      // Collection endpoints
+      expect(spec.paths['/contacts'].get).toBeDefined();
+      expect(spec.paths['/contacts'].post).toBeDefined();
+
+      // Item endpoints
+      expect(spec.paths['/contacts/{id}'].get).toBeDefined();
+      expect(spec.paths['/contacts/{id}'].patch).toBeDefined();
+      expect(spec.paths['/contacts/{id}'].delete).toBeDefined();
+    });
+
+    it('assigns correct operationIds', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      expect(spec.paths['/contacts'].get.operationId).toBe('listContacts');
+      expect(spec.paths['/contacts'].post.operationId).toBe('createContacts');
+      expect(spec.paths['/contacts/{id}'].get.operationId).toBe('getContacts');
+      expect(spec.paths['/contacts/{id}'].patch.operationId).toBe('updateContacts');
+      expect(spec.paths['/contacts/{id}'].delete.operationId).toBe('deleteContacts');
+    });
+
+    it('uses correct response status codes', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      expect(spec.paths['/contacts'].get.responses['200']).toBeDefined();
+      expect(spec.paths['/contacts'].post.responses['201']).toBeDefined();
+      expect(spec.paths['/contacts/{id}'].get.responses['200']).toBeDefined();
+      expect(spec.paths['/contacts/{id}'].patch.responses['200']).toBeDefined();
+    });
+
+    it('POST /contacts request body includes the name field as required', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      const body = spec.paths['/contacts'].post.requestBody;
+      expect(body).toBeDefined();
+      expect(body.required).toBe(true);
+
+      const schema = body.content['application/json'].schema;
+      expect(schema.properties.name).toBeDefined();
+      expect(schema.properties.name.type).toBe('string');
+      expect(schema.required).toContain('name');
+    });
+
+    it('response schema includes all contact model fields', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      const schema =
+        spec.paths['/contacts'].get.responses['200'].content['application/json'].schema;
+      expect(schema.properties.id).toBeDefined();
+      expect(schema.properties.name).toBeDefined();
+      expect(schema.properties.email).toBeDefined();
+      expect(schema.properties.phone).toBeDefined();
+      expect(schema.properties.notes).toBeDefined();
+      expect(schema.properties.createdAt).toBeDefined();
+      expect(schema.properties.updatedAt).toBeDefined();
+    });
+
+    it('tags operations with contacts', async () => {
+      const spec = await Bun.file(OPENAPI_PATH).json();
+      expect(spec.paths['/contacts'].get.tags).toContain('contacts');
+      expect(spec.tags).toContainEqual({ name: 'contacts' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add end-to-end tests for the contacts-api codegen pipeline, verifying both the OpenAPI spec and the generated SDK output

## Changes

### `examples/contacts-api/test/codegen.test.ts` (new)

**SDK output tests** (8 tests):
- Verifies all expected files are generated (index, client, entities, schemas, types)
- Validates SDK content: `createClient` export, CRUD methods on contacts entity, input/response type exports, schema exports

**OpenAPI spec tests** (12 tests):
- Validates OpenAPI 3.1.0 document structure
- Verifies `/contacts` and `/contacts/{id}` paths exist with correct HTTP methods
- Checks operationIds (`listContacts`, `createContacts`, `getContacts`, `updateContacts`, `deleteContacts`)
- Validates response status codes (200 for GET/PATCH, 201 for POST)
- Verifies POST request body schema includes `name` as required string
- Checks response schemas include all contact model fields (id, name, email, phone, notes, createdAt, updatedAt)
- Validates `contacts` tag assignment

Tests run the real `bun run codegen` pipeline (compiler → IR → SDK) against the contacts-api example — no mocks.

## Test plan

- [x] `bun test test/codegen.test.ts` — 20/20 pass
- [x] Full suite `bun test` — 28/28 pass (8 API + 20 codegen)
- [x] Pre-push quality gates pass (64/64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)