### PR TITLE
feat(entity-todo): add business logic examples with action() and entity hooks

### DIFF
--- a/examples/entity-todo/src/__tests__/api.test.ts
+++ b/examples/entity-todo/src/__tests__/api.test.ts
@@ -1,7 +1,9 @@
 import type { EntityDbAdapter } from '@vertz/server';
 import { createServer } from '@vertz/server';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { webhooks } from '../api/actions/webhooks/webhooks.action';
 import { todos } from '../api/entities/todos/todos.entity';
+import { clearEmailLog, getEmailLog } from '../api/services/notifications';
 
 // In-memory DB adapter for testing
 function createInMemoryDb(): EntityDbAdapter {
@@ -57,6 +59,7 @@ function createInMemoryDb(): EntityDbAdapter {
 function createTestApp(db: EntityDbAdapter) {
   return createServer({
     entities: [todos],
+    actions: [webhooks],
     db,
   });
 }
@@ -76,6 +79,10 @@ function request(
 }
 
 describe('Entity Todo API', () => {
+  beforeEach(() => {
+    clearEmailLog();
+  });
+
   it('creates a todo via POST /api/todos', async () => {
     const db = createInMemoryDb();
     const app = createTestApp(db);
@@ -165,5 +172,65 @@ describe('Entity Todo API', () => {
     // Response should be valid JSON
     const body = await res.text();
     expect(() => JSON.parse(body)).not.toThrow();
+  });
+
+  it('sends email notification when a todo is created', async () => {
+    const db = createInMemoryDb();
+    const app = createTestApp(db);
+    await request(app, 'POST', '/api/todos', { title: 'Notify me' });
+    const log = getEmailLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]?.to).toBe('team@example.com');
+    expect(log[0]?.subject).toContain('Notify me');
+  });
+
+  it('creates a todo via webhook task.created', async () => {
+    const db = createInMemoryDb();
+    const app = createTestApp(db);
+    const res = await request(app, 'POST', '/api/webhooks/sync', {
+      event: 'task.created',
+      task: { externalId: 'ext-1', title: 'From webhook', completed: false },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.todoId).toBeDefined();
+
+    // Verify the todo was actually created
+    const listRes = await request(app, 'GET', '/api/todos');
+    const list = (await listRes.json()) as { items: Record<string, unknown>[] };
+    expect(list.items.some((t) => t.title === 'From webhook')).toBe(true);
+  });
+
+  it('marks a todo complete via webhook task.completed', async () => {
+    const db = createInMemoryDb();
+    const app = createTestApp(db);
+    // Create a todo first
+    await request(app, 'POST', '/api/todos', { title: 'Complete me', completed: false });
+
+    // Send webhook to mark it complete
+    const res = await request(app, 'POST', '/api/webhooks/sync', {
+      event: 'task.completed',
+      task: { externalId: 'ext-2', title: 'Complete me', completed: true },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.todoId).toBeDefined();
+
+    // Verify the todo was updated
+    const getRes = await request(app, 'GET', `/api/todos/${body.todoId}`);
+    const todo = (await getRes.json()) as Record<string, unknown>;
+    expect(todo.completed).toBe(true);
+  });
+
+  it('returns 400 for invalid webhook payload', async () => {
+    const db = createInMemoryDb();
+    const app = createTestApp(db);
+    const res = await request(app, 'POST', '/api/webhooks/sync', {
+      event: 'invalid.event',
+      task: { title: 'Bad' },
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/examples/entity-todo/src/api/actions/webhooks/webhooks.action.ts
+++ b/examples/entity-todo/src/api/actions/webhooks/webhooks.action.ts
@@ -1,0 +1,51 @@
+import { s } from '@vertz/schema';
+import { action } from '@vertz/server';
+import { todos } from '../../entities/todos/todos.entity';
+
+const webhookEvents = ['task.created', 'task.completed'] as const;
+
+const syncBody = s.object({
+  event: s.enum(webhookEvents),
+  task: s.object({
+    externalId: s.string(),
+    title: s.string(),
+    completed: s.boolean(),
+  }),
+});
+
+const syncResponse = s.object({
+  ok: s.boolean(),
+  todoId: s.string().optional(),
+});
+
+export const webhooks = action('webhooks', {
+  inject: { todos },
+  // Open access for demo — production would validate a webhook secret header
+  access: { sync: () => true },
+  actions: {
+    sync: {
+      body: syncBody,
+      response: syncResponse,
+      handler: async (input, ctx) => {
+        if (input.event === 'task.created') {
+          const created = await ctx.entities.todos.create({
+            title: input.task.title,
+            completed: input.task.completed,
+          });
+          return { ok: true, todoId: created.id as string };
+        }
+
+        // task.completed — find by title and mark complete
+        const existing = await ctx.entities.todos.list({
+          where: { title: input.task.title },
+        });
+        const match = (existing.items as Record<string, unknown>[])[0];
+        if (!match) {
+          return { ok: false };
+        }
+        await ctx.entities.todos.update(match.id as string, { completed: true });
+        return { ok: true, todoId: match.id as string };
+      },
+    },
+  },
+});

--- a/examples/entity-todo/src/api/entities/todos/todos.entity.ts
+++ b/examples/entity-todo/src/api/entities/todos/todos.entity.ts
@@ -1,5 +1,6 @@
 import { entity } from '@vertz/server';
 import { todosModel } from '../../schema';
+import { sendEmail } from '../../services/notifications';
 
 export const todos = entity('todos', {
   model: todosModel,
@@ -9,5 +10,14 @@ export const todos = entity('todos', {
     create: () => true,
     update: () => true,
     delete: () => true,
+  },
+  after: {
+    create: (result) => {
+      sendEmail({
+        to: 'team@example.com',
+        subject: `New todo created: ${result.title}`,
+        body: `A new todo "${result.title}" was created (id: ${result.id}).`,
+      });
+    },
   },
 });

--- a/examples/entity-todo/src/api/server.ts
+++ b/examples/entity-todo/src/api/server.ts
@@ -1,4 +1,5 @@
 import { createServer } from '@vertz/server';
+import { webhooks } from './actions/webhooks/webhooks.action';
 import { createTodosDb } from './db';
 import { todos } from './entities/todos/todos.entity';
 
@@ -7,6 +8,7 @@ const todosDbAdapter = createTodosDb();
 const app = createServer({
   basePath: '/api',
   entities: [todos],
+  actions: [webhooks],
   db: todosDbAdapter,
 });
 

--- a/examples/entity-todo/src/api/services/notifications.ts
+++ b/examples/entity-todo/src/api/services/notifications.ts
@@ -1,0 +1,28 @@
+interface Email {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+interface EmailLogEntry extends Email {
+  sentAt: string;
+}
+
+const emailLog: EmailLogEntry[] = [];
+
+export function sendEmail(email: Email): void {
+  const entry: EmailLogEntry = {
+    ...email,
+    sentAt: new Date().toISOString(),
+  };
+  emailLog.push(entry);
+  console.log(`[email] To: ${email.to} | Subject: ${email.subject}`);
+}
+
+export function getEmailLog(): readonly EmailLogEntry[] {
+  return emailLog;
+}
+
+export function clearEmailLog(): void {
+  emailLog.length = 0;
+}


### PR DESCRIPTION
## Summary

- Add email notification service (mock) and wire it as an `after.create` hook on the todos entity — demonstrates entity hooks as the integration point for side effects
- Add webhook action (`POST /api/webhooks/sync`) that accepts external task events and creates/updates todos via entity injection — demonstrates `action()` with real business logic
- Wire the webhook action into the server config (`actions: [webhooks]`)
- Add 4 new test cases covering notification, webhook create/complete, and invalid payload validation

This shows how `entity()` and `action()` work together in a real app, addressing feedback that it was unclear how to handle business logic (external integrations, notifications) now that modules/services were removed.

## Test plan

- [x] `cd examples/entity-todo && bun test` — all 11 tests pass (7 existing + 4 new)
- [x] `cd examples/entity-todo && bun run typecheck` — no type errors
- [x] `bunx biome check examples/entity-todo/src/` — lint clean (only pre-existing warnings)


🤖 Generated with [Claude Code](https://claude.com/claude-code)