### PR TITLE
fix(changeset): use patch instead of minor for pre-v1 packages

### DIFF
--- a/.changeset/remove-index-html.md
+++ b/.changeset/remove-index-html.md
@@ -1,6 +1,6 @@
 ---
-'@vertz/cli': minor
-'@vertz/ui-server': minor
+'@vertz/cli': patch
+'@vertz/ui-server': patch
 ---
 
 Remove index.html from the framework


### PR DESCRIPTION
## Summary

- Fix `remove-index-html.md` changeset using `minor` instead of `patch` for `@vertz/cli` and `@vertz/ui-server`
- Pre-v1 packages (0.x.y) treat `minor` as a major bump per semver, causing the version PR (#911) to bump everything to 1.0.0

## Test plan

- [x] Verify changeset file uses `patch`
- [ ] After merge, version PR should regenerate with `0.2.x` bumps instead of `1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)