### PR TITLE
fix(task-manager): broken CSS token, debug logs, and @ts-ignore

### DIFF
--- a/examples/task-manager/dev-server.ts
+++ b/examples/task-manager/dev-server.ts
@@ -26,7 +26,7 @@ if (SSR_MODE) {
 // ── HMR Mode ──────────────────────────────────────────────────────
 
 function startHMRServer(): void {
-  // @ts-ignore — Bun HTML import, resolved at serve time
+  // @ts-expect-error — Bun HTML import, resolved at serve time
   const homepage = require('./index.html');
 
   // TODO: API handler composition — when the app has a @vertz/server backend:

--- a/examples/task-manager/src/pages/task-detail.tsx
+++ b/examples/task-manager/src/pages/task-detail.tsx
@@ -170,7 +170,7 @@ export function TaskDetailPage() {
           <div style="margin-top: 1.5rem">
             <div
               role="tablist"
-              style="display: flex; gap: 0.5rem; border-bottom: 1px solid var(--color-border-200); padding-bottom: 0.5rem; margin-bottom: 1rem"
+              style="display: flex; gap: 0.5rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.5rem; margin-bottom: 1rem"
             >
               <button
                 type="button"

--- a/examples/task-manager/src/pages/task-list.tsx
+++ b/examples/task-manager/src/pages/task-list.tsx
@@ -66,11 +66,8 @@ export function TaskListPage() {
   // ── Lifecycle ──────────────────────────────────────
 
   onMount(() => {
-    console.log('TaskListPage mounted');
-
     onCleanup(() => {
       tasksQuery.dispose();
-      console.log('TaskListPage cleaned up');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix `--color-border-200` (nonexistent token) → `--color-border` in tab bar border — was rendering invisible
- Remove debug `console.log` from TaskListPage mount/cleanup lifecycle
- Replace banned `@ts-ignore` with `@ts-expect-error` in dev-server.ts

Found during slop audit of the task-manager example.

## Test plan
- [x] `bun run typecheck` passes for task-manager
- [x] All 24 task-manager tests pass
- [x] Tab bar border now references a valid CSS custom property

🤖 Generated with [Claude Code](https://claude.com/claude-code)