### PR TITLE
chore: sync version bump 0.2.10 to main

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/cli",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz CLI — dev, build, create, and deploy commands",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/cloudflare",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "description": "Cloudflare Workers adapter for vertz",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/codegen",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz code generation — internal, no stability guarantee",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/compiler",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz compiler — internal, no stability guarantee",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/core",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz core framework primitives",

--- a/packages/create-vertz-app/package.json
+++ b/packages/create-vertz-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/create-vertz-app",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Create a new Vertz application",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/db",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Database layer for Vertz — typed queries, migrations, codegen",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/errors",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Unified error taxonomy for Vertz - Result types, domain errors, and mapping utilities",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/fetch",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Type-safe HTTP client for Vertz",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/schema",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Type-safe schema definitions for Vertz",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/server",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz server runtime — modules, routing, and auth",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/testing",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Testing utilities for Vertz applications",

--- a/packages/theme-shadcn/package.json
+++ b/packages/theme-shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/theme-shadcn",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Shadcn-inspired theme for Vertz — pre-built style definitions using variants() and css()",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/tui",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/ui-canvas/package.json
+++ b/packages/ui-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/ui-canvas",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz Canvas renderer with PixiJS and signals",

--- a/packages/ui-compiler/package.json
+++ b/packages/ui-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/ui-compiler",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz UI compiler — SSR and build-time optimizations",

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/ui-primitives",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Headless UI primitives for Vertz — Accordion, Dialog, Select, and more",

--- a/packages/ui-server/package.json
+++ b/packages/ui-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/ui-server",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz UI server-side rendering runtime",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/ui",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "Vertz UI framework — signals, components, JSX runtime",

--- a/packages/vertz/package.json
+++ b/packages/vertz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertz",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "type": "module",
   "license": "MIT",
   "description": "The first TypeScript stack built for LLMs",


### PR DESCRIPTION
## Summary

- Syncs the version bump to 0.2.10 that was published to npm but never merged back to main
- Main currently shows 0.2.8 for several packages while npm has 0.2.10
- This must land before any new changesets can be consumed, otherwise changesets would try to publish versions that already exist on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)