### PR TITLE
test(cli): add coverage for discoverInlineCSS and serveStaticFile

### DIFF
--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -10,7 +10,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { discoverSSRModule, startAction, validateBuildOutputs } from '../start';
+import {
+  discoverInlineCSS,
+  discoverSSRModule,
+  serveStaticFile,
+  startAction,
+  validateBuildOutputs,
+} from '../start';
 
 describe('discoverSSRModule', () => {
   let projectRoot: string;
@@ -120,6 +126,92 @@ describe('validateBuildOutputs', () => {
     writeFileSync(join(projectRoot, 'dist', 'server', 'app.js'), 'export default {}');
     const result = validateBuildOutputs(projectRoot, 'full-stack');
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('discoverInlineCSS', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'vertz-start-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns undefined when dist/client/assets/ does not exist', () => {
+    expect(discoverInlineCSS(projectRoot)).toBeUndefined();
+  });
+
+  it('returns undefined when assets dir has no CSS files', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client', 'assets'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'assets', 'app.js'), 'console.log()');
+    expect(discoverInlineCSS(projectRoot)).toBeUndefined();
+  });
+
+  it('returns a map of CSS file paths to contents', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client', 'assets'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'assets', 'style-abc.css'), 'body{margin:0}');
+    writeFileSync(join(projectRoot, 'dist', 'client', 'assets', 'theme-def.css'), ':root{--c:red}');
+    const result = discoverInlineCSS(projectRoot);
+    expect(result).toEqual({
+      '/assets/style-abc.css': 'body{margin:0}',
+      '/assets/theme-def.css': ':root{--c:red}',
+    });
+  });
+
+  it('ignores non-CSS files in the assets directory', () => {
+    mkdirSync(join(projectRoot, 'dist', 'client', 'assets'), { recursive: true });
+    writeFileSync(join(projectRoot, 'dist', 'client', 'assets', 'main.css'), 'h1{color:blue}');
+    writeFileSync(join(projectRoot, 'dist', 'client', 'assets', 'chunk.js'), 'export{}');
+    const result = discoverInlineCSS(projectRoot);
+    expect(result).toEqual({
+      '/assets/main.css': 'h1{color:blue}',
+    });
+  });
+});
+
+describe('serveStaticFile', () => {
+  let clientDir: string;
+
+  beforeEach(() => {
+    clientDir = mkdtempSync(join(tmpdir(), 'vertz-static-'));
+  });
+
+  afterEach(() => {
+    rmSync(clientDir, { recursive: true, force: true });
+  });
+
+  it('returns null for root path', () => {
+    expect(serveStaticFile(clientDir, '/')).toBeNull();
+  });
+
+  it('returns null for /index.html', () => {
+    expect(serveStaticFile(clientDir, '/index.html')).toBeNull();
+  });
+
+  it('returns null for path traversal attempts', () => {
+    expect(serveStaticFile(clientDir, '/../../../etc/passwd')).toBeNull();
+  });
+
+  it('returns null when file does not exist', () => {
+    expect(serveStaticFile(clientDir, '/nonexistent.js')).toBeNull();
+  });
+
+  it('serves existing file with short cache for non-hashed assets', () => {
+    writeFileSync(join(clientDir, 'favicon.ico'), 'icon-data');
+    const response = serveStaticFile(clientDir, '/favicon.ico');
+    expect(response).not.toBeNull();
+    expect(response?.headers.get('Cache-Control')).toBe('public, max-age=3600');
+  });
+
+  it('serves hashed assets with immutable cache', () => {
+    mkdirSync(join(clientDir, 'assets'), { recursive: true });
+    writeFileSync(join(clientDir, 'assets', 'chunk-abc123.js'), 'export{}');
+    const response = serveStaticFile(clientDir, '/assets/chunk-abc123.js');
+    expect(response).not.toBeNull();
+    expect(response?.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
   });
 });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -323,7 +323,7 @@ async function startFullStack(
 /**
  * Discover CSS files to inline from the client build.
  */
-function discoverInlineCSS(projectRoot: string): Record<string, string> | undefined {
+export function discoverInlineCSS(projectRoot: string): Record<string, string> | undefined {
   const cssDir = resolve(projectRoot, 'dist', 'client', 'assets');
   if (!existsSync(cssDir)) return undefined;
 
@@ -342,7 +342,7 @@ function discoverInlineCSS(projectRoot: string): Record<string, string> | undefi
  * Serve a static file from the client directory.
  * Returns null if the file doesn't exist or the path is outside the directory.
  */
-function serveStaticFile(clientDir: string, pathname: string): Response | null {
+export function serveStaticFile(clientDir: string, pathname: string): Response | null {
   // Skip root and html requests — let SSR handle those
   if (pathname === '/' || pathname === '/index.html') return null;
 


### PR DESCRIPTION
## Summary

- Export `discoverInlineCSS` and `serveStaticFile` from `start.ts` for testability
- Add 10 new unit tests covering the two previously-untested pure functions:
  - `discoverInlineCSS`: missing dir, empty dir, CSS map, non-CSS filtering
  - `serveStaticFile`: root/index.html bypass, path traversal guard, missing file, cache headers for hashed vs non-hashed assets

## Test plan

- [x] All 24 start command tests pass (14 existing + 10 new)
- [x] Lint clean (`biome check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)