### PR TITLE
test: entity-todo e2e + compiler integration tests for hydration interactivity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.4",
+      "version": "0.0.8",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "examples/component-catalog": {
       "name": "@vertz-examples/component-catalog",
-      "version": "0.0.4",
+      "version": "0.0.8",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -80,6 +80,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260305.0",
+        "@playwright/test": "^1.58.2",
         "@vertz/cli": "workspace:*",
         "@vertz/ui-compiler": "workspace:*",
         "bun-types": "^1.3.9",
@@ -103,7 +104,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.0.5",
+      "version": "0.0.9",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -126,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -170,7 +171,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -189,7 +190,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -203,7 +204,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -217,7 +218,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -231,7 +232,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.2",
+      "version": "0.2.10",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -245,7 +246,7 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
@@ -278,7 +279,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.1",
+      "version": "0.2.10",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.18",
         "bunup": "^0.16.31",
@@ -288,7 +289,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.1",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -322,7 +323,7 @@
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -335,11 +336,11 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
-        "@vertz/core": "workspace:*",
-        "@vertz/db": "workspace:*",
-        "@vertz/errors": "workspace:*",
+        "@vertz/core": "workspace:^",
+        "@vertz/db": "workspace:^",
+        "@vertz/errors": "workspace:^",
         "bcryptjs": "^3.0.3",
         "jose": "^6.0.11",
       },
@@ -353,7 +354,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/core": "workspace:*",
         "@vertz/server": "workspace:*",
@@ -369,10 +370,10 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.2",
+      "version": "0.2.10",
       "dependencies": {
-        "@vertz/ui": "workspace:*",
-        "@vertz/ui-primitives": "workspace:*",
+        "@vertz/ui": "workspace:^",
+        "@vertz/ui-primitives": "workspace:^",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
@@ -383,7 +384,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.3",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -397,7 +398,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.2",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -411,7 +412,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.2",
+      "version": "0.2.10",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -428,7 +429,7 @@
     },
     "packages/ui-compiler": {
       "name": "@vertz/ui-compiler",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@vertz/ui": "workspace:^",
@@ -447,14 +448,14 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.2",
+      "version": "0.2.10",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
-        "@vertz/ui": "workspace:*",
+        "@vertz/ui": "workspace:^",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
-        "@vertz/ui-compiler": "workspace:*",
+        "@vertz/ui-compiler": "workspace:^",
         "bunup": "^0.16.31",
         "happy-dom": "^20.7.0",
         "typescript": "^5.7.0",
@@ -462,7 +463,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -482,7 +483,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.4",
+      "version": "0.2.10",
       "dependencies": {
         "@vertz/cloudflare": "workspace:*",
         "@vertz/db": "workspace:*",
@@ -660,7 +661,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.7.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.7.0" } }, "sha512-JdsfSUVeWDP8klYL4y4C4Fae0nAv2V/2W+gHhdiuktyKGZvbSZfJpsk4loakPhTtxt91KHdDroXCCZcFIJrfYQ=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.3" } }, "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -1486,7 +1487,7 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@happy-dom/global-registrator/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+    "@happy-dom/global-registrator/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -1504,21 +1505,21 @@
 
     "@vertz/cli/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "@vertz/ui/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.3" } }, "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ=="],
+    "@vertz/theme-shadcn/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "@vertz/ui/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
-    "@vertz/ui-canvas/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.3" } }, "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ=="],
-
     "@vertz/ui-canvas/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
-    "@vertz/ui-server/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.3" } }, "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ=="],
+    "@vertz/ui-primitives/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "@vertz/ui-server/happy-dom": ["happy-dom@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA=="],
 
     "bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "contacts-api-example/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "entity-todo-example/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "entity-todo-example/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
 
@@ -1589,8 +1590,6 @@
     "@vertz/cli/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@vertz/cli/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "@vertz/ui-server/@happy-dom/global-registrator/happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "@vertz/ui-server/happy-dom/@types/node": ["@types/node@20.19.35", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ=="],
 

--- a/examples/entity-todo/e2e/todo-app.spec.ts
+++ b/examples/entity-todo/e2e/todo-app.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Todo App — Hydration & Interactivity', () => {
+  test('page loads with SSR content and becomes interactive', async ({ page }) => {
+    await page.goto('/');
+    // Page should render (SSR)
+    await expect(page.getByTestId('todo-list-page')).toBeVisible();
+    // Wait for data to load (queryMatch resolves to data state)
+    await expect(page.getByTestId('todo-list').or(page.getByText('No todos yet'))).toBeVisible({ timeout: 10000 });
+  });
+
+  test('create a new todo via form submission', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('todo-list-page')).toBeVisible();
+    // Wait for initial data load
+    await expect(page.getByTestId('todo-list').or(page.getByText('No todos yet'))).toBeVisible({ timeout: 10000 });
+
+    // Count existing todos
+    const initialCount = await page.getByTestId('todo-list').locator('[data-testid^="todo-item-"]').count().catch(() => 0);
+
+    // Fill in the form and submit
+    const uniqueTitle = `E2E Todo ${Date.now()}`;
+    await page.getByTestId('todo-title-input').fill(uniqueTitle);
+    await page.getByTestId('submit-todo').click();
+
+    // New todo should appear in the list (use title testid to avoid matching delete dialog text)
+    await expect(page.locator('[data-testid^="todo-title-"]', { hasText: uniqueTitle })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('toggle todo completion via checkbox', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('todo-list')).toBeVisible({ timeout: 10000 });
+
+    // Find the first todo item's checkbox
+    const firstItem = page.getByTestId('todo-list').locator('[data-testid^="todo-item-"]').first();
+    await expect(firstItem).toBeVisible();
+    const checkbox = firstItem.locator('[data-testid^="todo-checkbox-"]');
+
+    // Get initial state
+    const wasChecked = await checkbox.isChecked();
+
+    // Click to toggle
+    await checkbox.click();
+
+    // Verify toggled (optimistic update should be immediate)
+    if (wasChecked) {
+      await expect(checkbox).not.toBeChecked({ timeout: 5000 });
+    } else {
+      await expect(checkbox).toBeChecked({ timeout: 5000 });
+    }
+  });
+
+  test('delete dialog opens and closes', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('todo-list')).toBeVisible({ timeout: 10000 });
+
+    // Click delete on the first todo
+    const firstDeleteBtn = page.getByTestId('todo-list').locator('[data-testid^="todo-delete-"]').first();
+    await firstDeleteBtn.click();
+
+    // Dialog should open
+    const dialog = page.getByRole('alertdialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog).toContainText('Delete todo?');
+
+    // Cancel the dialog
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('delete todo with confirmation', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('todo-list')).toBeVisible({ timeout: 10000 });
+
+    // First, create a todo to delete (so we don't depend on existing data)
+    const uniqueTitle = `Delete Me ${Date.now()}`;
+    await page.getByTestId('todo-title-input').fill(uniqueTitle);
+    await page.getByTestId('submit-todo').click();
+    await expect(page.locator('[data-testid^="todo-title-"]', { hasText: uniqueTitle })).toBeVisible({ timeout: 10000 });
+
+    // Find the delete button for our newly created todo
+    const todoItem = page.locator('[data-testid^="todo-item-"]', { has: page.locator('[data-testid^="todo-title-"]', { hasText: uniqueTitle }) });
+    const deleteBtn = todoItem.locator('[data-testid^="todo-delete-"]');
+    await deleteBtn.click();
+
+    // Confirm deletion
+    const dialog = page.getByRole('alertdialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Delete' }).click();
+
+    // Todo should be removed from the list
+    await expect(page.locator('[data-testid^="todo-title-"]', { hasText: uniqueTitle })).not.toBeVisible({ timeout: 10000 });
+  });
+});

--- a/examples/entity-todo/package.json
+++ b/examples/entity-todo/package.json
@@ -9,7 +9,9 @@
     "deploy": "bash scripts/deploy.sh",
     "codegen": "bun node_modules/@vertz/cli/dist/vertz.js codegen",
     "test": "bun run codegen && bun test",
-    "typecheck": "bun run codegen && tsc --noEmit"
+    "typecheck": "bun run codegen && tsc --noEmit",
+    "e2e": "npx playwright test",
+    "e2e:headed": "npx playwright test --headed"
   },
   "imports": {
     "#generated": "./.vertz/generated/client.ts",
@@ -35,6 +37,7 @@
     "esbuild": "^0.27.3",
     "happy-dom": "^20.6.1",
     "typescript": "^5.8.0",
+    "@playwright/test": "^1.58.2",
     "wrangler": "^4.69.0"
   }
 }

--- a/examples/entity-todo/playwright.config.ts
+++ b/examples/entity-todo/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    headless: true,
+  },
+
+  webServer: {
+    command: 'bun run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/packages/ui-compiler/src/__tests__/integration.test.ts
+++ b/packages/ui-compiler/src/__tests__/integration.test.ts
@@ -375,6 +375,25 @@ function App() {
     expect(result.code).toContain('ctx.theme');
   });
 
+  it('IT-1B-16: signal API variable only in property access — no false __child from ref check', () => {
+    const result = compile(
+      `
+import { query } from '@vertz/ui';
+
+function TaskList() {
+  const tasks = query('/api/tasks');
+  return <div>{tasks.data}</div>;
+}
+    `.trim(),
+    );
+
+    // tasks.data is a signal property access — should still be __child (reactive)
+    // but via containsSignalApiPropertyAccess, not containsSignalApiReference
+    expect(result.code).toContain('__child(');
+    expect(result.code).toContain('tasks.data.value');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it('preserves inline whitespace between text and JSX expressions', () => {
     const result = compile(
       `


### PR DESCRIPTION
## Summary
- **Entity-todo Playwright e2e tests** (5 tests): SSR page load, form submission, checkbox toggle, delete dialog open/cancel, delete with confirmation — all exercising the SSR→hydration→interactivity pipeline
- **Compiler integration test** (IT-1B-16): verify signal property access in JSX emits `__child()` with `.value` auto-unwrap

## Context
The entity-todo example had **zero** e2e tests. These tests close the gap that allowed the queryMatch reactivity bug (#920) to ship undetected. The regression test (IT-1B-15) is in #920 alongside the fix.

## Test plan
- [x] All 5 entity-todo e2e tests pass
- [x] All 25 compiler integration tests pass (including 1 new)
- [x] Pre-push CI gates pass (e2e, quality-gates, trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)