### PR TITLE
feat(cli): add `vertz start` production server command

### DIFF
--- a/.changeset/start-command.md
+++ b/.changeset/start-command.md
@@ -1,0 +1,6 @@
+---
+'@vertz/cli': patch
+'@vertz/create-vertz-app': patch
+---
+
+Add `vertz start` command to serve production builds. Supports API-only, UI-only, and full-stack modes with SSR, static file serving, CSS inlining, and graceful shutdown.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import {
 import { devAction } from './commands/dev';
 import { generateAction } from './commands/generate';
 import { loadDbContext } from './commands/load-db-context';
+import { startAction } from './commands/start';
 
 export function createCLI(): Command {
   const program = new Command();
@@ -84,6 +85,25 @@ export function createCLI(): Command {
         host: opts.host,
         open: opts.open,
         typecheck: opts.typecheck !== false && !opts.noTypecheck,
+        verbose: opts.verbose,
+      });
+      if (!result.ok) {
+        console.error(result.error.message);
+        process.exit(1);
+      }
+    });
+
+  // Start command - serve the production build
+  program
+    .command('start')
+    .description('Start the production server (run "vertz build" first)')
+    .option('-p, --port <port>', 'Server port (default: PORT env or 3000)')
+    .option('--host <host>', 'Server host', '0.0.0.0')
+    .option('-v, --verbose', 'Verbose output')
+    .action(async (opts) => {
+      const result = await startAction({
+        port: opts.port ? parseInt(opts.port, 10) : undefined,
+        host: opts.host,
         verbose: opts.verbose,
       });
       if (!result.ok) {

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Start Command Tests
+ *
+ * Tests for the vertz start CLI command.
+ * Tests validation and discovery logic (pure functions, no Bun.serve).
+ */
+
+import type { Mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { discoverSSRModule, startAction, validateBuildOutputs } from '../start';
+
+describe('discoverSSRModule', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'vertz-start-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns undefined when dist/server/ does not exist', () => {
+    expect(discoverSSRModule(projectRoot)).toBeUndefined();
+  });
+
+  it('returns undefined when dist/server/ is empty', () => {
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    expect(discoverSSRModule(projectRoot)).toBeUndefined();
+  });
+
+  it('finds a single .js file in dist/server/', () => {
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'server', 'index.js'), 'export default {}');
+    expect(discoverSSRModule(projectRoot)).toBe(join(projectRoot, 'dist', 'server', 'index.js'));
+  });
+
+  it('prefers app.js over other files', () => {
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'server', 'index.js'), 'export default {}');
+    writeFileSync(join(projectRoot, 'dist', 'server', 'app.js'), 'export default {}');
+    expect(discoverSSRModule(projectRoot)).toBe(join(projectRoot, 'dist', 'server', 'app.js'));
+  });
+});
+
+describe('validateBuildOutputs', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'vertz-start-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns err when api-only build output is missing', () => {
+    const result = validateBuildOutputs(projectRoot, 'api-only');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('.vertz/build/index.js');
+    }
+  });
+
+  it('returns ok when api-only build output exists', () => {
+    mkdirSync(join(projectRoot, '.vertz', 'build'), { recursive: true });
+    writeFileSync(join(projectRoot, '.vertz', 'build', 'index.js'), 'export default {}');
+    const result = validateBuildOutputs(projectRoot, 'api-only');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns err when ui-only client output is missing', () => {
+    const result = validateBuildOutputs(projectRoot, 'ui-only');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('dist/client/index.html');
+    }
+  });
+
+  it('returns err when ui-only server output is missing', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'index.html'), '<html></html>');
+    const result = validateBuildOutputs(projectRoot, 'ui-only');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('dist/server/');
+    }
+  });
+
+  it('returns ok when ui-only build outputs exist', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client'), { recursive: true });
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'index.html'), '<html></html>');
+    writeFileSync(join(projectRoot, 'dist', 'server', 'app.js'), 'export default {}');
+    const result = validateBuildOutputs(projectRoot, 'ui-only');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns err when full-stack API build is missing', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client'), { recursive: true });
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'index.html'), '<html></html>');
+    writeFileSync(join(projectRoot, 'dist', 'server', 'app.js'), 'export default {}');
+    const result = validateBuildOutputs(projectRoot, 'full-stack');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('.vertz/build/index.js');
+    }
+  });
+
+  it('returns ok when full-stack build outputs exist', () => {
+    mkdirSync(join(projectRoot, '.vertz', 'build'), { recursive: true });
+    mkdirSync(join(projectRoot, 'dist', 'client'), { recursive: true });
+    mkdirSync(join(projectRoot, 'dist', 'server'), { recursive: true });
+    writeFileSync(join(projectRoot, '.vertz', 'build', 'index.js'), 'export default {}');
+    writeFileSync(join(projectRoot, 'dist', 'client', 'index.html'), '<html></html>');
+    writeFileSync(join(projectRoot, 'dist', 'server', 'app.js'), 'export default {}');
+    const result = validateBuildOutputs(projectRoot, 'full-stack');
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('startAction', () => {
+  let pathsSpy: Mock<(...args: unknown[]) => unknown>;
+
+  afterEach(() => {
+    pathsSpy?.mockRestore();
+  });
+
+  it('returns err when project root is not found', async () => {
+    const pathsMod = await import('../../utils/paths');
+    pathsSpy = vi.spyOn(pathsMod, 'findProjectRoot').mockReturnValue(undefined) as Mock<
+      (...args: unknown[]) => unknown
+    >;
+    const result = await startAction({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('project root');
+    }
+  });
+
+  it('returns err when app type detection fails', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'vertz-start-'));
+    try {
+      mkdirSync(join(tmpDir, 'src'), { recursive: true });
+      // No entry files → detectAppType throws
+      const pathsMod = await import('../../utils/paths');
+      pathsSpy = vi.spyOn(pathsMod, 'findProjectRoot').mockReturnValue(tmpDir) as Mock<
+        (...args: unknown[]) => unknown
+      >;
+      const result = await startAction({});
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('No app entry found');
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns err when build outputs are missing', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'vertz-start-'));
+    try {
+      mkdirSync(join(tmpDir, 'src'), { recursive: true });
+      writeFileSync(join(tmpDir, 'src', 'server.ts'), 'export default {}');
+      const pathsMod = await import('../../utils/paths');
+      pathsSpy = vi.spyOn(pathsMod, 'findProjectRoot').mockReturnValue(tmpDir) as Mock<
+        (...args: unknown[]) => unknown
+      >;
+      const result = await startAction({});
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Missing build outputs');
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,0 +1,384 @@
+/**
+ * Vertz Start Command - Production Server
+ *
+ * Starts the production server after `vertz build`.
+ * Dispatches to the correct server mode based on app type:
+ * - API-only:   Import built module, use its handler
+ * - UI-only:    SSR + static file serving
+ * - Full-stack: API handler + SSR + static file serving
+ */
+
+// Minimal ambient declaration for Bun APIs used by this module.
+// The CLI runs under Bun at runtime; these declarations let tsc validate
+// without pulling in bun-types (which conflicts with @types/node).
+declare const Bun: {
+  serve(options: {
+    port: number;
+    hostname: string;
+    fetch: (req: Request) => Response | Promise<Response>;
+  }): { port: number; stop(): void };
+  file(path: string): Blob & { size: number; type: string };
+};
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { err, ok, type Result } from '@vertz/errors';
+import type { AppType } from '../dev-server/app-detector';
+import { detectAppType } from '../dev-server/app-detector';
+import { findProjectRoot } from '../utils/paths';
+
+/**
+ * Discover the SSR module entry in dist/server/.
+ * Prefers app.js, falls back to the first .js file found.
+ */
+export function discoverSSRModule(projectRoot: string): string | undefined {
+  const serverDir = join(projectRoot, 'dist', 'server');
+  if (!existsSync(serverDir)) return undefined;
+
+  const files = readdirSync(serverDir).filter((f) => f.endsWith('.js'));
+  if (files.length === 0) return undefined;
+
+  // Prefer app.js
+  if (files.includes('app.js')) {
+    return join(serverDir, 'app.js');
+  }
+
+  const first = files[0];
+  return first ? join(serverDir, first) : undefined;
+}
+
+/**
+ * Validate that required build outputs exist for the given app type.
+ */
+export function validateBuildOutputs(projectRoot: string, appType: AppType): Result<void, Error> {
+  const missing: string[] = [];
+
+  if (appType === 'api-only' || appType === 'full-stack') {
+    const apiBuild = join(projectRoot, '.vertz', 'build', 'index.js');
+    if (!existsSync(apiBuild)) {
+      missing.push('.vertz/build/index.js');
+    }
+  }
+
+  if (appType === 'ui-only' || appType === 'full-stack') {
+    const clientHtml = join(projectRoot, 'dist', 'client', 'index.html');
+    if (!existsSync(clientHtml)) {
+      missing.push('dist/client/index.html');
+    }
+
+    const ssrModule = discoverSSRModule(projectRoot);
+    if (!ssrModule) {
+      missing.push('dist/server/ (no SSR module found)');
+    }
+  }
+
+  if (missing.length > 0) {
+    return err(
+      new Error(
+        `Missing build outputs:\n  - ${missing.join('\n  - ')}\n\nRun "vertz build" first.`,
+      ),
+    );
+  }
+
+  return ok(undefined);
+}
+
+export interface StartCommandOptions {
+  port?: number;
+  host?: string;
+  verbose?: boolean;
+}
+
+/**
+ * Start the production server.
+ */
+export async function startAction(options: StartCommandOptions = {}): Promise<Result<void, Error>> {
+  const { port = Number(process.env.PORT) || 3000, host = '0.0.0.0', verbose = false } = options;
+
+  // Find project root
+  const projectRoot = findProjectRoot(process.cwd());
+  if (!projectRoot) {
+    return err(new Error('Could not find project root. Are you in a Vertz project?'));
+  }
+
+  // Detect app type
+  let detected: ReturnType<typeof detectAppType>;
+  try {
+    detected = detectAppType(projectRoot);
+  } catch (error) {
+    return err(new Error(error instanceof Error ? error.message : String(error)));
+  }
+
+  if (verbose) {
+    console.log(`Detected app type: ${detected.type}`);
+  }
+
+  // Validate build outputs
+  const validation = validateBuildOutputs(projectRoot, detected.type);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  // Start server based on app type
+  switch (detected.type) {
+    case 'api-only':
+      return startApiOnly(projectRoot, port, host, verbose);
+    case 'ui-only':
+      return startUIOnly(projectRoot, port, host, verbose);
+    case 'full-stack':
+      return startFullStack(projectRoot, port, host, verbose);
+  }
+}
+
+/**
+ * Start an API-only production server.
+ */
+async function startApiOnly(
+  projectRoot: string,
+  port: number,
+  host: string,
+  _verbose: boolean,
+): Promise<Result<void, Error>> {
+  const entryPath = resolve(projectRoot, '.vertz', 'build', 'index.js');
+
+  let mod: { default?: { handler?: (req: Request) => Response | Promise<Response> } };
+  try {
+    mod = await import(entryPath);
+  } catch (error) {
+    return err(
+      new Error(
+        `Failed to import API module: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+
+  const handler = mod.default?.handler;
+  if (typeof handler !== 'function') {
+    return err(new Error('API module must export default with a .handler function.'));
+  }
+
+  const server = Bun.serve({
+    port,
+    hostname: host,
+    fetch: handler,
+  });
+
+  console.log(
+    `Vertz API server running at http://${host === '0.0.0.0' ? 'localhost' : host}:${server.port}`,
+  );
+
+  setupGracefulShutdown(server);
+  return ok(undefined);
+}
+
+/**
+ * Start a UI-only production server with SSR + static files.
+ */
+async function startUIOnly(
+  projectRoot: string,
+  port: number,
+  host: string,
+  _verbose: boolean,
+): Promise<Result<void, Error>> {
+  const ssrModulePath = discoverSSRModule(projectRoot);
+  if (!ssrModulePath) {
+    return err(new Error('No SSR module found in dist/server/. Run "vertz build" first.'));
+  }
+  const templatePath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  const template = readFileSync(templatePath, 'utf-8');
+
+  let ssrModule: import('@vertz/ui-server/ssr').SSRModule;
+  try {
+    ssrModule = await import(ssrModulePath);
+  } catch (error) {
+    return err(
+      new Error(
+        `Failed to import SSR module: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+
+  // Inline CSS to prevent FOUC
+  const inlineCSS = discoverInlineCSS(projectRoot);
+
+  const { createSSRHandler } = await import('@vertz/ui-server/ssr');
+  const ssrHandler = createSSRHandler({
+    module: ssrModule,
+    template,
+    inlineCSS,
+  });
+
+  const clientDir = resolve(projectRoot, 'dist', 'client');
+
+  const server = Bun.serve({
+    port,
+    hostname: host,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const pathname = url.pathname;
+
+      // Serve static files from dist/client/
+      const staticResponse = serveStaticFile(clientDir, pathname);
+      if (staticResponse) return staticResponse;
+
+      // Everything else → SSR
+      return ssrHandler(req);
+    },
+  });
+
+  console.log(
+    `Vertz server running at http://${host === '0.0.0.0' ? 'localhost' : host}:${server.port}`,
+  );
+
+  setupGracefulShutdown(server);
+  return ok(undefined);
+}
+
+/**
+ * Start a full-stack production server with API + SSR + static files.
+ */
+async function startFullStack(
+  projectRoot: string,
+  port: number,
+  host: string,
+  _verbose: boolean,
+): Promise<Result<void, Error>> {
+  // Load API handler
+  const apiEntryPath = resolve(projectRoot, '.vertz', 'build', 'index.js');
+  let apiMod: { default?: { handler?: (req: Request) => Response | Promise<Response> } };
+  try {
+    apiMod = await import(apiEntryPath);
+  } catch (error) {
+    return err(
+      new Error(
+        `Failed to import API module: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+
+  const apiHandler = apiMod.default?.handler;
+  if (typeof apiHandler !== 'function') {
+    return err(new Error('API module must export default with a .handler function.'));
+  }
+
+  // Load SSR module
+  const ssrModulePath = discoverSSRModule(projectRoot);
+  if (!ssrModulePath) {
+    return err(new Error('No SSR module found in dist/server/. Run "vertz build" first.'));
+  }
+  const templatePath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  const template = readFileSync(templatePath, 'utf-8');
+
+  let ssrModule: import('@vertz/ui-server/ssr').SSRModule;
+  try {
+    ssrModule = await import(ssrModulePath);
+  } catch (error) {
+    return err(
+      new Error(
+        `Failed to import SSR module: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+
+  const inlineCSS = discoverInlineCSS(projectRoot);
+
+  const { createSSRHandler } = await import('@vertz/ui-server/ssr');
+  const ssrHandler = createSSRHandler({
+    module: ssrModule,
+    template,
+    inlineCSS,
+  });
+
+  const clientDir = resolve(projectRoot, 'dist', 'client');
+
+  const server = Bun.serve({
+    port,
+    hostname: host,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const pathname = url.pathname;
+
+      // API routes
+      if (pathname.startsWith('/api')) {
+        return apiHandler(req);
+      }
+
+      // Static files
+      const staticResponse = serveStaticFile(clientDir, pathname);
+      if (staticResponse) return staticResponse;
+
+      // SSR fallback
+      return ssrHandler(req);
+    },
+  });
+
+  console.log(
+    `Vertz full-stack server running at http://${host === '0.0.0.0' ? 'localhost' : host}:${server.port}`,
+  );
+
+  setupGracefulShutdown(server);
+  return ok(undefined);
+}
+
+/**
+ * Discover CSS files to inline from the client build.
+ */
+function discoverInlineCSS(projectRoot: string): Record<string, string> | undefined {
+  const cssDir = resolve(projectRoot, 'dist', 'client', 'assets');
+  if (!existsSync(cssDir)) return undefined;
+
+  const cssFiles = readdirSync(cssDir).filter((f) => f.endsWith('.css'));
+  if (cssFiles.length === 0) return undefined;
+
+  const result: Record<string, string> = {};
+  for (const file of cssFiles) {
+    const content = readFileSync(join(cssDir, file), 'utf-8');
+    result[`/assets/${file}`] = content;
+  }
+  return result;
+}
+
+/**
+ * Serve a static file from the client directory.
+ * Returns null if the file doesn't exist or the path is outside the directory.
+ */
+function serveStaticFile(clientDir: string, pathname: string): Response | null {
+  // Skip root and html requests — let SSR handle those
+  if (pathname === '/' || pathname === '/index.html') return null;
+
+  const filePath = resolve(clientDir, `.${pathname}`);
+
+  // Path traversal guard
+  if (!filePath.startsWith(clientDir)) return null;
+
+  const file = Bun.file(filePath);
+  if (!file.size) return null;
+
+  // Cache headers
+  const isHashedAsset = pathname.startsWith('/assets/');
+  const cacheControl = isHashedAsset
+    ? 'public, max-age=31536000, immutable'
+    : 'public, max-age=3600';
+
+  return new Response(file, {
+    headers: {
+      'Cache-Control': cacheControl,
+      'Content-Type': file.type,
+    },
+  });
+}
+
+/**
+ * Set up graceful shutdown on SIGINT, SIGTERM, SIGHUP.
+ */
+function setupGracefulShutdown(server: ReturnType<typeof Bun.serve>): void {
+  const shutdown = () => {
+    console.log('\nShutting down...');
+    server.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  process.on('SIGHUP', shutdown);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ export { deployAction } from './commands/deploy';
 export { devAction, registerDevCommand } from './commands/dev';
 export { generateAction } from './commands/generate';
 export { routesAction } from './commands/routes';
+export { startAction } from './commands/start';
 export type { CLIConfig, DevConfig, GeneratedFile, GeneratorDefinition } from './config/defaults';
 export { defaultCLIConfig } from './config/defaults';
 export { findConfigFile, loadConfig } from './config/loader';

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -12,6 +12,7 @@ export function packageJsonTemplate(projectName: string): string {
     scripts: {
       dev: 'vertz dev',
       build: 'vertz build',
+      start: 'vertz start',
       codegen: 'vertz codegen',
     },
     imports: {


### PR DESCRIPTION
## Summary

- Add `vertz start` command that serves production builds after `vertz build`
- Three server modes based on `detectAppType()`: API-only, UI-only, full-stack
- SSR via `createSSRHandler()` from `@vertz/ui-server`, static file serving with cache headers, CSS inlining to prevent FOUC
- Scaffold template now includes `"start": "vertz start"` in scripts
- 14 unit tests covering discovery, validation, and action shell logic

## Test plan

- [x] `discoverSSRModule` — returns undefined for empty/missing dir, finds single .js, prefers app.js
- [x] `validateBuildOutputs` — returns err for missing artifacts per app type, ok when present
- [x] `startAction` shell — err for no project root, err for failed detection, err for missing build
- [x] All 383 CLI tests pass
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (`biome check`)
- [x] Pre-push quality gates pass (67/67 tasks)

Closes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)