### PR TITLE
feat(ui): auto-dispose query() via disposal scope

### DIFF
--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -167,15 +167,13 @@ Use inline `style` only for truly dynamic values or one-off layout (flex gaps, m
 
 ## Data Fetching & Forms
 
-### `query()` with cleanup
+### `query()` — auto-disposed
 
 ```tsx
 const tasks = query(() => fetchTasks(), { key: 'task-list' });
-
-onMount(() => {
-  return () => tasks.dispose();
-});
 ```
+
+`query()` auto-registers disposal with the current component/page scope via `_tryOnCleanup()`. No manual `onMount(() => () => tasks.dispose())` needed. The dispose stops reactive effects, timers, and in-flight tracking — but preserves the shared cache so navigating back serves data instantly.
 
 Signal properties (`.data`, `.loading`, `.error`) auto-unwrap in JSX. Use `.value` only outside JSX (in `watch()`, event handlers, etc.).
 

--- a/examples/entity-todo/src/pages/todo-list.tsx
+++ b/examples/entity-todo/src/pages/todo-list.tsx
@@ -8,7 +8,7 @@
  * - Declarative JSX conditionals for loading/error/content visibility
  */
 
-import { onMount, query } from '@vertz/ui';
+import { query } from '@vertz/ui';
 import { isOk, matchError, type Result, type FetchErrorType } from '@vertz/fetch';
 import type { Todo } from '../api/client';
 import { fetchTodos } from '../api/client';
@@ -62,12 +62,6 @@ export function TodoListPage() {
   const handleCreate = (_todo: Todo) => {
     todosQuery.refetch();
   };
-
-  onMount(() => {
-    return () => {
-      todosQuery.dispose();
-    };
-  });
 
   return (
     <div class={layoutStyles.container} data-testid="todo-list-page">

--- a/examples/task-manager/src/pages/task-detail.tsx
+++ b/examples/task-manager/src/pages/task-detail.tsx
@@ -11,7 +11,7 @@
  * - Compiler conditional transform for loading/error/content visibility
  */
 
-import { css, onMount, query, useParams } from '@vertz/ui';
+import { css, query, useParams } from '@vertz/ui';
 import { api } from '../api/mock-data';
 import { ConfirmDialog } from '../components/confirm-dialog';
 import { Icon } from '../components/icon';
@@ -88,14 +88,6 @@ export function TaskDetailPage() {
 
   // Tab state — compiler transforms `let` to signal()
   let activeTab = 'details';
-
-  // ── Cleanup ────────────────────────────────────────
-
-  onMount(() => {
-    return () => {
-      taskQuery.dispose();
-    };
-  });
 
   // ── Page layout with declarative conditionals ──────
 

--- a/examples/task-manager/src/pages/task-list.tsx
+++ b/examples/task-manager/src/pages/task-list.tsx
@@ -12,7 +12,7 @@
  * - <TaskCard /> JSX component embedding
  */
 
-import { onMount, query } from '@vertz/ui';
+import { query } from '@vertz/ui';
 import { api } from '../api/mock-data';
 import { Icon } from '../components/icon';
 import { TaskCard } from '../components/task-card';
@@ -61,14 +61,6 @@ export function TaskListPage() {
     { label: 'In Progress', value: 'in-progress' },
     { label: 'Done', value: 'done' },
   ];
-
-  // ── Lifecycle ──────────────────────────────────────
-
-  onMount(() => {
-    return () => {
-      tasksQuery.dispose();
-    };
-  });
 
   // ── Page layout with declarative conditionals and list rendering ──
 

--- a/packages/ui/src/query/query.ts
+++ b/packages/ui/src/query/query.ts
@@ -1,5 +1,6 @@
 import { isQueryDescriptor, type QueryDescriptor } from '@vertz/fetch';
 import { isNavPrefetchActive } from '../router/server-nav';
+import { _tryOnCleanup } from '../runtime/disposal';
 import { computed, lifecycleEffect, signal } from '../runtime/signal';
 import type { ReadonlySignal, Signal, Unwrapped } from '../runtime/signal-types';
 import { setReadValueCallback, untrack } from '../runtime/tracking';
@@ -508,6 +509,10 @@ export function query<T, E = unknown>(
     }
     inflightKeys.clear();
   }
+
+  // Auto-register disposal with the current scope (component/page/app).
+  // If no scope is active (standalone usage), this is a silent no-op.
+  _tryOnCleanup(dispose);
 
   // Return signals with type casts to match the unwrapped return types
   return {


### PR DESCRIPTION
## Summary

- **`query()` now auto-registers its `dispose()` with the active disposal scope** via `_tryOnCleanup()`, eliminating manual `onMount(() => () => query.dispose())` boilerplate from every component
- Cache entries are preserved across disposal — navigating back serves data instantly (no loading flash)
- Removed manual dispose patterns from all 3 example pages (`task-list`, `task-detail`, `todo-list`)
- Updated `ui-components.md` rule to document the new pattern

## Test plan

- [x] 4 new tests covering auto-dispose behavior:
  - Scope cleanup stops reactive effect from re-fetching
  - Scope cleanup removes in-flight entries from global map
  - Scope cleanup preserves cache entries for future queries
  - No-op when query is created outside a disposal scope (standalone usage)
- [x] All 30 query tests pass
- [x] Full quality gates pass (lint, typecheck, test, build)


🤖 Generated with [Claude Code](https://claude.com/claude-code)