### PR TITLE
fix(db): clean up stale comments and deduplicate annotation type utility

### DIFF
--- a/packages/db/src/query/helpers.ts
+++ b/packages/db/src/query/helpers.ts
@@ -44,7 +44,7 @@ export function getColumnsWithoutAnnotations(
  *
  * - undefined -> default columns (exclude hidden)
  * - { not: 'sensitive' } -> exclude sensitive + hidden
- * - { not: ['sensitive', 'patchable'] } -> exclude columns with any listed flag + hidden
+ * - { not: ['sensitive', 'patchable'] } -> exclude columns with any listed annotation + hidden
  * - { id: true, name: true } -> explicit pick
  */
 export function resolveSelectColumns(

--- a/packages/db/src/schema/__tests__/annotations.test-d.ts
+++ b/packages/db/src/schema/__tests__/annotations.test-d.ts
@@ -56,7 +56,7 @@ describe('$response', () => {
   it('excludes hidden columns', () => {
     type Response = typeof users.$response;
 
-    // passwordHash is .hidden() — should NOT appear on $response
+    // passwordHash is .is('hidden') — should NOT appear on $response
     expectTypeOf<Response>().not.toHaveProperty('passwordHash');
   });
 });

--- a/packages/db/src/schema/__tests__/model.test-d.ts
+++ b/packages/db/src/schema/__tests__/model.test-d.ts
@@ -25,7 +25,7 @@ describe('ModelDef schemas.response type', () => {
   it('excludes hidden columns from the parsed result', () => {
     type ResponseType = ReturnType<typeof usersModel.schemas.response.parse>;
 
-    // passwordHash is .hidden() — should NOT appear
+    // passwordHash is .is('hidden') — should NOT appear
     expectTypeOf<ResponseType>().not.toHaveProperty('passwordHash');
   });
 
@@ -103,7 +103,10 @@ describe('ModelDef schemas.createInput required vs optional', () => {
     type CreateType = ReturnType<typeof usersModel.schemas.createInput.parse>;
 
     // Should compile: role is optional (has default 'viewer'), omitting it is valid
-    expectTypeOf<{ email: string; name: string; passwordHash: string }>()
-      .toMatchTypeOf<CreateType>();
+    expectTypeOf<{
+      email: string;
+      name: string;
+      passwordHash: string;
+    }>().toMatchTypeOf<CreateType>();
   });
 });

--- a/packages/db/src/schema/__tests__/table.test-d.ts
+++ b/packages/db/src/schema/__tests__/table.test-d.ts
@@ -36,7 +36,7 @@ describe('$infer', () => {
   it('excludes hidden columns from $infer', () => {
     type User = typeof users.$infer;
 
-    // passwordHash is .hidden() -- should NOT appear on $infer
+    // passwordHash is .is('hidden') -- should NOT appear on $infer
     expectTypeOf<User>().not.toHaveProperty('passwordHash');
   });
 
@@ -116,7 +116,7 @@ describe('$insert', () => {
   it('includes hidden columns (visibility is read-side only)', () => {
     type UserInsert = typeof users.$insert;
 
-    // passwordHash is .hidden() but MUST be included in $insert
+    // passwordHash is .is('hidden') but MUST be included in $insert
     const _valid: UserInsert = {
       email: 'e@x.com',
       passwordHash: 'hash123',
@@ -129,7 +129,7 @@ describe('$insert', () => {
   it('includes sensitive columns (visibility is read-side only)', () => {
     type UserInsert = typeof users.$insert;
 
-    // email is .sensitive() but MUST be included in $insert
+    // email is .is('sensitive') but MUST be included in $insert
     const _valid: UserInsert = {
       email: 'sensitive@example.com',
       passwordHash: 'hash',

--- a/packages/db/src/schema/inference.ts
+++ b/packages/db/src/schema/inference.ts
@@ -1,6 +1,11 @@
 import type { ColumnBuilder, InferColumnType } from './column';
 import type { RelationDef } from './relation';
-import type { AllAnnotations, ColumnRecord, TableDef } from './table';
+import type {
+  AllAnnotations,
+  ColumnKeysWithoutAnyAnnotation,
+  ColumnRecord,
+  TableDef,
+} from './table';
 
 // ---------------------------------------------------------------------------
 // FilterType — typed where filters with operators
@@ -97,15 +102,6 @@ export type SelectOption<TColumns extends ColumnRecord> =
 // ---------------------------------------------------------------------------
 // SelectNarrow — narrows result to selected fields or excludes by visibility
 // ---------------------------------------------------------------------------
-
-/** Keys of columns that do NOT have ANY of the specified annotations in `_annotations`. */
-type ColumnKeysWithoutAnyAnnotation<T extends ColumnRecord, Annotations extends string> = {
-  [K in keyof T]: T[K] extends ColumnBuilder<unknown, infer M>
-    ? M['_annotations'] extends Record<Annotations, true>
-      ? never
-      : K
-    : never;
-}[keyof T];
 
 /** Extract selected keys from a select map (keys set to `true`). */
 type SelectedKeys<TColumns extends ColumnRecord, TSelect> = {

--- a/packages/db/src/schema/table.ts
+++ b/packages/db/src/schema/table.ts
@@ -52,7 +52,7 @@ type ColumnKeysWhereNot<T extends ColumnRecord, Flag extends keyof ColumnMetadat
 }[keyof T];
 
 /** Keys of columns that do NOT have ANY of the specified annotations in `_annotations`. */
-type ColumnKeysWithoutAnyAnnotation<T extends ColumnRecord, Annotations extends string> = {
+export type ColumnKeysWithoutAnyAnnotation<T extends ColumnRecord, Annotations extends string> = {
   [K in keyof T]: T[K] extends ColumnBuilder<unknown, infer M>
     ? M['_annotations'] extends Record<Annotations, true>
       ? never


### PR DESCRIPTION
## Summary

- Update stale test comments that still referenced removed `.hidden()` / `.sensitive()` methods to use `.is('hidden')` / `.is('sensitive')`
- Fix JSDoc in `resolveSelectColumns()` that still said "flag" instead of "annotation"
- Deduplicate `ColumnKeysWithoutAnyAnnotation` type — was defined identically in both `table.ts` and `inference.ts`. Now exported from `table.ts` and imported in `inference.ts`

Follow-up to #802.

## Test plan

- [x] All `@vertz/db` tests pass
- [x] All `@vertz/server` tests pass
- [x] Typecheck clean across `@vertz/db`, `@vertz/server`, `@vertz/integration-tests`
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)