### PR TITLE
feat(theme-shadcn): theme system with components and primitives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -347,9 +347,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@vertz/ui": "workspace:*",
+        "@vertz/ui-primitives": "workspace:*",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.7.0",
         "bunup": "latest",
+        "happy-dom": "^20.7.0",
         "typescript": "^5.7.0",
       },
     },

--- a/examples/task-manager/src/components/confirm-dialog.tsx
+++ b/examples/task-manager/src/components/confirm-dialog.tsx
@@ -5,20 +5,23 @@
  * - Fully declarative dialog with `let` signal for open/close state
  * - Reactive JSX attributes (aria-hidden, style) driven by signal
  * - WAI-ARIA dialog pattern (role, aria-modal, aria-labelledby)
+ * - Theme dialog styles from @vertz/theme-shadcn via configureTheme()
  * - No DOM manipulation — no effect(), no appendChild, no className assignment
  */
 
 import { css } from '@vertz/ui';
-import { button } from '../styles/components';
+import { button, dialogStyles as themeDialogStyles } from '../styles/components';
 
-const dialogStyles = css({
-  overlay: ['fixed', 'inset:0', 'bg:gray.900', 'opacity:50', 'z:40'],
-  wrapper: ['fixed', 'inset:0', 'flex', 'items:center', 'justify:center', 'z:50'],
-  panel: ['bg:background', 'rounded:lg', 'shadow:xl', 'p:6', 'max-w:md', 'w:full'],
-  title: ['font:lg', 'font:semibold', 'text:foreground', 'mb:2'],
-  description: ['text:sm', 'text:muted', 'mb:6'],
-  actions: ['flex', 'justify:end', 'gap:2'],
-});
+const dialogStyles = {
+  overlay: themeDialogStyles.overlay,
+  wrapper: css({
+    wrapper: ['fixed', 'inset:0', 'flex', 'items:center', 'justify:center', 'z:50'],
+  }).wrapper,
+  panel: themeDialogStyles.panel,
+  title: themeDialogStyles.title,
+  description: themeDialogStyles.description,
+  actions: themeDialogStyles.footer,
+};
 
 export interface ConfirmDialogProps {
   triggerLabel: string;

--- a/examples/task-manager/src/styles/components.ts
+++ b/examples/task-manager/src/styles/components.ts
@@ -16,6 +16,7 @@ export const cardStyles = themeStyles.card;
 export const inputStyles = themeStyles.input;
 export const labelStyles = themeStyles.label;
 export const formGroupStyles = themeStyles.formGroup;
+export const dialogStyles = themeStyles.dialog;
 
 // ── Layout styles (app-specific) ────────────────────────────
 

--- a/examples/task-manager/src/styles/theme.ts
+++ b/examples/task-manager/src/styles/theme.ts
@@ -8,7 +8,7 @@
 
 import { configureTheme } from '@vertz/theme-shadcn';
 
-const { theme, globals, styles } = configureTheme({
+const { theme, globals, styles, components } = configureTheme({
   palette: 'zinc',
   radius: 'md',
 });
@@ -16,3 +16,4 @@ const { theme, globals, styles } = configureTheme({
 export const taskManagerTheme = theme;
 export const themeGlobals = globals;
 export const themeStyles = styles;
+export const themeComponents = components;

--- a/packages/integration-tests/src/__tests__/theme-shadcn-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/theme-shadcn-walkthrough.test.ts
@@ -156,4 +156,59 @@ describe('Theme Shadcn Walkthrough', () => {
     expect(globals.css).toContain('box-sizing');
     expect(globals.css).toContain('font-family');
   });
+
+  // ── Components (Phase 3) ──────────────────────────────────
+
+  it('configureTheme() returns components alongside styles', () => {
+    const result = configureTheme();
+    expect(result.components).toBeDefined();
+    expect(typeof result.components.Button).toBe('function');
+    expect(typeof result.components.Badge).toBe('function');
+    expect(typeof result.components.Input).toBe('function');
+    expect(typeof result.components.Label).toBe('function');
+    expect(typeof result.components.Separator).toBe('function');
+  });
+
+  it('components.Card has all sub-component factories', () => {
+    const { components } = configureTheme();
+    expect(typeof components.Card.Card).toBe('function');
+    expect(typeof components.Card.CardHeader).toBe('function');
+    expect(typeof components.Card.CardTitle).toBe('function');
+    expect(typeof components.Card.CardDescription).toBe('function');
+    expect(typeof components.Card.CardContent).toBe('function');
+    expect(typeof components.Card.CardFooter).toBe('function');
+  });
+
+  it('components.FormGroup has FormGroup and FormError factories', () => {
+    const { components } = configureTheme();
+    expect(typeof components.FormGroup.FormGroup).toBe('function');
+    expect(typeof components.FormGroup.FormError).toBe('function');
+  });
+
+  it('components.primitives has all themed primitive factories', () => {
+    const { components } = configureTheme();
+    expect(typeof components.primitives.dialog).toBe('function');
+    expect(typeof components.primitives.select).toBe('function');
+    expect(typeof components.primitives.tabs).toBe('function');
+    expect(typeof components.primitives.checkbox).toBe('function');
+    expect(typeof components.primitives.switch).toBe('function');
+    expect(typeof components.primitives.progress).toBe('function');
+    expect(typeof components.primitives.accordion).toBe('function');
+    expect(typeof components.primitives.tooltip).toBe('function');
+  });
+
+  it('styles include primitive style definitions', () => {
+    const { styles } = configureTheme();
+    expect(typeof styles.dialog.overlay).toBe('string');
+    expect(typeof styles.dialog.panel).toBe('string');
+    expect(typeof styles.tabs.list).toBe('string');
+    expect(typeof styles.tabs.trigger).toBe('string');
+    expect(typeof styles.select.trigger).toBe('string');
+    expect(typeof styles.select.content).toBe('string');
+    expect(typeof styles.checkbox.root).toBe('string');
+    expect(typeof styles.switch.root).toBe('string');
+    expect(typeof styles.progress.root).toBe('string');
+    expect(typeof styles.accordion.item).toBe('string');
+    expect(typeof styles.tooltip.content).toBe('string');
+  });
 });

--- a/packages/theme-shadcn/bunfig.toml
+++ b/packages/theme-shadcn/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./happydom.ts"]

--- a/packages/theme-shadcn/happydom.ts
+++ b/packages/theme-shadcn/happydom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register({ url: 'http://localhost/' });

--- a/packages/theme-shadcn/package.json
+++ b/packages/theme-shadcn/package.json
@@ -35,10 +35,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vertz/ui": "workspace:*"
+    "@vertz/ui": "workspace:*",
+    "@vertz/ui-primitives": "workspace:*"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.7.0",
     "bunup": "latest",
+    "happy-dom": "^20.7.0",
     "typescript": "^5.7.0"
   },
   "engines": {

--- a/packages/theme-shadcn/src/__tests__/components.test.ts
+++ b/packages/theme-shadcn/src/__tests__/components.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'bun:test';
+import { createBadgeComponent } from '../components/badge';
+import { createButtonComponent } from '../components/button';
+import { createCardComponents } from '../components/card';
+import { createFormGroupComponents } from '../components/form-group';
+import { createInputComponent } from '../components/input';
+import { createLabelComponent } from '../components/label';
+import { createSeparatorComponent } from '../components/separator';
+import { createBadge } from '../styles/badge';
+import { createButton } from '../styles/button';
+import { createCard } from '../styles/card';
+import { createFormGroup } from '../styles/form-group';
+import { createInput } from '../styles/input';
+import { createLabel } from '../styles/label';
+import { createSeparator } from '../styles/separator';
+
+describe('Button component', () => {
+  const buttonStyles = createButton();
+  const Button = createButtonComponent(buttonStyles);
+
+  it('returns an HTMLButtonElement', () => {
+    const el = Button({ children: 'Click me' });
+    expect(el).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it('applies theme class', () => {
+    const el = Button({});
+    expect(el.className.length).toBeGreaterThan(0);
+  });
+
+  it('appends user class to theme class', () => {
+    const el = Button({ class: 'my-custom' });
+    expect(el.className).toContain('my-custom');
+    // Theme class should also be there
+    expect(el.className.split(' ').length).toBeGreaterThan(1);
+  });
+
+  it('sets disabled attribute', () => {
+    const el = Button({ disabled: true });
+    expect(el.disabled).toBe(true);
+  });
+
+  it('defaults type to button', () => {
+    const el = Button({});
+    expect(el.type).toBe('button');
+  });
+
+  it('allows type override', () => {
+    const el = Button({ type: 'submit' });
+    expect(el.type).toBe('submit');
+  });
+
+  it('resolves string children', () => {
+    const el = Button({ children: 'Hello' });
+    expect(el.textContent).toBe('Hello');
+  });
+
+  it('resolves node children', () => {
+    const span = document.createElement('span');
+    span.textContent = 'inner';
+    const el = Button({ children: span });
+    expect(el.querySelector('span')).toBeTruthy();
+    expect(el.querySelector('span')?.textContent).toBe('inner');
+  });
+
+  it('forwards extra HTML attributes', () => {
+    const el = Button({ 'aria-label': 'test' });
+    expect(el.getAttribute('aria-label')).toBe('test');
+  });
+});
+
+describe('Badge component', () => {
+  const badgeStyles = createBadge();
+  const Badge = createBadgeComponent(badgeStyles);
+
+  it('returns an HTMLSpanElement', () => {
+    const el = Badge({});
+    expect(el).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('applies theme class', () => {
+    const el = Badge({});
+    expect(el.className.length).toBeGreaterThan(0);
+  });
+
+  it('appends user class', () => {
+    const el = Badge({ class: 'extra' });
+    expect(el.className).toContain('extra');
+    expect(el.className.split(' ').length).toBeGreaterThan(1);
+  });
+
+  it('resolves string children', () => {
+    const el = Badge({ children: 'New' });
+    expect(el.textContent).toBe('New');
+  });
+});
+
+describe('Card components', () => {
+  const cardStyles = createCard();
+  const { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } =
+    createCardComponents(cardStyles);
+
+  it('Card returns an HTMLDivElement with root class', () => {
+    const el = Card({});
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toContain(cardStyles.root);
+  });
+
+  it('CardHeader returns an HTMLDivElement with header class', () => {
+    const el = CardHeader({});
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toContain(cardStyles.header);
+  });
+
+  it('CardTitle returns an HTMLHeadingElement (h3) with title class', () => {
+    const el = CardTitle({});
+    expect(el).toBeInstanceOf(HTMLHeadingElement);
+    expect(el.tagName).toBe('H3');
+    expect(el.className).toContain(cardStyles.title);
+  });
+
+  it('CardDescription returns an HTMLParagraphElement with description class', () => {
+    const el = CardDescription({});
+    expect(el).toBeInstanceOf(HTMLParagraphElement);
+    expect(el.className).toContain(cardStyles.description);
+  });
+
+  it('CardContent returns an HTMLDivElement with content class', () => {
+    const el = CardContent({});
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toContain(cardStyles.content);
+  });
+
+  it('CardFooter returns an HTMLDivElement with footer class', () => {
+    const el = CardFooter({});
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toContain(cardStyles.footer);
+  });
+
+  it('Card appends user class', () => {
+    const el = Card({ class: 'custom-card' });
+    expect(el.className).toContain('custom-card');
+    expect(el.className).toContain(cardStyles.root);
+  });
+
+  it('Card resolves children', () => {
+    const el = Card({ children: 'content' });
+    expect(el.textContent).toBe('content');
+  });
+});
+
+describe('Input component', () => {
+  const inputStyles = createInput();
+  const Input = createInputComponent(inputStyles);
+
+  it('returns an HTMLInputElement', () => {
+    const el = Input({});
+    expect(el).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('applies theme class', () => {
+    const el = Input({});
+    expect(el.className).toContain(inputStyles.base);
+  });
+
+  it('appends user class', () => {
+    const el = Input({ class: 'extra' });
+    expect(el.className).toContain('extra');
+    expect(el.className).toContain(inputStyles.base);
+  });
+
+  it('forwards name attribute', () => {
+    const el = Input({ name: 'email' });
+    expect(el.name).toBe('email');
+  });
+
+  it('forwards placeholder attribute', () => {
+    const el = Input({ placeholder: 'Enter email' });
+    expect(el.placeholder).toBe('Enter email');
+  });
+
+  it('forwards type attribute', () => {
+    const el = Input({ type: 'password' });
+    expect(el.type).toBe('password');
+  });
+
+  it('forwards disabled attribute', () => {
+    const el = Input({ disabled: true });
+    expect(el.disabled).toBe(true);
+  });
+
+  it('forwards value attribute', () => {
+    const el = Input({ value: 'hello' });
+    expect(el.value).toBe('hello');
+  });
+});
+
+describe('Label component', () => {
+  const labelStyles = createLabel();
+  const Label = createLabelComponent(labelStyles);
+
+  it('returns an HTMLLabelElement', () => {
+    const el = Label({});
+    expect(el).toBeInstanceOf(HTMLLabelElement);
+  });
+
+  it('applies theme class', () => {
+    const el = Label({});
+    expect(el.className).toContain(labelStyles.base);
+  });
+
+  it('appends user class', () => {
+    const el = Label({ class: 'extra' });
+    expect(el.className).toContain('extra');
+    expect(el.className).toContain(labelStyles.base);
+  });
+
+  it('forwards for attribute as htmlFor', () => {
+    const el = Label({ for: 'email-input' });
+    expect(el.htmlFor).toBe('email-input');
+  });
+
+  it('resolves string children', () => {
+    const el = Label({ children: 'Email' });
+    expect(el.textContent).toBe('Email');
+  });
+});
+
+describe('Separator component', () => {
+  const separatorStyles = createSeparator();
+  const Separator = createSeparatorComponent(separatorStyles);
+
+  it('returns an HTMLHRElement', () => {
+    const el = Separator({});
+    expect(el).toBeInstanceOf(HTMLHRElement);
+  });
+
+  it('applies theme class', () => {
+    const el = Separator({});
+    expect(el.className).toContain(separatorStyles.base);
+  });
+
+  it('appends user class', () => {
+    const el = Separator({ class: 'extra' });
+    expect(el.className).toContain('extra');
+    expect(el.className).toContain(separatorStyles.base);
+  });
+});
+
+describe('FormGroup components', () => {
+  const formGroupStyles = createFormGroup();
+  const { FormGroup, FormError } = createFormGroupComponents(formGroupStyles);
+
+  it('FormGroup returns an HTMLDivElement', () => {
+    const el = FormGroup({});
+    expect(el).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('FormGroup applies theme class', () => {
+    const el = FormGroup({});
+    expect(el.className).toContain(formGroupStyles.base);
+  });
+
+  it('FormGroup appends user class', () => {
+    const el = FormGroup({ class: 'custom' });
+    expect(el.className).toContain('custom');
+    expect(el.className).toContain(formGroupStyles.base);
+  });
+
+  it('FormGroup resolves children', () => {
+    const el = FormGroup({ children: 'field content' });
+    expect(el.textContent).toBe('field content');
+  });
+
+  it('FormError returns an HTMLSpanElement', () => {
+    const el = FormError({});
+    expect(el).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('FormError applies theme class', () => {
+    const el = FormError({});
+    expect(el.className).toContain(formGroupStyles.error);
+  });
+
+  it('FormError appends user class', () => {
+    const el = FormError({ class: 'custom' });
+    expect(el.className).toContain('custom');
+    expect(el.className).toContain(formGroupStyles.error);
+  });
+
+  it('FormError resolves children', () => {
+    const el = FormError({ children: 'Required field' });
+    expect(el.textContent).toBe('Required field');
+  });
+});

--- a/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'bun:test';
+import { createAccordionStyles } from '../styles/accordion';
+import { createCheckboxStyles } from '../styles/checkbox';
+import { createDialogStyles } from '../styles/dialog';
+import { createProgressStyles } from '../styles/progress';
+import { createSelectStyles } from '../styles/select';
+import { createSwitchStyles } from '../styles/switch';
+import { createTabsStyles } from '../styles/tabs';
+import { createTooltipStyles } from '../styles/tooltip';
+
+describe('dialog', () => {
+  const dialog = createDialogStyles();
+
+  it('has overlay, panel, title, description, close, and footer blocks', () => {
+    expect(typeof dialog.overlay).toBe('string');
+    expect(typeof dialog.panel).toBe('string');
+    expect(typeof dialog.title).toBe('string');
+    expect(typeof dialog.description).toBe('string');
+    expect(typeof dialog.close).toBe('string');
+    expect(typeof dialog.footer).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(dialog.overlay.length).toBeGreaterThan(0);
+    expect(dialog.panel.length).toBeGreaterThan(0);
+    expect(dialog.title.length).toBeGreaterThan(0);
+    expect(dialog.description.length).toBeGreaterThan(0);
+    expect(dialog.close.length).toBeGreaterThan(0);
+    expect(dialog.footer.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="closed" selectors for overlay and panel', () => {
+    expect(dialog.css).toContain('[data-state="closed"]');
+    expect(dialog.css).toContain('display: none');
+  });
+});
+
+describe('select', () => {
+  const select = createSelectStyles();
+
+  it('has trigger, content, and item blocks', () => {
+    expect(typeof select.trigger).toBe('string');
+    expect(typeof select.content).toBe('string');
+    expect(typeof select.item).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(select.trigger.length).toBeGreaterThan(0);
+    expect(select.content.length).toBeGreaterThan(0);
+    expect(select.item.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="closed" selector for content', () => {
+    expect(select.css).toContain('[data-state="closed"]');
+    expect(select.css).toContain('display: none');
+  });
+});
+
+describe('tabs', () => {
+  const tabs = createTabsStyles();
+
+  it('has list, trigger, and panel blocks', () => {
+    expect(typeof tabs.list).toBe('string');
+    expect(typeof tabs.trigger).toBe('string');
+    expect(typeof tabs.panel).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(tabs.list.length).toBeGreaterThan(0);
+    expect(tabs.trigger.length).toBeGreaterThan(0);
+    expect(tabs.panel.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="active" and data-state="inactive" selectors', () => {
+    expect(tabs.css).toContain('[data-state="active"]');
+    expect(tabs.css).toContain('[data-state="inactive"]');
+  });
+});
+
+describe('checkbox', () => {
+  const checkbox = createCheckboxStyles();
+
+  it('has root and indicator blocks', () => {
+    expect(typeof checkbox.root).toBe('string');
+    expect(typeof checkbox.indicator).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(checkbox.root.length).toBeGreaterThan(0);
+    expect(checkbox.indicator.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="unchecked" selector with display: none', () => {
+    expect(checkbox.css).toContain('[data-state="unchecked"]');
+    expect(checkbox.css).toContain('display: none');
+  });
+
+  it('CSS contains data-state="checked" and data-state="indeterminate" selectors', () => {
+    expect(checkbox.css).toContain('[data-state="checked"]');
+    expect(checkbox.css).toContain('[data-state="indeterminate"]');
+  });
+});
+
+describe('switch', () => {
+  const switchStyles = createSwitchStyles();
+
+  it('has root and thumb blocks', () => {
+    expect(typeof switchStyles.root).toBe('string');
+    expect(typeof switchStyles.thumb).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(switchStyles.root.length).toBeGreaterThan(0);
+    expect(switchStyles.thumb.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="checked" and data-state="unchecked" selectors', () => {
+    expect(switchStyles.css).toContain('[data-state="checked"]');
+    expect(switchStyles.css).toContain('[data-state="unchecked"]');
+  });
+});
+
+describe('progress', () => {
+  const progress = createProgressStyles();
+
+  it('has root and indicator blocks', () => {
+    expect(typeof progress.root).toBe('string');
+    expect(typeof progress.indicator).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(progress.root.length).toBeGreaterThan(0);
+    expect(progress.indicator.length).toBeGreaterThan(0);
+  });
+});
+
+describe('accordion', () => {
+  const accordion = createAccordionStyles();
+
+  it('has item, trigger, and content blocks', () => {
+    expect(typeof accordion.item).toBe('string');
+    expect(typeof accordion.trigger).toBe('string');
+    expect(typeof accordion.content).toBe('string');
+  });
+
+  it('all class names are non-empty', () => {
+    expect(accordion.item.length).toBeGreaterThan(0);
+    expect(accordion.trigger.length).toBeGreaterThan(0);
+    expect(accordion.content.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="closed" selector with display: none', () => {
+    expect(accordion.css).toContain('[data-state="closed"]');
+    expect(accordion.css).toContain('display: none');
+  });
+});
+
+describe('tooltip', () => {
+  const tooltip = createTooltipStyles();
+
+  it('has content block', () => {
+    expect(typeof tooltip.content).toBe('string');
+  });
+
+  it('class name is non-empty', () => {
+    expect(tooltip.content.length).toBeGreaterThan(0);
+  });
+
+  it('CSS contains data-state="closed" selector with display: none', () => {
+    expect(tooltip.css).toContain('[data-state="closed"]');
+    expect(tooltip.css).toContain('display: none');
+  });
+});

--- a/packages/theme-shadcn/src/__tests__/themed-primitives.test.ts
+++ b/packages/theme-shadcn/src/__tests__/themed-primitives.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'bun:test';
+import { createAccordionStyles } from '../styles/accordion';
+import { createCheckboxStyles } from '../styles/checkbox';
+import { createDialogStyles } from '../styles/dialog';
+import { createProgressStyles } from '../styles/progress';
+import { createSelectStyles } from '../styles/select';
+import { createSwitchStyles } from '../styles/switch';
+import { createTabsStyles } from '../styles/tabs';
+import { createTooltipStyles } from '../styles/tooltip';
+
+// ── Dialog ─────────────────────────────────────────────────
+
+describe('createThemedDialog', () => {
+  it('applies theme classes to dialog elements', async () => {
+    const { createThemedDialog } = await import('../components/primitives/dialog');
+    const styles = createDialogStyles();
+    const themedDialog = createThemedDialog(styles);
+    const dialog = themedDialog();
+
+    expect(dialog.overlay.classList.contains(styles.overlay)).toBe(true);
+    expect(dialog.content.classList.contains(styles.panel)).toBe(true);
+    expect(dialog.title.classList.contains(styles.title)).toBe(true);
+    expect(dialog.close.classList.contains(styles.close)).toBe(true);
+  });
+
+  it('preserves primitive behavior — trigger opens dialog', async () => {
+    const { createThemedDialog } = await import('../components/primitives/dialog');
+    const styles = createDialogStyles();
+    const themedDialog = createThemedDialog(styles);
+    const dialog = themedDialog();
+
+    expect(dialog.state.open.peek()).toBe(false);
+    dialog.trigger.click();
+    expect(dialog.state.open.peek()).toBe(true);
+  });
+
+  it('passes options through to primitive', async () => {
+    const { createThemedDialog } = await import('../components/primitives/dialog');
+    const styles = createDialogStyles();
+    const themedDialog = createThemedDialog(styles);
+    const dialog = themedDialog({ defaultOpen: true });
+
+    expect(dialog.state.open.peek()).toBe(true);
+  });
+
+  it('returns the same interface as the primitive', async () => {
+    const { createThemedDialog } = await import('../components/primitives/dialog');
+    const styles = createDialogStyles();
+    const themedDialog = createThemedDialog(styles);
+    const dialog = themedDialog();
+
+    expect(dialog.trigger).toBeInstanceOf(HTMLButtonElement);
+    expect(dialog.content).toBeInstanceOf(HTMLDivElement);
+    expect(dialog.overlay).toBeInstanceOf(HTMLDivElement);
+    expect(dialog.title).toBeInstanceOf(HTMLHeadingElement);
+    expect(dialog.close).toBeInstanceOf(HTMLButtonElement);
+    expect(dialog.state).toBeDefined();
+  });
+});
+
+// ── Tabs ───────────────────────────────────────────────────
+
+describe('createThemedTabs', () => {
+  it('applies theme classes to tabs elements', async () => {
+    const { createThemedTabs } = await import('../components/primitives/tabs');
+    const styles = createTabsStyles();
+    const themedTabs = createThemedTabs(styles);
+    const tabs = themedTabs({ defaultValue: 'one' });
+
+    expect(tabs.list.classList.contains(styles.list)).toBe(true);
+  });
+
+  it('Tab factory applies theme classes to trigger and panel', async () => {
+    const { createThemedTabs } = await import('../components/primitives/tabs');
+    const styles = createTabsStyles();
+    const themedTabs = createThemedTabs(styles);
+    const tabs = themedTabs({ defaultValue: 'one' });
+    const tab = tabs.Tab('one', 'Tab One');
+
+    expect(tab.trigger.classList.contains(styles.trigger)).toBe(true);
+    expect(tab.panel.classList.contains(styles.panel)).toBe(true);
+  });
+
+  it('preserves primitive behavior — Tab state', async () => {
+    const { createThemedTabs } = await import('../components/primitives/tabs');
+    const styles = createTabsStyles();
+    const themedTabs = createThemedTabs(styles);
+    const tabs = themedTabs({ defaultValue: 'one' });
+
+    expect(tabs.state.value.peek()).toBe('one');
+  });
+
+  it('returns root, list, state, and Tab factory', async () => {
+    const { createThemedTabs } = await import('../components/primitives/tabs');
+    const styles = createTabsStyles();
+    const themedTabs = createThemedTabs(styles);
+    const tabs = themedTabs();
+
+    expect(tabs.root).toBeInstanceOf(HTMLDivElement);
+    expect(tabs.list).toBeInstanceOf(HTMLDivElement);
+    expect(tabs.state).toBeDefined();
+    expect(typeof tabs.Tab).toBe('function');
+  });
+});
+
+// ── Select ─────────────────────────────────────────────────
+
+describe('createThemedSelect', () => {
+  it('applies theme classes to select elements', async () => {
+    const { createThemedSelect } = await import('../components/primitives/select');
+    const styles = createSelectStyles();
+    const themedSelect = createThemedSelect(styles);
+    const select = themedSelect();
+
+    expect(select.trigger.classList.contains(styles.trigger)).toBe(true);
+    expect(select.content.classList.contains(styles.content)).toBe(true);
+  });
+
+  it('Item factory applies theme classes', async () => {
+    const { createThemedSelect } = await import('../components/primitives/select');
+    const styles = createSelectStyles();
+    const themedSelect = createThemedSelect(styles);
+    const select = themedSelect();
+    const item = select.Item('opt1', 'Option 1');
+
+    expect(item.classList.contains(styles.item)).toBe(true);
+  });
+
+  it('preserves primitive behavior — state', async () => {
+    const { createThemedSelect } = await import('../components/primitives/select');
+    const styles = createSelectStyles();
+    const themedSelect = createThemedSelect(styles);
+    const select = themedSelect({ defaultValue: 'opt1' });
+
+    expect(select.state.value.peek()).toBe('opt1');
+  });
+});
+
+// ── Checkbox ───────────────────────────────────────────────
+
+describe('createThemedCheckbox', () => {
+  it('applies theme classes to checkbox root', async () => {
+    const { createThemedCheckbox } = await import('../components/primitives/checkbox');
+    const styles = createCheckboxStyles();
+    const themedCheckbox = createThemedCheckbox(styles);
+    const checkbox = themedCheckbox();
+
+    expect(checkbox.root.classList.contains(styles.root)).toBe(true);
+  });
+
+  it('preserves primitive behavior — click toggles', async () => {
+    const { createThemedCheckbox } = await import('../components/primitives/checkbox');
+    const styles = createCheckboxStyles();
+    const themedCheckbox = createThemedCheckbox(styles);
+    const checkbox = themedCheckbox();
+
+    expect(checkbox.state.checked.peek()).toBe(false);
+    checkbox.root.click();
+    expect(checkbox.state.checked.peek()).toBe(true);
+  });
+
+  it('passes options through', async () => {
+    const { createThemedCheckbox } = await import('../components/primitives/checkbox');
+    const styles = createCheckboxStyles();
+    const themedCheckbox = createThemedCheckbox(styles);
+    const checkbox = themedCheckbox({ defaultChecked: true });
+
+    expect(checkbox.state.checked.peek()).toBe(true);
+  });
+});
+
+// ── Switch ─────────────────────────────────────────────────
+
+describe('createThemedSwitch', () => {
+  it('applies theme classes to switch root', async () => {
+    const { createThemedSwitch } = await import('../components/primitives/switch');
+    const styles = createSwitchStyles();
+    const themedSwitch = createThemedSwitch(styles);
+    const sw = themedSwitch();
+
+    expect(sw.root.classList.contains(styles.root)).toBe(true);
+  });
+
+  it('preserves primitive behavior — click toggles', async () => {
+    const { createThemedSwitch } = await import('../components/primitives/switch');
+    const styles = createSwitchStyles();
+    const themedSwitch = createThemedSwitch(styles);
+    const sw = themedSwitch();
+
+    expect(sw.state.checked.peek()).toBe(false);
+    sw.root.click();
+    expect(sw.state.checked.peek()).toBe(true);
+  });
+});
+
+// ── Progress ───────────────────────────────────────────────
+
+describe('createThemedProgress', () => {
+  it('applies theme classes to progress elements', async () => {
+    const { createThemedProgress } = await import('../components/primitives/progress');
+    const styles = createProgressStyles();
+    const themedProgress = createThemedProgress(styles);
+    const progress = themedProgress();
+
+    expect(progress.root.classList.contains(styles.root)).toBe(true);
+    expect(progress.indicator.classList.contains(styles.indicator)).toBe(true);
+  });
+
+  it('preserves primitive behavior — setValue', async () => {
+    const { createThemedProgress } = await import('../components/primitives/progress');
+    const styles = createProgressStyles();
+    const themedProgress = createThemedProgress(styles);
+    const progress = themedProgress();
+
+    progress.setValue(50);
+    expect(progress.state.value.peek()).toBe(50);
+  });
+});
+
+// ── Accordion ──────────────────────────────────────────────
+
+describe('createThemedAccordion', () => {
+  it('applies theme class to accordion root', async () => {
+    const { createThemedAccordion } = await import('../components/primitives/accordion');
+    const styles = createAccordionStyles();
+    const themedAccordion = createThemedAccordion(styles);
+    const accordion = themedAccordion();
+
+    expect(accordion.root).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('Item factory applies theme classes', async () => {
+    const { createThemedAccordion } = await import('../components/primitives/accordion');
+    const styles = createAccordionStyles();
+    const themedAccordion = createThemedAccordion(styles);
+    const accordion = themedAccordion();
+    const item = accordion.Item('section1');
+
+    expect(item.item.classList.contains(styles.item)).toBe(true);
+    expect(item.trigger.classList.contains(styles.trigger)).toBe(true);
+    expect(item.content.classList.contains(styles.content)).toBe(true);
+  });
+
+  it('preserves primitive behavior — click toggles', async () => {
+    const { createThemedAccordion } = await import('../components/primitives/accordion');
+    const styles = createAccordionStyles();
+    const themedAccordion = createThemedAccordion(styles);
+    const accordion = themedAccordion();
+    const item = accordion.Item('section1');
+
+    expect(accordion.state.value.peek()).toEqual([]);
+    item.trigger.click();
+    expect(accordion.state.value.peek()).toEqual(['section1']);
+  });
+});
+
+// ── Tooltip ────────────────────────────────────────────────
+
+describe('createThemedTooltip', () => {
+  it('applies theme classes to tooltip content', async () => {
+    const { createThemedTooltip } = await import('../components/primitives/tooltip');
+    const styles = createTooltipStyles();
+    const themedTooltip = createThemedTooltip(styles);
+    const tooltip = themedTooltip();
+
+    expect(tooltip.content.classList.contains(styles.content)).toBe(true);
+  });
+
+  it('returns trigger, content, and state', async () => {
+    const { createThemedTooltip } = await import('../components/primitives/tooltip');
+    const styles = createTooltipStyles();
+    const themedTooltip = createThemedTooltip(styles);
+    const tooltip = themedTooltip();
+
+    expect(tooltip.trigger).toBeInstanceOf(HTMLElement);
+    expect(tooltip.content).toBeInstanceOf(HTMLDivElement);
+    expect(tooltip.state).toBeDefined();
+  });
+});

--- a/packages/theme-shadcn/src/components/badge.ts
+++ b/packages/theme-shadcn/src/components/badge.ts
@@ -1,0 +1,25 @@
+import type { ChildValue, VariantFunction } from '@vertz/ui';
+import { resolveChildren } from '@vertz/ui';
+
+type BadgeVariants = {
+  color: Record<string, string[]>;
+};
+
+export interface BadgeProps {
+  color?: string;
+  class?: string;
+  children?: ChildValue;
+}
+
+export function createBadgeComponent(
+  badgeStyles: VariantFunction<BadgeVariants>,
+): (props: BadgeProps) => HTMLSpanElement {
+  return function Badge({ color, class: className, children }: BadgeProps): HTMLSpanElement {
+    const el = document.createElement('span');
+    el.className = [badgeStyles({ color }), className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  };
+}

--- a/packages/theme-shadcn/src/components/button.ts
+++ b/packages/theme-shadcn/src/components/button.ts
@@ -1,0 +1,45 @@
+import type { ChildValue, VariantFunction } from '@vertz/ui';
+import { resolveChildren } from '@vertz/ui';
+
+type ButtonVariants = {
+  intent: Record<string, string[]>;
+  size: Record<string, string[]>;
+};
+
+export interface ButtonProps {
+  intent?: string;
+  size?: string;
+  class?: string;
+  children?: ChildValue;
+  disabled?: boolean;
+  type?: 'button' | 'submit' | 'reset';
+  [key: string]: unknown;
+}
+
+export function createButtonComponent(
+  buttonStyles: VariantFunction<ButtonVariants>,
+): (props: ButtonProps) => HTMLButtonElement {
+  return function Button({
+    intent,
+    size,
+    class: className,
+    children,
+    disabled,
+    type,
+    ...attrs
+  }: ButtonProps): HTMLButtonElement {
+    const el = document.createElement('button');
+    el.type = type ?? 'button';
+    el.className = [buttonStyles({ intent, size }), className].filter(Boolean).join(' ');
+    if (disabled) el.disabled = true;
+    for (const [key, value] of Object.entries(attrs)) {
+      if (value !== undefined && value !== null) {
+        el.setAttribute(key, String(value));
+      }
+    }
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  };
+}

--- a/packages/theme-shadcn/src/components/card.ts
+++ b/packages/theme-shadcn/src/components/card.ts
@@ -1,0 +1,90 @@
+import type { ChildValue, CSSOutput } from '@vertz/ui';
+import { resolveChildren } from '@vertz/ui';
+
+type CardBlocks = {
+  root: string[];
+  header: string[];
+  title: string[];
+  description: string[];
+  content: string[];
+  footer: string[];
+};
+
+export interface CardProps {
+  class?: string;
+  children?: ChildValue;
+}
+
+export interface CardComponents {
+  Card: (props: CardProps) => HTMLDivElement;
+  CardHeader: (props: CardProps) => HTMLDivElement;
+  CardTitle: (props: CardProps) => HTMLHeadingElement;
+  CardDescription: (props: CardProps) => HTMLParagraphElement;
+  CardContent: (props: CardProps) => HTMLDivElement;
+  CardFooter: (props: CardProps) => HTMLDivElement;
+}
+
+export function createCardComponents(cardStyles: CSSOutput<CardBlocks>): CardComponents {
+  function Card({ class: className, children }: CardProps): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = [cardStyles.root, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function CardHeader({ class: className, children }: CardProps): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = [cardStyles.header, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function CardTitle({ class: className, children }: CardProps): HTMLHeadingElement {
+    const el = document.createElement('h3');
+    el.className = [cardStyles.title, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function CardDescription({ class: className, children }: CardProps): HTMLParagraphElement {
+    const el = document.createElement('p');
+    el.className = [cardStyles.description, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function CardContent({ class: className, children }: CardProps): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = [cardStyles.content, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function CardFooter({ class: className, children }: CardProps): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = [cardStyles.footer, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  return {
+    Card: Card,
+    CardHeader: CardHeader,
+    CardTitle: CardTitle,
+    CardDescription: CardDescription,
+    CardContent: CardContent,
+    CardFooter: CardFooter,
+  };
+}

--- a/packages/theme-shadcn/src/components/form-group.ts
+++ b/packages/theme-shadcn/src/components/form-group.ts
@@ -1,0 +1,46 @@
+import type { ChildValue, CSSOutput } from '@vertz/ui';
+import { resolveChildren } from '@vertz/ui';
+
+type FormGroupBlocks = { base: string[]; error: string[] };
+
+export interface FormGroupProps {
+  class?: string;
+  children?: ChildValue;
+}
+
+export interface FormErrorProps {
+  class?: string;
+  children?: ChildValue;
+}
+
+export interface FormGroupComponents {
+  FormGroup: (props: FormGroupProps) => HTMLDivElement;
+  FormError: (props: FormErrorProps) => HTMLSpanElement;
+}
+
+export function createFormGroupComponents(
+  formGroupStyles: CSSOutput<FormGroupBlocks>,
+): FormGroupComponents {
+  function FormGroup({ class: className, children }: FormGroupProps): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = [formGroupStyles.base, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  function FormError({ class: className, children }: FormErrorProps): HTMLSpanElement {
+    const el = document.createElement('span');
+    el.className = [formGroupStyles.error, className].filter(Boolean).join(' ');
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  }
+
+  return {
+    FormGroup: FormGroup,
+    FormError: FormError,
+  };
+}

--- a/packages/theme-shadcn/src/components/index.ts
+++ b/packages/theme-shadcn/src/components/index.ts
@@ -1,0 +1,14 @@
+export type { BadgeProps } from './badge';
+export { createBadgeComponent } from './badge';
+export type { ButtonProps } from './button';
+export { createButtonComponent } from './button';
+export type { CardComponents, CardProps } from './card';
+export { createCardComponents } from './card';
+export type { FormErrorProps, FormGroupComponents, FormGroupProps } from './form-group';
+export { createFormGroupComponents } from './form-group';
+export type { InputProps } from './input';
+export { createInputComponent } from './input';
+export type { LabelProps } from './label';
+export { createLabelComponent } from './label';
+export type { SeparatorProps } from './separator';
+export { createSeparatorComponent } from './separator';

--- a/packages/theme-shadcn/src/components/input.ts
+++ b/packages/theme-shadcn/src/components/input.ts
@@ -1,0 +1,41 @@
+import type { CSSOutput } from '@vertz/ui';
+
+type InputBlocks = { base: string[] };
+
+export interface InputProps {
+  class?: string;
+  name?: string;
+  placeholder?: string;
+  type?: string;
+  disabled?: boolean;
+  value?: string;
+  [key: string]: unknown;
+}
+
+export function createInputComponent(
+  inputStyles: CSSOutput<InputBlocks>,
+): (props: InputProps) => HTMLInputElement {
+  return function Input({
+    class: className,
+    name,
+    placeholder,
+    type,
+    disabled,
+    value,
+    ...attrs
+  }: InputProps): HTMLInputElement {
+    const el = document.createElement('input');
+    el.className = [inputStyles.base, className].filter(Boolean).join(' ');
+    if (name !== undefined) el.name = name;
+    if (placeholder !== undefined) el.placeholder = placeholder;
+    if (type !== undefined) el.type = type;
+    if (disabled) el.disabled = true;
+    if (value !== undefined) el.value = value;
+    for (const [key, val] of Object.entries(attrs)) {
+      if (val !== undefined && val !== null) {
+        el.setAttribute(key, String(val));
+      }
+    }
+    return el;
+  };
+}

--- a/packages/theme-shadcn/src/components/label.ts
+++ b/packages/theme-shadcn/src/components/label.ts
@@ -1,0 +1,28 @@
+import type { ChildValue, CSSOutput } from '@vertz/ui';
+import { resolveChildren } from '@vertz/ui';
+
+type LabelBlocks = { base: string[] };
+
+export interface LabelProps {
+  class?: string;
+  for?: string;
+  children?: ChildValue;
+}
+
+export function createLabelComponent(
+  labelStyles: CSSOutput<LabelBlocks>,
+): (props: LabelProps) => HTMLLabelElement {
+  return function Label({
+    class: className,
+    for: htmlFor,
+    children,
+  }: LabelProps): HTMLLabelElement {
+    const el = document.createElement('label');
+    el.className = [labelStyles.base, className].filter(Boolean).join(' ');
+    if (htmlFor !== undefined) el.htmlFor = htmlFor;
+    for (const node of resolveChildren(children)) {
+      el.appendChild(node);
+    }
+    return el;
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/accordion.ts
+++ b/packages/theme-shadcn/src/components/primitives/accordion.ts
@@ -1,0 +1,37 @@
+import type { AccordionElements, AccordionOptions, AccordionState } from '@vertz/ui-primitives';
+import { Accordion } from '@vertz/ui-primitives';
+
+interface AccordionStyleClasses {
+  readonly item: string;
+  readonly trigger: string;
+  readonly content: string;
+}
+
+export interface ThemedAccordionResult extends AccordionElements {
+  state: AccordionState;
+  Item: (value: string) => {
+    item: HTMLDivElement;
+    trigger: HTMLButtonElement;
+    content: HTMLDivElement;
+  };
+}
+
+export function createThemedAccordion(
+  styles: AccordionStyleClasses,
+): (options?: AccordionOptions) => ThemedAccordionResult {
+  return function themedAccordion(options?: AccordionOptions): ThemedAccordionResult {
+    const result = Accordion.Root(options);
+    const originalItem = result.Item;
+    return {
+      root: result.root,
+      state: result.state,
+      Item: (value: string) => {
+        const item = originalItem(value);
+        item.item.classList.add(styles.item);
+        item.trigger.classList.add(styles.trigger);
+        item.content.classList.add(styles.content);
+        return item;
+      },
+    };
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/checkbox.ts
+++ b/packages/theme-shadcn/src/components/primitives/checkbox.ts
@@ -1,0 +1,16 @@
+import type { CheckboxElements, CheckboxOptions, CheckboxState } from '@vertz/ui-primitives';
+import { Checkbox } from '@vertz/ui-primitives';
+
+interface CheckboxStyleClasses {
+  readonly root: string;
+}
+
+export function createThemedCheckbox(
+  styles: CheckboxStyleClasses,
+): (options?: CheckboxOptions) => CheckboxElements & { state: CheckboxState } {
+  return function themedCheckbox(options?: CheckboxOptions) {
+    const result = Checkbox.Root(options);
+    result.root.classList.add(styles.root);
+    return result;
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/dialog.ts
+++ b/packages/theme-shadcn/src/components/primitives/dialog.ts
@@ -1,0 +1,22 @@
+import type { DialogElements, DialogOptions, DialogState } from '@vertz/ui-primitives';
+import { Dialog } from '@vertz/ui-primitives';
+
+interface DialogStyleClasses {
+  readonly overlay: string;
+  readonly panel: string;
+  readonly title: string;
+  readonly close: string;
+}
+
+export function createThemedDialog(
+  styles: DialogStyleClasses,
+): (options?: DialogOptions) => DialogElements & { state: DialogState } {
+  return function themedDialog(options?: DialogOptions) {
+    const result = Dialog.Root(options);
+    result.overlay.classList.add(styles.overlay);
+    result.content.classList.add(styles.panel);
+    result.title.classList.add(styles.title);
+    result.close.classList.add(styles.close);
+    return result;
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/index.ts
+++ b/packages/theme-shadcn/src/components/primitives/index.ts
@@ -1,0 +1,11 @@
+export type { ThemedAccordionResult } from './accordion';
+export { createThemedAccordion } from './accordion';
+export { createThemedCheckbox } from './checkbox';
+export { createThemedDialog } from './dialog';
+export { createThemedProgress } from './progress';
+export type { ThemedSelectResult } from './select';
+export { createThemedSelect } from './select';
+export { createThemedSwitch } from './switch';
+export type { ThemedTabsResult } from './tabs';
+export { createThemedTabs } from './tabs';
+export { createThemedTooltip } from './tooltip';

--- a/packages/theme-shadcn/src/components/primitives/progress.ts
+++ b/packages/theme-shadcn/src/components/primitives/progress.ts
@@ -1,0 +1,20 @@
+import type { ProgressElements, ProgressOptions, ProgressState } from '@vertz/ui-primitives';
+import { Progress } from '@vertz/ui-primitives';
+
+interface ProgressStyleClasses {
+  readonly root: string;
+  readonly indicator: string;
+}
+
+export function createThemedProgress(
+  styles: ProgressStyleClasses,
+): (
+  options?: ProgressOptions,
+) => ProgressElements & { state: ProgressState; setValue: (value: number) => void } {
+  return function themedProgress(options?: ProgressOptions) {
+    const result = Progress.Root(options);
+    result.root.classList.add(styles.root);
+    result.indicator.classList.add(styles.indicator);
+    return result;
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/select.ts
+++ b/packages/theme-shadcn/src/components/primitives/select.ts
@@ -1,0 +1,34 @@
+import type { SelectElements, SelectOptions, SelectState } from '@vertz/ui-primitives';
+import { Select } from '@vertz/ui-primitives';
+
+interface SelectStyleClasses {
+  readonly trigger: string;
+  readonly content: string;
+  readonly item: string;
+}
+
+export interface ThemedSelectResult extends SelectElements {
+  state: SelectState;
+  Item: (value: string, label?: string) => HTMLDivElement;
+}
+
+export function createThemedSelect(
+  styles: SelectStyleClasses,
+): (options?: SelectOptions) => ThemedSelectResult {
+  return function themedSelect(options?: SelectOptions): ThemedSelectResult {
+    const result = Select.Root(options);
+    const originalItem = result.Item;
+    result.trigger.classList.add(styles.trigger);
+    result.content.classList.add(styles.content);
+    return {
+      trigger: result.trigger,
+      content: result.content,
+      state: result.state,
+      Item: (value: string, label?: string) => {
+        const item = originalItem(value, label);
+        item.classList.add(styles.item);
+        return item;
+      },
+    };
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/switch.ts
+++ b/packages/theme-shadcn/src/components/primitives/switch.ts
@@ -1,0 +1,16 @@
+import type { SwitchElements, SwitchOptions, SwitchState } from '@vertz/ui-primitives';
+import { Switch } from '@vertz/ui-primitives';
+
+interface SwitchStyleClasses {
+  readonly root: string;
+}
+
+export function createThemedSwitch(
+  styles: SwitchStyleClasses,
+): (options?: SwitchOptions) => SwitchElements & { state: SwitchState } {
+  return function themedSwitch(options?: SwitchOptions) {
+    const result = Switch.Root(options);
+    result.root.classList.add(styles.root);
+    return result;
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/tabs.ts
+++ b/packages/theme-shadcn/src/components/primitives/tabs.ts
@@ -1,0 +1,34 @@
+import type { TabsElements, TabsOptions, TabsState } from '@vertz/ui-primitives';
+import { Tabs } from '@vertz/ui-primitives';
+
+interface TabsStyleClasses {
+  readonly list: string;
+  readonly trigger: string;
+  readonly panel: string;
+}
+
+export interface ThemedTabsResult extends TabsElements {
+  state: TabsState;
+  Tab: (value: string, label?: string) => { trigger: HTMLButtonElement; panel: HTMLDivElement };
+}
+
+export function createThemedTabs(
+  styles: TabsStyleClasses,
+): (options?: TabsOptions) => ThemedTabsResult {
+  return function themedTabs(options?: TabsOptions): ThemedTabsResult {
+    const result = Tabs.Root(options);
+    const originalTab = result.Tab;
+    result.list.classList.add(styles.list);
+    return {
+      root: result.root,
+      list: result.list,
+      state: result.state,
+      Tab: (value: string, label?: string) => {
+        const tab = originalTab(value, label);
+        tab.trigger.classList.add(styles.trigger);
+        tab.panel.classList.add(styles.panel);
+        return tab;
+      },
+    };
+  };
+}

--- a/packages/theme-shadcn/src/components/primitives/tooltip.ts
+++ b/packages/theme-shadcn/src/components/primitives/tooltip.ts
@@ -1,0 +1,16 @@
+import type { TooltipElements, TooltipOptions, TooltipState } from '@vertz/ui-primitives';
+import { Tooltip } from '@vertz/ui-primitives';
+
+interface TooltipStyleClasses {
+  readonly content: string;
+}
+
+export function createThemedTooltip(
+  styles: TooltipStyleClasses,
+): (options?: TooltipOptions) => TooltipElements & { state: TooltipState } {
+  return function themedTooltip(options?: TooltipOptions) {
+    const result = Tooltip.Root(options);
+    result.content.classList.add(styles.content);
+    return result;
+  };
+}

--- a/packages/theme-shadcn/src/components/separator.ts
+++ b/packages/theme-shadcn/src/components/separator.ts
@@ -1,0 +1,17 @@
+import type { CSSOutput } from '@vertz/ui';
+
+type SeparatorBlocks = { base: string[] };
+
+export interface SeparatorProps {
+  class?: string;
+}
+
+export function createSeparatorComponent(
+  separatorStyles: CSSOutput<SeparatorBlocks>,
+): (props: SeparatorProps) => HTMLHRElement {
+  return function Separator({ class: className }: SeparatorProps): HTMLHRElement {
+    const el = document.createElement('hr');
+    el.className = [separatorStyles.base, className].filter(Boolean).join(' ');
+    return el;
+  };
+}

--- a/packages/theme-shadcn/src/configure.ts
+++ b/packages/theme-shadcn/src/configure.ts
@@ -1,14 +1,67 @@
 import type { GlobalCSSOutput, Theme, VariantFunction } from '@vertz/ui';
 import { defineTheme, globalCss } from '@vertz/ui';
+import type {
+  AccordionOptions,
+  CheckboxElements,
+  CheckboxOptions,
+  CheckboxState,
+  DialogElements,
+  DialogOptions,
+  DialogState,
+  ProgressElements,
+  ProgressOptions,
+  ProgressState,
+  SelectOptions,
+  SwitchElements,
+  SwitchOptions,
+  SwitchState,
+  TabsOptions,
+  TooltipElements,
+  TooltipOptions,
+  TooltipState,
+} from '@vertz/ui-primitives';
+import type { BadgeProps } from './components/badge';
+import { createBadgeComponent } from './components/badge';
+import type { ButtonProps } from './components/button';
+import { createButtonComponent } from './components/button';
+import type { CardComponents } from './components/card';
+import { createCardComponents } from './components/card';
+import type { FormGroupComponents } from './components/form-group';
+import { createFormGroupComponents } from './components/form-group';
+import type { InputProps } from './components/input';
+import { createInputComponent } from './components/input';
+import type { LabelProps } from './components/label';
+import { createLabelComponent } from './components/label';
+import type { ThemedAccordionResult } from './components/primitives/accordion';
+import { createThemedAccordion } from './components/primitives/accordion';
+import { createThemedCheckbox } from './components/primitives/checkbox';
+import { createThemedDialog } from './components/primitives/dialog';
+import { createThemedProgress } from './components/primitives/progress';
+import type { ThemedSelectResult } from './components/primitives/select';
+import { createThemedSelect } from './components/primitives/select';
+import { createThemedSwitch } from './components/primitives/switch';
+import type { ThemedTabsResult } from './components/primitives/tabs';
+import { createThemedTabs } from './components/primitives/tabs';
+import { createThemedTooltip } from './components/primitives/tooltip';
+import type { SeparatorProps } from './components/separator';
+import { createSeparatorComponent } from './components/separator';
 import { deepMergeTokens } from './merge';
 import {
+  createAccordionStyles,
   createBadge,
   createButton,
   createCard,
+  createCheckboxStyles,
+  createDialogStyles,
   createFormGroup,
   createInput,
   createLabel,
+  createProgressStyles,
+  createSelectStyles,
   createSeparator,
+  createSwitchStyles,
+  createTabsStyles,
+  createTooltipStyles,
 } from './styles';
 import type { PaletteName } from './tokens';
 import { palettes } from './tokens';
@@ -57,6 +110,102 @@ export interface ThemeStyles {
   separator: { readonly base: string; readonly css: string };
   /** Form group css() result with base and error. */
   formGroup: { readonly base: string; readonly error: string; readonly css: string };
+  /** Dialog css() styles. */
+  dialog: {
+    readonly overlay: string;
+    readonly panel: string;
+    readonly title: string;
+    readonly description: string;
+    readonly close: string;
+    readonly footer: string;
+    readonly css: string;
+  };
+  /** Select css() styles. */
+  select: {
+    readonly trigger: string;
+    readonly content: string;
+    readonly item: string;
+    readonly css: string;
+  };
+  /** Tabs css() styles. */
+  tabs: {
+    readonly list: string;
+    readonly trigger: string;
+    readonly panel: string;
+    readonly css: string;
+  };
+  /** Checkbox css() styles. */
+  checkbox: {
+    readonly root: string;
+    readonly indicator: string;
+    readonly css: string;
+  };
+  /** Switch css() styles. */
+  switch: {
+    readonly root: string;
+    readonly thumb: string;
+    readonly css: string;
+  };
+  /** Progress css() styles. */
+  progress: {
+    readonly root: string;
+    readonly indicator: string;
+    readonly css: string;
+  };
+  /** Accordion css() styles. */
+  accordion: {
+    readonly item: string;
+    readonly trigger: string;
+    readonly content: string;
+    readonly css: string;
+  };
+  /** Tooltip css() styles. */
+  tooltip: {
+    readonly content: string;
+    readonly css: string;
+  };
+}
+
+/** Themed primitive factories returned by configureTheme(). */
+export interface ThemedPrimitives {
+  /** Themed Dialog — wraps @vertz/ui-primitives Dialog with shadcn styles. */
+  dialog: (options?: DialogOptions) => DialogElements & { state: DialogState };
+  /** Themed Select — wraps @vertz/ui-primitives Select with shadcn styles. */
+  select: (options?: SelectOptions) => ThemedSelectResult;
+  /** Themed Tabs — wraps @vertz/ui-primitives Tabs with shadcn styles. */
+  tabs: (options?: TabsOptions) => ThemedTabsResult;
+  /** Themed Checkbox — wraps @vertz/ui-primitives Checkbox with shadcn styles. */
+  checkbox: (options?: CheckboxOptions) => CheckboxElements & { state: CheckboxState };
+  /** Themed Switch — wraps @vertz/ui-primitives Switch with shadcn styles. */
+  switch: (options?: SwitchOptions) => SwitchElements & { state: SwitchState };
+  /** Themed Progress — wraps @vertz/ui-primitives Progress with shadcn styles. */
+  progress: (
+    options?: ProgressOptions,
+  ) => ProgressElements & { state: ProgressState; setValue: (value: number) => void };
+  /** Themed Accordion — wraps @vertz/ui-primitives Accordion with shadcn styles. */
+  accordion: (options?: AccordionOptions) => ThemedAccordionResult;
+  /** Themed Tooltip — wraps @vertz/ui-primitives Tooltip with shadcn styles. */
+  tooltip: (options?: TooltipOptions) => TooltipElements & { state: TooltipState };
+}
+
+/** Component functions returned by configureTheme(). */
+export interface ThemeComponents {
+  /** Button component — returns HTMLButtonElement with theme styles. */
+  Button: (props: ButtonProps) => HTMLButtonElement;
+  /** Badge component — returns HTMLSpanElement with theme styles. */
+  Badge: (props: BadgeProps) => HTMLSpanElement;
+  /** Card suite — Card, CardHeader, CardTitle, etc. */
+  Card: CardComponents;
+  /** Input component — returns HTMLInputElement with theme styles. */
+  Input: (props: InputProps) => HTMLInputElement;
+  /** Label component — returns HTMLLabelElement with theme styles. */
+  Label: (props: LabelProps) => HTMLLabelElement;
+  /** Separator component — returns HTMLHRElement with theme styles. */
+  Separator: (props: SeparatorProps) => HTMLHRElement;
+  /** FormGroup suite — FormGroup and FormError. */
+  FormGroup: FormGroupComponents;
+  /** Themed primitive factories. */
+  primitives: ThemedPrimitives;
 }
 
 /** Return type of configureTheme(). */
@@ -67,6 +216,8 @@ export interface ResolvedTheme {
   globals: GlobalCSSOutput;
   /** Pre-built style definitions. */
   styles: ThemeStyles;
+  /** Component functions — ready-to-use themed elements. */
+  components: ThemeComponents;
 }
 
 const RADIUS_VALUES: Record<string, string> = {
@@ -78,7 +229,7 @@ const RADIUS_VALUES: Record<string, string> = {
 /**
  * Configure the shadcn theme.
  *
- * Single entry point — selects palette, applies overrides, builds globals and styles.
+ * Single entry point — selects palette, applies overrides, builds globals, styles, and components.
  */
 export function configureTheme(config?: ThemeConfig): ResolvedTheme {
   const palette = config?.palette ?? 'zinc';
@@ -111,16 +262,61 @@ export function configureTheme(config?: ThemeConfig): ResolvedTheme {
     },
   });
 
-  // Build style definitions
+  // Build style definitions (simple + primitive)
+  const buttonStyles = createButton();
+  const badgeStyles = createBadge();
+  const cardStyles = createCard();
+  const inputStyles = createInput();
+  const labelStyles = createLabel();
+  const separatorStyles = createSeparator();
+  const formGroupStyles = createFormGroup();
+  const dialogStyles = createDialogStyles();
+  const selectStyles = createSelectStyles();
+  const tabsStyles = createTabsStyles();
+  const checkboxStyles = createCheckboxStyles();
+  const switchStyles = createSwitchStyles();
+  const progressStyles = createProgressStyles();
+  const accordionStyles = createAccordionStyles();
+  const tooltipStyles = createTooltipStyles();
+
   const styles: ThemeStyles = {
-    button: createButton(),
-    badge: createBadge(),
-    card: createCard(),
-    input: createInput(),
-    label: createLabel(),
-    separator: createSeparator(),
-    formGroup: createFormGroup(),
+    button: buttonStyles,
+    badge: badgeStyles,
+    card: cardStyles,
+    input: inputStyles,
+    label: labelStyles,
+    separator: separatorStyles,
+    formGroup: formGroupStyles,
+    dialog: dialogStyles,
+    select: selectStyles,
+    tabs: tabsStyles,
+    checkbox: checkboxStyles,
+    switch: switchStyles,
+    progress: progressStyles,
+    accordion: accordionStyles,
+    tooltip: tooltipStyles,
   };
 
-  return { theme, globals, styles };
+  // Build component functions
+  const components: ThemeComponents = {
+    Button: createButtonComponent(buttonStyles),
+    Badge: createBadgeComponent(badgeStyles),
+    Card: createCardComponents(cardStyles),
+    Input: createInputComponent(inputStyles),
+    Label: createLabelComponent(labelStyles),
+    Separator: createSeparatorComponent(separatorStyles),
+    FormGroup: createFormGroupComponents(formGroupStyles),
+    primitives: {
+      dialog: createThemedDialog(dialogStyles),
+      select: createThemedSelect(selectStyles),
+      tabs: createThemedTabs(tabsStyles),
+      checkbox: createThemedCheckbox(checkboxStyles),
+      switch: createThemedSwitch(switchStyles),
+      progress: createThemedProgress(progressStyles),
+      accordion: createThemedAccordion(accordionStyles),
+      tooltip: createThemedTooltip(tooltipStyles),
+    },
+  };
+
+  return { theme, globals, styles, components };
 }

--- a/packages/theme-shadcn/src/index.ts
+++ b/packages/theme-shadcn/src/index.ts
@@ -1,2 +1,8 @@
-export type { ResolvedTheme, ThemeConfig, ThemeStyles } from './configure';
+export type {
+  ResolvedTheme,
+  ThemeComponents,
+  ThemeConfig,
+  ThemedPrimitives,
+  ThemeStyles,
+} from './configure';
 export { configureTheme } from './configure';

--- a/packages/theme-shadcn/src/styles/accordion.ts
+++ b/packages/theme-shadcn/src/styles/accordion.ts
@@ -1,0 +1,27 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type AccordionBlocks = {
+  item: StyleEntry[];
+  trigger: StyleEntry[];
+  content: StyleEntry[];
+};
+
+/** Create accordion css() styles. */
+export function createAccordionStyles(): CSSOutput<AccordionBlocks> {
+  return css({
+    item: ['border-b:1', 'border:border'],
+    trigger: [
+      'flex',
+      'w:full',
+      'items:center',
+      'justify:between',
+      'py:4',
+      'font:medium',
+      'text:sm',
+      'cursor:pointer',
+      { '&[data-state="open"]': ['font:semibold'] },
+    ],
+    content: ['text:sm', 'pb:4', { '&[data-state="closed"]': ['hidden'] }],
+  });
+}

--- a/packages/theme-shadcn/src/styles/checkbox.ts
+++ b/packages/theme-shadcn/src/styles/checkbox.ts
@@ -1,0 +1,40 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type CheckboxBlocks = {
+  root: StyleEntry[];
+  indicator: StyleEntry[];
+};
+
+/** Create checkbox css() styles. */
+export function createCheckboxStyles(): CSSOutput<CheckboxBlocks> {
+  return css({
+    root: [
+      'h:4',
+      'w:4',
+      'rounded:sm',
+      'border:1',
+      'border:input',
+      'cursor:pointer',
+      'focus-visible:outline-none',
+      'focus-visible:ring:2',
+      'focus-visible:ring:ring',
+      'disabled:opacity:0.5',
+      'disabled:cursor:default',
+      {
+        '&[data-state="checked"]': ['bg:primary', 'text:primary-foreground', 'border:primary'],
+        '&[data-state="indeterminate"]': [
+          'bg:primary',
+          'text:primary-foreground',
+          'border:primary',
+        ],
+      },
+    ],
+    indicator: [
+      'flex',
+      'items:center',
+      'justify:center',
+      { '&[data-state="unchecked"]': ['hidden'] },
+    ],
+  });
+}

--- a/packages/theme-shadcn/src/styles/dialog.ts
+++ b/packages/theme-shadcn/src/styles/dialog.ts
@@ -1,0 +1,41 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type DialogBlocks = {
+  overlay: StyleEntry[];
+  panel: StyleEntry[];
+  title: StyleEntry[];
+  description: StyleEntry[];
+  close: StyleEntry[];
+  footer: StyleEntry[];
+};
+
+/** Create dialog css() styles. */
+export function createDialogStyles(): CSSOutput<DialogBlocks> {
+  return css({
+    overlay: [
+      'fixed',
+      'inset:0',
+      'z:40',
+      'bg:background',
+      'opacity:0.8',
+      { '&[data-state="closed"]': ['hidden'] },
+    ],
+    panel: [
+      'fixed',
+      'z:50',
+      'bg:card',
+      'text:card-foreground',
+      'rounded:lg',
+      'border:1',
+      'border:border',
+      'shadow:lg',
+      'p:6',
+      { '&[data-state="closed"]': ['hidden'] },
+    ],
+    title: ['text:lg', 'font:semibold', 'leading:none', 'tracking:tight'],
+    description: ['text:sm', 'text:muted-foreground'],
+    close: ['absolute', 'rounded:sm', 'opacity:0.7', 'hover:opacity:1', 'cursor:pointer'],
+    footer: ['flex', 'items:center', 'justify:end', 'gap:2', 'pt:4'],
+  });
+}

--- a/packages/theme-shadcn/src/styles/index.ts
+++ b/packages/theme-shadcn/src/styles/index.ts
@@ -1,7 +1,15 @@
+export { createAccordionStyles } from './accordion';
 export { badgeConfig, createBadge } from './badge';
 export { buttonConfig, createButton } from './button';
 export { createCard } from './card';
+export { createCheckboxStyles } from './checkbox';
+export { createDialogStyles } from './dialog';
 export { createFormGroup } from './form-group';
 export { createInput } from './input';
 export { createLabel } from './label';
+export { createProgressStyles } from './progress';
+export { createSelectStyles } from './select';
 export { createSeparator } from './separator';
+export { createSwitchStyles } from './switch';
+export { createTabsStyles } from './tabs';
+export { createTooltipStyles } from './tooltip';

--- a/packages/theme-shadcn/src/styles/progress.ts
+++ b/packages/theme-shadcn/src/styles/progress.ts
@@ -1,0 +1,15 @@
+import type { CSSOutput } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type ProgressBlocks = {
+  root: string[];
+  indicator: string[];
+};
+
+/** Create progress css() styles. */
+export function createProgressStyles(): CSSOutput<ProgressBlocks> {
+  return css({
+    root: ['relative', 'h:4', 'w:full', 'rounded:full', 'bg:secondary'],
+    indicator: ['h:full', 'w:full', 'bg:primary', 'transition:transform'],
+  });
+}

--- a/packages/theme-shadcn/src/styles/select.ts
+++ b/packages/theme-shadcn/src/styles/select.ts
@@ -1,0 +1,56 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type SelectBlocks = {
+  trigger: StyleEntry[];
+  content: StyleEntry[];
+  item: StyleEntry[];
+};
+
+/** Create select css() styles. */
+export function createSelectStyles(): CSSOutput<SelectBlocks> {
+  return css({
+    trigger: [
+      'flex',
+      'h:10',
+      'w:full',
+      'items:center',
+      'justify:between',
+      'rounded:md',
+      'border:1',
+      'border:input',
+      'bg:background',
+      'px:3',
+      'py:2',
+      'text:sm',
+      'cursor:pointer',
+      'focus-visible:outline-none',
+      'focus-visible:ring:2',
+      'focus-visible:ring:ring',
+      'disabled:opacity:0.5',
+      'disabled:cursor:default',
+      { '&[data-state="open"]': ['border:ring'] },
+    ],
+    content: [
+      'z:50',
+      'bg:card',
+      'text:card-foreground',
+      'rounded:md',
+      'border:1',
+      'border:border',
+      'shadow:md',
+      'py:1',
+      { '&[data-state="closed"]': ['hidden'] },
+    ],
+    item: [
+      'flex',
+      'items:center',
+      'px:3',
+      'py:1.5',
+      'text:sm',
+      'cursor:pointer',
+      'hover:bg:accent',
+      'hover:text:accent-foreground',
+    ],
+  });
+}

--- a/packages/theme-shadcn/src/styles/switch.ts
+++ b/packages/theme-shadcn/src/styles/switch.ts
@@ -1,0 +1,43 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type SwitchBlocks = {
+  root: StyleEntry[];
+  thumb: StyleEntry[];
+};
+
+/** Create switch css() styles. */
+export function createSwitchStyles(): CSSOutput<SwitchBlocks> {
+  return css({
+    root: [
+      'inline-flex',
+      'h:6',
+      'w:11',
+      'items:center',
+      'rounded:full',
+      'border:2',
+      'border:transparent',
+      'cursor:pointer',
+      'bg:input',
+      'transition:colors',
+      'focus-visible:outline-none',
+      'focus-visible:ring:2',
+      'focus-visible:ring:ring',
+      'disabled:opacity:0.5',
+      'disabled:cursor:default',
+      {
+        '&[data-state="checked"]': ['bg:primary'],
+        '&[data-state="unchecked"]': ['bg:input'],
+      },
+    ],
+    thumb: [
+      'block',
+      'h:5',
+      'w:5',
+      'rounded:full',
+      'bg:background',
+      'shadow:sm',
+      'transition:transform',
+    ],
+  });
+}

--- a/packages/theme-shadcn/src/styles/tabs.ts
+++ b/packages/theme-shadcn/src/styles/tabs.ts
@@ -1,0 +1,34 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type TabsBlocks = {
+  list: StyleEntry[];
+  trigger: StyleEntry[];
+  panel: StyleEntry[];
+};
+
+/** Create tabs css() styles. */
+export function createTabsStyles(): CSSOutput<TabsBlocks> {
+  return css({
+    list: ['flex', 'items:center', 'border-b:1', 'border:border', 'gap:1'],
+    trigger: [
+      'inline-flex',
+      'items:center',
+      'justify:center',
+      'px:3',
+      'py:1.5',
+      'text:sm',
+      'font:medium',
+      'cursor:pointer',
+      'border-b:2',
+      'border:transparent',
+      'text:muted-foreground',
+      'hover:text:foreground',
+      {
+        '&[data-state="active"]': ['border:primary', 'text:foreground'],
+        '&[data-state="inactive"]': ['border:transparent'],
+      },
+    ],
+    panel: ['pt:4'],
+  });
+}

--- a/packages/theme-shadcn/src/styles/tooltip.ts
+++ b/packages/theme-shadcn/src/styles/tooltip.ts
@@ -1,0 +1,25 @@
+import type { CSSOutput, StyleEntry } from '@vertz/ui';
+import { css } from '@vertz/ui';
+
+type TooltipBlocks = {
+  content: StyleEntry[];
+};
+
+/** Create tooltip css() styles. */
+export function createTooltipStyles(): CSSOutput<TooltipBlocks> {
+  return css({
+    content: [
+      'z:50',
+      'bg:card',
+      'text:card-foreground',
+      'rounded:md',
+      'border:1',
+      'border:border',
+      'shadow:md',
+      'px:3',
+      'py:1.5',
+      'text:sm',
+      { '&[data-state="closed"]': ['hidden'] },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `@vertz/theme-shadcn` package with `configureTheme()` — single entry point for palette selection, token overrides, style definitions, component factories, and themed primitive wrappers
- 5 color palettes (zinc, slate, stone, neutral, gray) with light/dark mode via contextual tokens
- 15 style definitions: button, badge, card, input, label, separator, formGroup, dialog, select, tabs, checkbox, switch, progress, accordion, tooltip
- 7 simple DOM component factories (Button, Badge, Card suite, Input, Label, Separator, FormGroup/FormError) using `resolveChildren()` from `@vertz/ui`
- 8 themed primitive factories wrapping `@vertz/ui-primitives` with CSS `[data-state]` selectors for state-driven visuals
- `configureTheme()` returns `{ theme, globals, styles, components }` — backward compatible, `components` is additive
- Task-manager example migrated to use theme styles
- Design doc in `plans/theme-system-architecture.md`

## Test plan

- [x] 142 unit tests passing in `@vertz/theme-shadcn` (tokens, styles, components, primitives)
- [x] 18 integration tests in walkthrough (`theme-shadcn-walkthrough.test.ts`)
- [x] Cross-package typecheck clean (`@vertz/integration-tests`, `@vertz/theme-shadcn`, `@vertz-examples/task-manager`)
- [x] Biome lint clean
- [x] Pre-push quality gates passing (64 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)