### PR TITLE
feat(ui,compiler): context signal auto-unwrap

### DIFF
--- a/examples/entity-todo/src/app.tsx
+++ b/examples/entity-todo/src/app.tsx
@@ -8,8 +8,8 @@
  * - Minimal app shell without router (single page)
  */
 
-import { css, getInjectedCSS, globalCss, ThemeProvider } from '@vertz/ui';
-import { createSettingsValue, SettingsContext, useSettings } from './lib/settings-context';
+import { css, getInjectedCSS, globalCss, ThemeProvider, useContext } from '@vertz/ui';
+import { createSettingsValue, SettingsContext } from './lib/settings-context';
 import { TodoListPage } from './pages/todo-list';
 import { layoutStyles } from './styles/components';
 import { themeGlobals, todoTheme } from './styles/theme';
@@ -53,12 +53,10 @@ export const styles = [themeGlobals.css, appGlobals.css];
 // ── App header with theme toggle ────────────────────────────
 
 function AppHeader() {
-  const settings = useSettings();
-  let currentTheme = settings.theme.peek();
+  const settings = useContext(SettingsContext)!;
 
   function toggleTheme() {
-    const next = currentTheme === 'light' ? 'dark' : 'light';
-    currentTheme = next;
+    const next = settings.theme === 'light' ? 'dark' : 'light';
     settings.setTheme(next);
   }
 
@@ -72,10 +70,10 @@ function AppHeader() {
         type="button"
         class={headerStyles.themeToggle}
         data-testid="theme-toggle"
-        aria-label={currentTheme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+        aria-label={settings.theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
         onClick={toggleTheme}
       >
-        {currentTheme === 'light' ? '☽' : '☀'}
+        {settings.theme === 'light' ? '☽' : '☀'}
       </button>
     </header>
   );

--- a/examples/entity-todo/src/lib/settings-context.ts
+++ b/examples/entity-todo/src/lib/settings-context.ts
@@ -4,7 +4,7 @@
  * Provides app-wide theme preference (light/dark) without prop drilling.
  */
 
-import type { Signal } from '@vertz/ui';
+import type { Signal, UnwrapSignals } from '@vertz/ui';
 import { createContext, signal, useContext } from '@vertz/ui';
 
 export type ThemeMode = 'light' | 'dark';
@@ -28,7 +28,7 @@ export function createSettingsValue(): SettingsContextValue {
   };
 }
 
-export function useSettings(): SettingsContextValue {
+export function useSettings(): UnwrapSignals<SettingsContextValue> {
   const ctx = useContext(SettingsContext);
   if (!ctx) {
     throw new Error('useSettings must be called within a SettingsContext.Provider');

--- a/examples/task-manager/src/app.tsx
+++ b/examples/task-manager/src/app.tsx
@@ -18,9 +18,10 @@ import {
   RouterContext,
   RouterView,
   ThemeProvider,
+  useContext,
 } from '@vertz/ui';
 import { Icon } from './components/icon';
-import { createSettingsValue, SettingsContext, useSettings } from './lib/settings-context';
+import { createSettingsValue, SettingsContext } from './lib/settings-context';
 import { appRouter, Link } from './router';
 import { layoutStyles } from './styles/components';
 import { taskManagerTheme, themeGlobals } from './styles/theme';
@@ -90,17 +91,19 @@ export const styles = [themeGlobals.css, appGlobals.css, viewTransitionsCss];
 // ── Sidebar with theme toggle ────────────────────────────────
 
 function Sidebar() {
-  const settings = useSettings();
-  let currentTheme = settings.theme.peek();
+  const settings = useContext(SettingsContext)!;
 
   function toggleTheme() {
-    const next = currentTheme === 'light' ? 'dark' : 'light';
-    currentTheme = next;
+    const next = settings.theme === 'light' ? 'dark' : 'light';
     settings.setTheme(next);
   }
 
   return (
-    <nav class={layoutStyles.sidebar} aria-label="Main navigation" style="display: flex; flex-direction: column">
+    <nav
+      class={layoutStyles.sidebar}
+      aria-label="Main navigation"
+      style="display: flex; flex-direction: column"
+    >
       <div class={navStyles.navTitle}>Task Manager</div>
       <div class={navStyles.navList}>
         <div class={navStyles.navItem}>
@@ -135,8 +138,12 @@ function Sidebar() {
           }
         }}
       >
-        {currentTheme === 'light' ? <Icon name="Moon" size={16} /> : <Icon name="Sun" size={16} />}
-        {currentTheme === 'light' ? 'Dark Mode' : 'Light Mode'}
+        {settings.theme === 'light' ? (
+          <Icon name="Moon" size={16} />
+        ) : (
+          <Icon name="Sun" size={16} />
+        )}
+        {settings.theme === 'light' ? 'Dark Mode' : 'Light Mode'}
       </div>
     </nav>
   );

--- a/examples/task-manager/src/lib/settings-context.ts
+++ b/examples/task-manager/src/lib/settings-context.ts
@@ -5,7 +5,7 @@
  * (theme, default priority) without prop drilling.
  */
 
-import type { Signal } from '@vertz/ui';
+import type { Signal, UnwrapSignals } from '@vertz/ui';
 import { createContext, signal, useContext } from '@vertz/ui';
 import type { Settings, TaskPriority } from './types';
 
@@ -49,7 +49,7 @@ export function createSettingsValue(): SettingsContextValue {
  * Convenience accessor for settings inside components.
  * Throws if called outside SettingsContext.Provider.
  */
-export function useSettings(): SettingsContextValue {
+export function useSettings(): UnwrapSignals<SettingsContextValue> {
   const ctx = useContext(SettingsContext);
   if (!ctx) {
     throw new Error('useSettings must be called within a SettingsContext.Provider');

--- a/examples/task-manager/src/pages/settings.tsx
+++ b/examples/task-manager/src/pages/settings.tsx
@@ -10,9 +10,9 @@
  * - Reactive class toggling via JSX expressions
  */
 
-import { css } from '@vertz/ui';
+import { css, useContext } from '@vertz/ui';
 import { Icon } from '../components/icon';
-import { useSettings } from '../lib/settings-context';
+import { SettingsContext } from '../lib/settings-context';
 import { formStyles } from '../styles/components';
 
 const settingsStyles = css({
@@ -33,12 +33,12 @@ const settingsStyles = css({
  * Render the settings page with theme switching.
  */
 export function SettingsPage() {
-  const settings = useSettings();
+  const settings = useContext(SettingsContext)!;
 
   // Local state: compiler transforms `let` to signal()
   let showSaved = false;
-  let currentTheme = settings.theme.peek();
-  let defaultPriority = settings.defaultPriority.peek();
+  let currentTheme = settings.theme;
+  let defaultPriority = settings.defaultPriority;
 
   function flashSaved(): void {
     showSaved = true;

--- a/packages/ui-compiler/src/__tests__/signal-api-registry.test.ts
+++ b/packages/ui-compiler/src/__tests__/signal-api-registry.test.ts
@@ -2,7 +2,7 @@
  * @file Tests for signal-api-registry configuration
  */
 import { describe, expect, it } from 'vitest';
-import { getSignalApiConfig } from '../signal-api-registry';
+import { getSignalApiConfig, isReactiveSourceApi } from '../signal-api-registry';
 
 describe('signal-api-registry', () => {
   it('should return updated form config with fieldSignalProperties', () => {
@@ -13,5 +13,18 @@ describe('signal-api-registry', () => {
       new Set(['action', 'method', 'onSubmit', 'reset', 'setFieldError', 'submit']),
     );
     expect(config?.fieldSignalProperties).toEqual(new Set(['error', 'dirty', 'touched', 'value']));
+  });
+
+  it('should recognize useContext as a reactive source API', () => {
+    expect(isReactiveSourceApi('useContext')).toBe(true);
+  });
+
+  it('should not recognize signal APIs as reactive source APIs', () => {
+    expect(isReactiveSourceApi('query')).toBe(false);
+    expect(isReactiveSourceApi('form')).toBe(false);
+  });
+
+  it('should not recognize unknown functions as reactive source APIs', () => {
+    expect(isReactiveSourceApi('unknownFn')).toBe(false);
   });
 });

--- a/packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts
@@ -76,4 +76,49 @@ describe('JsxAnalyzer', () => {
     expect(reactive[0]?.deps).toEqual(['count']);
     expect(staticExprs).toHaveLength(1);
   });
+
+  it('classifies reactive source property access as reactive', () => {
+    const code = `
+      function App() {
+        const ctx = useContext(ThemeCtx);
+        return <div>{ctx.theme}</div>;
+      }
+    `;
+    const variables: VariableInfo[] = [
+      { name: 'ctx', kind: 'static', start: 0, end: 0, isReactiveSource: true },
+    ];
+    const [result] = analyze(code, variables);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.reactive).toBe(true);
+  });
+
+  it('classifies reactive source in JSX attribute as reactive', () => {
+    const code = `
+      function App() {
+        const ctx = useContext(ThemeCtx);
+        return <div data-theme={ctx.theme}>hello</div>;
+      }
+    `;
+    const variables: VariableInfo[] = [
+      { name: 'ctx', kind: 'static', start: 0, end: 0, isReactiveSource: true },
+    ];
+    const [result] = analyze(code, variables);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.reactive).toBe(true);
+  });
+
+  it('classifies bare reactive source identifier as reactive', () => {
+    const code = `
+      function App() {
+        const ctx = useContext(ThemeCtx);
+        return <div>{ctx}</div>;
+      }
+    `;
+    const variables: VariableInfo[] = [
+      { name: 'ctx', kind: 'static', start: 0, end: 0, isReactiveSource: true },
+    ];
+    const [result] = analyze(code, variables);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.reactive).toBe(true);
+  });
 });

--- a/packages/ui-compiler/src/signal-api-registry.ts
+++ b/packages/ui-compiler/src/signal-api-registry.ts
@@ -31,10 +31,25 @@ export const SIGNAL_API_REGISTRY: Record<string, SignalApiConfig> = {
 };
 
 /**
+ * APIs that return objects whose properties are reactive sources.
+ * Unlike signal APIs (which have a static set of signal properties),
+ * reactive source APIs return objects where ALL property accesses
+ * should be treated as reactive (e.g., useContext returns getter-wrapped objects).
+ */
+export const REACTIVE_SOURCE_APIS = new Set(['useContext']);
+
+/**
  * Check if a function name is a registered signal API.
  */
 export function isSignalApi(functionName: string): boolean {
   return functionName in SIGNAL_API_REGISTRY;
+}
+
+/**
+ * Check if a function name is a reactive source API.
+ */
+export function isReactiveSourceApi(functionName: string): boolean {
+  return REACTIVE_SOURCE_APIS.has(functionName);
 }
 
 /**

--- a/packages/ui-compiler/src/types.ts
+++ b/packages/ui-compiler/src/types.ts
@@ -70,6 +70,8 @@ export interface VariableInfo {
   fieldSignalProperties?: Set<string>;
   /** Synthetic variable name this binding was destructured from (e.g., `__query_0`). */
   destructuredFrom?: string;
+  /** Whether this variable is a reactive source (e.g., useContext result). */
+  isReactiveSource?: boolean;
 }
 
 /** Information about a detected component function. */

--- a/packages/ui/src/component/__tests__/context.test-d.ts
+++ b/packages/ui/src/component/__tests__/context.test-d.ts
@@ -129,3 +129,43 @@ StringCtx.Provider({ children: () => null });
 
 // @ts-expect-error - wrong type for value in JSX props
 StringCtx.Provider({ value: 123, children: () => null });
+
+// ─── UnwrapSignals<T> — context auto-unwrap ──────────────────────
+
+import type { Signal } from '../../runtime/signal-types';
+import type { UnwrapSignals } from '../context';
+
+// Context with signal properties should auto-unwrap
+interface SettingsContext {
+  theme: Signal<string>;
+  setTheme: (t: string) => void;
+}
+
+const SettingsCtx = createContext<SettingsContext>();
+const settings = useContext(SettingsCtx);
+
+if (settings) {
+  // Positive: theme should be string (unwrapped from Signal<string>)
+  const _theme: string = settings.theme;
+  void _theme;
+
+  // Positive: setTheme should remain a function
+  const _setTheme: (t: string) => void = settings.setTheme;
+  void _setTheme;
+
+  // @ts-expect-error - theme is string, not Signal<string>, so .peek() doesn't exist
+  settings.theme.peek();
+
+  // @ts-expect-error - theme is string, not Signal<string>, so .value doesn't exist
+  settings.theme.value;
+}
+
+// UnwrapSignals on primitives passes through
+type _CheckPrimString = UnwrapSignals<string>;
+const _primStr: _CheckPrimString = 'hello';
+void _primStr;
+
+// UnwrapSignals on plain object leaves it unchanged
+type _CheckPlainObj = UnwrapSignals<{ name: string; count: number }>;
+const _plainObj: _CheckPlainObj = { name: 'test', count: 42 };
+void _plainObj;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -130,6 +130,7 @@ export type {
   DisposeFn,
   ReadonlySignal,
   Signal,
+  UnwrapSignals,
 } from './runtime/signal-types';
 export { untrack } from './runtime/tracking';
 // Entity store

--- a/packages/ui/src/router/__tests__/router-context.test.ts
+++ b/packages/ui/src/router/__tests__/router-context.test.ts
@@ -21,7 +21,13 @@ describe('RouterContext + useRouter', () => {
       result = useRouter();
     });
 
-    expect(result).toBe(router);
+    // wrapSignalProps creates a new object with getters, so reference
+    // identity differs. Verify behaviour: functions are the same refs,
+    // signal props are auto-unwrapped to their current values.
+    expect(result).toBeDefined();
+    expect(result!.navigate).toBe(router.navigate);
+    expect(result!.dispose).toBe(router.dispose);
+    expect(result!.current).toEqual(router.current.value);
     router.dispose();
   });
 
@@ -60,7 +66,11 @@ describe('RouterContext + useRouter', () => {
       });
     });
 
-    expect(capturedRouter).toBe(router);
+    // wrapSignalProps creates a new object, so check behaviour not identity
+    expect(capturedRouter).toBeDefined();
+    expect(capturedRouter!.navigate).toBe(router.navigate);
+    expect(capturedRouter!.dispose).toBe(router.dispose);
+    expect(capturedRouter!.current).toEqual(router.current.value);
     router.dispose();
   });
 });

--- a/packages/ui/src/router/__tests__/router-view.test.ts
+++ b/packages/ui/src/router/__tests__/router-view.test.ts
@@ -140,7 +140,9 @@ describe('RouterView', () => {
     RouterContext.Provider(router, () => {
       RouterView({ router });
     });
-    expect(capturedRouter).toBe(router);
+    // wrapSignalProps creates a new object, so check behaviour not identity
+    expect(capturedRouter).toBeDefined();
+    expect(capturedRouter!.navigate).toBe(router.navigate);
     router.dispose();
   });
 
@@ -162,7 +164,9 @@ describe('RouterView', () => {
       RouterView({ router });
     });
     await new Promise((r) => setTimeout(r, 0));
-    expect(capturedRouter).toBe(router);
+    // wrapSignalProps creates a new object, so check behaviour not identity
+    expect(capturedRouter).toBeDefined();
+    expect(capturedRouter!.navigate).toBe(router.navigate);
     router.dispose();
   });
 
@@ -209,7 +213,7 @@ describe('RouterView', () => {
       '/tasks/:id': {
         component: () => {
           const router = useRouter();
-          capturedId = router.current.value?.params.id;
+          capturedId = router.current?.params.id;
           return document.createElement('div');
         },
       },
@@ -240,7 +244,9 @@ describe('RouterView', () => {
       RouterView({ router });
     });
     await router.navigate('/about');
-    expect(capturedOnAbout).toBe(router);
+    // wrapSignalProps creates a new object, so check behaviour not identity
+    expect(capturedOnAbout).toBeDefined();
+    expect(capturedOnAbout!.navigate).toBe(router.navigate);
     router.dispose();
   });
 

--- a/packages/ui/src/router/__tests__/router.test-d.ts
+++ b/packages/ui/src/router/__tests__/router.test-d.ts
@@ -285,8 +285,8 @@ _plainRouter.navigate('/anything-goes');
 
 // ─── RouterContext + useRouter + RouterView type tests ──────────────────────
 
-// useRouter() returns Router
-const _routerResult: Router = useRouter();
+// useRouter() returns UnwrapSignals<Router> (signal properties auto-unwrapped)
+const _routerResult = useRouter();
 void _routerResult;
 
 // RouterView returns HTMLElement
@@ -348,11 +348,10 @@ _p4TypedRouter.navigate('/nonexistent');
 // @ts-expect-error - '/tasks' without param is not valid
 _p4TypedRouter.navigate('/tasks');
 
-// Phase 4 Cycle 4: useRouter() (no param) returns Router — backward compat
+// Phase 4 Cycle 4: useRouter() (no param) returns UnwrapSignals<Router> — backward compat
 const _p4UntypedRouter = useRouter();
 _p4UntypedRouter.navigate('/anything'); // OK — string accepted
-const _p4AsRouter: Router = _p4UntypedRouter;
-void _p4AsRouter;
+void _p4UntypedRouter;
 
 // Phase 4 Cycle 5: InferRouteMap extracts route map from TypedRoutes<T>
 type P4RouteMap = InferRouteMap<typeof _p4Routes>;

--- a/packages/ui/src/router/router-context.ts
+++ b/packages/ui/src/router/router-context.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../component/context';
 import { createContext, useContext } from '../component/context';
+import type { UnwrapSignals } from '../runtime/signal-types';
 import type { RouteConfigLike, RouteDefinitionMap } from './define-routes';
 import type { Router } from './navigate';
 import type { ExtractParams } from './params';
@@ -8,7 +9,7 @@ export const RouterContext: Context<Router> = createContext<Router>();
 
 export function useRouter<
   T extends Record<string, RouteConfigLike> = RouteDefinitionMap,
->(): Router<T> {
+>(): UnwrapSignals<Router<T>> {
   const router = useContext(RouterContext);
   if (!router) {
     throw new Error('useRouter() must be called within RouterContext.Provider');
@@ -16,7 +17,7 @@ export function useRouter<
   // Cast is safe: the stored Router was created by createRouter<T>(), which
   // returns Router<T> at the type level. The generic T only narrows navigate()
   // at compile time — at runtime, the router is identical regardless of T.
-  return router as Router<T>;
+  return router as UnwrapSignals<Router<T>>;
 }
 
 export function useParams<TPath extends string = string>(): ExtractParams<TPath> {
@@ -24,5 +25,5 @@ export function useParams<TPath extends string = string>(): ExtractParams<TPath>
   if (!router) {
     throw new Error('useParams() must be called within RouterContext.Provider');
   }
-  return (router.current.value?.params ?? {}) as ExtractParams<TPath>;
+  return (router.current?.params ?? {}) as ExtractParams<TPath>;
 }

--- a/packages/ui/src/runtime/signal-types.ts
+++ b/packages/ui/src/runtime/signal-types.ts
@@ -33,6 +33,19 @@ export interface ReadonlySignal<T> {
 export type Unwrapped<T> = T extends ReadonlySignal<infer U> ? U : T;
 
 /**
+ * Unwraps all signal properties of an object type.
+ * Properties that are signals become their inner value type.
+ * Non-signal properties and primitive types pass through unchanged.
+ *
+ * Used by `useContext` to present context values without the Signal wrapper.
+ *
+ * @example
+ * type Settings = { theme: Signal<string>; setTheme: (t: string) => void };
+ * type Unwrapped = UnwrapSignals<Settings>; // { theme: string; setTheme: (t: string) => void }
+ */
+export type UnwrapSignals<T> = T extends object ? { [K in keyof T]: Unwrapped<T[K]> } : T;
+
+/**
  * A computed signal — lazily evaluated, cached, and automatically re-computed
  * when dependencies change.
  */

--- a/plans/context-signal-auto-unwrap.md
+++ b/plans/context-signal-auto-unwrap.md
@@ -1,0 +1,233 @@
+# Context Signal Auto-Unwrap
+
+## Problem
+
+The compiler abstracts signals from users — `let` becomes a signal, `const` becomes computed, and APIs like `query()` and `form()` auto-unwrap their signal properties (`.data`, `.loading`, `.error`) so users never write `.value` or `.peek()`.
+
+**Context values break this abstraction.** When a context returns an object with `Signal<T>` properties, users are forced to manually call `.peek()` or `.value`:
+
+```tsx
+// Current: signal abstraction leaks
+const settings = useSettings();
+let currentTheme = settings.theme.peek();  // user must know about .peek()
+```
+
+This violates the framework's core principle: users should never interact with signal internals. They use `let` and `const` — the compiler handles reactivity.
+
+## Affected Code
+
+### Context definitions exposing `Signal<T>` in their types
+
+- `examples/task-manager/src/lib/settings-context.ts` — `theme: Signal<Settings['theme']>`, `defaultPriority: Signal<TaskPriority>`
+- `examples/entity-todo/src/lib/settings-context.ts` — `theme: Signal<ThemeMode>`
+
+### Consumer code using `.peek()` / `.value`
+
+- `examples/task-manager/src/app.tsx` — `settings.theme.peek()` (lines 94, 162)
+- `examples/task-manager/src/pages/settings.tsx` — `settings.theme.peek()`, `settings.defaultPriority.peek()` (lines 40-41)
+- `examples/entity-todo/src/app.tsx` — `settings.theme.peek()` (lines 57, 92)
+- `packages/ui/src/router/router-context.ts` — `router.current.value?.params` (line 27)
+
+### Custom `use*` hooks wrapping `useContext`
+
+- `examples/task-manager/src/lib/settings-context.ts` — `useSettings()`
+- `examples/entity-todo/src/lib/settings-context.ts` — `useSettings()`
+- `packages/ui/src/router/router-context.ts` — `useRouter()`, `useParams()`
+
+## Root Cause Analysis
+
+The signal API registry (`packages/ui-compiler/src/signal-api-registry.ts`) tells the compiler which functions return objects with signal properties:
+
+```typescript
+const SIGNAL_API_REGISTRY = {
+  query:        { signalProperties: new Set(['data', 'loading', 'error']), ... },
+  form:         { signalProperties: new Set(['submitting', 'dirty', 'valid']), ... },
+  createLoader: { signalProperties: new Set(['data', 'loading', 'error']), ... },
+};
+```
+
+`useContext` is not in this registry. And even if it were, the registry uses a **static shape** — every `query()` returns the same signal properties. Context values have **user-defined shapes** that vary per context. The registry model doesn't fit.
+
+### Why cross-file analysis is NOT needed
+
+The compiler is per-file, single-pass (like Babel). Initially this seemed like a blocker — the Provider and consumer are in different files, so the compiler can't see the Provider's signals when compiling the consumer.
+
+But the compiler already solves this exact problem for **component props**. When a parent passes a reactive value as a prop:
+
+```tsx
+<TaskItem task={tasks.data} />
+```
+
+The compiler transforms it to a **getter at the call site** (the parent):
+
+```tsx
+TaskItem({ get task() { return tasks.data.value; } })
+```
+
+The child accesses `props.task` normally — the getter fires, reads the signal, effects track it. No cross-file analysis needed. All the work happens in the parent's compilation unit.
+
+## Proposed Solution
+
+Apply the same getter mechanism to Provider `value` props. The compiler already knows which variables are signals at the Provider site.
+
+### Before (current)
+
+User writes:
+
+```tsx
+function SettingsProvider({ children }: { children: unknown }) {
+  let theme: ThemeMode = 'light';
+  const setTheme = (t: ThemeMode) => { theme = t; };
+
+  return (
+    <SettingsContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+```
+
+Compiler output today (signals transformed, but value object passes raw signals):
+
+```tsx
+function SettingsProvider({ children }: { children: unknown }) {
+  const theme = signal<ThemeMode>('light');
+  const setTheme = (t: ThemeMode) => { theme.value = t; };
+
+  return (
+    SettingsContext.Provider({
+      value: { theme: theme.value, setTheme },  // reads value once, not reactive!
+      children: () => children,
+    })
+  );
+}
+```
+
+Consumer must use `.peek()` because the context type exposes `Signal<T>`:
+
+```tsx
+const settings = useContext(SettingsContext);
+let currentTheme = settings.theme.peek();  // manual unwrap
+```
+
+### After (proposed)
+
+Same user code, but the compiler generates getters for signal properties in the `value` object:
+
+```tsx
+function SettingsProvider({ children }: { children: unknown }) {
+  const theme = signal<ThemeMode>('light');
+  const setTheme = (t: ThemeMode) => { theme.value = t; };
+
+  return (
+    SettingsContext.Provider({
+      value: { get theme() { return theme.value; }, setTheme },  // getter!
+      children: () => children,
+    })
+  );
+}
+```
+
+Consumer just accesses the property — the getter fires, reads the signal, effects track it:
+
+```tsx
+const settings = useContext(SettingsContext);
+let currentTheme = settings.theme;  // just works — getter unwraps the signal
+```
+
+### What changes
+
+1. **Context type definitions** — Properties change from `Signal<T>` to `T`:
+   ```typescript
+   // Before
+   interface SettingsContextValue {
+     theme: Signal<ThemeMode>;
+     setTheme: (theme: ThemeMode) => void;
+   }
+
+   // After
+   interface SettingsContextValue {
+     theme: ThemeMode;
+     setTheme: (theme: ThemeMode) => void;
+   }
+   ```
+
+2. **Compiler JSX transformer** — When the compiler sees a `.Provider` call with a `value` prop containing an object literal, it applies the same getter transformation it already uses for component props: signal-classified variables become getters, everything else stays plain.
+
+3. **Consumer code** — Remove all `.peek()` / `.value` calls on context-returned values. Just access the property directly.
+
+4. **Custom `use*` hooks** — These become optional convenience wrappers (for the error-on-missing-provider pattern). They don't need signal awareness. For v1, it's acceptable to require `useContext(SomeContext)` directly in the component, same as `query()` and `form()` must be called directly. Custom hooks can be supported later.
+
+### Constraints (v1)
+
+- `useContext()` must be called directly inside the component (same as `query()` and `form()`). The compiler needs to see the call to know it's a context access.
+- Custom `use*` hooks that wrap `useContext` won't get auto-unwrapping from the compiler. Users should call `useContext` directly for now. This creates some friction but keeps the compiler simple.
+- Context values should be provided via object literals in the `value` prop so the compiler can analyze the shape statically. Dynamic value objects (e.g., passing a variable) would not get getter transformation.
+
+## Manifesto Alignment
+
+- **Explicit over implicit** — The context type shows plain values (`theme: ThemeMode`), not wrapped signals. What you see is what you get.
+- **Compile-time over runtime** — Getters are generated at compile time. No runtime proxy, no wrapper objects.
+- **One way to do things** — Same mechanism as component props. Signals are always hidden by the compiler, whether in props, query results, or context values.
+- **LLM-first** — An LLM generating code doesn't need to know about `.peek()` or `.value`. It just uses the context value's properties directly.
+
+## Non-Goals
+
+- **Custom `use*` hook support** — Deferred. For v1, `useContext()` must be called directly in the component.
+- **Dynamic value objects** — If the Provider passes a variable instead of an object literal, the compiler won't transform it. The object literal pattern is the supported path.
+- **Nested signal properties** — Only top-level properties of the value object are getter-transformed. Deeply nested signals are out of scope for v1.
+
+## Unknowns
+
+### How does the JSX transformer currently handle Provider value props?
+
+**Needs investigation.** The JSX transformer already generates getters for component props. We need to verify:
+- Does it recognize `SomeContext.Provider` as a component call?
+- Does it analyze the `value` prop's object literal for reactive properties?
+- If not, what changes are needed to the JSX analyzer + transformer?
+
+### Does `useContext` need compiler recognition?
+
+**Discussion-resolvable.** If the Provider generates getters correctly, the consumer side might not need any compiler changes — `useContext` returns the object as-is, and getters just work. But the consumer's type would need to reflect the unwrapped values, not `Signal<T>`. This may require changes to how `createContext<T>` is typed.
+
+### What about `watch()` on context values?
+
+If a consumer wants to react to context changes via `watch()`:
+```tsx
+const settings = useContext(SettingsContext);
+watch(() => settings.theme, (newTheme) => { ... });
+```
+The getter returns a plain value, so `watch()` would work correctly — it re-evaluates the getter expression, which reads the signal, which is tracked. This should work but needs verification.
+
+## E2E Acceptance Test
+
+```tsx
+// Provider component
+function ThemeProvider({ children }: { children: unknown }) {
+  let theme: 'light' | 'dark' = 'light';
+  const setTheme = (t: 'light' | 'dark') => { theme = t; };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+// Consumer component — NO .peek(), NO .value
+function ThemeDisplay() {
+  const ctx = useContext(ThemeContext);
+  // ctx.theme is 'light' | 'dark', not Signal<'light' | 'dark'>
+  return <div data-testid="theme">{ctx.theme}</div>;
+}
+
+// Test
+const root = ThemeProvider({ children: () => ThemeDisplay() });
+expect(root.querySelector('[data-testid="theme"]').textContent).toBe('light');
+
+// Trigger change
+ctx.setTheme('dark');
+expect(root.querySelector('[data-testid="theme"]').textContent).toBe('dark');
+```
+
+The test passes without any `.peek()` or `.value` — the getter mechanism handles reactivity transparently.


### PR DESCRIPTION
## Summary

- **Runtime**: Provider auto-wraps signal properties in getter-based proxies so consumers read plain values (`settings.theme`) instead of signal internals (`settings.theme.peek()`)
- **Types**: `UnwrapSignals<T>` mapped type ensures `useContext` return types reflect unwrapped values at the type level
- **Compiler**: Recognizes `useContext` results as reactive sources, generating thunks and getters in JSX without appending `.value`
- **Examples**: Updated `entity-todo` and `task-manager` to use the new pattern, removing all `.peek()` calls on context-returned signals

## Details

### Runtime (`@vertz/ui`)
- `isSignalLike()` duck-type detection (has `.peek` function)
- `wrapSignalProps()` creates getter-wrapped copies for objects with signal properties; primitives, arrays, and plain objects pass through unchanged
- Provider (both callback and JSX patterns) wraps values before storage
- `useContext` return type updated to `UnwrapSignals<T> | undefined`
- Router context updated: `useRouter()` returns `UnwrapSignals<Router<T>>`, `useParams()` no longer needs `.value` on `router.current`

### Compiler (`@vertz/ui-compiler`)
- Reactive source API registry (`REACTIVE_SOURCE_APIS = Set(['useContext'])`)
- ReactivityAnalyzer tracks `useContext` variables as reactive sources
- JsxAnalyzer marks property accesses on reactive sources as reactive expressions
- Signal transformer correctly skips reactive sources (no `.value` appending)

### Design doc
- `plans/context-signal-auto-unwrap.md` added

## Test plan

- [x] 29 context runtime tests (isSignalLike, wrapSignalProps, Provider auto-unwrap, reactive tracking, edge cases)
- [x] Type-level tests in `context.test-d.ts` (UnwrapSignals positive/negative, signal property unwrapping)
- [x] 275 compiler tests pass (7 new integration tests for reactive source recognition)
- [x] Router context + router view tests updated for auto-unwrap behavior
- [x] Full turbo pipeline passes (64/64 tasks: lint, typecheck, test, build)
- [x] Cross-package typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)