### PR TITLE
chore: add @vertz/icons and @vertz/cli-runtime to changeset fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
   "commit": false,
   "fixed": [[
     "@vertz/cli",
+    "@vertz/cli-runtime",
     "@vertz/cloudflare",
     "@vertz/codegen",
     "@vertz/compiler",
@@ -15,6 +16,7 @@
     "@vertz/db",
     "@vertz/errors",
     "@vertz/fetch",
+    "@vertz/icons",
     "@vertz/schema",
     "@vertz/server",
     "@vertz/testing",


### PR DESCRIPTION
## Summary

- Add `@vertz/icons` and `@vertz/cli-runtime` to the changeset `fixed` version group so they release in sync with the rest of the framework

## Test plan

- [x] No code changes — config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)