### PR TITLE
feat(ui-compiler): distinguish reactive reads from stable closure refs

### DIFF
--- a/.changeset/stable-closure-refs.md
+++ b/.changeset/stable-closure-refs.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-compiler': patch
+---
+
+Distinguish reactive reads from stable closure references in computed classification. Callbacks that only call plain methods (`.refetch()`, `.revalidate()`) on signal API vars now stay `static` instead of being unnecessarily wrapped in `computed()`. Only accesses to signal properties (`.data`, `.error`, `.loading`) trigger computed classification.

--- a/packages/ui-compiler/src/__tests__/integration.test.ts
+++ b/packages/ui-compiler/src/__tests__/integration.test.ts
@@ -242,7 +242,7 @@ function TaskList() {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it('IT-1B-14: plain property over-classification (documents known trade-off)', () => {
+  it('IT-1B-14: plain property access stays static (not over-classified)', () => {
     const result = compile(
       `
 import { query } from '@vertz/ui';
@@ -255,8 +255,9 @@ function TaskList() {
     `.trim(),
     );
 
-    // fn becomes computed (over-classified but harmless)
-    expect(result.code).toContain('computed(() => tasks.refetch)');
+    // fn stays static — refetch is a plain property, not a signal property
+    expect(result.code).not.toContain('computed(');
+    expect(result.code).toContain('const fn = tasks.refetch');
     expect(result.diagnostics).toHaveLength(0);
   });
 

--- a/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
@@ -338,6 +338,95 @@ describe('ReactivityAnalyzer', () => {
     expect(v.isReactiveSource).toBeUndefined();
   });
 
+  // ─── Signal API property access classification (#907) ──────────────
+
+  it('classifies callback calling plain method on signal API var as static', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasksQuery = query('/api/tasks');
+        const handleSuccess = () => tasksQuery.refetch();
+        return <div>{handleSuccess}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'tasksQuery')?.kind).toBe('static');
+    expect(findVar(result?.variables, 'handleSuccess')?.kind).toBe('static');
+  });
+
+  it('classifies object with closure referencing plain method as static', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasksQuery = query('/api/tasks');
+        const opts = { onSuccess: () => tasksQuery.refetch() };
+        return <div>{opts}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'opts')?.kind).toBe('static');
+  });
+
+  it('classifies const reading signal property via optional chaining as computed', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasks = query('/api/tasks');
+        const items = tasks.data?.items ?? [];
+        return <div>{items}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'items')?.kind).toBe('computed');
+  });
+
+  it('classifies mixed signal+plain property access as computed', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasks = query('/api/tasks');
+        const x = tasks.error ? tasks.refetch : null;
+        return <div>{x}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'x')?.kind).toBe('computed');
+  });
+
+  it('classifies nested closure reading signal property as computed', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasks = query('/api/tasks');
+        const fn = () => { if (tasks.loading) return; tasks.refetch(); };
+        return <div>{fn}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'fn')?.kind).toBe('computed');
+  });
+
+  it('classifies identity reference to signal API var as static', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasks = query('/api/tasks');
+        const ref = tasks;
+        return <div>{ref}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'ref')?.kind).toBe('static');
+  });
+
+  it('classifies transitive plain method reference as static', () => {
+    const [result] = analyze(`
+      import { query } from '@vertz/ui';
+      function TaskList() {
+        const tasks = query('/api/tasks');
+        const reload = () => tasks.refetch();
+        const handler = reload;
+        return <div>{handler}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'reload')?.kind).toBe('static');
+    expect(findVar(result?.variables, 'handler')?.kind).toBe('static');
+  });
+
   it('handles aliased import of useContext', () => {
     const [result] = analyze(`
       import { useContext as getCtx } from '@vertz/ui';

--- a/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
@@ -30,8 +30,14 @@ export class ReactivityAnalyzer {
     const declaredNames = collectDeclaredNames(bodyNode);
 
     // Pass 1: Collect declarations
-    const lets = new Map<string, { start: number; end: number; deps: string[] }>();
-    const consts = new Map<string, { start: number; end: number; deps: string[] }>();
+    const lets = new Map<
+      string,
+      { start: number; end: number; deps: string[]; propertyAccesses: Map<string, Set<string>> }
+    >();
+    const consts = new Map<
+      string,
+      { start: number; end: number; deps: string[]; propertyAccesses: Map<string, Set<string>> }
+    >();
     const signalApiVars = new Map<string, SignalApiConfig>(); // Track variables assigned from signal APIs
     const reactiveSourceVars = new Set<string>(); // Track variables assigned from reactive source APIs (e.g., useContext)
     const destructuredFromMap = new Map<string, string>(); // binding name → synthetic var name
@@ -86,6 +92,7 @@ export class ReactivityAnalyzer {
                     start: decl.getStart(),
                     end: decl.getEnd(),
                     deps: [],
+                    propertyAccesses: new Map(),
                   });
                 }
               }
@@ -100,12 +107,23 @@ export class ReactivityAnalyzer {
               // Classify based on registry: signal props are computed, everything else is static
               const isSignalProp = signalApiConfig.signalProperties.has(propName);
               const deps = isSignalProp ? [syntheticName] : [];
-              const entry = { start: decl.getStart(), end: decl.getEnd(), deps };
+              const propAccesses = new Map<string, Set<string>>();
+              if (isSignalProp) {
+                propAccesses.set(syntheticName, new Set([propName]));
+              }
+              const entry = {
+                start: decl.getStart(),
+                end: decl.getEnd(),
+                deps,
+                propertyAccesses: propAccesses,
+              };
               consts.set(bindingName, entry);
               destructuredFromMap.set(bindingName, syntheticName);
             } else {
-              const deps = init ? collectIdentifierRefs(init) : [];
-              const entry = { start: decl.getStart(), end: decl.getEnd(), deps };
+              const { refs: deps, propertyAccesses } = init
+                ? collectDeps(init)
+                : { refs: [] as string[], propertyAccesses: new Map<string, Set<string>>() };
+              const entry = { start: decl.getStart(), end: decl.getEnd(), deps, propertyAccesses };
               if (isLet) {
                 lets.set(bindingName, entry);
               } else if (isConst) {
@@ -117,8 +135,10 @@ export class ReactivityAnalyzer {
         }
 
         const name = decl.getName();
-        const deps = init ? collectIdentifierRefs(init) : [];
-        const entry = { start: decl.getStart(), end: decl.getEnd(), deps };
+        const { refs: deps, propertyAccesses } = init
+          ? collectDeps(init)
+          : { refs: [] as string[], propertyAccesses: new Map<string, Set<string>>() };
+        const entry = { start: decl.getStart(), end: decl.getEnd(), deps, propertyAccesses };
 
         // Check if this is assigned from a signal API call or reactive source API call.
         // Unwrap NonNullExpression (the ! operator) to handle patterns like:
@@ -204,13 +224,16 @@ export class ReactivityAnalyzer {
       for (const [name, info] of consts) {
         if (computeds.has(name)) continue;
         if (signalApiVars.has(name)) continue;
-        const dependsOnReactive = info.deps.some(
-          (dep) =>
-            signals.has(dep) ||
-            computeds.has(dep) ||
-            signalApiVars.has(dep) ||
-            reactiveSourceVars.has(dep),
-        );
+        const dependsOnReactive = info.deps.some((dep) => {
+          if (signals.has(dep) || computeds.has(dep) || reactiveSourceVars.has(dep)) return true;
+          const apiConfig = signalApiVars.get(dep);
+          if (apiConfig) {
+            const accessed = info.propertyAccesses.get(dep);
+            if (!accessed || accessed.size === 0) return false;
+            return [...accessed].some((prop) => apiConfig.signalProperties.has(prop));
+          }
+          return false;
+        });
         if (dependsOnReactive) {
           computeds.add(name);
           changed = true;
@@ -284,10 +307,35 @@ function addIdentifiers(node: Node, refs: Set<string>): void {
   }
 }
 
-/** Collect identifier refs from an initializer expression. */
-function collectIdentifierRefs(node: Node): string[] {
+/**
+ * Collect identifier refs and property accesses from an initializer expression.
+ * For PropertyAccessExpressions like `q.error`, records that `q` accesses property `error`.
+ * This enables distinguishing reactive reads (signal properties) from stable references (plain methods).
+ */
+function collectDeps(node: Node): {
+  refs: string[];
+  propertyAccesses: Map<string, Set<string>>;
+} {
   const refs: string[] = [];
+  const propertyAccesses = new Map<string, Set<string>>();
   const walk = (n: Node): void => {
+    if (n.isKind(SyntaxKind.PropertyAccessExpression)) {
+      const expr = n.getExpression();
+      const propName = n.getName();
+      if (expr.isKind(SyntaxKind.Identifier)) {
+        const varName = expr.getText();
+        refs.push(varName);
+        let props = propertyAccesses.get(varName);
+        if (!props) {
+          props = new Set();
+          propertyAccesses.set(varName, props);
+        }
+        props.add(propName);
+      } else {
+        walk(expr);
+      }
+      return;
+    }
     if (n.isKind(SyntaxKind.Identifier)) {
       refs.push(n.getText());
     }
@@ -296,7 +344,7 @@ function collectIdentifierRefs(node: Node): string[] {
     }
   };
   walk(node);
-  return refs;
+  return { refs, propertyAccesses };
 }
 
 /**


### PR DESCRIPTION
## Summary

- The reactivity analyzer now tracks **property accesses** on signal API variables to distinguish reactive reads (`.data`, `.error`, `.loading`) from stable references (`.refetch()`, `.revalidate()`, `.dispose()`)
- Only reactive reads trigger `computed` classification — callbacks that only call plain methods now correctly stay `static`
- Updated integration test IT-1B-14 from documenting "known trade-off" to asserting the correct behavior

## Patterns affected

| Pattern | Before | After |
|---|---|---|
| `const cb = () => q.refetch()` | `computed` | `static` |
| `const opts = { onSuccess: () => q.refetch() }` | `computed` | `static` |
| `const ref = q` (identity) | `computed` | `static` |
| `const msg = q.error ? 'fail' : ''` | `computed` | `computed` (unchanged) |
| `const x = q.error ? q.refetch : null` | `computed` | `computed` (mixed access) |
| `const fn = () => { if (q.loading) return; }` | `computed` | `computed` (nested signal read) |

## Test plan

- [x] 6 new unit tests covering every pattern from the table above
- [x] All 332 existing ui-compiler tests pass
- [x] Integration test IT-1B-14 updated to assert correct behavior
- [x] Typecheck clean
- [x] Lint/format clean
- [x] E2E pre-push hooks pass (entity-todo + task-manager)
- [x] Manual testing: entity-todo app works correctly in browser

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)