### PR TITLE
fix(ui): narrow ListTransition/Presence return type to DocumentFragment

### DIFF
--- a/packages/ui/src/component/list-transition.ts
+++ b/packages/ui/src/component/list-transition.ts
@@ -15,7 +15,7 @@ export interface ListTransitionProps<T> {
  * Props are accessed as getters (not destructured) so the compiler-generated
  * reactive getters are tracked by the underlying domEffect.
  */
-export function ListTransition<T>(props: ListTransitionProps<T>): Node {
+export function ListTransition<T>(props: ListTransitionProps<T>): DocumentFragment {
   const startMarker = document.createComment('lt-start');
   const endMarker = document.createComment('lt-end');
   const fragment = document.createDocumentFragment();

--- a/packages/ui/src/component/presence.ts
+++ b/packages/ui/src/component/presence.ts
@@ -15,7 +15,7 @@ export interface PresenceProps {
  * Props are accessed as getters (not destructured) so the compiler-generated
  * reactive getters are tracked by domEffect.
  */
-export function Presence(props: PresenceProps): Node {
+export function Presence(props: PresenceProps): DocumentFragment {
   const anchor = document.createComment('presence');
   let currentNode: HTMLElement | null = null;
   let exitingNode: HTMLElement | null = null;


### PR DESCRIPTION
## Summary
- `ListTransition` and `Presence` components returned `Node`, preventing them from being used as JSX components since `JSX.Element` is `HTMLElement | SVGElement | DocumentFragment`
- Narrowed return type to `DocumentFragment` which matches what both functions actually construct and return
- Fixes typecheck failure in freshly scaffolded projects using `@vertz/create-vertz-app@0.2.12`

## Found During
Developer walkthrough of 0.2.12 scaffold — `npx tsc --noEmit` failed with TS2786 on `ListTransition`.

## Test plan
- [x] `@vertz/ui` typecheck passes
- [x] `@vertz/ui` tests pass (1437 tests)
- [x] `task-manager` example typecheck passes
- [x] Pre-push quality gates pass (67 tasks)

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)