### PR TITLE
fix(server): action pipeline returns Result instead of throwing

### DIFF
--- a/.changeset/action-pipeline-result-type.md
+++ b/.changeset/action-pipeline-result-type.md
@@ -1,0 +1,5 @@
+---
+'@vertz/server': patch
+---
+
+Migrate action pipeline from throwing `NotFoundException` to returning `Result<CrudResult, EntityError>`, aligning custom entity actions with the CRUD pipeline's errors-as-values pattern.

--- a/packages/server/src/entity/action-pipeline.ts
+++ b/packages/server/src/entity/action-pipeline.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@vertz/core';
+import { type EntityError, EntityNotFoundError, err, ok, type Result } from '@vertz/errors';
 import { enforceAccess } from './access-enforcer';
 import type { CrudResult, EntityDbAdapter } from './crud-pipeline';
 import type { EntityActionDef, EntityContext, EntityDefinition } from './types';
@@ -13,12 +13,12 @@ export function createActionHandler(
   actionName: string,
   actionDef: EntityActionDef,
   db: EntityDbAdapter,
-): (ctx: EntityContext, id: string, rawInput: unknown) => Promise<CrudResult> {
+): (ctx: EntityContext, id: string, rawInput: unknown) => Promise<Result<CrudResult, EntityError>> {
   return async (ctx, id, rawInput) => {
     // 1. Fetch the row
     const row = await db.get(id);
     if (!row) {
-      throw new NotFoundException(`${def.name} with id "${id}" not found`);
+      return err(new EntityNotFoundError(`${def.name} with id "${id}" not found`));
     }
 
     // 2. Enforce access
@@ -41,6 +41,6 @@ export function createActionHandler(
       }
     }
 
-    return { status: 200, body: result };
+    return ok({ status: 200, body: result });
   };
 }

--- a/packages/server/src/entity/route-generator.ts
+++ b/packages/server/src/entity/route-generator.ts
@@ -419,7 +419,11 @@ export function generateEntityRoutes(
             const id = getParams(ctx).id as string;
             const input = ctx.body;
             const result = await actionHandler(entityCtx, id, input);
-            return jsonResponse(result.body, result.status);
+            if (!result.ok) {
+              const { status, body } = entityErrorHandler(result.error);
+              return jsonResponse(body, status);
+            }
+            return jsonResponse(result.data.body, result.data.status);
           } catch (error) {
             const { status, body } = entityErrorHandler(error);
             return jsonResponse(body, status);


### PR DESCRIPTION
## Summary

- Migrates `createActionHandler` from throwing `NotFoundException` to returning `Result<CrudResult, EntityError>`, aligning custom entity actions with the CRUD pipeline's errors-as-values pattern
- Updates `route-generator.ts` to check `result.ok` before extracting the response, matching how CRUD handlers are already consumed
- Replaces `@vertz/core` `NotFoundException` import with `@vertz/errors` `EntityNotFoundError`, `ok`, `err`, and `Result`

Partial fix for #399 — covers the action pipeline. Auth type consolidation (`AuthResult` → `Result`) is deferred to a separate PR.

## Test plan

- [x] Updated `action-pipeline.test.ts`: "not found" test asserts `result.ok === false` with `EntityNotFoundError` instead of `rejects.toThrow`
- [x] Updated success test to assert `result.ok === true` and access `result.data.status` / `result.data.body`
- [x] All 295 server tests pass
- [x] Typecheck clean
- [x] 61/61 quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)