### PR TITLE
fix(theme-shadcn): resolve CSS class collision, missing border reset, and card radius

### DIFF
--- a/packages/theme-shadcn/src/configure.ts
+++ b/packages/theme-shadcn/src/configure.ts
@@ -249,6 +249,9 @@ export function configureTheme(config?: ThemeConfig): ResolvedTheme {
       boxSizing: 'border-box',
       margin: '0',
       padding: '0',
+      borderWidth: '0',
+      borderStyle: 'solid',
+      borderColor: 'currentColor',
     },
     ':root': {
       '--radius': RADIUS_VALUES[radius] ?? '0.375rem',

--- a/packages/theme-shadcn/src/styles/accordion.ts
+++ b/packages/theme-shadcn/src/styles/accordion.ts
@@ -9,9 +9,9 @@ type AccordionBlocks = {
 
 /** Create accordion css() styles. */
 export function createAccordionStyles(): CSSOutput<AccordionBlocks> {
-  return css({
-    item: ['border-b:1', 'border:border'],
-    trigger: [
+  const s = css({
+    accordionItem: ['border-b:1', 'border:border'],
+    accordionTrigger: [
       'flex',
       'w:full',
       'items:center',
@@ -22,6 +22,12 @@ export function createAccordionStyles(): CSSOutput<AccordionBlocks> {
       'cursor:pointer',
       { '&[data-state="open"]': ['font:semibold'] },
     ],
-    content: ['text:sm', 'pb:4', { '&[data-state="closed"]': ['hidden'] }],
+    accordionContent: ['text:sm', 'pb:4', { '&[data-state="closed"]': ['hidden'] }],
   });
+  return {
+    item: s.accordionItem,
+    trigger: s.accordionTrigger,
+    content: s.accordionContent,
+    css: s.css,
+  } as CSSOutput<AccordionBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/card.ts
+++ b/packages/theme-shadcn/src/styles/card.ts
@@ -12,19 +12,28 @@ type CardBlocks = {
 
 /** Create card css() styles. */
 export function createCard(): CSSOutput<CardBlocks> {
-  return css({
-    root: [
+  const s = css({
+    cardRoot: [
       'bg:card',
       'text:card-foreground',
-      'rounded:lg',
+      'rounded:xl',
       'border:1',
       'border:border',
       'shadow:sm',
     ],
-    header: ['flex', 'flex-col', 'gap:1.5', 'p:6'],
-    title: ['text:2xl', 'font:semibold', 'leading:none', 'tracking:tight'],
-    description: ['text:sm', 'text:muted-foreground'],
-    content: ['p:6', 'pt:0'],
-    footer: ['flex', 'items:center', 'p:6', 'pt:0'],
+    cardHeader: ['flex', 'flex-col', 'gap:1.5', 'p:6'],
+    cardTitle: ['text:2xl', 'font:semibold', 'leading:none', 'tracking:tight'],
+    cardDescription: ['text:sm', 'text:muted-foreground'],
+    cardContent: ['p:6', 'pt:0'],
+    cardFooter: ['flex', 'items:center', 'p:6', 'pt:0'],
   });
+  return {
+    root: s.cardRoot,
+    header: s.cardHeader,
+    title: s.cardTitle,
+    description: s.cardDescription,
+    content: s.cardContent,
+    footer: s.cardFooter,
+    css: s.css,
+  } as CSSOutput<CardBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/checkbox.ts
+++ b/packages/theme-shadcn/src/styles/checkbox.ts
@@ -8,8 +8,8 @@ type CheckboxBlocks = {
 
 /** Create checkbox css() styles. */
 export function createCheckboxStyles(): CSSOutput<CheckboxBlocks> {
-  return css({
-    root: [
+  const s = css({
+    checkboxRoot: [
       'h:4',
       'w:4',
       'rounded:sm',
@@ -30,11 +30,16 @@ export function createCheckboxStyles(): CSSOutput<CheckboxBlocks> {
         ],
       },
     ],
-    indicator: [
+    checkboxIndicator: [
       'flex',
       'items:center',
       'justify:center',
       { '&[data-state="unchecked"]': ['hidden'] },
     ],
   });
+  return {
+    root: s.checkboxRoot,
+    indicator: s.checkboxIndicator,
+    css: s.css,
+  } as CSSOutput<CheckboxBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/dialog.ts
+++ b/packages/theme-shadcn/src/styles/dialog.ts
@@ -12,8 +12,8 @@ type DialogBlocks = {
 
 /** Create dialog css() styles. */
 export function createDialogStyles(): CSSOutput<DialogBlocks> {
-  return css({
-    overlay: [
+  const s = css({
+    dialogOverlay: [
       'fixed',
       'inset:0',
       'z:40',
@@ -21,7 +21,7 @@ export function createDialogStyles(): CSSOutput<DialogBlocks> {
       'opacity:0.8',
       { '&[data-state="closed"]': ['hidden'] },
     ],
-    panel: [
+    dialogPanel: [
       'fixed',
       'z:50',
       'bg:card',
@@ -33,9 +33,18 @@ export function createDialogStyles(): CSSOutput<DialogBlocks> {
       'p:6',
       { '&[data-state="closed"]': ['hidden'] },
     ],
-    title: ['text:lg', 'font:semibold', 'leading:none', 'tracking:tight'],
-    description: ['text:sm', 'text:muted-foreground'],
-    close: ['absolute', 'rounded:sm', 'opacity:0.7', 'hover:opacity:1', 'cursor:pointer'],
-    footer: ['flex', 'items:center', 'justify:end', 'gap:2', 'pt:4'],
+    dialogTitle: ['text:lg', 'font:semibold', 'leading:none', 'tracking:tight'],
+    dialogDescription: ['text:sm', 'text:muted-foreground'],
+    dialogClose: ['absolute', 'rounded:sm', 'opacity:0.7', 'hover:opacity:1', 'cursor:pointer'],
+    dialogFooter: ['flex', 'items:center', 'justify:end', 'gap:2', 'pt:4'],
   });
+  return {
+    overlay: s.dialogOverlay,
+    panel: s.dialogPanel,
+    title: s.dialogTitle,
+    description: s.dialogDescription,
+    close: s.dialogClose,
+    footer: s.dialogFooter,
+    css: s.css,
+  } as CSSOutput<DialogBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/form-group.ts
+++ b/packages/theme-shadcn/src/styles/form-group.ts
@@ -5,8 +5,13 @@ type FormGroupBlocks = { base: string[]; error: string[] };
 
 /** Create formGroup css() styles. */
 export function createFormGroup(): CSSOutput<FormGroupBlocks> {
-  return css({
-    base: ['flex', 'flex-col', 'gap:1.5'],
-    error: ['text:xs', 'text:destructive'],
+  const s = css({
+    formGroupBase: ['flex', 'flex-col', 'gap:1.5'],
+    formGroupError: ['text:xs', 'text:destructive'],
   });
+  return {
+    base: s.formGroupBase,
+    error: s.formGroupError,
+    css: s.css,
+  } as CSSOutput<FormGroupBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/input.ts
+++ b/packages/theme-shadcn/src/styles/input.ts
@@ -5,8 +5,8 @@ type InputBlocks = { base: string[] };
 
 /** Create input css() styles. */
 export function createInput(): CSSOutput<InputBlocks> {
-  return css({
-    base: [
+  const s = css({
+    inputBase: [
       'flex',
       'h:10',
       'w:full',
@@ -25,4 +25,8 @@ export function createInput(): CSSOutput<InputBlocks> {
       'disabled:opacity:0.5',
     ],
   });
+  return {
+    base: s.inputBase,
+    css: s.css,
+  } as CSSOutput<InputBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/label.ts
+++ b/packages/theme-shadcn/src/styles/label.ts
@@ -5,7 +5,11 @@ type LabelBlocks = { base: string[] };
 
 /** Create label css() styles. */
 export function createLabel(): CSSOutput<LabelBlocks> {
-  return css({
-    base: ['text:sm', 'font:medium', 'leading:none', 'text:foreground'],
+  const s = css({
+    labelBase: ['text:sm', 'font:medium', 'leading:none', 'text:foreground'],
   });
+  return {
+    base: s.labelBase,
+    css: s.css,
+  } as CSSOutput<LabelBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/progress.ts
+++ b/packages/theme-shadcn/src/styles/progress.ts
@@ -8,8 +8,13 @@ type ProgressBlocks = {
 
 /** Create progress css() styles. */
 export function createProgressStyles(): CSSOutput<ProgressBlocks> {
-  return css({
-    root: ['relative', 'h:4', 'w:full', 'rounded:full', 'bg:secondary'],
-    indicator: ['h:full', 'w:full', 'bg:primary', 'transition:transform'],
+  const s = css({
+    progressRoot: ['relative', 'h:4', 'w:full', 'rounded:full', 'bg:secondary'],
+    progressIndicator: ['h:full', 'w:full', 'bg:primary', 'transition:transform'],
   });
+  return {
+    root: s.progressRoot,
+    indicator: s.progressIndicator,
+    css: s.css,
+  } as CSSOutput<ProgressBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/select.ts
+++ b/packages/theme-shadcn/src/styles/select.ts
@@ -9,8 +9,8 @@ type SelectBlocks = {
 
 /** Create select css() styles. */
 export function createSelectStyles(): CSSOutput<SelectBlocks> {
-  return css({
-    trigger: [
+  const s = css({
+    selectTrigger: [
       'flex',
       'h:10',
       'w:full',
@@ -31,7 +31,7 @@ export function createSelectStyles(): CSSOutput<SelectBlocks> {
       'disabled:cursor:default',
       { '&[data-state="open"]': ['border:ring'] },
     ],
-    content: [
+    selectContent: [
       'z:50',
       'bg:card',
       'text:card-foreground',
@@ -42,7 +42,7 @@ export function createSelectStyles(): CSSOutput<SelectBlocks> {
       'py:1',
       { '&[data-state="closed"]': ['hidden'] },
     ],
-    item: [
+    selectItem: [
       'flex',
       'items:center',
       'px:3',
@@ -53,4 +53,10 @@ export function createSelectStyles(): CSSOutput<SelectBlocks> {
       'hover:text:accent-foreground',
     ],
   });
+  return {
+    trigger: s.selectTrigger,
+    content: s.selectContent,
+    item: s.selectItem,
+    css: s.css,
+  } as CSSOutput<SelectBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/separator.ts
+++ b/packages/theme-shadcn/src/styles/separator.ts
@@ -5,7 +5,11 @@ type SeparatorBlocks = { base: string[] };
 
 /** Create separator css() styles. */
 export function createSeparator(): CSSOutput<SeparatorBlocks> {
-  return css({
-    base: ['bg:border', 'h:0.5', 'w:full'],
+  const s = css({
+    separatorBase: ['bg:border', 'h:0.5', 'w:full'],
   });
+  return {
+    base: s.separatorBase,
+    css: s.css,
+  } as CSSOutput<SeparatorBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/switch.ts
+++ b/packages/theme-shadcn/src/styles/switch.ts
@@ -8,8 +8,8 @@ type SwitchBlocks = {
 
 /** Create switch css() styles. */
 export function createSwitchStyles(): CSSOutput<SwitchBlocks> {
-  return css({
-    root: [
+  const s = css({
+    switchRoot: [
       'inline-flex',
       'h:6',
       'w:11',
@@ -30,7 +30,7 @@ export function createSwitchStyles(): CSSOutput<SwitchBlocks> {
         '&[data-state="unchecked"]': ['bg:input'],
       },
     ],
-    thumb: [
+    switchThumb: [
       'block',
       'h:5',
       'w:5',
@@ -40,4 +40,9 @@ export function createSwitchStyles(): CSSOutput<SwitchBlocks> {
       'transition:transform',
     ],
   });
+  return {
+    root: s.switchRoot,
+    thumb: s.switchThumb,
+    css: s.css,
+  } as CSSOutput<SwitchBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/tabs.ts
+++ b/packages/theme-shadcn/src/styles/tabs.ts
@@ -9,9 +9,9 @@ type TabsBlocks = {
 
 /** Create tabs css() styles. */
 export function createTabsStyles(): CSSOutput<TabsBlocks> {
-  return css({
-    list: ['flex', 'items:center', 'border-b:1', 'border:border', 'gap:1'],
-    trigger: [
+  const s = css({
+    tabsList: ['flex', 'items:center', 'border-b:1', 'border:border', 'gap:1'],
+    tabsTrigger: [
       'inline-flex',
       'items:center',
       'justify:center',
@@ -29,6 +29,12 @@ export function createTabsStyles(): CSSOutput<TabsBlocks> {
         '&[data-state="inactive"]': ['border:transparent'],
       },
     ],
-    panel: ['pt:4'],
+    tabsPanel: ['pt:4'],
   });
+  return {
+    list: s.tabsList,
+    trigger: s.tabsTrigger,
+    panel: s.tabsPanel,
+    css: s.css,
+  } as CSSOutput<TabsBlocks>;
 }

--- a/packages/theme-shadcn/src/styles/tooltip.ts
+++ b/packages/theme-shadcn/src/styles/tooltip.ts
@@ -7,8 +7,8 @@ type TooltipBlocks = {
 
 /** Create tooltip css() styles. */
 export function createTooltipStyles(): CSSOutput<TooltipBlocks> {
-  return css({
-    content: [
+  const s = css({
+    tooltipContent: [
       'z:50',
       'bg:card',
       'text:card-foreground',
@@ -22,4 +22,8 @@ export function createTooltipStyles(): CSSOutput<TooltipBlocks> {
       { '&[data-state="closed"]': ['hidden'] },
     ],
   });
+  return {
+    content: s.tooltipContent,
+    css: s.css,
+  } as CSSOutput<TooltipBlocks>;
 }


### PR DESCRIPTION
## Summary

- **CSS class collision fix**: Prefix all `css()` block names with component names (e.g. `root` → `cardRoot`, `trigger` → `selectTrigger`) so each produces a unique hash. Prevents checkbox/switch/progress styles from bleeding into card elements. Public API property names unchanged.
- **Border reset**: Add `border-width: 0; border-style: solid; border-color: currentColor` to the global `*` selector (matching Tailwind preflight) so `border:1` produces visible borders.
- **Card radius**: Update `rounded:lg` → `rounded:xl` to match current shadcn conventions.

## Test plan

- [x] `bun test` in `packages/theme-shadcn` — 142 tests pass
- [x] `turbo run typecheck --filter @vertz/theme-shadcn` — clean
- [x] `turbo run build --filter @vertz/theme-shadcn` — clean
- [x] Integration test `theme-shadcn-walkthrough.test.ts` — 18 tests pass
- [ ] Visual verification: start dev server, confirm cards have visible borders, proper spacing, no overlapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)