### PR TITLE
refactor(server): rename action() to service() [#952]

### DIFF
--- a/examples/entity-todo/src/__tests__/api.test.ts
+++ b/examples/entity-todo/src/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import type { EntityDbAdapter } from '@vertz/server';
 import { createServer } from '@vertz/server';
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { webhooks } from '../api/actions/webhooks/webhooks.action';
+import { webhooks } from '../api/actions/webhooks/webhooks.service';
 import { todos } from '../api/entities/todos/todos.entity';
 import { clearEmailLog, getEmailLog } from '../api/services/notifications';
 
@@ -59,7 +59,7 @@ function createInMemoryDb(): EntityDbAdapter {
 function createTestApp(db: EntityDbAdapter) {
   return createServer({
     entities: [todos],
-    actions: [webhooks],
+    services: [webhooks],
     db,
   });
 }

--- a/examples/entity-todo/src/api/actions/webhooks/webhooks.service.ts
+++ b/examples/entity-todo/src/api/actions/webhooks/webhooks.service.ts
@@ -1,5 +1,5 @@
 import { s } from '@vertz/schema';
-import { action } from '@vertz/server';
+import { service } from '@vertz/server';
 import { todos } from '../../entities/todos/todos.entity';
 
 const webhookEvents = ['task.created', 'task.completed'] as const;
@@ -18,7 +18,7 @@ const syncResponse = s.object({
   todoId: s.string().optional(),
 });
 
-export const webhooks = action('webhooks', {
+export const webhooks = service('webhooks', {
   inject: { todos },
   // Open access for demo — production would validate a webhook secret header
   access: { sync: () => true },

--- a/examples/entity-todo/src/api/server.ts
+++ b/examples/entity-todo/src/api/server.ts
@@ -1,5 +1,5 @@
 import { createServer } from '@vertz/server';
-import { webhooks } from './actions/webhooks/webhooks.action';
+import { webhooks } from './actions/webhooks/webhooks.service';
 import { createTodosDb } from './db';
 import { todos } from './entities/todos/todos.entity';
 
@@ -8,7 +8,7 @@ const todosDbAdapter = createTodosDb();
 const app = createServer({
   basePath: '/api',
   entities: [todos],
-  actions: [webhooks],
+  services: [webhooks],
   db: todosDbAdapter,
 });
 

--- a/packages/integration-tests/src/__tests__/service-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/service-walkthrough.test.ts
@@ -1,10 +1,10 @@
 // ===========================================================================
-// Action Developer Walkthrough — Public API Validation Test
+// Service Developer Walkthrough — Public API Validation Test
 //
-// This test validates that a developer can use the standalone action() API
+// This test validates that a developer can use the standalone service() API
 // using ONLY public imports from @vertz/server and @vertz/db.
 //
-// action() provides non-entity endpoints (webhooks, OAuth, health checks)
+// service() provides non-entity endpoints (webhooks, OAuth, health checks)
 // with typed entity DI — no model, no CRUD, just custom handlers.
 //
 // Written as RED in Phase 1 — will fail until Phase 2 wires route generation.
@@ -12,7 +12,7 @@
 
 import { d } from '@vertz/db';
 import type { EntityDbAdapter } from '@vertz/server';
-import { action, createServer, entity } from '@vertz/server';
+import { createServer, entity, service } from '@vertz/server';
 import { describe, expect, it } from 'bun:test';
 
 // ---------------------------------------------------------------------------
@@ -71,7 +71,7 @@ function createInMemoryDb(initial: Record<string, unknown>[] = []): EntityDbAdap
 }
 
 // ---------------------------------------------------------------------------
-// 3. Standalone action — uses entity DI to access users
+// 3. Standalone service — uses entity DI to access users
 // ---------------------------------------------------------------------------
 
 const loginBodySchema = {
@@ -96,7 +96,7 @@ const healthResponseSchema = {
   },
 };
 
-const authAction = action('auth', {
+const authService = service('auth', {
   inject: { users: usersEntity },
   access: {
     login: () => true,
@@ -151,14 +151,14 @@ function request(
 // Tests
 // ===========================================================================
 
-describe('Action Developer Walkthrough (public API only)', () => {
+describe('Service Developer Walkthrough (public API only)', () => {
   it('POST /api/auth/login returns 200 with token when user exists', async () => {
     const db = createInMemoryDb([
       { id: 'u1', email: 'alice@example.com', name: 'Alice', role: 'user' },
     ]);
     const app = createServer({
       entities: [usersEntity],
-      actions: [authAction],
+      services: [authService],
       db,
     });
 
@@ -176,7 +176,7 @@ describe('Action Developer Walkthrough (public API only)', () => {
     const db = createInMemoryDb();
     const app = createServer({
       entities: [usersEntity],
-      actions: [authAction],
+      services: [authService],
       db,
     });
 
@@ -193,7 +193,7 @@ describe('Action Developer Walkthrough (public API only)', () => {
     const db = createInMemoryDb();
     const app = createServer({
       entities: [usersEntity],
-      actions: [authAction],
+      services: [authService],
       db,
     });
 
@@ -206,7 +206,7 @@ describe('Action Developer Walkthrough (public API only)', () => {
     const db = createInMemoryDb();
     const app = createServer({
       entities: [usersEntity],
-      actions: [authAction],
+      services: [authService],
       db,
     });
 
@@ -215,9 +215,9 @@ describe('Action Developer Walkthrough (public API only)', () => {
     expect(res.status).toBe(404);
   });
 
-  it('action() definition has kind discriminator', () => {
-    expect(authAction.kind).toBe('action');
-    expect(authAction.name).toBe('auth');
+  it('service() definition has kind discriminator', () => {
+    expect(authService.kind).toBe('service');
+    expect(authService.name).toBe('auth');
   });
 
   it('entity definition has kind discriminator', () => {

--- a/packages/server/src/action/index.ts
+++ b/packages/server/src/action/index.ts
@@ -1,2 +1,0 @@
-export { action } from './action';
-export type { ActionActionDef, ActionConfig, ActionContext, ActionDefinition } from './types';

--- a/packages/server/src/create-server.ts
+++ b/packages/server/src/create-server.ts
@@ -6,13 +6,13 @@ import {
   type EntityDbAdapter,
   type ModelEntry,
 } from '@vertz/db';
-import { generateActionRoutes } from './action/route-generator';
-import type { ActionDefinition } from './action/types';
 import type { EntityOperations } from './entity/entity-operations';
 import { EntityRegistry } from './entity/entity-registry';
 import { stripHiddenFields } from './entity/field-filter';
 import { generateEntityRoutes } from './entity/route-generator';
 import type { EntityDefinition } from './entity/types';
+import { generateServiceRoutes } from './service/route-generator';
+import type { ServiceDefinition } from './service/types';
 
 // ---------------------------------------------------------------------------
 // DatabaseClient detection
@@ -38,8 +38,8 @@ function isDatabaseClient(
 export interface ServerConfig extends Omit<AppConfig, '_entityDbFactory' | 'entities'> {
   /** Entity definitions created via entity() from @vertz/server */
   entities?: EntityDefinition[];
-  /** Standalone action definitions created via action() from @vertz/server */
-  actions?: ActionDefinition[];
+  /** Standalone service definitions created via service() from @vertz/server */
+  services?: ServiceDefinition[];
   /**
    * Database for entity CRUD operations.
    * Accepts either:
@@ -167,10 +167,10 @@ export function createServer(config: ServerConfig): AppBuilder {
     }
   }
 
-  // Process actions after entities (actions use registry for entity DI)
-  if (config.actions && config.actions.length > 0) {
-    for (const actionDef of config.actions) {
-      const routes = generateActionRoutes(actionDef, registry, { apiPrefix });
+  // Process services after entities (services use registry for entity DI)
+  if (config.services && config.services.length > 0) {
+    for (const serviceDef of config.services) {
+      const routes = generateServiceRoutes(serviceDef, registry, { apiPrefix });
       allRoutes.push(...routes);
     }
   }

--- a/packages/server/src/entity/access-enforcer.ts
+++ b/packages/server/src/entity/access-enforcer.ts
@@ -5,7 +5,7 @@ import type { AccessRule, BaseContext } from './types';
  * Evaluates an access rule for the given operation.
  * Returns err(EntityForbiddenError) if access is denied.
  *
- * Accepts BaseContext so both EntityContext and ActionContext can use it.
+ * Accepts BaseContext so both EntityContext and ServiceContext can use it.
  *
  * - No rule defined → deny (deny by default)
  * - Rule is false → operation is disabled

--- a/packages/server/src/entity/types.ts
+++ b/packages/server/src/entity/types.ts
@@ -18,7 +18,7 @@ type InjectToOperations<TInject extends Record<string, EntityDefinition> = {}> =
 };
 
 // ---------------------------------------------------------------------------
-// BaseContext — shared by EntityContext and ActionContext
+// BaseContext — shared by EntityContext and ServiceContext
 // ---------------------------------------------------------------------------
 
 export interface BaseContext {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -42,9 +42,6 @@ export {
   VertzException,
   vertz,
 } from '@vertz/core';
-// Action API
-export type { ActionActionDef, ActionConfig, ActionContext, ActionDefinition } from './action';
-export { action } from './action';
 export type {
   AccessConfig,
   AccessInstance,
@@ -111,3 +108,6 @@ export {
   stripHiddenFields,
   stripReadOnlyFields,
 } from './entity';
+// Service API
+export type { ServiceActionDef, ServiceConfig, ServiceContext, ServiceDefinition } from './service';
+export { service } from './service';

--- a/packages/server/src/service/__tests__/context.test.ts
+++ b/packages/server/src/service/__tests__/context.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { createActionContext } from '../context';
+import { createServiceContext } from '../context';
 
-describe('Feature: createActionContext', () => {
+describe('Feature: createServiceContext', () => {
   describe('Given request info with userId', () => {
-    describe('When creating an action context', () => {
+    describe('When creating a service context', () => {
       it('Then context has userId and authenticated() returns true', () => {
-        const ctx = createActionContext({ userId: 'user-1', roles: ['admin'] }, {});
+        const ctx = createServiceContext({ userId: 'user-1', roles: ['admin'] }, {});
 
         expect(ctx.userId).toBe('user-1');
         expect(ctx.authenticated()).toBe(true);
@@ -14,9 +14,9 @@ describe('Feature: createActionContext', () => {
   });
 
   describe('Given request info without userId', () => {
-    describe('When creating an action context', () => {
+    describe('When creating a service context', () => {
       it('Then authenticated() returns false', () => {
-        const ctx = createActionContext({}, {});
+        const ctx = createServiceContext({}, {});
 
         expect(ctx.userId).toBeNull();
         expect(ctx.authenticated()).toBe(false);
@@ -27,7 +27,7 @@ describe('Feature: createActionContext', () => {
   describe('Given request info with roles', () => {
     describe('When checking role()', () => {
       it('Then returns true for matching role', () => {
-        const ctx = createActionContext({ userId: 'user-1', roles: ['admin', 'editor'] }, {});
+        const ctx = createServiceContext({ userId: 'user-1', roles: ['admin', 'editor'] }, {});
 
         expect(ctx.role('admin')).toBe(true);
         expect(ctx.role('editor')).toBe(true);
@@ -39,13 +39,13 @@ describe('Feature: createActionContext', () => {
   describe('Given request info with tenantId', () => {
     describe('When checking tenant()', () => {
       it('Then returns true when tenantId is set', () => {
-        const ctx = createActionContext({ userId: 'user-1', tenantId: 'tenant-1' }, {});
+        const ctx = createServiceContext({ userId: 'user-1', tenantId: 'tenant-1' }, {});
 
         expect(ctx.tenant()).toBe(true);
       });
 
       it('Then returns false when tenantId is not set', () => {
-        const ctx = createActionContext({ userId: 'user-1' }, {});
+        const ctx = createServiceContext({ userId: 'user-1' }, {});
 
         expect(ctx.tenant()).toBe(false);
       });
@@ -56,7 +56,7 @@ describe('Feature: createActionContext', () => {
     describe('When accessing ctx.entities', () => {
       it('Then returns the registry proxy', () => {
         const proxy = { users: { get: () => {} } };
-        const ctx = createActionContext({ userId: 'user-1' }, proxy);
+        const ctx = createServiceContext({ userId: 'user-1' }, proxy);
 
         expect(ctx.entities).toBe(proxy);
       });

--- a/packages/server/src/service/__tests__/route-generator.test.ts
+++ b/packages/server/src/service/__tests__/route-generator.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import { d } from '@vertz/db';
 import { entity } from '../../entity/entity';
 import { EntityRegistry } from '../../entity/entity-registry';
-import { action } from '../action';
-import { generateActionRoutes } from '../route-generator';
+import { generateServiceRoutes } from '../route-generator';
+import { service } from '../service';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -38,11 +38,11 @@ const responseSchema = {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Feature: generateActionRoutes', () => {
-  describe('Given an action with access rules', () => {
+describe('Feature: generateServiceRoutes', () => {
+  describe('Given a service with access rules', () => {
     describe('When generating routes', () => {
-      it('Then generates POST route for action handler with access rule', () => {
-        const authAction = action('auth', {
+      it('Then generates POST route for service handler with access rule', () => {
+        const authService = service('auth', {
           access: { login: () => true },
           actions: {
             login: {
@@ -54,7 +54,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         expect(routes).toHaveLength(1);
         expect(routes[0]?.method).toBe('POST');
@@ -63,10 +63,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action handler with no access rule', () => {
+  describe('Given a service handler with no access rule', () => {
     describe('When generating routes', () => {
       it('Then skips the handler (deny by default)', () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: () => true },
           actions: {
             login: {
@@ -83,7 +83,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         // Only 'login' has access rule, 'secret' is skipped
         expect(routes).toHaveLength(1);
@@ -92,10 +92,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action with custom apiPrefix', () => {
+  describe('Given a service with custom apiPrefix', () => {
     describe('When generating routes', () => {
       it('Then uses the custom prefix', () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: () => true },
           actions: {
             login: {
@@ -107,17 +107,17 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry, { apiPrefix: '/v2' });
+        const routes = generateServiceRoutes(authService, registry, { apiPrefix: '/v2' });
 
         expect(routes[0]?.path).toBe('/v2/auth/login');
       });
     });
   });
 
-  describe('Given an action with access: false (disabled)', () => {
+  describe('Given a service with access: false (disabled)', () => {
     describe('When generating routes', () => {
       it('Then generates 405 handler', async () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: false },
           actions: {
             login: {
@@ -129,7 +129,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         expect(routes).toHaveLength(1);
         const response = await routes[0]?.handler({});
@@ -138,10 +138,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action handler that returns data', () => {
+  describe('Given a service handler that returns data', () => {
     describe('When the route handler is called with valid input', () => {
       it('Then returns 200 with the handler result', async () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: () => true },
           actions: {
             login: {
@@ -153,7 +153,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         const response = await routes[0]?.handler({
           body: { email: 'alice@example.com' },
@@ -166,10 +166,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action handler with body validation', () => {
+  describe('Given a service handler with body validation', () => {
     describe('When called with invalid body', () => {
       it('Then returns 400 with validation error', async () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: () => true },
           actions: {
             login: {
@@ -181,7 +181,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         const response = await routes[0]?.handler({
           body: {},
@@ -192,10 +192,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action with entity DI', () => {
+  describe('Given a service with entity DI', () => {
     describe('When the handler accesses injected entities', () => {
       it('Then ctx.entities provides the registry proxy', async () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           inject: { users: usersEntity },
           access: { login: () => true },
           actions: {
@@ -212,7 +212,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         await routes[0]?.handler({
           body: { email: 'alice@example.com' },
@@ -221,10 +221,10 @@ describe('Feature: generateActionRoutes', () => {
     });
   });
 
-  describe('Given an action with access rule that denies', () => {
+  describe('Given a service with access rule that denies', () => {
     describe('When the route handler is called', () => {
       it('Then returns 403', async () => {
-        const authAction = action('auth', {
+        const authService = service('auth', {
           access: { login: () => false },
           actions: {
             login: {
@@ -236,7 +236,7 @@ describe('Feature: generateActionRoutes', () => {
         });
 
         const registry = new EntityRegistry();
-        const routes = generateActionRoutes(authAction, registry);
+        const routes = generateServiceRoutes(authService, registry);
 
         const response = await routes[0]?.handler({
           body: { email: 'alice@example.com' },

--- a/packages/server/src/service/__tests__/service.test-d.ts
+++ b/packages/server/src/service/__tests__/service.test-d.ts
@@ -1,9 +1,9 @@
-import { d } from '@vertz/db';
 import { describe, it } from 'bun:test';
+import { d } from '@vertz/db';
 import { entity } from '../../entity/entity';
 import type { BaseContext } from '../../entity/types';
-import { action } from '../action';
-import type { ActionContext } from '../types';
+import { service } from '../service';
+import type { ServiceContext } from '../types';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -38,18 +38,18 @@ const responseSchema = {
 };
 
 // ---------------------------------------------------------------------------
-// ActionContext type flow
+// ServiceContext type flow
 // ---------------------------------------------------------------------------
 
-describe('ActionContext type flow', () => {
-  it('ActionContext extends BaseContext', () => {
-    type Ctx = ActionContext<{ users: typeof usersEntity }>;
+describe('ServiceContext type flow', () => {
+  it('ServiceContext extends BaseContext', () => {
+    type Ctx = ServiceContext<{ users: typeof usersEntity }>;
     const _check: BaseContext = {} as Ctx;
     void _check;
   });
 
-  it('ActionContext.entities has typed injected entity', () => {
-    type Ctx = ActionContext<{ users: typeof usersEntity }>;
+  it('ServiceContext.entities has typed injected entity', () => {
+    type Ctx = ServiceContext<{ users: typeof usersEntity }>;
     type UsersOps = Ctx['entities']['users'];
     type GetReturn = Awaited<ReturnType<UsersOps['get']>>;
 
@@ -59,22 +59,22 @@ describe('ActionContext type flow', () => {
     void _check2;
   });
 
-  it('ActionContext.entities rejects non-injected entity', () => {
-    type Ctx = ActionContext<{ users: typeof usersEntity }>;
+  it('ServiceContext.entities rejects non-injected entity', () => {
+    type Ctx = ServiceContext<{ users: typeof usersEntity }>;
 
     // @ts-expect-error — products not in inject map
     type _Test = Ctx['entities']['products'];
   });
 
-  it('ActionContext has NO entity property (no self-CRUD)', () => {
-    type Ctx = ActionContext<{ users: typeof usersEntity }>;
+  it('ServiceContext has NO entity property (no self-CRUD)', () => {
+    type Ctx = ServiceContext<{ users: typeof usersEntity }>;
 
-    // @ts-expect-error — actions don't have self-CRUD
+    // @ts-expect-error — services don't have self-CRUD
     type _Test = Ctx['entity'];
   });
 
-  it('ActionContext with multiple injected entities are all typed', () => {
-    type Ctx = ActionContext<{
+  it('ServiceContext with multiple injected entities are all typed', () => {
+    type Ctx = ServiceContext<{
       users: typeof usersEntity;
       products: typeof productsEntity;
     }>;
@@ -92,12 +92,12 @@ describe('ActionContext type flow', () => {
 });
 
 // ---------------------------------------------------------------------------
-// action() definition type flow
+// service() definition type flow
 // ---------------------------------------------------------------------------
 
-describe('action() definition type flow', () => {
-  it('action() returns ActionDefinition with kind "action"', () => {
-    const def = action('auth', {
+describe('service() definition type flow', () => {
+  it('service() returns ServiceDefinition with kind "service"', () => {
+    const def = service('auth', {
       actions: {
         login: {
           body: bodySchema,
@@ -107,15 +107,16 @@ describe('action() definition type flow', () => {
       },
     });
 
-    const _check1: 'action' = def.kind;
-    const _check1r: typeof def.kind = 'action' as const;
-    void _check1; void _check1r;
+    const _check1: 'service' = def.kind;
+    const _check1r: typeof def.kind = 'service' as const;
+    void _check1;
+    void _check1r;
     const _check2: string = def.name;
     void _check2;
   });
 
-  it('action() with inject stores the inject map', () => {
-    const def = action('auth', {
+  it('service() with inject stores the inject map', () => {
+    const def = service('auth', {
       inject: { users: usersEntity },
       actions: {
         login: {

--- a/packages/server/src/service/__tests__/service.test.ts
+++ b/packages/server/src/service/__tests__/service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { action } from '../action';
+import { service } from '../service';
 
 // ---------------------------------------------------------------------------
 // Minimal schema fixtures
@@ -21,11 +21,11 @@ const responseSchema = {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Feature: action() definition', () => {
-  describe('Given a valid action config with actions', () => {
-    describe('When calling action("auth", config)', () => {
-      it('Then returns an object with kind "action" and name "auth"', () => {
-        const def = action('auth', {
+describe('Feature: service() definition', () => {
+  describe('Given a valid service config with actions', () => {
+    describe('When calling service("auth", config)', () => {
+      it('Then returns an object with kind "service" and name "auth"', () => {
+        const def = service('auth', {
           actions: {
             login: {
               body: bodySchema,
@@ -35,12 +35,12 @@ describe('Feature: action() definition', () => {
           },
         });
 
-        expect(def.kind).toBe('action');
+        expect(def.kind).toBe('service');
         expect(def.name).toBe('auth');
       });
 
       it('Then the returned object is frozen (deep freeze)', () => {
-        const def = action('auth', {
+        const def = service('auth', {
           actions: {
             login: {
               body: bodySchema,
@@ -58,7 +58,7 @@ describe('Feature: action() definition', () => {
 
       it('Then .access contains the passed access rules', () => {
         const loginRule = () => true;
-        const def = action('auth', {
+        const def = service('auth', {
           access: { login: loginRule },
           actions: {
             login: {
@@ -73,7 +73,7 @@ describe('Feature: action() definition', () => {
       });
 
       it('Then .inject defaults to {} when not provided', () => {
-        const def = action('auth', {
+        const def = service('auth', {
           actions: {
             login: {
               body: bodySchema,
@@ -88,11 +88,11 @@ describe('Feature: action() definition', () => {
     });
   });
 
-  describe('Given an invalid action name', () => {
-    describe('When calling action() with empty name', () => {
+  describe('Given an invalid service name', () => {
+    describe('When calling service() with empty name', () => {
       it('Then throws with a descriptive error', () => {
         expect(() =>
-          action('', {
+          service('', {
             actions: {
               login: {
                 body: bodySchema,
@@ -101,14 +101,14 @@ describe('Feature: action() definition', () => {
               },
             },
           }),
-        ).toThrow(/action\(\) name must be a non-empty lowercase string/);
+        ).toThrow(/service\(\) name must be a non-empty lowercase string/);
       });
     });
 
-    describe('When calling action() with uppercase name', () => {
+    describe('When calling service() with uppercase name', () => {
       it('Then rejects the name', () => {
         expect(() =>
-          action('Auth', {
+          service('Auth', {
             actions: {
               login: {
                 body: bodySchema,
@@ -117,14 +117,14 @@ describe('Feature: action() definition', () => {
               },
             },
           }),
-        ).toThrow(/action\(\) name/);
+        ).toThrow(/service\(\) name/);
       });
     });
 
-    describe('When calling action() with valid names', () => {
+    describe('When calling service() with valid names', () => {
       it('Then accepts lowercase with hyphens and numbers', () => {
         expect(() =>
-          action('auth-v2', {
+          service('auth-v2', {
             actions: {
               login: {
                 body: bodySchema,
@@ -138,14 +138,14 @@ describe('Feature: action() definition', () => {
     });
   });
 
-  describe('Given an action config with no actions', () => {
-    describe('When calling action() with empty actions', () => {
+  describe('Given a service config with no actions', () => {
+    describe('When calling service() with empty actions', () => {
       it('Then throws with a descriptive error', () => {
         expect(() =>
-          action('auth', {
+          service('auth', {
             actions: {},
           }),
-        ).toThrow(/action\(\) requires at least one action/);
+        ).toThrow(/service\(\) requires at least one action/);
       });
     });
   });

--- a/packages/server/src/service/context.ts
+++ b/packages/server/src/service/context.ts
@@ -1,15 +1,15 @@
 import type { RequestInfo } from '../entity/context';
 import type { EntityOperations } from '../entity/entity-operations';
-import type { ActionContext } from './types';
+import type { ServiceContext } from './types';
 
 /**
- * Creates an ActionContext from request info and registry proxy.
+ * Creates a ServiceContext from request info and registry proxy.
  * Mirrors createEntityContext() but without the `entity` (self-CRUD) property.
  */
-export function createActionContext(
+export function createServiceContext(
   request: RequestInfo,
   registryProxy: Record<string, EntityOperations>,
-): ActionContext {
+): ServiceContext {
   const userId = request.userId ?? null;
   const roles = request.roles ?? [];
   const tenantId = request.tenantId ?? null;

--- a/packages/server/src/service/index.ts
+++ b/packages/server/src/service/index.ts
@@ -1,0 +1,2 @@
+export { service } from './service';
+export type { ServiceActionDef, ServiceConfig, ServiceContext, ServiceDefinition } from './types';

--- a/packages/server/src/service/route-generator.ts
+++ b/packages/server/src/service/route-generator.ts
@@ -3,14 +3,14 @@ import { enforceAccess } from '../entity/access-enforcer';
 import type { RequestInfo } from '../entity/context';
 import type { EntityOperations } from '../entity/entity-operations';
 import type { EntityRegistry } from '../entity/entity-registry';
-import { createActionContext } from './context';
-import type { ActionDefinition } from './types';
+import { createServiceContext } from './context';
+import type { ServiceDefinition } from './types';
 
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
 
-export interface ActionRouteOptions {
+export interface ServiceRouteOptions {
   apiPrefix?: string;
 }
 
@@ -42,16 +42,16 @@ function extractRequestInfo(ctx: Record<string, unknown>): RequestInfo {
 // ---------------------------------------------------------------------------
 
 /**
- * Generates HTTP route entries for a standalone action definition.
+ * Generates HTTP route entries for a standalone service definition.
  *
- * Each action handler produces one route: `{method} /{prefix}/{actionName}/{handlerName}`.
+ * Each action handler produces one route: `{method} /{prefix}/{serviceName}/{handlerName}`.
  * Handlers with no access rule are skipped (deny by default = no route).
  * Handlers with `access: false` get a 405 handler.
  */
-export function generateActionRoutes(
-  def: ActionDefinition,
+export function generateServiceRoutes(
+  def: ServiceDefinition,
   registry: EntityRegistry,
-  options?: ActionRouteOptions,
+  options?: ServiceRouteOptions,
 ): EntityRouteEntry[] {
   const prefix = options?.apiPrefix ?? '/api';
   const inject = def.inject ?? {};
@@ -98,10 +98,10 @@ export function generateActionRoutes(
       handler: async (ctx) => {
         try {
           const requestInfo = extractRequestInfo(ctx);
-          const actionCtx = createActionContext(requestInfo, registryProxy);
+          const serviceCtx = createServiceContext(requestInfo, registryProxy);
 
           // Enforce access rule
-          const accessResult = await enforceAccess(handlerName, def.access, actionCtx);
+          const accessResult = await enforceAccess(handlerName, def.access, serviceCtx);
           if (!accessResult.ok) {
             return jsonResponse(
               { error: { code: 'Forbidden', message: accessResult.error.message } },
@@ -119,7 +119,7 @@ export function generateActionRoutes(
           }
 
           // Execute handler
-          const result = await handlerDef.handler(parsed.data, actionCtx);
+          const result = await handlerDef.handler(parsed.data, serviceCtx);
 
           // Validate response
           const responseParsed = handlerDef.response.parse(result);
@@ -128,7 +128,7 @@ export function generateActionRoutes(
               responseParsed.error instanceof Error
                 ? responseParsed.error.message
                 : 'Response validation failed';
-            console.warn(`[vertz] Action response validation warning: ${message}`);
+            console.warn(`[vertz] Service response validation warning: ${message}`);
           }
 
           return jsonResponse(result, 200);

--- a/packages/server/src/service/service.ts
+++ b/packages/server/src/service/service.ts
@@ -1,35 +1,35 @@
 import { deepFreeze } from '@vertz/core';
 import type { EntityDefinition } from '../entity/types';
-import type { ActionActionDef, ActionConfig, ActionDefinition } from './types';
+import type { ServiceActionDef, ServiceConfig, ServiceDefinition } from './types';
 
-const ACTION_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+const SERVICE_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 
-export function action<
+export function service<
   // biome-ignore lint/complexity/noBannedTypes: {} represents no injected entities
   TInject extends Record<string, EntityDefinition> = {},
   // biome-ignore lint/suspicious/noExplicitAny: constraint uses any to accept all action type parameter combinations
-  TActions extends Record<string, ActionActionDef<any, any, any>> = Record<
+  TActions extends Record<string, ServiceActionDef<any, any, any>> = Record<
     string,
     // biome-ignore lint/suspicious/noExplicitAny: constraint uses any to accept all action type parameter combinations
-    ActionActionDef<any, any, any>
+    ServiceActionDef<any, any, any>
   >,
->(name: string, config: ActionConfig<TActions, TInject>): ActionDefinition {
-  if (!name || !ACTION_NAME_PATTERN.test(name)) {
+>(name: string, config: ServiceConfig<TActions, TInject>): ServiceDefinition {
+  if (!name || !SERVICE_NAME_PATTERN.test(name)) {
     throw new Error(
-      `action() name must be a non-empty lowercase string matching /^[a-z][a-z0-9-]*$/. Got: "${name}"`,
+      `service() name must be a non-empty lowercase string matching /^[a-z][a-z0-9-]*$/. Got: "${name}"`,
     );
   }
 
   if (!config.actions || Object.keys(config.actions).length === 0) {
-    throw new Error('action() requires at least one action in the actions config.');
+    throw new Error('service() requires at least one action in the actions config.');
   }
 
-  const def: ActionDefinition = {
-    kind: 'action',
+  const def: ServiceDefinition = {
+    kind: 'service',
     name,
     inject: (config.inject ?? {}) as Record<string, EntityDefinition>,
     access: config.access ?? {},
-    actions: config.actions as Record<string, ActionActionDef>,
+    actions: config.actions as Record<string, ServiceActionDef>,
   };
   return deepFreeze(def);
 }

--- a/packages/server/src/service/types.ts
+++ b/packages/server/src/service/types.ts
@@ -19,10 +19,10 @@ type InjectToOperations<TInject extends Record<string, EntityDefinition> = {}> =
 };
 
 // ---------------------------------------------------------------------------
-// ActionContext — runtime context for action handlers
+// ServiceContext — runtime context for service handlers
 // ---------------------------------------------------------------------------
 
-export interface ActionContext<
+export interface ServiceContext<
   // biome-ignore lint/complexity/noBannedTypes: {} represents no injected entities — the correct default
   TInject extends Record<string, EntityDefinition> = {},
 > extends BaseContext {
@@ -31,13 +31,13 @@ export interface ActionContext<
 }
 
 // ---------------------------------------------------------------------------
-// ActionActionDef — definition of a single handler within an action group
+// ServiceActionDef — definition of a single handler within a service
 // ---------------------------------------------------------------------------
 
-export interface ActionActionDef<
+export interface ServiceActionDef<
   TInput = unknown,
   TOutput = unknown,
-  TCtx extends ActionContext = ActionContext,
+  TCtx extends ServiceContext = ServiceContext,
 > {
   readonly method?: string;
   readonly path?: string;
@@ -47,15 +47,15 @@ export interface ActionActionDef<
 }
 
 // ---------------------------------------------------------------------------
-// ActionConfig — what developers pass to action()
+// ServiceConfig — what developers pass to service()
 // ---------------------------------------------------------------------------
 
-export interface ActionConfig<
+export interface ServiceConfig<
   // biome-ignore lint/suspicious/noExplicitAny: constraint uses any to accept all action type parameter combinations
-  TActions extends Record<string, ActionActionDef<any, any, any>> = Record<
+  TActions extends Record<string, ServiceActionDef<any, any, any>> = Record<
     string,
     // biome-ignore lint/suspicious/noExplicitAny: constraint uses any to accept all action type parameter combinations
-    ActionActionDef<any, any, any>
+    ServiceActionDef<any, any, any>
   >,
   // biome-ignore lint/complexity/noBannedTypes: {} represents no injected entities — the correct default
   TInject extends Record<string, EntityDefinition> = {},
@@ -66,13 +66,13 @@ export interface ActionConfig<
 }
 
 // ---------------------------------------------------------------------------
-// ActionDefinition — the frozen output of action()
+// ServiceDefinition — the frozen output of service()
 // ---------------------------------------------------------------------------
 
-export interface ActionDefinition {
-  readonly kind: 'action';
+export interface ServiceDefinition {
+  readonly kind: 'service';
   readonly name: string;
   readonly inject: Record<string, EntityDefinition>;
   readonly access: Partial<Record<string, AccessRule>>;
-  readonly actions: Record<string, ActionActionDef>;
+  readonly actions: Record<string, ServiceActionDef>;
 }


### PR DESCRIPTION
## Summary

- Renames the standalone `action()` primitive to `service()` to align with DDD Application Service terminology
- The inner `actions` key is kept unchanged — consistent with entity's existing `actions` key, so `service()` reads as "entity minus CRUD"
- `ServerConfig.actions` → `ServerConfig.services`
- All types renamed: `ActionDefinition` → `ServiceDefinition`, `ActionContext` → `ServiceContext`, `ServiceActionDef`, etc.
- Updated integration walkthrough, example app, and all unit/type tests

Closes #952

## Test plan

- [x] 22 service unit tests passing (definition, context, route generator)
- [x] 7 type-level tests passing (ServiceContext type flow, kind discriminator)
- [x] 6 integration walkthrough tests passing (public API imports only)
- [x] 11 example app tests passing (webhooks via service)
- [x] 363 total server package tests passing
- [x] Typecheck clean on `@vertz/server` and `@vertz/integration-tests`
- [x] Pre-push quality gates: 67/67 tasks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)