### PR TITLE
chore: gitignore cleanup + remove abandoned file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ data/
 .wrangler/
 :memory:
 .vertz/
+
+# Claude Code
+.claude/worktrees/
+.mcp.json


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` and `.mcp.json` to `.gitignore` (machine-specific Claude Code files)
- Delete abandoned `packages/db/src/schema/define-flags.ts` (superseded by the annotations API)

## Test plan
- [x] Quality gates pass (lint, typecheck, test, build — all cached/green)
- [x] Verify `.claude/worktrees/` and `.mcp.json` no longer show in `git status`
- [x] Verify `define-flags.ts` is removed from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)