### PR TITLE
fix: address second-pass security audit findings [#858]

### DIFF
--- a/.changeset/security-audit-pass2-858.md
+++ b/.changeset/security-audit-pass2-858.md
@@ -1,0 +1,7 @@
+---
+'@vertz/server': patch
+'@vertz/ui': patch
+'@vertz/schema': patch
+---
+
+fix: address second-pass security audit findings — hidden field stripping in action pipeline, CSS value sanitization, empty string coercion guard

--- a/packages/schema/src/schemas/__tests__/coerced.test.ts
+++ b/packages/schema/src/schemas/__tests__/coerced.test.ts
@@ -32,6 +32,28 @@ describe('CoercedNumberSchema', () => {
     expect(schema.parse(true).data).toBe(1);
     expect(schema.parse(false).data).toBe(0);
   });
+
+  it('rejects empty string instead of coercing to 0', () => {
+    const schema = new CoercedNumberSchema();
+    const result = schema.safeParse('');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects whitespace-only string instead of coercing to 0', () => {
+    const schema = new CoercedNumberSchema();
+    const result = schema.safeParse('  ');
+    expect(result.ok).toBe(false);
+  });
+
+  it('still coerces "0" to 0', () => {
+    const schema = new CoercedNumberSchema();
+    expect(schema.parse('0').data).toBe(0);
+  });
+
+  it('still coerces "3.14" to 3.14', () => {
+    const schema = new CoercedNumberSchema();
+    expect(schema.parse('3.14').data).toBe(3.14);
+  });
 });
 
 describe('CoercedBooleanSchema', () => {

--- a/packages/schema/src/schemas/coerced.ts
+++ b/packages/schema/src/schemas/coerced.ts
@@ -19,6 +19,13 @@ export class CoercedStringSchema extends StringSchema {
 
 export class CoercedNumberSchema extends NumberSchema {
   _parse(value: unknown, ctx: ParseContext): number {
+    if (typeof value === 'string' && value.trim() === '') {
+      ctx.addIssue({
+        code: ErrorCode.InvalidType,
+        message: 'Expected number, received empty string',
+      });
+      return 0;
+    }
     return super._parse(Number(value), ctx);
   }
 

--- a/packages/server/src/entity/__tests__/action-pipeline.test.ts
+++ b/packages/server/src/entity/__tests__/action-pipeline.test.ts
@@ -15,6 +15,7 @@ const tasksTable = d.table('tasks', {
   title: d.text(),
   status: d.text().default('pending'),
   assigneeId: d.uuid(),
+  passwordHash: d.text().is('hidden'),
   createdAt: d.timestamp().default('now').readOnly(),
 });
 
@@ -26,7 +27,13 @@ const tasksModel = d.model(tasksTable);
 
 function createStubDb() {
   const rows: Record<string, Record<string, unknown>> = {
-    'task-1': { id: 'task-1', title: 'Fix bug', status: 'pending', assigneeId: 'user-1' },
+    'task-1': {
+      id: 'task-1',
+      title: 'Fix bug',
+      status: 'pending',
+      assigneeId: 'user-1',
+      passwordHash: 'secret-hash',
+    },
   };
 
   return {
@@ -198,6 +205,69 @@ describe('Feature: action pipeline', () => {
         await handler(ctx, 'task-1', { reason: 'done' });
 
         expect(afterCompleteSpy).toHaveBeenCalledOnce();
+      });
+    });
+  });
+
+  describe('Given an entity with a hidden field and action with after hook', () => {
+    const afterCompleteSpy = mock();
+    const handlerSpy = mock(
+      async (_input: unknown, _ctx: unknown, row: Record<string, unknown> | null) => ({
+        done: true,
+        passwordHash: row?.passwordHash ?? 'leaked',
+      }),
+    );
+    const def = entity('tasks', {
+      model: tasksModel,
+      access: {
+        complete: () => true,
+      },
+      actions: {
+        complete: {
+          body: { parse: (v: unknown) => ({ ok: true as const, data: v as { reason: string } }) },
+          response: {
+            parse: (v: unknown) => ({
+              ok: true as const,
+              data: v as { done: boolean; passwordHash?: string },
+            }),
+          },
+          handler: handlerSpy,
+        },
+      },
+      after: {
+        complete: afterCompleteSpy,
+      } as any,
+    });
+
+    describe('When the action completes and handler returns hidden fields', () => {
+      it('Then after hook receives result with hidden fields stripped', async () => {
+        afterCompleteSpy.mockClear();
+        handlerSpy.mockClear();
+        const db = createStubDb();
+        const handler = createActionHandler(def, 'complete', def.actions.complete, db, true);
+        const ctx = makeCtx();
+
+        await handler(ctx, 'task-1', { reason: 'done' });
+
+        expect(afterCompleteSpy).toHaveBeenCalledOnce();
+        const [hookResult] = afterCompleteSpy.mock.calls[0]!;
+        expect(hookResult).not.toHaveProperty('passwordHash');
+        expect(hookResult).toHaveProperty('done', true);
+      });
+
+      it('Then response body does NOT contain the hidden field', async () => {
+        handlerSpy.mockClear();
+        const db = createStubDb();
+        const handler = createActionHandler(def, 'complete', def.actions.complete, db, true);
+        const ctx = makeCtx();
+
+        const result = await handler(ctx, 'task-1', { reason: 'done' });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.data.body).not.toHaveProperty('passwordHash');
+          expect(result.data.body).toHaveProperty('done', true);
+        }
       });
     });
   });

--- a/packages/server/src/entity/action-pipeline.ts
+++ b/packages/server/src/entity/action-pipeline.ts
@@ -8,6 +8,7 @@ import {
 } from '@vertz/errors';
 import { enforceAccess } from './access-enforcer';
 import type { CrudResult, EntityDbAdapter } from './crud-pipeline';
+import { stripHiddenFields } from './field-filter';
 import type { EntityActionDef, EntityContext, EntityDefinition } from './types';
 
 /**
@@ -50,7 +51,14 @@ export function createActionHandler(
     const input = parseResult.data;
 
     // Run the handler
-    const result = await actionDef.handler(input, ctx, row);
+    const rawResult = await actionDef.handler(input, ctx, row);
+
+    // Strip hidden fields from the result before exposing to hooks or response
+    const table = def.model.table;
+    const result =
+      rawResult && typeof rawResult === 'object' && !Array.isArray(rawResult)
+        ? stripHiddenFields(table, rawResult as Record<string, unknown>)
+        : rawResult;
 
     // Fire after hook (fire-and-forget)
     const afterHooks = def.after as Record<string, ((...args: unknown[]) => void) | undefined>;

--- a/packages/ui/src/css/__tests__/theme.test.ts
+++ b/packages/ui/src/css/__tests__/theme.test.ts
@@ -202,6 +202,82 @@ describe('compileTheme()', () => {
     expect(() => compileTheme(theme)).not.toThrow();
   });
 
+  it('strips semicolons from values to prevent CSS property injection', () => {
+    const theme = defineTheme({
+      colors: {
+        danger: { 500: 'red; } body { background: url(evil)' },
+      },
+    });
+    const { css } = compileTheme(theme);
+    // Extract the value portion — should not contain injected semicolons or braces
+    const valueMatch = css.match(/--color-danger-500:\s*([^;]+)/);
+    expect(valueMatch).not.toBeNull();
+    expect(valueMatch?.[1]?.trim()).not.toContain(';');
+    expect(valueMatch?.[1]?.trim()).not.toContain('}');
+    expect(valueMatch?.[1]?.trim()).toContain('red');
+  });
+
+  it('strips curly braces from values to prevent CSS rule breakout', () => {
+    const theme = defineTheme({
+      colors: {
+        danger: { 500: 'red } .evil { color: green' },
+      },
+    });
+    const { css } = compileTheme(theme);
+    // Only structural braces from :root { ... }, not injected ones
+    const valueMatch = css.match(/--color-danger-500:\s*([^;]+)/);
+    expect(valueMatch?.[1]?.trim()).not.toContain('}');
+    expect(valueMatch?.[1]?.trim()).not.toContain('{');
+  });
+
+  it('strips url( from values to prevent resource loading', () => {
+    const theme = defineTheme({
+      colors: {
+        background: { DEFAULT: 'url(https://evil.com/tracker.png)' },
+      },
+    });
+    const { css } = compileTheme(theme);
+    expect(css).not.toContain('url(');
+  });
+
+  it('strips expression( from values to prevent IE expression injection', () => {
+    const theme = defineTheme({
+      colors: {
+        background: { DEFAULT: 'expression(alert(1))' },
+      },
+    });
+    const { css } = compileTheme(theme);
+    expect(css).not.toContain('expression(');
+  });
+
+  it('strips @import from values to prevent stylesheet injection', () => {
+    const theme = defineTheme({
+      colors: {
+        background: { DEFAULT: '@import "https://evil.com/styles.css"' },
+      },
+    });
+    const { css } = compileTheme(theme);
+    expect(css).not.toContain('@import');
+  });
+
+  it('passes through normal CSS values unchanged', () => {
+    const theme = defineTheme({
+      colors: {
+        primary: { 500: '#ff0000' },
+        background: { DEFAULT: 'white' },
+      },
+      spacing: {
+        sm: '0.5rem',
+        scale: '1.5',
+      },
+    });
+    const { css } = compileTheme(theme);
+    expect(css).toContain('--color-primary-500: #ff0000');
+    expect(css).toContain('--color-background: white');
+    expect(css).toContain('--spacing-sm: 0.5rem');
+    expect(css).toContain('--spacing-scale: 1.5');
+  });
+
   it('returns token map with all flat token paths', () => {
     const theme = defineTheme({
       colors: {

--- a/packages/ui/src/css/theme.ts
+++ b/packages/ui/src/css/theme.ts
@@ -51,6 +51,20 @@ export interface CompiledTheme {
   tokens: string[];
 }
 
+// ─── Sanitization ──────────────────────────────────────────────
+
+/**
+ * Sanitize a CSS value to prevent injection attacks.
+ * Strips characters and patterns that could break out of a CSS property value.
+ */
+function sanitizeCssValue(value: string): string {
+  return value
+    .replace(/[;{}]/g, '')
+    .replace(/url\s*\(/gi, '')
+    .replace(/expression\s*\(/gi, '')
+    .replace(/@import/gi, '');
+}
+
 // ─── defineTheme ────────────────────────────────────────────────
 
 /**
@@ -112,19 +126,19 @@ export function compileTheme(theme: Theme): CompiledTheme {
       if (key === 'DEFAULT') {
         // Contextual token: default value goes in :root
         const varName = `--color-${name}`;
-        rootVars.push(`  ${varName}: ${value};`);
+        rootVars.push(`  ${varName}: ${sanitizeCssValue(value)};`);
         tokenPaths.push(name);
       } else if (key.startsWith('_')) {
         // Contextual variant (e.g., _dark)
         const variant = key.slice(1); // Remove leading underscore
         const varName = `--color-${name}`;
         if (variant === 'dark') {
-          darkVars.push(`  ${varName}: ${value};`);
+          darkVars.push(`  ${varName}: ${sanitizeCssValue(value)};`);
         }
       } else {
         // Raw token shade (e.g., 500, 600)
         const varName = `--color-${name}-${key}`;
-        rootVars.push(`  ${varName}: ${value};`);
+        rootVars.push(`  ${varName}: ${sanitizeCssValue(value)};`);
         tokenPaths.push(`${name}.${key}`);
       }
     }
@@ -134,7 +148,7 @@ export function compileTheme(theme: Theme): CompiledTheme {
   if (theme.spacing) {
     for (const [name, value] of Object.entries(theme.spacing)) {
       const varName = `--spacing-${name}`;
-      rootVars.push(`  ${varName}: ${value};`);
+      rootVars.push(`  ${varName}: ${sanitizeCssValue(value)};`);
       tokenPaths.push(`spacing.${name}`);
     }
   }


### PR DESCRIPTION
## Summary

- **Action pipeline hidden field stripping**: `action-pipeline.ts` now calls `stripHiddenFields()` on handler results before passing to after hooks and returning in the response body — matching the pattern in `crud-pipeline.ts`
- **CSS value sanitization**: `compileTheme()` now sanitizes all interpolated values via `sanitizeCssValue()`, stripping `;`, `{}`, `url(`, `expression(`, and `@import` to prevent CSS injection
- **Empty string coercion guard**: `CoercedNumberSchema` now rejects empty/whitespace-only strings instead of silently coercing them to `0`

Closes #858

## Test plan

- [x] Action pipeline: hidden field stripped from after hook args and response body
- [x] CSS: semicolons, braces, `url(`, `expression(`, `@import` all stripped; normal values pass through
- [x] Schema: `""` and `"  "` rejected; `"0"` and `"3.14"` still coerce correctly
- [x] All quality gates pass (tests, typecheck, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)