### PR TITLE
fix: address remaining security audit findings [#855]

### DIFF
--- a/packages/schema/src/schemas/__tests__/object.test.ts
+++ b/packages/schema/src/schemas/__tests__/object.test.ts
@@ -187,6 +187,32 @@ describe('ObjectSchema', () => {
     }
   });
 
+  it('.passthrough() strips __proto__ key to prevent prototype pollution', () => {
+    const schema = new ObjectSchema({ name: new StringSchema() }).passthrough();
+    const malicious = JSON.parse('{"name":"Alice","__proto__":{"polluted":true},"extra":"kept"}');
+    const result = schema.parse(malicious);
+    // __proto__ assignment via bracket notation changes the result's prototype chain.
+    // The result should NOT inherit 'polluted' from a tampered prototype.
+    expect((result.data as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
+  });
+
+  it('.passthrough() keeps constructor and prototype as legitimate string values', () => {
+    const schema = new ObjectSchema({ name: new StringSchema() }).passthrough();
+    const input = { name: 'Alice', constructor: 'MyClass', prototype: 'v1' };
+    const result = schema.parse(input);
+    expect(result.data).toEqual({ name: 'Alice', constructor: 'MyClass', prototype: 'v1' });
+  });
+
+  it('.catchall() strips __proto__ key to prevent prototype pollution', () => {
+    const schema = new ObjectSchema({ name: new StringSchema() }).catchall(new StringSchema());
+    const malicious = JSON.parse('{"name":"Alice","__proto__":"injected","extra":"kept"}');
+    const result = schema.parse(malicious);
+    // Even with a valid catchall value, __proto__ should be filtered
+    expect(Object.keys(result.data as object)).not.toContain('__proto__');
+    expect(result.data).toEqual({ name: 'Alice', extra: 'kept' });
+  });
+
   it('.catchall() overrides .strict() when chained', () => {
     const schema = new ObjectSchema({ name: new StringSchema() })
       .strict()

--- a/packages/schema/src/schemas/__tests__/record.test.ts
+++ b/packages/schema/src/schemas/__tests__/record.test.ts
@@ -35,6 +35,25 @@ describe('RecordSchema', () => {
     }
   });
 
+  it('strips __proto__ key to prevent prototype pollution', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    const malicious = JSON.parse('{"a":1,"__proto__":{"polluted":true},"b":2}');
+    const result = schema.parse(malicious);
+    // __proto__ with object value pollutes the result's prototype chain.
+    // The result should NOT inherit 'polluted' from a tampered prototype.
+    expect((result.data as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
+    expect(result.data?.a).toBe(1);
+    expect(result.data?.b).toBe(2);
+  });
+
+  it('keeps constructor and prototype as legitimate keys', () => {
+    const schema = new RecordSchema(new NumberSchema());
+    const input = { a: 1, constructor: 2, prototype: 3 };
+    const result = schema.parse(input);
+    expect(result.data).toEqual({ a: 1, constructor: 2, prototype: 3 });
+  });
+
   it('.toJSONSchema() returns { type: "object", additionalProperties: { ... } }', () => {
     const schema = new RecordSchema(new NumberSchema());
     expect(schema.toJSONSchema()).toEqual({

--- a/packages/schema/src/schemas/object.ts
+++ b/packages/schema/src/schemas/object.ts
@@ -67,6 +67,7 @@ export class ObjectSchema<S extends Shape = Shape> extends Schema<InferShape<S>>
     if (unknownKeys.length > 0) {
       if (this._catchall) {
         for (const key of unknownKeys) {
+          if (key === '__proto__') continue;
           ctx.pushPath(key);
           result[key] = this._catchall._runPipeline(obj[key], ctx);
           ctx.popPath();
@@ -78,6 +79,7 @@ export class ObjectSchema<S extends Shape = Shape> extends Schema<InferShape<S>>
         });
       } else if (this._unknownKeys === 'passthrough') {
         for (const key of unknownKeys) {
+          if (key === '__proto__') continue;
           result[key] = obj[key];
         }
       }

--- a/packages/schema/src/schemas/record.ts
+++ b/packages/schema/src/schemas/record.ts
@@ -40,6 +40,7 @@ export class RecordSchema<V> extends Schema<Record<string, V>> {
     const result: Record<string, V> = {};
 
     for (const key of Object.keys(obj)) {
+      if (key === '__proto__') continue;
       ctx.pushPath(key);
       if (this._keySchema) {
         this._keySchema._runPipeline(key, ctx);

--- a/packages/server/src/auth/__tests__/access.test.ts
+++ b/packages/server/src/auth/__tests__/access.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+import { createAccess } from '../access';
+
+const testAccess = createAccess({
+  roles: {
+    admin: { entitlements: ['user:read', 'user:delete', 'post:*'] },
+    user: { entitlements: ['user:read', 'post:update'] },
+  },
+  entitlements: {
+    'user:read': { roles: ['user', 'admin'] },
+    'user:delete': { roles: ['admin'] },
+    'post:update': { roles: ['user', 'admin'] },
+  },
+});
+
+const now = new Date();
+const adminUser = {
+  id: '1',
+  email: 'admin@test.com',
+  role: 'admin',
+  createdAt: now,
+  updatedAt: now,
+};
+const normalUser = {
+  id: '2',
+  email: 'user@test.com',
+  role: 'user',
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe('createAccess — default-deny', () => {
+  it('denies access when entitlement is not defined in config', async () => {
+    // 'post:create' is not in the entitlements config
+    expect(await testAccess.can('post:create', adminUser)).toBe(false);
+  });
+
+  it('allows access when user role matches entitlement config', async () => {
+    expect(await testAccess.can('user:delete', adminUser)).toBe(true);
+  });
+
+  it('denies access to unauthenticated users', async () => {
+    expect(await testAccess.can('user:read', null)).toBe(false);
+  });
+
+  it('denies access when user role is not in entitlement roles', async () => {
+    expect(await testAccess.can('user:delete', normalUser)).toBe(false);
+  });
+});
+
+describe('canWithResource — ownership validation', () => {
+  it('allows access when resource has no ownerId', async () => {
+    const resource = { id: 'post-1', type: 'post' };
+    expect(await testAccess.canWithResource('post:update', resource, normalUser)).toBe(true);
+  });
+
+  it('allows access when resource ownerId matches user id', async () => {
+    const resource = { id: 'post-1', type: 'post', ownerId: '2' };
+    expect(await testAccess.canWithResource('post:update', resource, normalUser)).toBe(true);
+  });
+
+  it('denies access when resource ownerId does not match user id', async () => {
+    const resource = { id: 'post-1', type: 'post', ownerId: '999' };
+    expect(await testAccess.canWithResource('post:update', resource, normalUser)).toBe(false);
+  });
+
+  it('allows access with empty string ownerId (not nullish)', async () => {
+    // Empty string is not nullish — ownership check is skipped
+    const resource = { id: 'post-1', type: 'post', ownerId: '' };
+    expect(await testAccess.canWithResource('post:update', resource, normalUser)).toBe(true);
+  });
+
+  it('denies unauthenticated users even with no ownerId', async () => {
+    const resource = { id: 'post-1', type: 'post' };
+    expect(await testAccess.canWithResource('post:update', resource, null)).toBe(false);
+  });
+});

--- a/packages/server/src/auth/__tests__/cookie-config.test.ts
+++ b/packages/server/src/auth/__tests__/cookie-config.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { existsSync, rmSync } from 'node:fs';
 import { createAuth } from '../index';
 import type { AuthConfig } from '../types';
 
@@ -133,5 +134,73 @@ describe('cookie config security validations', () => {
         }),
       ),
     ).not.toThrow();
+  });
+});
+
+describe('JWT secret handling', () => {
+  const testSecretDir = '/tmp/vertz-test-jwt-secret';
+
+  beforeEach(() => {
+    if (existsSync(testSecretDir)) {
+      rmSync(testSecretDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (existsSync(testSecretDir)) {
+      rmSync(testSecretDir, { recursive: true });
+    }
+  });
+
+  it('throws when jwtSecret is missing in production', () => {
+    expect(() =>
+      createAuth({
+        session: { strategy: 'jwt', ttl: '1h' },
+        isProduction: true,
+      }),
+    ).toThrow('jwtSecret is required in production');
+  });
+
+  it('auto-generates and persists a dev secret when jwtSecret is missing in dev mode', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    // Should not throw — generates a secret automatically
+    expect(() =>
+      createAuth({
+        session: { strategy: 'jwt', ttl: '1h' },
+        isProduction: false,
+        devSecretPath: testSecretDir,
+      }),
+    ).not.toThrow();
+
+    // Should have persisted the secret
+    expect(existsSync(`${testSecretDir}/jwt-secret`)).toBe(true);
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('reuses persisted dev secret across createAuth calls', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    // First call generates and persists
+    createAuth({
+      session: { strategy: 'jwt', ttl: '1h' },
+      isProduction: false,
+      devSecretPath: testSecretDir,
+    });
+
+    // Second call reads from file (no "Generated" message)
+    warnSpy.mockClear();
+    createAuth({
+      session: { strategy: 'jwt', ttl: '1h' },
+      isProduction: false,
+      devSecretPath: testSecretDir,
+    });
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
   });
 });

--- a/packages/server/src/auth/access.ts
+++ b/packages/server/src/auth/access.ts
@@ -131,8 +131,8 @@ export function createAccess(config: AccessConfig): AccessInstance {
     // Phase 1: Check role -> entitlement mapping
     const allowedRoles = entitlementRoles.get(entitlement);
     if (!allowedRoles) {
-      // Entitlement not defined - allow for now (could be feature flag in Phase 2)
-      return true;
+      // Entitlement not defined in config — deny by default (secure posture)
+      return false;
     }
 
     return allowedRoles.has(user.role) || roleHasEntitlement(user.role, entitlement);
@@ -152,18 +152,18 @@ export function createAccess(config: AccessConfig): AccessInstance {
 
   async function canWithResource(
     entitlement: Entitlement,
-    _resource: Resource,
+    resource: Resource,
     user: AuthUser | null,
   ): Promise<boolean> {
-    // Phase 1: Basic RBAC only
-    // No resource hierarchy, no ownership checks
-
-    // Check if user has the entitlement
     const hasEntitlement = await checkEntitlement(entitlement, user);
     if (!hasEntitlement) return false;
 
-    // Phase 1 limitation: No ownership checks yet
-    // Phase 2 would add: return resource.ownerId === user?.id || hasEntitlement;
+    // Ownership check: if resource declares an owner, user must match.
+    // Uses nullish check (!=) so empty string ownerId is treated as "no owner".
+    // Admins who need to bypass ownership should use can() without resource.
+    if (resource.ownerId != null && resource.ownerId !== '' && resource.ownerId !== user?.id) {
+      return false;
+    }
 
     return true;
   }

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -3,6 +3,8 @@
  * JWT sessions, email/password authentication
  */
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   type AuthError,
   type AuthValidationError,
@@ -238,7 +240,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
     (typeof process === 'undefined' ||
       (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test'));
 
-  // Validate JWT secret - throw in production, warn in development
+  // Validate JWT secret - throw in production, auto-generate in development
   let jwtSecret: string;
 
   if (configJwtSecret) {
@@ -248,10 +250,20 @@ export function createAuth(config: AuthConfig): AuthInstance {
       'jwtSecret is required in production. Provide it via createAuth({ jwtSecret: "..." }).',
     );
   } else {
-    console.warn(
-      'Using insecure default JWT secret. Provide jwtSecret in createAuth() config for production.',
-    );
-    jwtSecret = 'dev-secret-change-in-production';
+    // Auto-generate a stable dev secret, persisted to disk so it survives restarts
+    const secretDir = config.devSecretPath ?? join(process.cwd(), '.vertz');
+    const secretFile = join(secretDir, 'jwt-secret');
+
+    if (existsSync(secretFile)) {
+      jwtSecret = readFileSync(secretFile, 'utf-8').trim();
+    } else {
+      jwtSecret = crypto.randomUUID() + crypto.randomUUID();
+      mkdirSync(secretDir, { recursive: true });
+      writeFileSync(secretFile, jwtSecret, 'utf-8');
+      console.warn(
+        `[Auth] Auto-generated dev JWT secret at ${secretFile}. Add this path to .gitignore.`,
+      );
+    }
   }
 
   const cookieConfig = { ...DEFAULT_COOKIE_CONFIG, ...session.cookie };

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -67,6 +67,12 @@ export interface AuthConfig {
    * Defaults to true when process.env is unavailable (secure-by-default for edge runtimes).
    */
   isProduction?: boolean;
+  /**
+   * Directory to persist auto-generated dev JWT secret.
+   * Defaults to `.vertz` in the current working directory.
+   * Only used in non-production mode when jwtSecret is not provided.
+   */
+  devSecretPath?: string;
 }
 
 // ============================================================================

--- a/packages/ui-server/src/types.ts
+++ b/packages/ui-server/src/types.ts
@@ -4,7 +4,25 @@ export interface RawHtml {
   html: string;
 }
 
-/** Create a raw HTML string that will not be escaped during serialization. */
+/**
+ * Create a raw HTML string that will NOT be escaped during SSR serialization.
+ *
+ * **WARNING: XSS RISK** — This function bypasses all HTML escaping. Never pass
+ * user-controlled input directly. Always sanitize with a trusted library (e.g.
+ * DOMPurify) before wrapping in `rawHtml()`.
+ *
+ * @example Safe usage
+ * ```ts
+ * rawHtml('<svg>...</svg>') // static markup — OK
+ * rawHtml(DOMPurify.sanitize(userInput)) // sanitized — OK
+ * ```
+ *
+ * @example Unsafe usage — NEVER do this
+ * ```ts
+ * rawHtml(userInput) // XSS vulnerability
+ * rawHtml(`<div>${userInput}</div>`) // XSS via interpolation
+ * ```
+ */
 export function rawHtml(html: string): RawHtml {
   return { __raw: true, html };
 }

--- a/packages/ui/src/router/__tests__/link.test.ts
+++ b/packages/ui/src/router/__tests__/link.test.ts
@@ -121,6 +121,107 @@ describe('Link component', () => {
   });
 });
 
+// ─── XSS Prevention ──────────────────────────────────────────
+
+describe('Link XSS prevention', () => {
+  test('blocks javascript: href', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: 'javascript:alert(1)' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('blocks JAVASCRIPT: href (case insensitive)', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: 'JAVASCRIPT:alert(1)' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('blocks data: href', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({
+      children: 'XSS',
+      href: 'data:text/html,<script>alert(1)</script>' as any,
+    });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('blocks vbscript: href', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: 'vbscript:msgbox' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('blocks protocol-relative URLs', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: '//evil.com/phishing' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('blocks javascript: with whitespace injection', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: ' javascript:alert(1)' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
+  test('does not navigate to blocked URLs on click', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: 'javascript:alert(1)' as any });
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    el.dispatchEvent(event);
+
+    expect(navigate).toHaveBeenCalledWith('#');
+  });
+
+  test('allows safe URLs', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    const safeHrefs = ['/about', '#section', 'https://example.com', 'http://example.com'];
+
+    for (const href of safeHrefs) {
+      // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety with external URLs
+      const el = Link({ children: 'Link', href: href as any });
+      expect(el.getAttribute('href')).toBe(href);
+    }
+  });
+});
+
 // ─── Hover Prefetch ──────────────────────────────────────────
 
 describe('Link hover prefetch', () => {

--- a/packages/ui/src/router/link.ts
+++ b/packages/ui/src/router/link.ts
@@ -16,6 +16,22 @@ import type { ReadonlySignal } from '../runtime/signal-types';
 import type { RouteConfigLike, RouteDefinitionMap } from './define-routes';
 import type { RoutePaths } from './params';
 
+/** Dangerous URL schemes that must never appear in href attributes. */
+const DANGEROUS_SCHEMES = ['javascript:', 'data:', 'vbscript:'];
+
+/**
+ * Validate that a URL is safe for use as an href attribute.
+ * Blocks javascript:, data:, vbscript: schemes and protocol-relative URLs.
+ */
+function isSafeUrl(url: string): boolean {
+  const normalized = url.replace(/\s/g, '').toLowerCase();
+  if (normalized.startsWith('//')) return false;
+  for (const scheme of DANGEROUS_SCHEMES) {
+    if (normalized.startsWith(scheme)) return false;
+  }
+  return true;
+}
+
 /**
  * Props for the Link component.
  *
@@ -61,6 +77,9 @@ export function createLink(
     className,
     prefetch,
   }: LinkProps): HTMLAnchorElement {
+    // Sanitize href to prevent XSS via javascript:, data:, vbscript: schemes
+    const safeHref = isSafeUrl(href) ? href : '#';
+
     const handleClick = (event: Event) => {
       const mouseEvent = event as MouseEvent;
       // Allow modifier-key clicks to open in new tab
@@ -68,11 +87,11 @@ export function createLink(
         return;
       }
       mouseEvent.preventDefault();
-      navigate(href);
+      navigate(safeHref);
     };
 
     // Build static props for the anchor element
-    const props: Record<string, string> = { href };
+    const props: Record<string, string> = { href: safeHref };
     if (className) {
       props.class = className;
     }
@@ -98,7 +117,7 @@ export function createLink(
     // Reactive active state — re-evaluates whenever currentPath changes.
     if (activeClass) {
       __classList(el, {
-        [activeClass]: () => currentPath.value === href,
+        [activeClass]: () => currentPath.value === safeHref,
       });
     }
 
@@ -108,7 +127,7 @@ export function createLink(
       const triggerPrefetch = () => {
         if (prefetched) return;
         prefetched = true;
-        factoryOptions.onPrefetch?.(href);
+        factoryOptions.onPrefetch?.(safeHref);
       };
       __on(el, 'mouseenter', triggerPrefetch);
       __on(el, 'focus', triggerPrefetch);


### PR DESCRIPTION
## Summary

Addresses the remaining security vulnerabilities identified in the full codebase audit (#855). PR #854 fixed path traversal, SSR XSS, SQL injection hardening, CORS, and CSRF. This PR covers:

- **CRITICAL — Prototype pollution:** Filter `__proto__` key in `ObjectSchema` passthrough/catchall and `RecordSchema` iteration to prevent `JSON.parse`-based prototype pollution attacks. Only `__proto__` is filtered — `constructor` and `prototype` remain valid as string/number data values.
- **HIGH — Link XSS:** Add `isSafeUrl()` denylist in the `Link` component blocking `javascript:`, `data:`, `vbscript:` schemes and protocol-relative URLs. Handles case variations and whitespace injection.
- **HIGH — Auth default-deny:** Undefined entitlements now return `false` instead of `true` in the access control system.
- **HIGH — Auth ownership:** `canWithResource()` validates `resource.ownerId` against `user.id` using nullish checks (empty string is allowed, `null`/`undefined` skip the check).
- **MEDIUM — JWT secret:** Auto-generate and persist a random dev JWT secret to `.vertz/jwt-secret` instead of using a hardcoded fallback. Production still requires explicit configuration.
- **MEDIUM — rawHtml docs:** Comprehensive XSS warning JSDoc on `rawHtml()` with safe/unsafe usage examples.

### Dropped after adversarial review
- **Env sanitization** — Dev server child process IS the user's app and needs full env access
- **Safe default returns** — `parse()`/`safeParse()` already discard values on error; changing would break type contracts

## Test plan

- [x] `packages/schema` — 3 new prototype pollution tests (passthrough, catchall, record) + legitimacy tests for `constructor`/`prototype` keys
- [x] `packages/ui` — 8 new Link XSS prevention tests (javascript:, case-insensitive, data:, vbscript:, protocol-relative, whitespace injection, click blocking, safe URLs)
- [x] `packages/server` — 9 new access control tests (default-deny, ownership validation) + 3 JWT secret tests (production throws, dev generates, dev reuses)
- [x] All package-level test suites pass with 0 failures
- [x] Full pre-push quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)