### PR TITLE
feat(ui): add refetchInterval to query()

### DIFF
--- a/packages/ui/src/query/__tests__/query.test.ts
+++ b/packages/ui/src/query/__tests__/query.test.ts
@@ -1289,4 +1289,136 @@ describe('query()', () => {
 
     result.dispose();
   });
+
+  test('refetchInterval function receives data and iteration count', async () => {
+    const intervals: Array<{ data: string | undefined; iteration: number }> = [];
+    let callCount = 0;
+
+    const result = query(
+      () => {
+        callCount++;
+        return Promise.resolve(`call-${callCount}`);
+      },
+      {
+        key: 'interval-fn',
+        refetchInterval: (data, iteration) => {
+          intervals.push({ data, iteration });
+          // Exponential backoff: 1s, 2s, 4s
+          return 1000 * 2 ** iteration;
+        },
+      },
+    );
+
+    // Initial fetch
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(result.data.value).toBe('call-1');
+    // First schedule: iteration=0, data='call-1' → 1000ms
+    expect(intervals[0]).toEqual({ data: 'call-1', iteration: 0 });
+
+    // After 1s, poll fires
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.data.value).toBe('call-2');
+    // Second schedule: iteration=1, data='call-2' → 2000ms
+    expect(intervals[1]).toEqual({ data: 'call-2', iteration: 1 });
+
+    // After 2s, poll fires
+    vi.advanceTimersByTime(2000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.data.value).toBe('call-3');
+    // Third schedule: iteration=2, data='call-3' → 4000ms
+    expect(intervals[2]).toEqual({ data: 'call-3', iteration: 2 });
+
+    result.dispose();
+  });
+
+  test('refetchInterval function returning false stops polling', async () => {
+    let callCount = 0;
+
+    const result = query(
+      () => {
+        callCount++;
+        return Promise.resolve(callCount >= 3 ? 'done' : 'pending');
+      },
+      {
+        key: 'interval-fn-stop',
+        refetchInterval: (data) => {
+          if (data === 'done') return false;
+          return 1000;
+        },
+      },
+    );
+
+    // Initial fetch → 'pending'
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(result.data.value).toBe('pending');
+
+    // Poll 1 → 'pending'
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.data.value).toBe('pending');
+
+    // Poll 2 → 'done' → function returns false → polling stops
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.data.value).toBe('done');
+
+    // No more polls
+    vi.advanceTimersByTime(10000);
+    await Promise.resolve();
+    expect(callCount).toBe(3);
+
+    result.dispose();
+  });
+
+  test('iteration resets to 0 after refetchInterval returns false', async () => {
+    let callCount = 0;
+    const iterations: number[] = [];
+
+    const result = query(
+      () => {
+        callCount++;
+        // Stop after 2 polls, then manual refetch restarts
+        return Promise.resolve(callCount === 2 ? 'done' : 'pending');
+      },
+      {
+        key: 'interval-fn-reset',
+        refetchInterval: (data, iteration) => {
+          iterations.push(iteration);
+          if (data === 'done') return false;
+          return 1000;
+        },
+      },
+    );
+
+    // Initial fetch
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(iterations).toEqual([0]); // iteration=0
+
+    // Poll → 'done' → false → stops
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.data.value).toBe('done');
+    expect(iterations).toEqual([0, 1]); // iteration=1, returned false
+
+    // Manual refetch → restarts polling
+    callCount = 0; // reset so next call returns 'pending'
+    result.refetch();
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Iteration should have reset to 0
+    expect(iterations[2]).toBe(0);
+
+    result.dispose();
+  });
 });

--- a/packages/ui/src/query/query.ts
+++ b/packages/ui/src/query/query.ts
@@ -37,8 +37,17 @@ export interface QueryOptions<T> {
   cache?: CacheStore<T>;
   /** Timeout in ms for SSR data loading. Default: 300. Set to 0 to disable. */
   ssrTimeout?: number;
-  /** Polling interval in ms. When set, the query re-fetches automatically. 0 or false disables. */
-  refetchInterval?: number | false;
+  /**
+   * Polling interval in ms, or a function for dynamic intervals.
+   *
+   * - `number` — fixed interval in ms
+   * - `false` or `0` — disabled
+   * - `(data, iteration) => number | false` — called after each fetch to
+   *   determine the next interval. Return `false` to stop polling.
+   *   `iteration` counts polls since the last start/restart (resets to 0
+   *   when the function returns `false`).
+   */
+  refetchInterval?: number | false | ((data: T | undefined, iteration: number) => number | false);
 }
 
 /** The reactive object returned by query(). */
@@ -289,10 +298,11 @@ export function query<T, E = unknown>(
   let fetchId = 0;
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   let intervalTimer: ReturnType<typeof setTimeout> | undefined;
-  const intervalMs =
-    typeof options.refetchInterval === 'number' && options.refetchInterval > 0
-      ? options.refetchInterval
-      : 0;
+  const refetchIntervalOption = options.refetchInterval;
+  const hasInterval =
+    typeof refetchIntervalOption === 'function' ||
+    (typeof refetchIntervalOption === 'number' && refetchIntervalOption > 0);
+  let intervalIteration = 0;
 
   // Track all in-flight keys for this query instance so dispose() can clean them all.
   const inflightKeys = new Set<string>();
@@ -306,17 +316,31 @@ export function query<T, E = unknown>(
   let intervalPaused = false;
 
   function scheduleInterval(): void {
-    if (intervalMs > 0 && !isSSR() && !intervalPaused) {
-      clearTimeout(intervalTimer);
-      intervalTimer = setTimeout(() => {
-        refetch();
-      }, intervalMs);
+    if (!hasInterval || isSSR() || intervalPaused) return;
+
+    let ms: number | false;
+    if (typeof refetchIntervalOption === 'function') {
+      ms = refetchIntervalOption(data.peek() as T | undefined, intervalIteration);
+    } else {
+      ms = refetchIntervalOption as number;
     }
+
+    if (ms === false || ms <= 0) {
+      // Stop polling and reset iteration for next restart.
+      intervalIteration = 0;
+      return;
+    }
+
+    intervalIteration++;
+    clearTimeout(intervalTimer);
+    intervalTimer = setTimeout(() => {
+      refetch();
+    }, ms);
   }
 
   // Visibility-based pause/resume for polling
   let visibilityHandler: (() => void) | undefined;
-  if (intervalMs > 0 && enabled && !isSSR() && typeof document !== 'undefined') {
+  if (hasInterval && enabled && !isSSR() && typeof document !== 'undefined') {
     visibilityHandler = () => {
       if (document.visibilityState === 'hidden') {
         intervalPaused = true;


### PR DESCRIPTION
## Summary

- Adds `refetchInterval` option to `query()` in `@vertz/ui` for automatic polling
- Uses `setTimeout` (not `setInterval`) to prevent stacking — next poll only schedules after current fetch completes
- Pauses polling when `document.visibilityState === 'hidden'`, resumes + immediately refetches when tab becomes visible
- Cleans up timer and visibility listener on dispose / scope cleanup
- Continues polling after failed fetches (error recovery)
- No polling during SSR, when `enabled: false`, or when `refetchInterval` is `0` / `false`

Closes #816

## Test plan

- [x] Basic polling at specified interval (3s)
- [x] `refetchInterval: false` disables polling
- [x] `refetchInterval: 0` disables polling
- [x] `enabled: false` with `refetchInterval` does not poll
- [x] Dispose stops polling
- [x] Auto-dispose via scope cleanup stops polling
- [x] No stacking — slow fetch delays next poll
- [x] In-flight poll on dispose is silently ignored (no errors)
- [x] Polling continues after a failed fetch
- [x] Visibility-based pause when tab hidden, resume + refetch on visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)