### PR TITLE
fix: harden security fixes after diverse area review [#855]

### DIFF
--- a/.changeset/security-audit-855.md
+++ b/.changeset/security-audit-855.md
@@ -1,0 +1,11 @@
+---
+'@vertz/schema': patch
+'@vertz/server': patch
+'@vertz/ui': patch
+---
+
+fix: address security audit findings — prototype pollution, Link XSS, auth hardening
+
+- **@vertz/schema**: Filter `__proto__` key in ObjectSchema passthrough/catchall and RecordSchema to prevent prototype pollution via `JSON.parse`
+- **@vertz/server**: Default-deny for undefined entitlements, ownership validation in `canWithResource()`, auto-generated dev JWT secret persisted to `.vertz/jwt-secret`
+- **@vertz/ui**: Block dangerous URL schemes (`javascript:`, `data:`, `vbscript:`) and protocol-relative URLs in Link component href

--- a/packages/schema/src/schemas/__tests__/object.test.ts
+++ b/packages/schema/src/schemas/__tests__/object.test.ts
@@ -3,6 +3,7 @@ import { ErrorCode, ParseError } from '../../core/errors';
 import { SchemaRegistry } from '../../core/registry';
 import { NumberSchema } from '../number';
 import { ObjectSchema } from '../object';
+import { AnySchema } from '../special';
 import { StringSchema } from '../string';
 
 describe('ObjectSchema', () => {
@@ -205,12 +206,12 @@ describe('ObjectSchema', () => {
   });
 
   it('.catchall() strips __proto__ key to prevent prototype pollution', () => {
-    const schema = new ObjectSchema({ name: new StringSchema() }).catchall(new StringSchema());
-    const malicious = JSON.parse('{"name":"Alice","__proto__":"injected","extra":"kept"}');
+    const schema = new ObjectSchema({ name: new StringSchema() }).catchall(new AnySchema());
+    const malicious = JSON.parse('{"name":"Alice","__proto__":{"polluted":true},"extra":"kept"}');
     const result = schema.parse(malicious);
-    // Even with a valid catchall value, __proto__ should be filtered
-    expect(Object.keys(result.data as object)).not.toContain('__proto__');
-    expect(result.data).toEqual({ name: 'Alice', extra: 'kept' });
+    // Without the filter, result["__proto__"] = {polluted:true} would change the prototype chain
+    expect((result.data as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
   });
 
   it('.catchall() overrides .strict() when chained', () => {

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -259,7 +259,16 @@ export function createAuth(config: AuthConfig): AuthInstance {
     } else {
       jwtSecret = crypto.randomUUID() + crypto.randomUUID();
       mkdirSync(secretDir, { recursive: true });
-      writeFileSync(secretFile, jwtSecret, 'utf-8');
+      try {
+        writeFileSync(secretFile, jwtSecret, { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
+      } catch (err: unknown) {
+        // Another process created the file first (race) — read theirs
+        if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+          jwtSecret = readFileSync(secretFile, 'utf-8').trim();
+        } else {
+          throw err;
+        }
+      }
       console.warn(
         `[Auth] Auto-generated dev JWT secret at ${secretFile}. Add this path to .gitignore.`,
       );

--- a/packages/ui/src/router/__tests__/link.test.ts
+++ b/packages/ui/src/router/__tests__/link.test.ts
@@ -193,6 +193,17 @@ describe('Link XSS prevention', () => {
     expect(el.getAttribute('href')).toBe('#');
   });
 
+  test('blocks javascript: with null byte injection', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety against untyped input
+    const el = Link({ children: 'XSS', href: '\0javascript:alert(1)' as any });
+
+    expect(el.getAttribute('href')).toBe('#');
+  });
+
   test('does not navigate to blocked URLs on click', () => {
     const currentPath = signal('/');
     const navigate = vi.fn();

--- a/packages/ui/src/router/link.ts
+++ b/packages/ui/src/router/link.ts
@@ -24,7 +24,7 @@ const DANGEROUS_SCHEMES = ['javascript:', 'data:', 'vbscript:'];
  * Blocks javascript:, data:, vbscript: schemes and protocol-relative URLs.
  */
 function isSafeUrl(url: string): boolean {
-  const normalized = url.replace(/\s/g, '').toLowerCase();
+  const normalized = url.replace(/[\s\0]/g, '').toLowerCase();
   if (normalized.startsWith('//')) return false;
   for (const scheme of DANGEROUS_SCHEMES) {
     if (normalized.startsWith(scheme)) return false;


### PR DESCRIPTION
## Summary

Hardening fixes from a diverse area review of #856. Four independent reviewers (security bypass, correctness, test quality, breaking changes) examined the PR and found these issues:

- **Null byte XSS bypass (Medium):** `\0javascript:alert(1)` passed `isSafeUrl` — Chrome strips null bytes before scheme resolution. Fixed by stripping `\0` in the regex: `/[\s\0]/g`
- **JWT secret world-readable (Medium):** `writeFileSync` used default `0o644` permissions. Fixed with `mode: 0o600` (owner-only) + `flag: 'wx'` (atomic create-or-fail, reads on race)
- **Catchall test false positive (High — test quality):** The `__proto__` catchall test used a string value (`"injected"`), but JS silently ignores string assignment to `result["__proto__"]` — both assertions passed *without* the fix. Switched to `AnySchema` with an object value so the test actually catches regressions
- **Missing changeset:** Added `.changeset/security-audit-855.md` for `@vertz/schema`, `@vertz/server`, `@vertz/ui`

## Test plan

- [x] Verified catchall test is no longer false positive (removed fix → test fails with `Received: true`)
- [x] New null byte injection test for Link XSS
- [x] All package test suites pass: schema (367), ui (1349), server (361)
- [x] Full pre-push quality gates pass (64/64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)