### PR TITLE
refactor(ui): remove selector param from mount() — always #app

### DIFF
--- a/benchmarks/generate-app.mjs
+++ b/benchmarks/generate-app.mjs
@@ -1225,7 +1225,7 @@ import { mount } from '@vertz/ui';
 import { App, styles } from './app';
 import { benchmarkTheme } from './styles/theme';
 
-mount(App, '#app', {
+mount(App, {
   theme: benchmarkTheme,
   styles,
 });

--- a/docs/fullstack-app-setup.md
+++ b/docs/fullstack-app-setup.md
@@ -68,7 +68,7 @@ import { App } from './app';
 // Prevents full page reloads — component-level Fast Refresh handles actual changes.
 import.meta.hot.accept();
 
-mount(App, '#app');
+mount(App);
 ```
 
 > Pass `theme` and `styles` options to `mount()` as needed — see `examples/task-manager/src/entry-client.ts`.

--- a/docs/guides/bun-dev-server.md
+++ b/docs/guides/bun-dev-server.md
@@ -45,7 +45,7 @@ export const styles = [globalStyles.css];
 // Mount on the client — the compiler skips this during SSR
 const isSSR = typeof (globalThis as any).__SSR_URL__ !== 'undefined' || typeof document === 'undefined';
 if (!isSSR) {
-  mount(App, '#app', { styles: [globalStyles.css] });
+  mount(App, { styles: [globalStyles.css] });
 }
 ```
 

--- a/examples/component-catalog/src/entry-client.ts
+++ b/examples/component-catalog/src/entry-client.ts
@@ -4,7 +4,7 @@ import { catalogTheme } from './styles/theme';
 
 import.meta.hot.accept();
 
-mount(App, '#app', {
+mount(App, {
   theme: catalogTheme,
   styles,
 });

--- a/examples/entity-todo/src/entry-client.ts
+++ b/examples/entity-todo/src/entry-client.ts
@@ -13,7 +13,7 @@ import { todoTheme } from './styles/theme';
 // Bun's file watcher). Component-level Fast Refresh handles actual changes.
 import.meta.hot.accept();
 
-mount(App, '#app', {
+mount(App, {
   theme: todoTheme,
   styles,
 });

--- a/examples/task-manager/src/entry-client.ts
+++ b/examples/task-manager/src/entry-client.ts
@@ -14,7 +14,7 @@ import { taskManagerTheme } from './styles/theme';
 // Bun's file watcher). Component-level Fast Refresh handles actual changes.
 import.meta.hot.accept();
 
-mount(App, '#app', {
+mount(App, {
   theme: taskManagerTheme,
   styles,
 });

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -310,7 +310,7 @@ import { App, globalStyles, theme } from './app';
 
 import.meta.hot.accept();
 
-mount(App, '#app', {
+mount(App, {
   theme,
   styles: globalStyles,
 });

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -103,7 +103,7 @@ function App() {
   return <button onClick={() => count++}>Count: {count}</button>;
 }
 
-const { unmount, root } = mount(App, '#app');
+const { unmount, root } = mount(App);
 ```
 
 **With options:**
@@ -116,20 +116,17 @@ const theme = defineTheme({
   colors: { primary: { 500: '#3b82f6' } },
 });
 
-mount(App, '#app', {
+mount(App, {
   theme,
   styles: ['body { margin: 0; }'],
   onMount: (root) => console.log('Mounted to', root),
 });
 ```
 
-`mount(app, selector, options?)` accepts:
+`mount(app, options?)` accepts:
 
-- `selector` — CSS selector string or `HTMLElement`
 - `options.theme` — theme definition for CSS vars
 - `options.styles` — global CSS strings to inject
-- `options.hydration` — `'replace'` (default) or `false`
-- `options.registry` — component registry for per-component hydration
 - `options.onMount` — callback after mount completes
 
 Returns a `MountHandle` with `unmount()` and `root`.

--- a/packages/ui/src/__tests__/hydration-e2e.test.ts
+++ b/packages/ui/src/__tests__/hydration-e2e.test.ts
@@ -19,6 +19,7 @@ describe('tolerant hydration e2e', () => {
 
   beforeEach(() => {
     root = document.createElement('div');
+    root.id = 'app';
     document.body.appendChild(root);
     resetInjectedStyles();
   });
@@ -75,7 +76,7 @@ describe('tolerant hydration e2e', () => {
       return el;
     };
 
-    const handle = mount(App, root);
+    const handle = mount(App);
 
     // 4. Verify: no flash (SSR nodes adopted, not recreated)
     expect(root.innerHTML).toContain('Hello');
@@ -135,7 +136,7 @@ describe('tolerant hydration e2e', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     // The SSR span must still be in the DOM — not ripped out
     expect(root.querySelector('span')).toBe(ssrSpan);
@@ -164,7 +165,7 @@ describe('tolerant hydration e2e', () => {
       return btn;
     };
 
-    mount(App, root);
+    mount(App);
 
     // After hydration, button should show "Add Todo" (no duplication)
     const btn = root.querySelector('button')!;
@@ -208,7 +209,7 @@ describe('tolerant hydration e2e', () => {
       return ul;
     };
 
-    mount(App, root);
+    mount(App);
 
     // SSR li nodes were adopted (same references)
     const currentItems = Array.from(root.querySelectorAll('li'));

--- a/packages/ui/src/__tests__/mount-hydration.test.ts
+++ b/packages/ui/src/__tests__/mount-hydration.test.ts
@@ -20,6 +20,7 @@ describe('mount() — tolerant hydration', () => {
 
   beforeEach(() => {
     root = document.createElement('div');
+    root.id = 'app';
     document.body.appendChild(root);
     resetInjectedStyles();
   });
@@ -45,7 +46,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    const handle = mount(App, root);
+    const handle = mount(App);
 
     // Content preserved (no flash)
     expect(root.innerHTML).toContain('Hello');
@@ -71,7 +72,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    const handle = mount(App, root);
+    const handle = mount(App);
 
     expect(root.innerHTML).toContain('text');
     expect(root.querySelector('p')).not.toBeNull();
@@ -98,7 +99,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     const button = root.querySelector('button')!;
     button.click();
@@ -119,7 +120,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
     expect(root.textContent).toContain('Count: 0');
 
     count.value = 42;
@@ -134,7 +135,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     expect(root.textContent).toBe('fresh');
   });
@@ -156,7 +157,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Hydration failed'),
@@ -191,7 +192,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     // The effect from the failed hydration ran once during setup
     const runCountAfterMount = effectRunCount;
@@ -215,7 +216,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root, { onMount });
+    mount(App, { onMount });
 
     expect(onMount).toHaveBeenCalledTimes(1);
     expect(onMount).toHaveBeenCalledWith(root);
@@ -249,7 +250,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     // SSR nodes were adopted — same DOM references
     const currentDiv = root.firstChild as HTMLElement;
@@ -302,7 +303,7 @@ describe('mount() — tolerant hydration', () => {
       return el;
     };
 
-    mount(App, root);
+    mount(App);
 
     // Button should be the SSR button (adopted, not recreated)
     expect(ssrDiv.querySelector('button')).toBe(ssrButton);
@@ -414,7 +415,7 @@ describe('mount() — tolerant hydration', () => {
 
     const App = () => Layout({ children: () => PageContent() });
 
-    mount(App, root);
+    mount(App);
 
     // Button should be the SSR button (adopted, not recreated)
     expect(root.querySelector('button')).toBe(ssrButton);
@@ -458,7 +459,7 @@ describe('mount() — tolerant hydration', () => {
     };
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mount(App, root);
+    mount(App);
 
     // No claim verification warnings (no false positives)
     const claimWarns = warnSpy.mock.calls.filter(
@@ -555,7 +556,7 @@ describe('mount() — tolerant hydration', () => {
     const App = () => Layout({ children: () => PageContent() });
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mount(App, root);
+    mount(App);
 
     const claimWarns = warnSpy.mock.calls.filter(
       (args) => typeof args[0] === 'string' && args[0].includes('not claimed'),
@@ -612,7 +613,7 @@ describe('mount() — tolerant hydration', () => {
         children: () => InnerLayout({ children: () => Content() }),
       });
 
-    mount(App, root);
+    mount(App);
 
     // Button should be the SSR button (adopted via claim)
     expect(root.querySelector('button')).toBe(ssrButton);
@@ -675,7 +676,7 @@ describe('mount() — tolerant hydration', () => {
       return ret;
     };
 
-    mount(App, root);
+    mount(App);
 
     // Button should be the SSR button (adopted, not recreated)
     expect((root.firstChild as HTMLElement).querySelector('button')).toBe(ssrButton);

--- a/packages/ui/src/__tests__/mount.test-d.ts
+++ b/packages/ui/src/__tests__/mount.test-d.ts
@@ -8,21 +8,20 @@
 import { mount } from '../mount';
 
 const App = () => document.createElement('div');
-const root = document.createElement('div');
 
 // ─── Valid usage ─────────────────────────────────────────────
 
-mount(App, root); // default (no options)
-mount(App, root, {}); // empty options
-mount(App, root, { theme: undefined }); // valid option
+mount(App); // default (no options)
+mount(App, {}); // empty options
+mount(App, { theme: undefined }); // valid option
 
 // ─── Invalid: hydration option no longer exists ──────────────
 
 // @ts-expect-error — hydration option has been removed; tolerant is always used
-mount(App, root, { hydration: 'tolerant' });
+mount(App, { hydration: 'tolerant' });
 
 // @ts-expect-error — hydration option has been removed
-mount(App, root, { hydration: 'replace' });
+mount(App, { hydration: 'replace' });
 
 // @ts-expect-error — hydration option has been removed
-mount(App, root, { hydration: 'strict' });
+mount(App, { hydration: 'strict' });

--- a/packages/ui/src/__tests__/mount.test.ts
+++ b/packages/ui/src/__tests__/mount.test.ts
@@ -8,6 +8,7 @@ describe('mount()', () => {
 
   beforeEach(() => {
     root = document.createElement('div');
+    root.id = 'app';
     document.body.appendChild(root);
     resetInjectedStyles();
   });
@@ -20,7 +21,7 @@ describe('mount()', () => {
   // Test 1: mount with minimal args mounts app to root
   test('mount with minimal args mounts app to root', () => {
     const app = () => document.createElement('div');
-    const handle = mount(app, root);
+    const handle = mount(app);
 
     expect(root.children.length).toBe(1);
     expect(handle.root).toBe(root);
@@ -36,7 +37,7 @@ describe('mount()', () => {
     };
 
     const app = () => document.createElement('div');
-    mount(app, root, { theme });
+    mount(app, { theme });
 
     // Theme CSS is injected via adoptedStyleSheets
     const allText = Array.from(document.adoptedStyleSheets)
@@ -49,7 +50,7 @@ describe('mount()', () => {
   // Test 3: mount with styles injects global styles
   test('mount with styles injects global styles', () => {
     const app = () => document.createElement('div');
-    mount(app, root, { styles: ['body { margin: 0; }', '.hidden { display: none; }'] });
+    mount(app, { styles: ['body { margin: 0; }', '.hidden { display: none; }'] });
 
     // Global styles are injected via adoptedStyleSheets
     const allText = Array.from(document.adoptedStyleSheets)
@@ -59,61 +60,26 @@ describe('mount()', () => {
     expect(allText).toContain('display: none');
   });
 
-  // Test 4: mount with string selector finds root element
-  test('mount with string selector finds root element', () => {
-    root.id = 'root'; // Add id so querySelector can find it
+  // Test 4: mount throws when #app root not found
+  test('mount throws when #app root not found', () => {
     const app = () => document.createElement('div');
-    const handle = mount(app, '#root');
 
-    expect(handle.root).toBe(root);
-    expect(root.children.length).toBe(1);
-  });
-
-  // Test 5: mount with HTMLElement selector uses it directly
-  test('mount with HTMLElement selector uses it directly', () => {
-    const customRoot = document.createElement('div');
-    customRoot.id = 'custom-root';
-    document.body.appendChild(customRoot);
-
+    // Remove the #app element so mount can't find it
+    document.body.removeChild(root);
     try {
-      const app = () => document.createElement('div');
-      const handle = mount(app, customRoot);
-
-      expect(handle.root).toBe(customRoot);
-      expect(customRoot.children.length).toBe(1);
+      expect(() => {
+        mount(app);
+      }).toThrow('mount(): root element "#app" not found');
     } finally {
-      document.body.removeChild(customRoot);
+      // Re-add so afterEach cleanup doesn't fail
+      document.body.appendChild(root);
     }
   });
 
-  // Test 6: mount throws when root not found
-  test('mount throws when root not found', () => {
-    const app = () => document.createElement('div');
-
-    expect(() => {
-      mount(app, '#non-existent-element');
-    }).toThrow('mount(): root element "#non-existent-element" not found');
-  });
-
-  // Test 7: mount throws when selector is invalid type
-  test('mount throws when selector is invalid type', () => {
-    const app = () => document.createElement('div');
-
-    // @ts-expect-error - intentional invalid type for testing
-    expect(() => mount(app, 123)).toThrow(
-      'mount(): selector must be a string or HTMLElement, got number',
-    );
-
-    // @ts-expect-error - intentional invalid type for testing
-    expect(() => mount(app, null)).toThrow(
-      'mount(): selector must be a string or HTMLElement, got object',
-    );
-  });
-
-  // Test 8: unmount clears root content
+  // Test 5: unmount clears root content
   test('unmount clears root content', () => {
     const app = () => document.createElement('div');
-    const handle = mount(app, root);
+    const handle = mount(app);
 
     expect(root.children.length).toBe(1);
 
@@ -123,7 +89,7 @@ describe('mount()', () => {
     expect(root.textContent).toBe('');
   });
 
-  // Test 9: mount renders fresh content on empty root (CSR)
+  // Test 6: mount renders fresh content on empty root (CSR)
   test('mount renders fresh content on empty root', () => {
     // Empty root — no SSR content to hydrate, direct CSR render
     expect(root.children.length).toBe(0);
@@ -133,48 +99,48 @@ describe('mount()', () => {
       el.textContent = 'fresh';
       return el;
     };
-    mount(app, root);
+    mount(app);
 
     expect(root.children.length).toBe(1);
     expect(root.textContent).toBe('fresh');
   });
 
-  // Test 10: second mount() on same root returns existing handle (HMR guard)
+  // Test 7: second mount() on same root returns existing handle (HMR guard)
   test('second mount on same root returns existing handle without re-running app', () => {
     const app = vi.fn(() => document.createElement('div'));
 
-    const handle1 = mount(app, root);
+    const handle1 = mount(app);
     expect(app).toHaveBeenCalledTimes(1);
     expect(root.children.length).toBe(1);
 
     // Second mount on same root — should return existing handle, NOT re-run app
-    const handle2 = mount(app, root);
+    const handle2 = mount(app);
     expect(app).toHaveBeenCalledTimes(1); // NOT called again
     expect(handle2).toBe(handle1);
     expect(root.children.length).toBe(1); // DOM unchanged
   });
 
-  // Test 11: unmount clears HMR guard so re-mount is possible
+  // Test 8: unmount clears HMR guard so re-mount is possible
   test('unmount clears HMR guard allowing re-mount', () => {
     const app = vi.fn(() => document.createElement('div'));
 
-    const handle1 = mount(app, root);
+    const handle1 = mount(app);
     handle1.unmount();
     expect(root.children.length).toBe(0);
 
     // After unmount, mount() should work again on the same root
-    const handle2 = mount(app, root);
+    const handle2 = mount(app);
     expect(app).toHaveBeenCalledTimes(2);
     expect(handle2).not.toBe(handle1);
     expect(root.children.length).toBe(1);
   });
 
-  // Test 12: mount calls onMount callback after mounting
+  // Test 9: mount calls onMount callback after mounting
   test('mount calls onMount callback after mounting', () => {
     const app = () => document.createElement('div');
     const onMount = vi.fn();
 
-    mount(app, root, { onMount });
+    mount(app, { onMount });
 
     expect(onMount).toHaveBeenCalledTimes(1);
     expect(onMount).toHaveBeenCalledWith(root);

--- a/packages/ui/src/hydrate/ARCHITECTURE.md
+++ b/packages/ui/src/hydrate/ARCHITECTURE.md
@@ -8,7 +8,7 @@ A **global cursor** tracks position in the tree. Compiler output functions
 cursor and return matching nodes.
 
 ```
-mount(App, root)
+mount(App)
   │
   ├─ root has children? ─── no ──→ CSR: create from scratch
   │          │

--- a/packages/ui/src/mount.ts
+++ b/packages/ui/src/mount.ts
@@ -42,33 +42,24 @@ export interface MountHandle {
 }
 
 /**
- * Mount an app to a DOM element.
+ * Mount an app to the `#app` root element.
  *
  * Uses tolerant hydration automatically: if the root element has SSR content,
  * it walks the existing DOM and attaches reactivity without re-creating nodes.
  * If the root is empty (CSR), it renders from scratch.
  *
  * @param app - App function that returns an HTMLElement
- * @param selector - CSS selector string or HTMLElement
  * @param options - Mount options (theme, styles, onMount, etc.)
  * @returns MountHandle with unmount function and root element
  */
 export function mount<AppFn extends () => Element | DocumentFragment>(
   app: AppFn,
-  selector: string | HTMLElement,
   options?: MountOptions,
 ): MountHandle {
-  // Validate selector type
-  if (typeof selector !== 'string' && !(selector instanceof HTMLElement)) {
-    throw new Error(`mount(): selector must be a string or HTMLElement, got ${typeof selector}`);
-  }
-
-  // Resolve root element
-  const root: HTMLElement =
-    typeof selector === 'string' ? (document.querySelector(selector) as HTMLElement) : selector;
+  const root = document.getElementById('app');
 
   if (!root) {
-    throw new Error(`mount(): root element "${selector}" not found`);
+    throw new Error('mount(): root element "#app" not found');
   }
 
   // HMR guard: if this root was already mounted, return existing handle.

--- a/plans/hydration-jsx-ordering.md
+++ b/plans/hydration-jsx-ordering.md
@@ -348,7 +348,7 @@ function App() {
 // SSR renders to HTML string
 const html = ssrRenderToString(App);
 // Client hydrates — adopts SSR nodes, attaches reactivity
-mount(App, '#app');
+mount(App);
 // Click handler works, conditional renders, no cursor errors
 ```
 


### PR DESCRIPTION
## Summary

- Removed the `selector` parameter from `mount()` — it now always targets `#app` via `document.getElementById('app')` internally
- The framework controls the HTML in every context (SSR, dev server, templates), so the selector was always `'#app'` — pure ceremony
- Updated all examples, tests, docs, benchmarks, and the `create-vertz-app` template

Closes #947

## Test plan

- [x] All 28 mount-related tests pass (`mount.test.ts`, `mount-hydration.test.ts`, `hydration-e2e.test.ts`)
- [x] Type-level tests updated (`mount.test-d.ts`)
- [x] All quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)