### PR TITLE
feat(ui): dialog stack — imperative, promise-based dialog management

### DIFF
--- a/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
+++ b/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createContext, getContextScope, useContext } from '../../component/context';
+import type { DialogHandle, DialogStack } from '../dialog-stack';
+import {
+  createDialogStack,
+  DialogDismissedError,
+  DialogStackContext,
+  useDialogStack,
+} from '../dialog-stack';
+
+describe('DialogStack', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('opens a dialog and resolves with the close value', async () => {
+    const stack = createDialogStack(container);
+
+    function ConfirmDialog({
+      message,
+      dialog,
+    }: {
+      message: string;
+      dialog: DialogHandle<boolean>;
+    }) {
+      const el = document.createElement('div');
+      el.textContent = message;
+      const btn = document.createElement('button');
+      btn.textContent = 'OK';
+      btn.addEventListener('click', () => dialog.close(true));
+      el.appendChild(btn);
+      return el;
+    }
+
+    const result = stack.open(ConfirmDialog, { message: 'Are you sure?' });
+
+    expect(container.textContent).toContain('Are you sure?');
+
+    container.querySelector('button')!.click();
+
+    expect(await result).toBe(true);
+  });
+
+  it('tracks stack size', async () => {
+    const stack = createDialogStack(container);
+
+    function DialogA({ dialog }: { dialog: DialogHandle<void> }) {
+      const el = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-testid', 'close-a');
+      btn.addEventListener('click', () => dialog.close());
+      el.appendChild(btn);
+      return el;
+    }
+
+    function DialogB({ dialog }: { dialog: DialogHandle<void> }) {
+      const el = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-testid', 'close-b');
+      btn.addEventListener('click', () => dialog.close());
+      el.appendChild(btn);
+      return el;
+    }
+
+    expect(stack.size).toBe(0);
+
+    const r1 = stack.open(DialogA, {});
+    expect(stack.size).toBe(1);
+
+    const r2 = stack.open(DialogB, {});
+    expect(stack.size).toBe(2);
+
+    container.querySelector('[data-testid="close-b"]')!.click();
+    await r2;
+    expect(stack.size).toBe(1);
+
+    container.querySelector('[data-testid="close-a"]')!.click();
+    await r1;
+    expect(stack.size).toBe(0);
+  });
+
+  it('sets data-state attributes on wrapper elements', () => {
+    const stack = createDialogStack(container);
+
+    function DialogA({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    function DialogB({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    stack.open(DialogA, {});
+    const wrapperA = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+    expect(wrapperA.getAttribute('data-state')).toBe('open');
+
+    stack.open(DialogB, {});
+    expect(wrapperA.getAttribute('data-state')).toBe('background');
+
+    const wrapperB = container.querySelectorAll('[data-dialog-wrapper]')[1] as HTMLElement;
+    expect(wrapperB.getAttribute('data-state')).toBe('open');
+  });
+
+  it('sets data-dialog-depth attributes', () => {
+    const stack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    stack.open(SimpleDialog, {});
+    const wrapperA = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+    expect(wrapperA.getAttribute('data-dialog-depth')).toBe('0');
+
+    stack.open(SimpleDialog, {});
+    expect(wrapperA.getAttribute('data-dialog-depth')).toBe('1');
+
+    const wrapperB = container.querySelectorAll('[data-dialog-wrapper]')[1] as HTMLElement;
+    expect(wrapperB.getAttribute('data-dialog-depth')).toBe('0');
+  });
+
+  it('reveals previous dialog when top dialog closes', async () => {
+    const stack = createDialogStack(container);
+
+    function DialogA({ dialog }: { dialog: DialogHandle<string> }) {
+      const el = document.createElement('div');
+      el.setAttribute('data-testid', 'dialog-a');
+      return el;
+    }
+
+    function DialogB({ dialog }: { dialog: DialogHandle<void> }) {
+      const el = document.createElement('div');
+      el.setAttribute('data-testid', 'dialog-b');
+      const btn = document.createElement('button');
+      btn.addEventListener('click', () => dialog.close());
+      el.appendChild(btn);
+      return el;
+    }
+
+    stack.open(DialogA, {});
+    const wrapperA = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+
+    const resultB = stack.open(DialogB, {});
+    expect(wrapperA.getAttribute('data-state')).toBe('background');
+
+    container.querySelector('[data-testid="dialog-b"] button')!.click();
+    await resultB;
+
+    expect(wrapperA.getAttribute('data-state')).toBe('open');
+  });
+
+  it('closeAll dismisses all dialogs with DialogDismissedError', async () => {
+    const stack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    const r1 = stack.open(SimpleDialog, {});
+    const r2 = stack.open(SimpleDialog, {});
+    expect(stack.size).toBe(2);
+
+    stack.closeAll();
+
+    await expect(r1).rejects.toBeInstanceOf(DialogDismissedError);
+    await expect(r2).rejects.toBeInstanceOf(DialogDismissedError);
+    expect(stack.size).toBe(0);
+  });
+
+  it('supports void result — close() with no arguments', async () => {
+    const stack = createDialogStack(container);
+
+    function InfoDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      const btn = document.createElement('button');
+      btn.addEventListener('click', () => dialog.close());
+      return btn;
+    }
+
+    const result = stack.open(InfoDialog, {});
+    container.querySelector('button')!.click();
+
+    expect(await result).toBeUndefined();
+  });
+
+  it('renders dialog within captured context scope', () => {
+    const stack = createDialogStack(container);
+    const ProjectContext = createContext<string>();
+    let capturedProject: string | undefined;
+
+    function ConfirmDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      capturedProject = useContext(ProjectContext);
+      return document.createElement('div');
+    }
+
+    // Capture scope inside a Provider (simulates useDialogStack during component init)
+    let scope: ReturnType<typeof getContextScope>;
+    ProjectContext.Provider('my-project', () => {
+      scope = getContextScope();
+    });
+
+    // Open with the captured scope — outside any Provider (simulates event handler)
+    stack.openWithScope(ConfirmDialog, {}, scope!);
+
+    expect(capturedProject).toBe('my-project');
+  });
+
+  it('removes wrapper from DOM after close', async () => {
+    const stack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      const btn = document.createElement('button');
+      btn.addEventListener('click', () => dialog.close());
+      return btn;
+    }
+
+    const result = stack.open(SimpleDialog, {});
+    expect(container.querySelectorAll('[data-dialog-wrapper]').length).toBe(1);
+
+    container.querySelector('button')!.click();
+    await result;
+
+    expect(container.querySelectorAll('[data-dialog-wrapper]').length).toBe(0);
+  });
+
+  it('useDialogStack throws outside DialogStackContext', () => {
+    expect(() => useDialogStack()).toThrow(
+      'useDialogStack() must be called within DialogStackProvider',
+    );
+  });
+
+  it('useDialogStack returns a working stack when inside context', async () => {
+    const internalStack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<boolean> }) {
+      const btn = document.createElement('button');
+      btn.addEventListener('click', () => dialog.close(true));
+      return btn;
+    }
+
+    let dialogs: DialogStack;
+    DialogStackContext.Provider(internalStack, () => {
+      dialogs = useDialogStack();
+    });
+
+    const result = dialogs!.open(SimpleDialog, {});
+    container.querySelector('button')!.click();
+    expect(await result).toBe(true);
+  });
+
+  it('dismisses topmost dialog on Escape key', async () => {
+    const stack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    const result = stack.open(SimpleDialog, {});
+
+    const wrapper = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+    wrapper.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    await expect(result).rejects.toBeInstanceOf(DialogDismissedError);
+    expect(stack.size).toBe(0);
+  });
+
+  it('sets data-state="closed" immediately on close for exit animation', () => {
+    const stack = createDialogStack(container);
+
+    function SimpleDialog({ dialog }: { dialog: DialogHandle<boolean> }) {
+      const btn = document.createElement('button');
+      btn.addEventListener('click', () => dialog.close(true));
+      return btn;
+    }
+
+    stack.open(SimpleDialog, {});
+    const wrapper = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+    expect(wrapper.getAttribute('data-state')).toBe('open');
+
+    // Click close — data-state changes immediately for CSS animation
+    container.querySelector('button')!.click();
+    expect(wrapper.getAttribute('data-state')).toBe('closed');
+  });
+
+  it('does not close on Escape when not the topmost dialog', async () => {
+    const stack = createDialogStack(container);
+
+    function DialogA({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    function DialogB({ dialog }: { dialog: DialogHandle<void> }) {
+      return document.createElement('div');
+    }
+
+    stack.open(DialogA, {});
+    stack.open(DialogB, {});
+
+    // Dispatch Escape on dialog A's wrapper — should not dismiss A
+    const wrapperA = container.querySelector('[data-dialog-wrapper]') as HTMLElement;
+    wrapperA.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    // B should still be on top, stack size unchanged
+    // (In practice the focus trap prevents this, but the handler
+    // should only dismiss if the entry is the topmost)
+    expect(stack.size).toBe(2);
+  });
+
+  it('useDialogStack captures context scope eagerly for use in event handlers', () => {
+    const internalStack = createDialogStack(container);
+    const ProjectContext = createContext<string>();
+    let capturedProject: string | undefined;
+
+    function MyDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      capturedProject = useContext(ProjectContext);
+      return document.createElement('div');
+    }
+
+    let dialogs: DialogStack;
+    DialogStackContext.Provider(internalStack, () => {
+      ProjectContext.Provider('my-project', () => {
+        dialogs = useDialogStack();
+      });
+    });
+
+    // Called outside any Provider (simulates onClick handler)
+    dialogs!.open(MyDialog, {});
+
+    expect(capturedProject).toBe('my-project');
+  });
+});

--- a/packages/ui/src/dialog/dialog-stack.ts
+++ b/packages/ui/src/dialog/dialog-stack.ts
@@ -1,0 +1,241 @@
+import type { ContextScope } from '../component/context';
+import { createContext, getContextScope, setContextScope, useContext } from '../component/context';
+import { onAnimationsComplete } from '../dom/animation';
+import { popScope, pushScope, runCleanups } from '../runtime/disposal';
+import type { DisposeFn } from '../runtime/signal-types';
+
+// ── Context ──
+
+import type { Context } from '../component/context';
+
+export const DialogStackContext: Context<DialogStack> = createContext<DialogStack>();
+
+export function useDialogStack(): DialogStack {
+  const stack = useContext(DialogStackContext);
+  if (!stack) {
+    throw new Error('useDialogStack() must be called within DialogStackProvider');
+  }
+
+  // Capture scope NOW — during component factory execution.
+  // Event handlers (onClick etc.) run outside any Provider, so
+  // getContextScope() would return null there. By capturing here,
+  // every open() call uses the scope from initialization time.
+  const capturedScope = getContextScope();
+
+  return {
+    open<TResult, TProps>(
+      component: DialogComponent<TResult, TProps>,
+      props: TProps,
+    ): Promise<TResult> {
+      return stack.openWithScope(component, props, capturedScope);
+    },
+    openWithScope: stack.openWithScope,
+    get size() {
+      return stack.size;
+    },
+    closeAll() {
+      stack.closeAll();
+    },
+  };
+}
+
+// ── Public types ──
+
+export interface DialogHandle<TResult> {
+  close(...args: void extends TResult ? [] : [result: TResult]): void;
+}
+
+export type DialogComponent<TResult, TProps = Record<string, never>> = (
+  props: TProps & { dialog: DialogHandle<TResult> },
+) => Node;
+
+export class DialogDismissedError extends Error {
+  constructor() {
+    super('Dialog was dismissed');
+    this.name = 'DialogDismissedError';
+  }
+}
+
+export interface DialogStack {
+  open<TResult, TProps>(
+    component: DialogComponent<TResult, TProps>,
+    props: TProps,
+  ): Promise<TResult>;
+
+  /** @internal — used by useDialogStack() to pass captured context scope */
+  openWithScope<TResult, TProps>(
+    component: DialogComponent<TResult, TProps>,
+    props: TProps,
+    scope: ContextScope | null,
+  ): Promise<TResult>;
+
+  readonly size: number;
+
+  closeAll(): void;
+}
+
+// ── Internal types ──
+
+interface StackEntry {
+  id: number;
+  wrapper: HTMLDivElement;
+  node: Node;
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  cleanups: DisposeFn[];
+  dismissible: boolean;
+}
+
+// ── Implementation ──
+
+export function createDialogStack(container: HTMLElement): DialogStack {
+  const entries: StackEntry[] = [];
+  let nextId = 0;
+
+  function open<TResult, TProps>(
+    component: DialogComponent<TResult, TProps>,
+    props: TProps,
+    capturedScope?: ContextScope | null,
+  ): Promise<TResult> {
+    return new Promise<TResult>((resolve, reject) => {
+      // Background current top entry
+      if (entries.length > 0) {
+        entries[entries.length - 1]!.wrapper.setAttribute('data-state', 'background');
+      }
+
+      // Create wrapper
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('data-dialog-wrapper', '');
+      wrapper.setAttribute('data-state', 'open');
+      wrapper.setAttribute('data-dialog-depth', '0');
+
+      const entry: StackEntry = {
+        id: nextId++,
+        wrapper,
+        node: null!,
+        resolve: resolve as (result: unknown) => void,
+        reject,
+        cleanups: [],
+        dismissible: true,
+      };
+
+      // Render within captured context scope
+      const prevScope = setContextScope(capturedScope ?? null);
+      const scope = pushScope();
+
+      const handle: DialogHandle<TResult> = {
+        close: ((...args: unknown[]) => {
+          closeEntry(entry, args[0] as TResult);
+        }) as DialogHandle<TResult>['close'],
+      };
+
+      entry.node = component({ ...props, dialog: handle });
+
+      entry.cleanups = [...scope];
+      popScope();
+      setContextScope(prevScope);
+
+      // Escape key handler — only dismisses if this is the topmost entry
+      if (entry.dismissible) {
+        wrapper.addEventListener('keydown', (e: KeyboardEvent) => {
+          if (e.key === 'Escape' && entries[entries.length - 1] === entry) {
+            e.preventDefault();
+            e.stopPropagation();
+            dismissEntry(entry);
+          }
+        });
+      }
+
+      // Mount
+      wrapper.appendChild(entry.node);
+      container.appendChild(wrapper);
+      entries.push(entry);
+      updateDepthAttributes();
+    });
+  }
+
+  function closeEntry(entry: StackEntry, result: unknown): void {
+    const idx = entries.indexOf(entry);
+    if (idx === -1) return;
+
+    // Set closed state for exit animation
+    entry.wrapper.setAttribute('data-state', 'closed');
+
+    onAnimationsComplete(entry.wrapper, () => {
+      runCleanups(entry.cleanups);
+
+      if (entry.wrapper.parentNode === container) {
+        container.removeChild(entry.wrapper);
+      }
+
+      const entryIdx = entries.indexOf(entry);
+      if (entryIdx !== -1) {
+        entries.splice(entryIdx, 1);
+      }
+
+      // Reveal previous entry
+      if (entries.length > 0) {
+        entries[entries.length - 1]!.wrapper.setAttribute('data-state', 'open');
+      }
+      updateDepthAttributes();
+
+      entry.resolve(result);
+    });
+  }
+
+  function updateDepthAttributes(): void {
+    for (let i = 0; i < entries.length; i++) {
+      entries[i]!.wrapper.setAttribute('data-dialog-depth', String(entries.length - 1 - i));
+    }
+  }
+
+  return {
+    open<TResult, TProps>(
+      component: DialogComponent<TResult, TProps>,
+      props: TProps,
+    ): Promise<TResult> {
+      return open(component, props);
+    },
+    openWithScope<TResult, TProps>(
+      component: DialogComponent<TResult, TProps>,
+      props: TProps,
+      scope: ContextScope | null,
+    ): Promise<TResult> {
+      return open(component, props, scope);
+    },
+    get size() {
+      return entries.length;
+    },
+    closeAll() {
+      for (let i = entries.length - 1; i >= 0; i--) {
+        dismissEntry(entries[i]!);
+      }
+    },
+  };
+
+  function dismissEntry(entry: StackEntry): void {
+    const idx = entries.indexOf(entry);
+    if (idx === -1) return;
+
+    entry.wrapper.setAttribute('data-state', 'closed');
+    onAnimationsComplete(entry.wrapper, () => {
+      runCleanups(entry.cleanups);
+
+      if (entry.wrapper.parentNode === container) {
+        container.removeChild(entry.wrapper);
+      }
+
+      const entryIdx = entries.indexOf(entry);
+      if (entryIdx !== -1) {
+        entries.splice(entryIdx, 1);
+      }
+
+      if (entries.length > 0) {
+        entries[entries.length - 1]!.wrapper.setAttribute('data-state', 'open');
+      }
+      updateDepthAttributes();
+
+      entry.reject(new DialogDismissedError());
+    });
+  }
+}

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -1,0 +1,7 @@
+export type { DialogComponent, DialogHandle, DialogStack } from './dialog-stack';
+export {
+  createDialogStack,
+  DialogDismissedError,
+  DialogStackContext,
+  useDialogStack,
+} from './dialog-stack';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,7 +12,6 @@ export type { Ref } from './component/refs';
 export { ref } from './component/refs';
 export type { SuspenseProps } from './component/suspense';
 export { Suspense } from './component/suspense';
-
 // CSS & Theming
 export type {
   ColorPalette,
@@ -61,6 +60,14 @@ export {
   zoomIn,
   zoomOut,
 } from './css';
+// Dialog stack
+export type { DialogComponent, DialogHandle, DialogStack } from './dialog';
+export {
+  createDialogStack,
+  DialogDismissedError,
+  DialogStackContext,
+  useDialogStack,
+} from './dialog';
 // Render adapter
 export type { RenderAdapter, RenderElement, RenderNode, RenderText } from './dom/adapter';
 export { getAdapter, isRenderNode, RENDER_NODE_BRAND, setAdapter } from './dom/adapter';


### PR DESCRIPTION
## Summary

Implements the core Dialog Stack feature for `@vertz/ui` as designed in `plans/dialog-stack.md` (PR #870).

- **`createDialogStack(container)`** — creates a stack instance that manages dialog lifecycle
- **`dialogs.open(Component, props)`** → `Promise<TResult>` — opens a dialog, resolves when closed
- **`useDialogStack()`** — hook with eager context capture at component init time (works in event handlers)
- **`DialogStackContext`** — context for Provider pattern
- **Push/pop stack** — `data-state` attributes (`open`/`background`/`closed`) for CSS animations
- **`data-dialog-depth`** — stacking order attribute for CSS targeting
- **Animation support** — `data-state="closed"` set immediately, DOM removal deferred via `onAnimationsComplete()`
- **Escape dismissal** — topmost dialog only, rejects with `DialogDismissedError`
- **`closeAll()`** — dismisses all dialogs with `DialogDismissedError`
- **Prop-based `DialogHandle<TResult>`** — zero-cast type safety, TResult flows naturally

### Context inheritance

`useDialogStack()` captures the context scope eagerly during component initialization (when Providers are on the call stack). This captured scope is restored when `open()` renders the dialog — even when called from an `onClick` handler where `getContextScope()` would normally return `null`.

## Test plan

- [x] 15 tests covering:
  - Open/close with promise resolution
  - Stack size tracking
  - data-state attributes (open/background/closed)
  - data-dialog-depth attributes
  - Reveal previous dialog on close
  - closeAll with DialogDismissedError
  - Void result (no-argument close)
  - DOM cleanup after close
  - Escape key dismissal (topmost only)
  - Escape ignored for non-topmost dialog
  - Animation state on close
  - useDialogStack throws outside context
  - useDialogStack works inside context
  - Eager context scope capture
  - Context inheritance via openWithScope
- [x] Typecheck clean
- [x] Biome lint clean
- [x] Full test suite (1369 tests, 0 failures)

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)