### PR TITLE
feat(ui): add Presence component for mount/unmount animations

### DIFF
--- a/packages/ui-primitives/src/utils.ts
+++ b/packages/ui-primitives/src/utils.ts
@@ -6,7 +6,7 @@
  */
 
 // Animation utilities
-export { onAnimationsComplete } from './utils/animation';
+export { onAnimationsComplete } from '@vertz/ui/internals';
 
 // ARIA attribute helpers
 export {

--- a/packages/ui-primitives/src/utils/aria.ts
+++ b/packages/ui-primitives/src/utils/aria.ts
@@ -3,7 +3,7 @@
  * Provides functions for setting and toggling ARIA attributes on DOM elements.
  */
 
-import { onAnimationsComplete } from './animation';
+import { onAnimationsComplete } from '@vertz/ui/internals';
 
 /**
  * Generation counter per element to invalidate stale hide callbacks.

--- a/packages/ui/src/component/__tests__/presence.test.ts
+++ b/packages/ui/src/component/__tests__/presence.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, it } from 'bun:test';
+import { onCleanup } from '../../runtime/disposal';
+import { domEffect, signal } from '../../runtime/signal';
+import { Presence } from '../presence';
+
+describe('Presence', () => {
+  it('renders nothing when `when` is false', () => {
+    const container = document.createElement('div');
+    const result = Presence({
+      when: false,
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'hello';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    // Should only have the comment anchor, no child content
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders children when `when` is true', () => {
+    const container = document.createElement('div');
+    const result = Presence({
+      when: true,
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'hello';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(container.textContent).toBe('hello');
+  });
+
+  it('mounts child on false→true transition', () => {
+    const show = signal(false);
+    const container = document.createElement('div');
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'mounted';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(container.textContent).toBe('');
+
+    show.value = true;
+    expect(container.textContent).toBe('mounted');
+  });
+
+  it('removes child on true→false transition', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'visible';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(container.textContent).toBe('visible');
+
+    show.value = false;
+    expect(container.textContent).toBe('');
+  });
+
+  it('runs cleanups on exit', () => {
+    const show = signal(true);
+    let cleanedUp = false;
+    const container = document.createElement('div');
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        onCleanup(() => {
+          cleanedUp = true;
+        });
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(cleanedUp).toBe(false);
+
+    show.value = false;
+    expect(cleanedUp).toBe(true);
+  });
+
+  it('disposes effects inside children on exit', () => {
+    const show = signal(true);
+    const counter = signal(0);
+    let effectRunCount = 0;
+    const container = document.createElement('div');
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        domEffect(() => {
+          counter.value;
+          effectRunCount++;
+        });
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(effectRunCount).toBe(1);
+
+    // Hide the child
+    show.value = false;
+
+    // The effect should be disposed — updating counter should NOT re-run it
+    effectRunCount = 0;
+    counter.value = 1;
+    expect(effectRunCount).toBe(0);
+  });
+
+  it('throws on non-HTMLElement child', () => {
+    expect(() => {
+      Presence({
+        when: true,
+        children: () => document.createTextNode('text') as unknown as HTMLElement,
+      });
+    }).toThrow('Presence requires a single HTMLElement child');
+  });
+
+  it('dispose() cleans up everything on parent disposal', () => {
+    const show = signal(true);
+    const counter = signal(0);
+    let effectRunCount = 0;
+    let cleanedUp = false;
+    const container = document.createElement('div');
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        onCleanup(() => {
+          cleanedUp = true;
+        });
+        domEffect(() => {
+          counter.value;
+          effectRunCount++;
+        });
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(effectRunCount).toBe(1);
+    expect(cleanedUp).toBe(false);
+    expect(container.textContent).toBe('child');
+
+    // Dispose the Presence
+    (result as unknown as { dispose: () => void }).dispose();
+
+    expect(cleanedUp).toBe(true);
+
+    // Effect should be disposed
+    effectRunCount = 0;
+    counter.value = 1;
+    expect(effectRunCount).toBe(0);
+  });
+
+  it('sets data-presence="enter" on mount', () => {
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+    const result = Presence({
+      when: true,
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        // Mock getAnimations to return a pending animation so
+        // data-presence persists (not cleared immediately)
+        span.getAnimations = () => [
+          {
+            finished: new Promise<void>(() => {}),
+          } as unknown as Animation,
+        ];
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(childEl.getAttribute('data-presence')).toBe('enter');
+  });
+
+  it('removes data-presence after enter animation completes', async () => {
+    let resolveAnim!: () => void;
+    const container = document.createElement('div');
+    const result = Presence({
+      when: true,
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        const animFinished = new Promise<void>((r) => {
+          resolveAnim = r;
+        });
+        span.getAnimations = () => [{ finished: animFinished } as unknown as Animation];
+        return span;
+      },
+    });
+    container.appendChild(result);
+    const child = container.querySelector('span')!;
+    expect(child.getAttribute('data-presence')).toBe('enter');
+
+    // Resolve the animation
+    resolveAnim();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(child.getAttribute('data-presence')).toBeNull();
+  });
+
+  it('sets data-presence="exit" on unmount', () => {
+    const show = signal(true);
+    let resolveExitAnim!: () => void;
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(container.textContent).toBe('child');
+
+    // Mock getAnimations on the child BEFORE triggering exit
+    // so the exit animation is deferred
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    childEl.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    show.value = false;
+    expect(childEl.getAttribute('data-presence')).toBe('exit');
+
+    // Cleanup
+    resolveExitAnim();
+  });
+
+  it('defers removal until exit animation completes', async () => {
+    const show = signal(true);
+    let resolveExitAnim!: () => void;
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+
+    // Mock getAnimations before triggering exit
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    childEl.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    show.value = false;
+
+    // Element should still be in the DOM during animation
+    expect(container.contains(childEl)).toBe(true);
+    expect(childEl.getAttribute('data-presence')).toBe('exit');
+
+    // Resolve the exit animation
+    resolveExitAnim();
+    await exitAnimFinished;
+    await new Promise((r) => setTimeout(r, 0));
+
+    // NOW the element should be removed
+    expect(container.contains(childEl)).toBe(false);
+  });
+
+  it('runs cleanups immediately on exit, before animation completes', () => {
+    const show = signal(true);
+    let cleanedUp = false;
+    let resolveExitAnim!: () => void;
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        onCleanup(() => {
+          cleanedUp = true;
+        });
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+
+    // Mock animations before exit
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    childEl.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    show.value = false;
+
+    // Cleanup should fire immediately even though animation is pending
+    expect(cleanedUp).toBe(true);
+    // Element still in DOM during animation
+    expect(container.contains(childEl)).toBe(true);
+
+    // Cleanup
+    resolveExitAnim();
+  });
+
+  it('rapid true→false→true cancels pending exit removal', async () => {
+    const show = signal(true);
+    let resolveExitAnim!: () => void;
+    const container = document.createElement('div');
+    let childCount = 0;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        childCount++;
+        const span = document.createElement('span');
+        span.textContent = `child-${childCount}`;
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(container.textContent).toBe('child-1');
+
+    // Get reference to first child and mock exit animation
+    const firstChild = container.querySelector('span')!;
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    firstChild.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    // Toggle false → exit animation starts
+    show.value = false;
+    expect(firstChild.getAttribute('data-presence')).toBe('exit');
+    expect(container.contains(firstChild)).toBe(true);
+
+    // Toggle true immediately → should cancel exit and mount new child
+    show.value = true;
+    const secondChild = container.querySelector('span:last-of-type');
+    expect(secondChild?.textContent).toBe('child-2');
+
+    // Now resolve the old exit animation — should NOT remove the new child
+    resolveExitAnim();
+    await exitAnimFinished;
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Second child should still be in the DOM
+    expect(container.contains(secondChild)).toBe(true);
+  });
+
+  it('rapid toggle re-creates element in fresh scope', () => {
+    const show = signal(true);
+    const counter = signal(0);
+    let effect1Runs = 0;
+    let effect2Runs = 0;
+    let resolveExitAnim!: () => void;
+    const container = document.createElement('div');
+    let isFirstChild = true;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        if (isFirstChild) {
+          domEffect(() => {
+            counter.value;
+            effect1Runs++;
+          });
+          isFirstChild = false;
+        } else {
+          domEffect(() => {
+            counter.value;
+            effect2Runs++;
+          });
+        }
+        return span;
+      },
+    });
+    container.appendChild(result);
+    expect(effect1Runs).toBe(1);
+
+    // Get reference to first child and mock exit animation
+    const firstChild = container.querySelector('span')!;
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    firstChild.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    // Exit
+    show.value = false;
+    // First effect should be disposed
+    effect1Runs = 0;
+    counter.value = 1;
+    expect(effect1Runs).toBe(0);
+
+    // Re-enter — new scope, new effect
+    show.value = true;
+    expect(effect2Runs).toBe(1);
+
+    // Second effect should track counter
+    effect2Runs = 0;
+    counter.value = 2;
+    expect(effect2Runs).toBe(1);
+
+    // Cleanup
+    resolveExitAnim();
+  });
+
+  // ─── Integration Tests ──────────────────────────────────────────────
+
+  it('data-presence attribute is available for CSS hooks', () => {
+    const container = document.createElement('div');
+    let childEl!: HTMLDivElement;
+    const result = Presence({
+      when: true,
+      children: () => {
+        const div = document.createElement('div');
+        div.className = 'panel';
+        div.textContent = 'styled';
+        div.getAnimations = () => [
+          { finished: new Promise<void>(() => {}) } as unknown as Animation,
+        ];
+        childEl = div;
+        return div;
+      },
+    });
+    container.appendChild(result);
+
+    // CSS can target [data-presence="enter"] for animations
+    expect(childEl.getAttribute('data-presence')).toBe('enter');
+    expect(childEl.className).toBe('panel');
+  });
+
+  it('respects prefers-reduced-motion — immediate removal', () => {
+    const originalMatchMedia = globalThis.matchMedia;
+    globalThis.matchMedia = ((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+    })) as typeof globalThis.matchMedia;
+
+    const show = signal(true);
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        // Even with animations, reduced-motion should skip them
+        span.getAnimations = () => [
+          { finished: new Promise<void>(() => {}) } as unknown as Animation,
+        ];
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+    // With reduced motion, data-presence="enter" is cleared immediately
+    expect(childEl.getAttribute('data-presence')).toBeNull();
+
+    show.value = false;
+    // With reduced motion, element should be removed immediately
+    expect(container.contains(childEl)).toBe(false);
+
+    globalThis.matchMedia = originalMatchMedia;
+  });
+
+  it('parent disposal cleans up Presence including pending exit animations', async () => {
+    const show = signal(true);
+    let resolveExitAnim!: () => void;
+    let cleanedUp = false;
+    const container = document.createElement('div');
+    let childEl!: HTMLSpanElement;
+
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        onCleanup(() => {
+          cleanedUp = true;
+        });
+        const span = document.createElement('span');
+        span.textContent = 'child';
+        childEl = span;
+        return span;
+      },
+    });
+    container.appendChild(result);
+
+    // Mock exit animation
+    const exitAnimFinished = new Promise<void>((r) => {
+      resolveExitAnim = r;
+    });
+    childEl.getAnimations = () => [{ finished: exitAnimFinished } as unknown as Animation];
+
+    // Start exit animation
+    show.value = false;
+    expect(container.contains(childEl)).toBe(true);
+    expect(cleanedUp).toBe(true);
+
+    // Dispose the Presence entirely (parent disposal)
+    (result as unknown as { dispose: () => void }).dispose();
+
+    // Resolve exit animation after disposal
+    resolveExitAnim();
+    await exitAnimFinished;
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The stale exit callback should NOT crash or do unexpected things
+    // (generation counter prevents removal of already-disposed elements)
+  });
+
+  it('nested __conditional inside Presence children is disposed on exit', () => {
+    const { __conditional } = require('../../dom/conditional');
+
+    const show = signal(true);
+    const innerShow = signal(true);
+    const counter = signal(0);
+    let innerEffectRuns = 0;
+    const container = document.createElement('div');
+
+    const result = Presence({
+      get when() {
+        return show.value;
+      },
+      children: () => {
+        const div = document.createElement('div');
+        const conditional = __conditional(
+          () => innerShow.value,
+          () => {
+            const span = document.createElement('span');
+            span.textContent = 'inner-yes';
+            domEffect(() => {
+              counter.value;
+              innerEffectRuns++;
+            });
+            return span;
+          },
+          () => {
+            const span = document.createElement('span');
+            span.textContent = 'inner-no';
+            return span;
+          },
+        );
+        div.appendChild(conditional);
+        return div;
+      },
+    });
+    container.appendChild(result);
+    expect(innerEffectRuns).toBe(1);
+
+    // Hiding Presence should dispose the nested conditional and its effects
+    show.value = false;
+
+    innerEffectRuns = 0;
+    counter.value = 1;
+    expect(innerEffectRuns).toBe(0);
+  });
+});

--- a/packages/ui/src/component/index.ts
+++ b/packages/ui/src/component/index.ts
@@ -5,6 +5,8 @@ export { createContext, useContext } from './context';
 export type { ErrorBoundaryProps } from './error-boundary';
 export { ErrorBoundary } from './error-boundary';
 export { onMount } from './lifecycle';
+export type { PresenceProps } from './presence';
+export { Presence } from './presence';
 export type { Ref } from './refs';
 export { ref } from './refs';
 export type { SuspenseProps } from './suspense';

--- a/packages/ui/src/component/presence.ts
+++ b/packages/ui/src/component/presence.ts
@@ -1,0 +1,109 @@
+import { onAnimationsComplete } from '../dom/animation';
+import { _tryOnCleanup, popScope, pushScope, runCleanups } from '../runtime/disposal';
+import { domEffect } from '../runtime/signal';
+import type { DisposeFn } from '../runtime/signal-types';
+
+export interface PresenceProps {
+  when: boolean;
+  children: () => HTMLElement;
+}
+
+/**
+ * Presence component for mount/unmount animations.
+ * Defers unmounting until CSS exit animations complete.
+ *
+ * Props are accessed as getters (not destructured) so the compiler-generated
+ * reactive getters are tracked by domEffect.
+ */
+export function Presence(props: PresenceProps): Node {
+  const anchor = document.createComment('presence');
+  let currentNode: HTMLElement | null = null;
+  let exitingNode: HTMLElement | null = null;
+  let branchCleanups: DisposeFn[] = [];
+  let generation = 0;
+
+  const outerScope = pushScope();
+  try {
+    domEffect(() => {
+      const show = props.when;
+
+      if (show && !currentNode) {
+        // Invalidate any pending exit callback
+        generation++;
+
+        // Force-remove any exiting element from a previous exit animation
+        if (exitingNode?.parentNode) {
+          exitingNode.parentNode.removeChild(exitingNode);
+          exitingNode = null;
+        }
+
+        // Mount
+        const scope = pushScope();
+        const child = props.children();
+        popScope();
+
+        if (!(child instanceof HTMLElement)) {
+          runCleanups(scope);
+          throw new Error(
+            'Presence requires a single HTMLElement child. Wrap multiple children in a container element.',
+          );
+        }
+
+        branchCleanups = scope;
+
+        currentNode = child;
+        child.setAttribute('data-presence', 'enter');
+        anchor.parentNode?.insertBefore(currentNode, anchor.nextSibling);
+
+        // Remove data-presence after enter animation completes
+        onAnimationsComplete(child, () => {
+          if (currentNode === child) {
+            child.removeAttribute('data-presence');
+          }
+        });
+      } else if (!show && currentNode) {
+        // Freeze — dispose reactive effects immediately
+        const gen = ++generation;
+        const exitingEl = currentNode;
+        currentNode = null;
+        exitingNode = exitingEl;
+
+        runCleanups(branchCleanups);
+        branchCleanups = [];
+
+        // Animate — element is now static
+        exitingEl.setAttribute('data-presence', 'exit');
+        void exitingEl.offsetHeight; // force reflow
+
+        // Remove after animation
+        onAnimationsComplete(exitingEl, () => {
+          if (generation === gen) {
+            exitingEl.parentNode?.removeChild(exitingEl);
+            exitingNode = null;
+          }
+        });
+      }
+    });
+  } finally {
+    popScope();
+  }
+
+  const dispose: DisposeFn = () => {
+    runCleanups(branchCleanups);
+    runCleanups(outerScope);
+    if (currentNode?.parentNode) {
+      currentNode.parentNode.removeChild(currentNode);
+      currentNode = null;
+    }
+  };
+
+  _tryOnCleanup(dispose);
+
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(anchor);
+  if (currentNode) {
+    fragment.appendChild(currentNode);
+  }
+
+  return Object.assign(fragment, { dispose });
+}

--- a/packages/ui/src/dom/__tests__/animation.test.ts
+++ b/packages/ui/src/dom/__tests__/animation.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
-import { onAnimationsComplete } from '../animation';
 
 describe('onAnimationsComplete', () => {
+  let onAnimationsComplete: typeof import('../animation').onAnimationsComplete;
   let el: HTMLElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Re-import to reset module state
+    const mod = await import('../animation');
+    onAnimationsComplete = mod.onAnimationsComplete;
     el = document.createElement('div');
   });
 
@@ -44,20 +47,6 @@ describe('onAnimationsComplete', () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
-  it('handles cancelled animations gracefully', async () => {
-    const cancelledAnim = Promise.reject(new DOMException('Cancelled', 'AbortError'));
-
-    el.getAnimations = () => [{ finished: cancelledAnim } as unknown as Animation];
-
-    const cb = mock(() => {});
-    onAnimationsComplete(el, cb);
-
-    // Allow microtask queue to flush
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(cb).toHaveBeenCalledTimes(1);
-  });
-
   it('skips wait when prefers-reduced-motion: reduce', () => {
     // Mock matchMedia to report reduced motion
     const original = globalThis.matchMedia;
@@ -81,5 +70,44 @@ describe('onAnimationsComplete', () => {
     // Cleanup
     resolveAnim();
     globalThis.matchMedia = original;
+  });
+
+  it('handles cancelled animations gracefully', async () => {
+    const cancelledAnim = Promise.reject(new DOMException('Cancelled', 'AbortError'));
+
+    el.getAnimations = () => [{ finished: cancelledAnim } as unknown as Animation];
+
+    const cb = mock(() => {});
+    onAnimationsComplete(el, cb);
+
+    // Allow microtask queue to flush
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('forces reflow before snapshotting animations', () => {
+    // Track that offsetHeight is accessed before getAnimations
+    const accessOrder: string[] = [];
+
+    Object.defineProperty(el, 'offsetHeight', {
+      get() {
+        accessOrder.push('offsetHeight');
+        return 0;
+      },
+    });
+
+    const originalGetAnimations = el.getAnimations;
+    el.getAnimations = () => {
+      accessOrder.push('getAnimations');
+      return originalGetAnimations ? originalGetAnimations.call(el) : [];
+    };
+
+    const cb = mock(() => {});
+    onAnimationsComplete(el, cb);
+
+    // offsetHeight should be accessed BEFORE getAnimations
+    expect(accessOrder).toEqual(['offsetHeight', 'getAnimations']);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/dom/animation.ts
+++ b/packages/ui/src/dom/animation.ts
@@ -10,6 +10,12 @@ export function onAnimationsComplete(el: HTMLElement, callback: () => void): voi
     return;
   }
 
+  // Force style recalculation so animations triggered by recent
+  // attribute/class changes are registered before we snapshot.
+  // Without this, getAnimations() returns [] if called in the same
+  // microtask as the attribute change that triggers the CSS animation.
+  void el.offsetHeight;
+
   if (typeof el.getAnimations === 'function') {
     const animations = el.getAnimations();
     if (animations.length > 0) {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,8 @@ export { createContext, useContext } from './component/context';
 export type { ErrorBoundaryProps } from './component/error-boundary';
 export { ErrorBoundary } from './component/error-boundary';
 export { onMount } from './component/lifecycle';
+export type { PresenceProps } from './component/presence';
+export { Presence } from './component/presence';
 export type { Ref } from './component/refs';
 export { ref } from './component/refs';
 export type { SuspenseProps } from './component/suspense';

--- a/packages/ui/src/internals.ts
+++ b/packages/ui/src/internals.ts
@@ -34,6 +34,8 @@ export {
 // Render adapter (used by SSR adapter and other rendering backends)
 export type { RenderAdapter, RenderElement, RenderNode, RenderText } from './dom/adapter';
 export { getAdapter, isRenderNode, RENDER_NODE_BRAND, setAdapter } from './dom/adapter';
+// Animation utilities (used by sibling packages like ui-primitives)
+export { onAnimationsComplete } from './dom/animation';
 // DOM helpers (used by compiler-generated JSX output)
 export { __attr, __classList, __show } from './dom/attributes';
 export { __conditional } from './dom/conditional';


### PR DESCRIPTION
## Summary

- Add `Presence` component that defers unmounting until CSS exit animations complete
- Move `onAnimationsComplete` from `@vertz/ui-primitives` to `@vertz/ui` with reflow timing fix (`void el.offsetHeight` before `getAnimations()` snapshot)
- `data-presence="enter"/"exit"` attributes for CSS animation hooks
- Freeze-then-animate exit: dispose reactive effects immediately, animate the static element, remove after animation completes
- Generation counter prevents stale exit callbacks on rapid toggle
- Respects `prefers-reduced-motion` (immediate removal, no animation wait)

Closes #787

## Test plan

- [x] 6 tests for `onAnimationsComplete` (immediate callback, wait for animations, reduced motion, cancelled animations, reflow ordering)
- [x] 8 unit tests for basic Presence mount/unmount (static rendering, reactive transitions, cleanups, effect disposal, error handling, parent disposal)
- [x] 7 tests for animation-aware exit (enter/exit attributes, deferred removal, immediate cleanup before animation, rapid toggle, fresh scope on re-entry)
- [x] 4 integration tests (CSS hook availability, reduced motion, parent disposal with pending animations, nested `__conditional` disposal)
- [x] All 1248 `@vertz/ui` tests pass, all 129 `@vertz/ui-primitives` tests pass
- [x] Typecheck, lint, build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)