### PR TITLE
chore: align @vertz/icons and task-manager versions to 0.2.11

### DIFF
--- a/examples/task-manager/package.json
+++ b/examples/task-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz-examples/task-manager",
-  "version": "0.0.11",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertz/icons",
-  "version": "0.0.2",
+  "version": "0.2.11",
   "type": "module",
   "license": "MIT",
   "description": "Tree-shakeable Lucide icon components for Vertz",


### PR DESCRIPTION
## Summary

- Bumps `@vertz/icons` from `0.0.2` to `0.2.11`
- Bumps `@vertz-examples/task-manager` from `0.0.11` to `0.2.11`

Both packages were on older version series (`0.0.x`) while the rest of the ecosystem is at `0.2.11`.

## Test plan

- [x] All pre-push quality gates pass (lint, typecheck, test, build, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)