### PR TITLE
fix(ui-server): fix double-nesting signal collection in Fast Refresh

### DIFF
--- a/packages/ui-server/src/__tests__/fast-refresh-runtime.test.ts
+++ b/packages/ui-server/src/__tests__/fast-refresh-runtime.test.ts
@@ -8,6 +8,8 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
+import { signal } from '@vertz/ui';
+import { startSignalCollection, stopSignalCollection } from '@vertz/ui/internals';
 import {
   __$refreshPerform,
   __$refreshReg,
@@ -30,12 +32,37 @@ function clearRegistry(): void {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
+/** Signal ref used for state preservation in tests. */
+interface SignalRef {
+  peek(): unknown;
+  value: unknown;
+}
+
 /** Create a simple factory that produces a div with text. */
 function createFactory(text: string) {
   return () => {
     const el = document.createElement('div');
     el.textContent = text;
     return el;
+  };
+}
+
+/**
+ * Wrap a factory with the same signal collection + tracking pattern
+ * that the Fast Refresh codegen generates. This simulates:
+ *   __$startSigCol(); const el = orig(); const sigs = __$stopSigCol();
+ *   return __$refreshTrack(moduleId, name, el, args, scope, ctx, sigs);
+ */
+function wrapFactory(
+  moduleId: string,
+  name: string,
+  factory: () => HTMLElement,
+): () => HTMLElement {
+  return () => {
+    startSignalCollection();
+    const el = factory();
+    const sigs = stopSignalCollection() as SignalRef[];
+    return __$refreshTrack(moduleId, name, el, [], [], null, sigs);
   };
 }
 
@@ -380,6 +407,48 @@ describe('Fast Refresh Runtime', () => {
       expect(document.body.children.length).toBe(2);
       expect(document.body.children[0]?.textContent).toBe('Updated Item');
       expect(document.body.children[1]?.textContent).toBe('Updated Item');
+    });
+
+    it('preserves signal state across HMR when wrapper collects signals', () => {
+      // Simulates real HMR: the codegen wrapper calls startSignalCollection/
+      // stopSignalCollection around the factory, then passes signals to
+      // __$refreshTrack. Without the refreshSignals stash fix, the nested
+      // signal collection causes __$refreshPerform to get empty signals.
+
+      // V1 factory creates a real signal (like `let count = 0` → signal(0))
+      let sig1 = signal(0); // placeholder, overwritten by factory
+      const rawV1 = () => {
+        sig1 = signal(0);
+        const el = document.createElement('div');
+        el.textContent = 'v1';
+        return el;
+      };
+      const factoryV1 = wrapFactory('mod1', 'App', rawV1);
+      __$refreshReg('mod1', 'App', factoryV1);
+
+      // Initial mount — wrapper collects sig1
+      const el = factoryV1();
+      mount(el);
+
+      // User interaction: increment the signal
+      sig1.value = 42;
+
+      // HMR: new factory creates a fresh signal (initial value 0)
+      let sig2 = signal(0); // placeholder, overwritten by factory
+      const rawV2 = () => {
+        sig2 = signal(0);
+        const el = document.createElement('div');
+        el.textContent = 'v2';
+        return el;
+      };
+      const factoryV2 = wrapFactory('mod1', 'App', rawV2);
+      __$refreshReg('mod1', 'App', factoryV2);
+
+      __$refreshPerform('mod1');
+
+      // Signal value should be restored: 42 from old signal → new signal
+      expect(sig2.value).toBe(42);
+      expect(document.body.textContent).toBe('v2');
     });
 
     it('updates all instances with different args inside a container (like .map())', () => {

--- a/packages/ui-server/src/bun-plugin/fast-refresh-runtime.ts
+++ b/packages/ui-server/src/bun-plugin/fast-refresh-runtime.ts
@@ -101,6 +101,15 @@ const dirtyModules: Set<string> = ((globalThis as Record<symbol, Set<string>>)[D
 let performingRefresh = false;
 
 /**
+ * During __$refreshPerform, the factory wrapper's signal collection intercepts
+ * all signals before __$refreshPerform's own collector can see them (stack-based
+ * nesting). The wrapper passes collected signals to __$refreshTrack, which
+ * normally discards them during refresh. Instead, we stash them here so
+ * __$refreshPerform can retrieve them.
+ */
+let refreshSignals: SignalRef[] | null = null;
+
+/**
  * Get or create the component map for a module.
  */
 function getModule(moduleId: string): Map<string, ComponentRecord> {
@@ -159,7 +168,12 @@ export function __$refreshTrack(
 ): HTMLElement {
   // During __$refreshPerform, the factory wrapper calls __$refreshTrack.
   // Skip tracking here — __$refreshPerform manages instances itself.
-  if (performingRefresh) return element;
+  // But stash the signals so __$refreshPerform can retrieve them (the wrapper's
+  // signal collection intercepts them before __$refreshPerform's collector).
+  if (performingRefresh) {
+    refreshSignals = signals;
+    return element;
+  }
 
   const mod = registry.get(moduleId);
   if (!mod) return element;
@@ -219,16 +233,20 @@ export function __$refreshPerform(moduleId: string): void {
       let newSignals: SignalRef[];
       let newContextScope: ContextScope | null;
       try {
-        // 3. Collect signals during factory re-execution
-        startSignalCollection();
+        // 3. Re-execute the factory. Signal collection is handled by the
+        //    factory wrapper (which calls startSignalCollection/stopSignalCollection
+        //    internally). The wrapper passes collected signals to __$refreshTrack,
+        //    which stashes them in `refreshSignals` during refresh mode.
+        refreshSignals = null;
         newElement = factory(...args);
-        newSignals = stopSignalCollection() as SignalRef[];
+        newSignals = refreshSignals ?? ([] as SignalRef[]);
+        refreshSignals = null;
         // Capture the context scope established during factory execution
         newContextScope = getContextScope();
       } catch (err) {
-        // Factory failed — clean up signal collection, run any partial
-        // cleanups registered during the failed execution, and keep old instance.
-        stopSignalCollection();
+        // Factory failed — run any partial cleanups registered during
+        // the failed execution, and keep old instance.
+        refreshSignals = null;
         runCleanups(newCleanups);
         popScope();
         setContextScope(prevScope);


### PR DESCRIPTION
## Summary

- Fix signal state never being preserved across HMR cycles due to double-nesting in signal collection
- The factory wrapper (codegen) and `__$refreshPerform` both called `startSignalCollection`/`stopSignalCollection`, but the stack-based collector meant the inner (wrapper) collection captured all signals, then `__$refreshTrack` discarded them during refresh mode — leaving `__$refreshPerform` with an empty array
- Add `refreshSignals` stash mechanism: `__$refreshTrack` stashes signals during refresh instead of discarding, and `__$refreshPerform` reads from the stash instead of its own (empty) collection
- Add test that exercises the real wrapper pattern with actual `signal()` calls to prevent regression

Closes #721

## Test plan

- [x] New test: `preserves signal state across HMR when wrapper collects signals` — creates real signals via `signal()`, wraps factory with codegen-equivalent `startSignalCollection`/`stopSignalCollection` + `__$refreshTrack`, verifies old signal value (42) is restored to new signal after `__$refreshPerform`
- [x] All 20 existing fast-refresh-runtime tests still pass
- [x] Typecheck passes (`turbo run typecheck --filter=@vertz/ui-server`)
- [x] Manual verification: add `let counter = 0` to task-card.tsx, click to increment, save file — counter value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)