### PR TITLE
fix(ui-server): restore index.html on unclean process exit

### DIFF
--- a/packages/ui-server/src/__tests__/bun-dev-server.test.ts
+++ b/packages/ui-server/src/__tests__/bun-dev-server.test.ts
@@ -666,6 +666,33 @@ describe('createIndexHtmlStasher', () => {
     expect(readFileSync(join(tmpDir, 'index.html'), 'utf-8')).toBe('<html></html>');
   });
 
+  it('process exit restores index.html when stashed', () => {
+    writeFileSync(join(tmpDir, 'index.html'), '<html></html>');
+    const stasher = createIndexHtmlStasher(tmpDir);
+
+    stasher.stash();
+    expect(existsSync(join(tmpDir, 'index.html'))).toBe(false);
+
+    // Simulate process exit — fires 'exit' event listeners
+    process.emit('exit', 0);
+
+    expect(existsSync(join(tmpDir, 'index.html'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.vertz', 'dev', 'index.html.bak'))).toBe(false);
+  });
+
+  it('process exit is a no-op after clean restore', () => {
+    writeFileSync(join(tmpDir, 'index.html'), '<html></html>');
+    const stasher = createIndexHtmlStasher(tmpDir);
+
+    stasher.stash();
+    stasher.restore();
+
+    // Should not throw or re-rename
+    process.emit('exit', 0);
+
+    expect(existsSync(join(tmpDir, 'index.html'))).toBe(true);
+  });
+
   it('restore() is a no-op when called twice', () => {
     writeFileSync(join(tmpDir, 'index.html'), '<html></html>');
     const stasher = createIndexHtmlStasher(tmpDir);

--- a/packages/ui-server/src/bun-dev-server.ts
+++ b/packages/ui-server/src/bun-dev-server.ts
@@ -125,6 +125,21 @@ export function createIndexHtmlStasher(projectRoot: string): IndexHtmlStasher {
   const indexHtmlBackupPath = resolve(projectRoot, '.vertz', 'dev', 'index.html.bak');
   let stashed = false;
 
+  // Best-effort restore on process exit (covers crashes, uncaught exceptions,
+  // and signal handlers that call process.exit). renameSync is synchronous,
+  // which is required for 'exit' handlers. The only unrecoverable scenario
+  // is SIGKILL, which the crash recovery in stash() already handles.
+  const exitHandler = () => {
+    if (stashed && existsSync(indexHtmlBackupPath)) {
+      try {
+        renameSync(indexHtmlBackupPath, indexHtmlPath);
+        stashed = false;
+      } catch {
+        // Best effort — process is exiting
+      }
+    }
+  };
+
   return {
     stash() {
       // Recover from a previous crashed session that left index.html stashed
@@ -135,6 +150,9 @@ export function createIndexHtmlStasher(projectRoot: string): IndexHtmlStasher {
       if (existsSync(indexHtmlPath)) {
         mkdirSync(resolve(projectRoot, '.vertz', 'dev'), { recursive: true });
         renameSync(indexHtmlPath, indexHtmlBackupPath);
+        if (!stashed) {
+          process.on('exit', exitHandler);
+        }
         stashed = true;
       }
     },
@@ -142,6 +160,7 @@ export function createIndexHtmlStasher(projectRoot: string): IndexHtmlStasher {
       if (stashed && existsSync(indexHtmlBackupPath)) {
         renameSync(indexHtmlBackupPath, indexHtmlPath);
         stashed = false;
+        process.removeListener('exit', exitHandler);
       }
     },
   };


### PR DESCRIPTION
## Summary

- Register a `process.on('exit')` handler in `createIndexHtmlStasher` that restores `index.html` when the process exits without a clean shutdown
- Clean `restore()` calls remove the exit handler to avoid double-restores
- Guard against multiple listener registrations when `stash()` is called repeatedly

## Problem

The dev server renames `index.html` → `.vertz/dev/index.html.bak` during dev to prevent Bun from auto-serving it (bypassing SSR). On clean shutdown, `stop()` → `restore()` renames it back. But when the process exits uncleanly (crash, uncaught exception, killed background process), the file stays "deleted" in the git working tree:

```
$ git status
D  examples/entity-todo/index.html
D  examples/task-manager/index.html
```

## Fix

The `exit` event fires synchronously for almost all termination scenarios. Since `renameSync` is synchronous, it's safe to call in an exit handler. Combined with the existing crash recovery for SIGKILL (the only unrecoverable case), this covers all scenarios.

## Test plan

- [x] New test: `process exit restores index.html when stashed`
- [x] New test: `process exit is a no-op after clean restore`
- [x] All 56 existing bun-dev-server tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] E2E pre-push hooks pass

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)