### PR TITLE
fix(core,db,server): platform agnosticism for runtime packages

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -629,6 +629,50 @@ router.post('/send', {
 });
 ```
 
+### Environment Validation
+
+`createEnv` validates environment variables against a schema at startup, returning a frozen, typed configuration object.
+
+```typescript
+import { createEnv } from '@vertz/core';
+import { s } from '@vertz/schema';
+
+const env = createEnv({
+  schema: s.object({
+    DATABASE_URL: s.string(),
+    PORT: s.coerce.number().default(3000),
+    NODE_ENV: s.enum(['development', 'production', 'test']),
+  }),
+});
+
+// env.DATABASE_URL — fully typed, validated, immutable
+```
+
+By default, `createEnv` reads from `process.env`. You can pass an explicit `env` record instead — useful for edge runtimes (Cloudflare Workers, Deno Deploy) or testing:
+
+```typescript
+// Edge runtime — pass env explicitly
+const env = createEnv({
+  schema: s.object({
+    DATABASE_URL: s.string(),
+    API_KEY: s.string(),
+  }),
+  env: context.env, // Cloudflare Workers env bindings
+});
+
+// Testing — inject controlled values
+const env = createEnv({
+  schema: s.object({ PORT: s.coerce.number() }),
+  env: { PORT: '4000' },
+});
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `schema` | `Schema<T>` | A `@vertz/schema` schema to validate against |
+| `env` | `Record<string, string \| undefined>` | Explicit env record. Defaults to `process.env` with a `typeof process` guard for non-Node runtimes |
+| `load` | `string[]` | Dotenv file paths to load before validation |
+
 ### Custom Server Adapters
 
 Use the `.handler` property to integrate with custom servers:


### PR DESCRIPTION
## Summary

- Remove all direct `process.env` and `node:crypto` usage from runtime packages (`@vertz/core`, `@vertz/db`, `@vertz/server`, `@vertz/ui`)
- Add `typeof process` guards to all `NODE_ENV` checks across `@vertz/core`, `@vertz/ui`, and `@vertz/db`
- Replace `node:crypto` with Web Crypto API (`crypto.subtle`) in `@vertz/db` for cross-platform SHA-256 hashing
- Add optional `env` parameter to `createEnv` so edge runtimes can inject env bindings explicitly
- Extract `SnapshotStorage` interface to decouple auto-migrate from `node:fs`, with lazy-import of `NodeSnapshotStorage`
- Add `isProduction` config to `createAuth` with secure-by-default behavior (unknown environments default to production)
- Document all new APIs in package READMEs

## Changes by phase

**Phase 1 — `typeof process` guards** (5 files)
Adds `typeof process !== 'undefined' &&` before every unguarded `process.env.NODE_ENV` check in `@vertz/core`, `@vertz/ui`, and `@vertz/db`.

**Phase 2 — `createEnv` optional `env` param** (3 files)
Adds `env?: Record<string, string | undefined>` to `EnvConfig`. Falls back to `process.env` with a typeof guard. Two new tests.

**Phase 3 — Web Crypto API** (10 files)
Replaces `node:crypto` with `crypto.subtle.digest('SHA-256', ...)`. Makes `computeChecksum` and `fingerprint` async. Breaking change (pre-v1).

**Phase 4 — `SnapshotStorage` interface** (7 files)
Extracts `SnapshotStorage` interface, converts `snapshot-storage.ts` to `NodeSnapshotStorage` class, adds `storage` option to `autoMigrate` and `createDbProvider`. Lazy-imports `NodeSnapshotStorage` to avoid loading `node:fs` on edge runtimes.

**Phase 5 — Auth `isProduction` config** (3 files)
Removes `process.env.AUTH_JWT_SECRET` fallback. Adds `isProduction` to `AuthConfig` with secure-by-default: only explicit `NODE_ENV=development` or `NODE_ENV=test` opts into insecure defaults.

## Test plan

- [x] `bun test --filter core` — all tests pass (5 existing + 2 new env tests)
- [x] `bun test --filter db` — 1102 tests pass (including async checksum, fingerprint, snapshot-storage)
- [x] `bun test packages/server/src/__tests__/auth/` — 50 auth tests pass
- [x] Typecheck passes on `@vertz/core`, `@vertz/db`, `@vertz/server`
- [x] `bunx biome check` clean on all changed files
- [x] Pre-push quality gates pass (64/64 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)