### PR TITLE
fix(server,errors): migrate auth + access enforcer to Result type

### DIFF
--- a/.changeset/auth-result-access-enforcer-migration.md
+++ b/.changeset/auth-result-access-enforcer-migration.md
@@ -1,0 +1,11 @@
+---
+'@vertz/errors': patch
+'@vertz/server': patch
+---
+
+Migrate auth module and access enforcer to use Result from @vertz/errors instead of throwing exceptions or using custom result types.
+
+- Add `AuthValidationError` to `@vertz/errors` with `field` + `constraint` discriminators, replacing per-code error types (`INVALID_EMAIL`, `PASSWORD_TOO_SHORT`, etc.)
+- Access enforcer returns `Result<void, EntityForbiddenError>` instead of throwing `ForbiddenException`
+- Auth API methods return `Result<T, AuthError>` from `@vertz/errors` instead of custom `AuthResult<T>`
+- Remove `AuthResult` and local `AuthError` types from `@vertz/server` (consumers import `AuthError` from `@vertz/errors`)

--- a/packages/errors/src/domain/auth.ts
+++ b/packages/errors/src/domain/auth.ts
@@ -168,6 +168,47 @@ export function isRateLimitedError(error: { readonly code: string }): error is R
 }
 
 // ============================================================================
+// Auth Validation Errors
+// ============================================================================
+
+/**
+ * Auth validation error.
+ *
+ * Returned when auth input fails validation (invalid email, weak password, etc.).
+ */
+export interface AuthValidationError {
+  readonly code: 'AUTH_VALIDATION_ERROR';
+  readonly message: string;
+  readonly field: 'email' | 'password';
+  readonly constraint?: string;
+}
+
+/**
+ * Creates an AuthValidationError.
+ */
+export function createAuthValidationError(
+  message: string,
+  field: 'email' | 'password',
+  constraint?: string,
+): AuthValidationError {
+  return {
+    code: 'AUTH_VALIDATION_ERROR',
+    message,
+    field,
+    ...(constraint !== undefined ? { constraint } : {}),
+  };
+}
+
+/**
+ * Type guard for AuthValidationError.
+ */
+export function isAuthValidationError(error: {
+  readonly code: string;
+}): error is AuthValidationError {
+  return error.code === 'AUTH_VALIDATION_ERROR';
+}
+
+// ============================================================================
 // Combined Types
 // ============================================================================
 
@@ -179,4 +220,5 @@ export type AuthError =
   | UserExistsError
   | SessionExpiredError
   | PermissionDeniedError
-  | RateLimitedError;
+  | RateLimitedError
+  | AuthValidationError;

--- a/packages/errors/src/domain/index.ts
+++ b/packages/errors/src/domain/index.ts
@@ -8,12 +8,15 @@
 // Auth errors - using prefixed names to avoid conflicts
 export {
   type AuthError,
+  type AuthValidationError,
+  createAuthValidationError,
   createInvalidCredentialsError,
   createPermissionDeniedError,
   createRateLimitedError as createAuthRateLimitedError,
   createSessionExpiredError,
   createUserExistsError,
   type InvalidCredentialsError,
+  isAuthValidationError,
   isInvalidCredentialsError,
   isPermissionDeniedError,
   isRateLimitedError as isAuthRateLimitedError,

--- a/packages/server/src/__tests__/auth/auth.test.ts
+++ b/packages/server/src/__tests__/auth/auth.test.ts
@@ -57,27 +57,33 @@ describe('Auth Module', () => {
       it('should reject short password', () => {
         const result = validatePassword('short', { minLength: 8 });
         expect(result).not.toBeNull();
-        expect(result?.code).toBe('PASSWORD_TOO_SHORT');
+        expect(result?.code).toBe('AUTH_VALIDATION_ERROR');
+        expect(result?.field).toBe('password');
+        expect(result?.constraint).toBe('TOO_SHORT');
       });
 
       it('should reject password without uppercase when required', () => {
         const result = validatePassword('password123', { requireUppercase: true });
-        expect(result?.code).toBe('PASSWORD_NO_UPPERCASE');
+        expect(result?.code).toBe('AUTH_VALIDATION_ERROR');
+        expect(result?.constraint).toBe('NO_UPPERCASE');
       });
 
       it('should reject password without numbers when required', () => {
         const result = validatePassword('PasswordABC', { requireNumbers: true });
-        expect(result?.code).toBe('PASSWORD_NO_NUMBER');
+        expect(result?.code).toBe('AUTH_VALIDATION_ERROR');
+        expect(result?.constraint).toBe('NO_NUMBER');
       });
 
       it('should reject password without symbols when required', () => {
         const result = validatePassword('Password123', { requireSymbols: true });
-        expect(result?.code).toBe('PASSWORD_NO_SYMBOL');
+        expect(result?.code).toBe('AUTH_VALIDATION_ERROR');
+        expect(result?.constraint).toBe('NO_SYMBOL');
       });
 
       it('should use default requirements when not specified', () => {
         const result = validatePassword('abc'); // Too short
-        expect(result?.code).toBe('PASSWORD_TOO_SHORT');
+        expect(result?.code).toBe('AUTH_VALIDATION_ERROR');
+        expect(result?.constraint).toBe('TOO_SHORT');
       });
     });
   });
@@ -157,7 +163,10 @@ describe('Auth Module', () => {
         });
 
         expect(result.ok).toBe(false);
-        expect(result.error?.code).toBe('INVALID_EMAIL');
+        if (!result.ok) {
+          expect(result.error.code).toBe('AUTH_VALIDATION_ERROR');
+          expect(result.error).toHaveProperty('field', 'email');
+        }
       });
 
       it('should reject weak password', async () => {
@@ -168,7 +177,11 @@ describe('Auth Module', () => {
         });
 
         expect(result.ok).toBe(false);
-        expect(result.error?.code).toBe('PASSWORD_TOO_SHORT');
+        if (!result.ok) {
+          expect(result.error.code).toBe('AUTH_VALIDATION_ERROR');
+          expect(result.error).toHaveProperty('field', 'password');
+          expect(result.error).toHaveProperty('constraint', 'TOO_SHORT');
+        }
       });
 
       it('should reject duplicate email', { timeout: 15_000 }, async () => {

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ModelEntry } from '@vertz/db';
+import type { AuthError, Result } from '@vertz/errors';
 
 // ============================================================================
 // Session Types
@@ -109,11 +110,11 @@ export interface SignInInput {
 }
 
 export interface AuthApi {
-  signUp: (data: SignUpInput) => Promise<AuthResult<Session>>;
-  signIn: (data: SignInInput) => Promise<AuthResult<Session>>;
-  signOut: (ctx: AuthContext) => Promise<AuthResult<void>>;
-  getSession: (headers: Headers) => Promise<AuthResult<Session | null>>;
-  refreshSession: (ctx: AuthContext) => Promise<AuthResult<Session>>;
+  signUp: (data: SignUpInput) => Promise<Result<Session, AuthError>>;
+  signIn: (data: SignInInput) => Promise<Result<Session, AuthError>>;
+  signOut: (ctx: AuthContext) => Promise<Result<void, AuthError>>;
+  getSession: (headers: Headers) => Promise<Result<Session | null, AuthError>>;
+  refreshSession: (ctx: AuthContext) => Promise<Result<Session, AuthError>>;
 }
 
 // ============================================================================
@@ -142,16 +143,11 @@ export interface AuthContext {
 }
 
 // ============================================================================
-// Result Type
+// Result Type (re-exported from @vertz/errors)
 // ============================================================================
 
-export type AuthResult<T> = { ok: true; data: T } | { ok: false; error: AuthError };
-
-export interface AuthError {
-  code: string;
-  message: string;
-  status: number;
-}
+// AuthResult is now Result<T, AuthError> from @vertz/errors
+// AuthError is now the union type from @vertz/errors
 
 // ============================================================================
 // Rate Limiting

--- a/packages/server/src/entity/access-enforcer.ts
+++ b/packages/server/src/entity/access-enforcer.ts
@@ -1,9 +1,9 @@
-import { ForbiddenException } from '@vertz/core';
+import { EntityForbiddenError, err, ok, type Result } from '@vertz/errors';
 import type { AccessRule, EntityContext } from './types';
 
 /**
  * Evaluates an access rule for the given operation.
- * Throws ForbiddenException if access is denied.
+ * Returns err(EntityForbiddenError) if access is denied.
  *
  * - No rule defined → deny (deny by default)
  * - Rule is false → operation is disabled
@@ -14,22 +14,26 @@ export async function enforceAccess(
   accessRules: Partial<Record<string, AccessRule>>,
   ctx: EntityContext,
   row?: Record<string, unknown>,
-): Promise<void> {
+): Promise<Result<void, EntityForbiddenError>> {
   const rule = accessRules[operation];
 
   // No rule defined → deny by default
   if (rule === undefined) {
-    throw new ForbiddenException(`Access denied: no access rule for operation "${operation}"`);
+    return err(
+      new EntityForbiddenError(`Access denied: no access rule for operation "${operation}"`),
+    );
   }
 
   // Explicitly disabled
   if (rule === false) {
-    throw new ForbiddenException(`Operation "${operation}" is disabled`);
+    return err(new EntityForbiddenError(`Operation "${operation}" is disabled`));
   }
 
   // Function rule — evaluate
   const allowed = await rule(ctx, row ?? {});
   if (!allowed) {
-    throw new ForbiddenException(`Access denied for operation "${operation}"`);
+    return err(new EntityForbiddenError(`Access denied for operation "${operation}"`));
   }
+
+  return ok(undefined);
 }

--- a/packages/server/src/entity/action-pipeline.ts
+++ b/packages/server/src/entity/action-pipeline.ts
@@ -22,7 +22,8 @@ export function createActionHandler(
     }
 
     // 2. Enforce access
-    await enforceAccess(actionName, def.access, ctx, row);
+    const accessResult = await enforceAccess(actionName, def.access, ctx, row);
+    if (!accessResult.ok) return err(accessResult.error);
 
     // 3. Validate input against schema
     const input = actionDef.input.parse(rawInput);

--- a/packages/server/src/entity/crud-pipeline.ts
+++ b/packages/server/src/entity/crud-pipeline.ts
@@ -85,7 +85,8 @@ export function createCrudHandlers(def: EntityDefinition, db: EntityDbAdapter): 
 
   return {
     async list(ctx, options) {
-      await enforceAccess('list', def.access, ctx);
+      const accessResult = await enforceAccess('list', def.access, ctx);
+      if (!accessResult.ok) return err(accessResult.error);
 
       // Strip hidden fields from where filter to prevent enumeration attacks
       const rawWhere = options?.where;
@@ -119,7 +120,8 @@ export function createCrudHandlers(def: EntityDefinition, db: EntityDbAdapter): 
         return err(new EntityNotFoundError(`${def.name} with id "${id}" not found`));
       }
 
-      await enforceAccess('get', def.access, ctx, row);
+      const accessResult = await enforceAccess('get', def.access, ctx, row);
+      if (!accessResult.ok) return err(accessResult.error);
 
       return ok({
         status: 200,
@@ -128,7 +130,8 @@ export function createCrudHandlers(def: EntityDefinition, db: EntityDbAdapter): 
     },
 
     async create(ctx, data) {
-      await enforceAccess('create', def.access, ctx);
+      const accessResult = await enforceAccess('create', def.access, ctx);
+      if (!accessResult.ok) return err(accessResult.error);
 
       let input = stripReadOnlyFields(table, data);
 
@@ -159,7 +162,8 @@ export function createCrudHandlers(def: EntityDefinition, db: EntityDbAdapter): 
         return err(new EntityNotFoundError(`${def.name} with id "${id}" not found`));
       }
 
-      await enforceAccess('update', def.access, ctx, existing);
+      const accessResult = await enforceAccess('update', def.access, ctx, existing);
+      if (!accessResult.ok) return err(accessResult.error);
 
       let input = stripReadOnlyFields(table, data);
 
@@ -194,7 +198,8 @@ export function createCrudHandlers(def: EntityDefinition, db: EntityDbAdapter): 
         return err(new EntityNotFoundError(`${def.name} with id "${id}" not found`));
       }
 
-      await enforceAccess('delete', def.access, ctx, existing);
+      const accessResult = await enforceAccess('delete', def.access, ctx, existing);
+      if (!accessResult.ok) return err(accessResult.error);
 
       await db.delete(id);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,18 +59,13 @@ export {
   VertzException,
   vertz,
 } from '@vertz/core';
-// Server — wraps core's createServer with entity route generation
-export type { ServerConfig } from './create-server';
-export { createServer } from './create-server';
 export type {
   AccessConfig,
   AccessInstance,
   AuthApi,
   AuthConfig,
   AuthContext,
-  AuthError,
   AuthInstance,
-  AuthResult,
   AuthUser,
   CookieConfig,
   EmailPasswordConfig,
@@ -97,6 +92,9 @@ export {
   validatePassword,
   verifyPassword,
 } from './auth';
+// Server — wraps core's createServer with entity route generation
+export type { ServerConfig } from './create-server';
+export { createServer } from './create-server';
 // Entity API
 export type {
   AccessRule,
@@ -120,10 +118,10 @@ export type {
 export {
   createCrudHandlers,
   createEntityContext,
+  EntityRegistry,
   enforceAccess,
   entity,
   entityErrorHandler,
-  EntityRegistry,
   generateEntityRoutes,
   stripHiddenFields,
   stripReadOnlyFields,


### PR DESCRIPTION
## Summary

Completes #399 — migrates the remaining two areas of `@vertz/server` from throwing exceptions / custom result types to returning `Result` from `@vertz/errors`:

- **Add `AuthValidationError`** to `@vertz/errors` — single type with `field` + `constraint` discriminators replaces 5 individual validation codes (`INVALID_EMAIL`, `PASSWORD_TOO_SHORT`, `PASSWORD_NO_UPPERCASE`, `PASSWORD_NO_NUMBER`, `PASSWORD_NO_SYMBOL`)
- **Access enforcer** returns `Result<void, EntityForbiddenError>` instead of throwing `ForbiddenException`. All 6 call sites in crud-pipeline and action-pipeline updated to propagate via `err()`.
- **Auth module** returns `Result<T, AuthError>` from `@vertz/errors` instead of custom `AuthResult<T>`. Removes `AuthResult` and local `AuthError` from `@vertz/server` public API. Maps `NO_SESSION` to `SessionExpiredError`.

Closes #399

## Test plan

- [x] `cd packages/errors && bun test` — 242 tests pass (new AuthValidationError tests included)
- [x] `cd packages/server && bun test` — 295 tests pass with updated assertions
- [x] `cd packages/errors && bun run typecheck` — clean
- [x] `cd packages/server && bun run typecheck` — clean
- [x] Pre-push quality gates — 61/61 tasks pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)