### PR TITLE
feat(compiler): auto-reverse destructured component props

### DIFF
--- a/examples/entity-todo/src/components/todo-item.tsx
+++ b/examples/entity-todo/src/components/todo-item.tsx
@@ -21,13 +21,13 @@ export interface TodoItemProps {
   completed: boolean;
 }
 
-export function TodoItem(props: TodoItemProps) {
+export function TodoItem({ id, title, completed }: TodoItemProps) {
   let isConfirmOpen = false;
 
   const handleToggle = async () => {
     // Automatic optimistic update: the framework applies the patch to EntityStore
     // immediately, and rolls back if the server returns an error.
-    const result = await api.todos.update(props.id, { completed: !props.completed });
+    const result = await api.todos.update(id, { completed: !completed });
     if (!result.ok) {
       console.error('Failed to update todo:', result.error.message);
     }
@@ -36,26 +36,26 @@ export function TodoItem(props: TodoItemProps) {
   const handleDelete = async () => {
     isConfirmOpen = false;
 
-    const result = await api.todos.delete(props.id);
+    const result = await api.todos.delete(id);
     if (!result.ok) {
       console.error('Failed to delete todo:', result.error.message);
     }
   };
 
   return (
-    <div class={todoItemStyles.item} data-testid={`todo-item-${props.id}`}>
+    <div class={todoItemStyles.item} data-testid={`todo-item-${id}`}>
       <input
         type="checkbox"
         class={todoItemStyles.checkbox}
-        checked={props.completed}
+        checked={completed}
         onChange={handleToggle}
-        data-testid={`todo-checkbox-${props.id}`}
+        data-testid={`todo-checkbox-${id}`}
       />
       <span
-        class={props.completed ? todoItemStyles.labelCompleted : todoItemStyles.label}
-        data-testid={`todo-title-${props.id}`}
+        class={completed ? todoItemStyles.labelCompleted : todoItemStyles.label}
+        data-testid={`todo-title-${id}`}
       >
-        {props.title}
+        {title}
       </span>
       <button
         type="button"
@@ -63,7 +63,7 @@ export function TodoItem(props: TodoItemProps) {
         onClick={() => {
           isConfirmOpen = true;
         }}
-        data-testid={`todo-delete-${props.id}`}
+        data-testid={`todo-delete-${id}`}
       >
         Delete
       </button>
@@ -83,7 +83,7 @@ export function TodoItem(props: TodoItemProps) {
         >
           <h2 class={alertDialogStyles.title}>Delete todo?</h2>
           <p class={alertDialogStyles.description}>
-            This will permanently delete "{props.title}". This action cannot be undone.
+            This will permanently delete "{title}". This action cannot be undone.
           </p>
           <div class={alertDialogStyles.footer}>
             <button

--- a/packages/ui-compiler/src/__tests__/compiler.test.ts
+++ b/packages/ui-compiler/src/__tests__/compiler.test.ts
@@ -80,17 +80,33 @@ function Counter() {
     expect(result.map.sources).toEqual(['input.tsx']);
   });
 
-  it('returns diagnostics', () => {
+  it('returns diagnostics for unsupported destructuring patterns', () => {
+    // Nested destructuring is not auto-transformed — diagnostic should fire
     const result = compile(
       `
-function Card({ title }) {
-  return <div>{title}</div>;
+function Card({ style: { color } }: { style: { color: string } }) {
+  return <div>{color}</div>;
 }
     `.trim(),
     );
 
     expect(result.diagnostics.length).toBeGreaterThanOrEqual(1);
     expect(result.diagnostics[0]?.code).toBe('props-destructuring');
+  });
+
+  it('does not emit props-destructuring diagnostic for auto-transformed components', () => {
+    const result = compile(
+      `
+function Card({ title }: { title: string }) {
+  return <div>{title}</div>;
+}
+    `.trim(),
+    );
+
+    const propsDestructuringDiags = result.diagnostics.filter(
+      (d) => d.code === 'props-destructuring',
+    );
+    expect(propsDestructuringDiags.length).toBe(0);
   });
 
   it('adds runtime imports based on used features', () => {

--- a/packages/ui-compiler/src/analyzers/component-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/component-analyzer.ts
@@ -1,11 +1,12 @@
 import {
   type FunctionDeclaration,
   type Node,
+  type ParameterDeclaration,
   type SourceFile,
   SyntaxKind,
   type VariableDeclaration,
 } from 'ts-morph';
-import type { ComponentInfo } from '../types';
+import type { ComponentInfo, PropsBindingInfo } from '../types';
 
 /**
  * Detect functions that return JSX — the component boundaries
@@ -82,23 +83,11 @@ export class ComponentAnalyzer {
     const bodyEnd = body ? body.getEnd() : fn.getEnd();
 
     const param = fn.getParameters()[0];
-    let propsParam: string | null = null;
-    let hasDestructuredProps = false;
-
-    if (param) {
-      const nameNode = param.getNameNode();
-      if (nameNode.isKind(SyntaxKind.ObjectBindingPattern)) {
-        hasDestructuredProps = true;
-        propsParam = null;
-      } else {
-        propsParam = param.getName();
-      }
-    }
+    const propsInfo = this._extractPropsInfo(param);
 
     return {
       name: fn.getName() ?? 'anonymous',
-      propsParam,
-      hasDestructuredProps,
+      ...propsInfo,
       bodyStart,
       bodyEnd,
     };
@@ -106,9 +95,6 @@ export class ComponentAnalyzer {
 
   private _fromVariableDeclaration(decl: VariableDeclaration, init: Node): ComponentInfo {
     const name = decl.getName();
-
-    let propsParam: string | null = null;
-    let hasDestructuredProps = false;
 
     // Get parameters from arrow function or function expression
     const params = init.isKind(SyntaxKind.ArrowFunction)
@@ -118,15 +104,7 @@ export class ComponentAnalyzer {
         : [];
 
     const param = params[0];
-    if (param) {
-      const nameNode = param.getNameNode();
-      if (nameNode.isKind(SyntaxKind.ObjectBindingPattern)) {
-        hasDestructuredProps = true;
-        propsParam = null;
-      } else {
-        propsParam = param.getName();
-      }
-    }
+    const propsInfo = this._extractPropsInfo(param);
 
     // Body range
     let bodyNode: Node;
@@ -140,10 +118,77 @@ export class ComponentAnalyzer {
 
     return {
       name,
-      propsParam,
-      hasDestructuredProps,
+      ...propsInfo,
       bodyStart: bodyNode.getStart(),
       bodyEnd: bodyNode.getEnd(),
+    };
+  }
+
+  private _extractPropsInfo(
+    param: ParameterDeclaration | undefined,
+  ): Pick<ComponentInfo, 'propsParam' | 'hasDestructuredProps' | 'destructuredProps'> {
+    if (!param) {
+      return { propsParam: null, hasDestructuredProps: false };
+    }
+
+    const nameNode = param.getNameNode();
+    if (!nameNode.isKind(SyntaxKind.ObjectBindingPattern)) {
+      return { propsParam: param.getName(), hasDestructuredProps: false };
+    }
+
+    // Extract binding details from the ObjectBindingPattern
+    const bindings: PropsBindingInfo[] = [];
+    let hasRest = false;
+    let hasNestedDestructuring = false;
+
+    for (const element of nameNode.getElements()) {
+      if (element.getDotDotDotToken()) {
+        hasRest = true;
+        bindings.push({
+          propName: element.getName(),
+          bindingName: element.getName(),
+          isRest: true,
+        });
+        continue;
+      }
+
+      // Check for nested destructuring
+      const elementName = element.getNameNode();
+      if (
+        elementName.isKind(SyntaxKind.ObjectBindingPattern) ||
+        elementName.isKind(SyntaxKind.ArrayBindingPattern)
+      ) {
+        hasNestedDestructuring = true;
+        continue;
+      }
+
+      const bindingName = element.getName();
+      const propertyNameNode = element.getPropertyNameNode();
+      const propName = propertyNameNode ? propertyNameNode.getText() : bindingName;
+      const initializer = element.getInitializer();
+
+      bindings.push({
+        propName,
+        bindingName,
+        defaultValue: initializer?.getText(),
+        isRest: false,
+      });
+    }
+
+    const typeNode = param.getTypeNode();
+    const typeAnnotation = typeNode ? `: ${typeNode.getText()}` : null;
+
+    return {
+      propsParam: null,
+      hasDestructuredProps: true,
+      destructuredProps: {
+        bindings,
+        hasRest,
+        hasNestedDestructuring,
+        paramStart: param.getStart(),
+        paramEnd: param.getEnd(),
+        typeAnnotation,
+      },
     };
   }
 }

--- a/packages/ui-compiler/src/compiler.ts
+++ b/packages/ui-compiler/src/compiler.ts
@@ -10,6 +10,7 @@ import { SSRSafetyDiagnostics } from './diagnostics/ssr-safety-diagnostics';
 import { ComputedTransformer } from './transformers/computed-transformer';
 import { JsxTransformer } from './transformers/jsx-transformer';
 import { MutationTransformer } from './transformers/mutation-transformer';
+import { PropsDestructuringTransformer } from './transformers/props-destructuring-transformer';
 import { SignalTransformer } from './transformers/signal-transformer';
 import type { CompileOptions, CompileOutput, CompilerDiagnostic } from './types';
 
@@ -54,6 +55,12 @@ export function compile(
       map: s.generateMap({ source: filename, includeContent: true }),
       diagnostics: [],
     };
+  }
+
+  // 2.5. Props destructuring transform (before reactivity analysis)
+  const propsTransformer = new PropsDestructuringTransformer();
+  for (const component of components) {
+    propsTransformer.transform(s, sourceFile, component);
   }
 
   // Track which runtime features are used

--- a/packages/ui-compiler/src/transformers/__tests__/props-destructuring-transformer.test.ts
+++ b/packages/ui-compiler/src/transformers/__tests__/props-destructuring-transformer.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'bun:test';
+import { compile } from '../../compiler';
+
+describe('PropsDestructuringTransformer', () => {
+  it('rewrites simple destructured prop to __props access', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        return <div>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props');
+    expect(result.code).toContain('__props.title');
+    expect(result.code).not.toContain('{ title }');
+  });
+
+  it('rewrites multiple bindings', () => {
+    const code = `
+      function Card({ title, subtitle }: { title: string; subtitle: string }) {
+        return <div>{title} {subtitle}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.title');
+    expect(result.code).toContain('__props.subtitle');
+  });
+
+  it('preserves type annotation', () => {
+    const code = `
+      interface CardProps { title: string }
+      function Card({ title }: CardProps) {
+        return <div>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props: CardProps');
+  });
+
+  it('wraps prop access in __attr thunk for JSX attributes', () => {
+    const code = `
+      function Card({ completed }: { completed: boolean }) {
+        return <div class={completed ? 'done' : 'pending'}>text</div>;
+      }
+    `;
+    const result = compile(code);
+    // __attr wraps non-literal expressions in a thunk
+    expect(result.code).toContain('__attr');
+    expect(result.code).toContain('__props.completed');
+  });
+
+  it('wraps prop access in __child thunk for JSX children', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        return <div>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__child(() => __props.title)');
+  });
+
+  it('works alongside signal transforms', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        let count = 0;
+        return <div>{title} {count}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.title');
+    expect(result.code).toContain('count.value');
+  });
+
+  it('does not transform non-component functions', () => {
+    const code = `
+      function helper({ x }: { x: number }) {
+        return x + 1;
+      }
+    `;
+    const result = compile(code);
+    // No JSX → not a component → no transform
+    expect(result.code).not.toContain('__props');
+  });
+
+  it('does not transform components without destructured props', () => {
+    const code = `
+      function Card(props: { title: string }) {
+        return <div>{props.title}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).not.toContain('__props');
+    expect(result.code).toContain('props.title');
+  });
+
+  it('transforms arrow function components', () => {
+    const code = `
+      const Card = ({ title }: { title: string }) => {
+        return <div>{title}</div>;
+      };
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.title');
+    expect(result.code).toContain('__props: { title: string }');
+  });
+
+  it('transforms arrow expression body components', () => {
+    const code = `
+      const Card = ({ title }: { title: string }) => <div>{title}</div>;
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.title');
+  });
+
+  it('does not replace shadowed bindings in inner scope', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        const inner = () => {
+          const title = 'override';
+          return title;
+        };
+        return <div>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    // The JSX {title} should be __props.title
+    expect(result.code).toContain('__props.title');
+    // The inner const title = 'override' should remain
+    expect(result.code).toContain("const title = 'override'");
+    // The inner return title should NOT be __props.title
+    expect(result.code).toContain('return title');
+  });
+
+  it('handles shorthand property assignment', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        const obj = { title };
+        return <div>{obj.title}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('{ title: __props.title }');
+  });
+
+  it('does not emit props-destructuring diagnostic for transformed components', () => {
+    const code = `
+      function Card({ title }: { title: string }) {
+        return <div>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    const propsDiags = result.diagnostics.filter((d) => d.code === 'props-destructuring');
+    expect(propsDiags).toHaveLength(0);
+  });
+
+  it('still emits diagnostic for nested destructuring (unsupported)', () => {
+    const code = `
+      function Card({ style: { color } }: { style: { color: string } }) {
+        return <div>{color}</div>;
+      }
+    `;
+    const result = compile(code);
+    const propsDiags = result.diagnostics.filter((d) => d.code === 'props-destructuring');
+    expect(propsDiags).toHaveLength(1);
+  });
+
+  it('uses prop in template literal', () => {
+    const code =
+      `
+      function Card({ title }: { title: string }) {
+        return <div>{` +
+      '`Hello ${title}`' +
+      `}</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.title');
+  });
+
+  // Phase 2: Aliases and defaults
+  it('rewrites aliased binding to original prop name', () => {
+    const code = `
+      function Card({ id: cardId }: { id: string }) {
+        return <div data-id={cardId}>content</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain('__props.id');
+    expect(result.code).not.toContain('cardId');
+  });
+
+  it('rewrites binding with default value using nullish coalescing', () => {
+    const code = `
+      function Card({ size = 'md' }: { size?: string }) {
+        return <div class={size}>content</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain("__props.size ?? 'md'");
+  });
+
+  it('rewrites alias with default', () => {
+    const code = `
+      function Card({ size: s = 'md' }: { size?: string }) {
+        return <div class={s}>content</div>;
+      }
+    `;
+    const result = compile(code);
+    expect(result.code).toContain("__props.size ?? 'md'");
+    expect(result.code).not.toContain(' s ');
+  });
+
+  it('wraps default in parens in JSX attribute context', () => {
+    const code = `
+      function Card({ size = 'md' }: { size?: string }) {
+        return <div class={size}>content</div>;
+      }
+    `;
+    const result = compile(code);
+    // Should be wrapped in parens for correct precedence in thunk
+    expect(result.code).toContain("(__props.size ?? 'md')");
+  });
+
+  // Phase 3: Rest patterns
+  it('handles rest pattern: named props use __props, rest gets destructured at body top', () => {
+    const code = `
+      function Card({ title, ...rest }: CardProps) {
+        return <div class={rest.className}>{title}</div>;
+      }
+    `;
+    const result = compile(code);
+    // Named prop uses __props access
+    expect(result.code).toContain('__props.title');
+    // Rest gets real destructuring at body top
+    expect(result.code).toContain('const { title: __$drop_0, ...rest } = __props');
+    // Parameter rewritten
+    expect(result.code).toContain('__props: CardProps');
+  });
+
+  it('handles rest pattern with alias', () => {
+    const code = `
+      function Card({ id: cardId, ...rest }: CardProps) {
+        return <div data-id={cardId} class={rest.className}>content</div>;
+      }
+    `;
+    const result = compile(code);
+    // Alias uses original prop name via __props
+    expect(result.code).toContain('__props.id');
+    expect(result.code).not.toContain('cardId');
+    // Rest gets destructuring with drop for 'id'
+    expect(result.code).toContain('const { id: __$drop_0, ...rest } = __props');
+  });
+});

--- a/packages/ui-compiler/src/transformers/props-destructuring-transformer.ts
+++ b/packages/ui-compiler/src/transformers/props-destructuring-transformer.ts
@@ -1,0 +1,239 @@
+import type MagicString from 'magic-string';
+import { type Node, type SourceFile, SyntaxKind } from 'ts-morph';
+import type { ComponentInfo, DestructuredPropsInfo, PropsBindingInfo } from '../types';
+import { findBodyNode } from '../utils';
+
+/**
+ * Find the body node for a component, handling both block bodies and
+ * arrow expression bodies (which findBodyNode doesn't cover).
+ */
+function findComponentBody(sourceFile: SourceFile, component: ComponentInfo): Node | null {
+  // Try block body first (function declarations, arrow with block body)
+  const block = findBodyNode(sourceFile, component);
+  if (block) return block;
+
+  // Arrow expression body: find the node at the body position range
+  const allNodes = sourceFile.getDescendants();
+  for (const node of allNodes) {
+    if (node.getStart() === component.bodyStart && node.getEnd() === component.bodyEnd) {
+      return node;
+    }
+  }
+  return null;
+}
+
+/**
+ * Reverse destructured component props to preserve getter-based reactivity.
+ *
+ * Rewrites `function Card({ title, completed }: Props)` to
+ * `function Card(__props: Props)` and replaces all body references to
+ * `title` → `__props.title`, `completed` → `__props.completed`.
+ *
+ * Must run BEFORE reactivity analysis so downstream transforms see `__props.xxx`.
+ */
+export class PropsDestructuringTransformer {
+  transform(source: MagicString, sourceFile: SourceFile, component: ComponentInfo): void {
+    const { destructuredProps } = component;
+    if (!destructuredProps) return;
+
+    // Skip nested destructuring (unsupported)
+    if (destructuredProps.hasNestedDestructuring) return;
+
+    // Skip if no simple bindings to transform
+    const simpleBindings = destructuredProps.bindings.filter((b) => !b.isRest);
+    if (simpleBindings.length === 0 && !destructuredProps.hasRest) return;
+
+    // Build the binding name → binding info map (excludes rest)
+    const bindingMap = new Map<string, PropsBindingInfo>();
+    for (const binding of simpleBindings) {
+      bindingMap.set(binding.bindingName, binding);
+    }
+
+    // 1. Rewrite the parameter
+    const newParam = `__props${destructuredProps.typeAnnotation ?? ''}`;
+    source.overwrite(destructuredProps.paramStart, destructuredProps.paramEnd, newParam);
+
+    // 2. Replace all references in the function body
+    const bodyNode = findComponentBody(sourceFile, component);
+    if (!bodyNode) return;
+
+    this._replaceReferences(source, bodyNode, bindingMap);
+
+    // 3. Insert rest destructuring at body top if needed
+    if (destructuredProps.hasRest) {
+      this._insertRestDestructuring(source, bodyNode, destructuredProps);
+    }
+
+    // 3. Update component info for downstream transforms
+    component.propsParam = '__props';
+    component.hasDestructuredProps = false;
+  }
+
+  private _replaceReferences(
+    source: MagicString,
+    bodyNode: Node,
+    bindingMap: Map<string, PropsBindingInfo>,
+  ): void {
+    const identifiers = bodyNode.getDescendantsOfKind(SyntaxKind.Identifier);
+
+    for (const id of identifiers) {
+      const name = id.getText();
+      const binding = bindingMap.get(name);
+      if (!binding) continue;
+
+      // Skip if not a reference to the destructured binding
+      if (!this._isBindingReference(id, name)) continue;
+
+      const parent = id.getParent();
+      const replacement = this._buildReplacement(binding);
+
+      // Handle shorthand property assignment: { title } → { title: __props.title }
+      if (parent?.isKind(SyntaxKind.ShorthandPropertyAssignment)) {
+        source.overwrite(parent.getStart(), parent.getEnd(), `${name}: ${replacement}`);
+        continue;
+      }
+
+      // Regular identifier replacement
+      source.overwrite(id.getStart(), id.getEnd(), replacement);
+    }
+  }
+
+  private _buildReplacement(binding: PropsBindingInfo): string {
+    const access = `__props.${binding.propName}`;
+    if (!binding.defaultValue) return access;
+    return `(${access} ?? ${binding.defaultValue})`;
+  }
+
+  /**
+   * Insert a rest destructuring statement at the top of the component body.
+   * Named bindings are dropped (replaced with __props.xxx), rest variable
+   * gets the real destructured rest object.
+   *
+   * Example: `const { title: __$drop_0, id: __$drop_1, ...rest } = __props;`
+   */
+  private _insertRestDestructuring(
+    source: MagicString,
+    bodyNode: Node,
+    props: DestructuredPropsInfo,
+  ): void {
+    const restBinding = props.bindings.find((b) => b.isRest);
+    if (!restBinding) return;
+
+    const namedBindings = props.bindings.filter((b) => !b.isRest);
+    const drops = namedBindings.map((b, i) => `${b.propName}: __$drop_${i}`);
+    const pattern = [...drops, `...${restBinding.bindingName}`].join(', ');
+    const stmt = `\n  const { ${pattern} } = __props;`;
+
+    // Insert after the opening brace of the body block
+    if (bodyNode.isKind(SyntaxKind.Block)) {
+      source.appendRight(bodyNode.getStart() + 1, stmt);
+    }
+  }
+
+  private _isBindingReference(id: Node, bindingName: string): boolean {
+    const parent = id.getParent();
+    if (!parent) return false;
+
+    // Skip: right side of property access (obj.title → skip the `title`)
+    if (parent.isKind(SyntaxKind.PropertyAccessExpression) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: property name in object literal ({ title: value } → skip `title` key)
+    if (parent.isKind(SyntaxKind.PropertyAssignment) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: variable declaration name (const title = ...)
+    if (parent.isKind(SyntaxKind.VariableDeclaration) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: function parameter name
+    if (parent.isKind(SyntaxKind.Parameter) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: binding element name (const { title } = ...)
+    if (parent.isKind(SyntaxKind.BindingElement) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: function declaration name
+    if (parent.isKind(SyntaxKind.FunctionDeclaration) && parent.getNameNode() === id) {
+      return false;
+    }
+
+    // Skip: if shadowed by a declaration in an enclosing scope
+    if (this._isShadowed(id, bindingName)) return false;
+
+    return true;
+  }
+
+  /**
+   * Check if an identifier is shadowed by a declaration in a scope between
+   * the identifier and the component body root.
+   */
+  private _isShadowed(id: Node, bindingName: string): boolean {
+    let current = id.getParent();
+    // Walk up to find scopes that might shadow this binding
+    while (current) {
+      if (
+        current.isKind(SyntaxKind.Block) ||
+        current.isKind(SyntaxKind.ArrowFunction) ||
+        current.isKind(SyntaxKind.FunctionDeclaration) ||
+        current.isKind(SyntaxKind.FunctionExpression)
+      ) {
+        if (this._scopeDeclaresName(current, bindingName)) return true;
+      }
+      current = current.getParent();
+    }
+    return false;
+  }
+
+  private _scopeDeclaresName(scope: Node, name: string): boolean {
+    // Check variable declarations
+    const varDecls = scope.getDescendantsOfKind(SyntaxKind.VariableDeclaration);
+    for (const decl of varDecls) {
+      // Only check direct children of this scope's blocks (not nested scopes)
+      if (decl.getName() === name && this._isDirectChild(scope, decl)) {
+        return true;
+      }
+    }
+
+    // Check function parameters (arrow functions, function expressions)
+    if (
+      scope.isKind(SyntaxKind.ArrowFunction) ||
+      scope.isKind(SyntaxKind.FunctionDeclaration) ||
+      scope.isKind(SyntaxKind.FunctionExpression)
+    ) {
+      const params = scope.getParameters();
+      for (const param of params) {
+        if (param.getName() === name) return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if a declaration is a direct child of the given scope
+   * (not nested inside a deeper scope).
+   */
+  private _isDirectChild(scope: Node, decl: Node): boolean {
+    let current = decl.getParent();
+    while (current && current !== scope) {
+      if (
+        current.isKind(SyntaxKind.Block) ||
+        current.isKind(SyntaxKind.ArrowFunction) ||
+        current.isKind(SyntaxKind.FunctionDeclaration) ||
+        current.isKind(SyntaxKind.FunctionExpression)
+      ) {
+        // Found an intermediate scope — decl is not a direct child
+        return current === scope;
+      }
+      current = current.getParent();
+    }
+    return current === scope;
+  }
+}

--- a/packages/ui-compiler/src/types.ts
+++ b/packages/ui-compiler/src/types.ts
@@ -74,6 +74,34 @@ export interface VariableInfo {
   isReactiveSource?: boolean;
 }
 
+/** Information about a single binding from a destructured props parameter. */
+export interface PropsBindingInfo {
+  /** Property name in the props object (e.g., 'id' in `{ id: cardId }`). */
+  propName: string;
+  /** Local binding name (e.g., 'cardId' in `{ id: cardId }`, or same as propName). */
+  bindingName: string;
+  /** Default value expression text, if any. */
+  defaultValue?: string;
+  /** Whether this is a rest element (`...rest`). */
+  isRest: boolean;
+}
+
+/** Detailed info about a destructured props parameter, for the transform. */
+export interface DestructuredPropsInfo {
+  /** All bindings from the destructuring pattern. */
+  bindings: PropsBindingInfo[];
+  /** Whether the pattern includes a rest element. */
+  hasRest: boolean;
+  /** Whether the pattern includes nested destructuring. */
+  hasNestedDestructuring: boolean;
+  /** 0-based start position of the entire parameter (including type annotation). */
+  paramStart: number;
+  /** 0-based end position of the entire parameter (including type annotation). */
+  paramEnd: number;
+  /** The type annotation text (e.g., ': TodoItemProps'), or null if none. */
+  typeAnnotation: string | null;
+}
+
 /** Information about a detected component function. */
 export interface ComponentInfo {
   /** Component function name. */
@@ -86,6 +114,8 @@ export interface ComponentInfo {
   bodyStart: number;
   /** 0-based end position of the function body. */
   bodyEnd: number;
+  /** Detailed destructuring info, populated when hasDestructuredProps is true. */
+  destructuredProps?: DestructuredPropsInfo;
 }
 
 /** Classification of a JSX expression's reactivity. */


### PR DESCRIPTION
## Summary

- Adds a new compiler transform (`PropsDestructuringTransformer`) that automatically reverses destructured component props parameters to preserve getter-based reactivity
- Users write idiomatic `{ title, completed }` in parameters; the compiler outputs `__props.title`, `__props.completed` with thunk wrapping in JSX
- Supports simple bindings, aliases (`{ id: cardId }`), defaults (`{ size = 'md' }` → `__props.size ?? 'md'`), and rest patterns (`{ title, ...rest }`)
- Reverts TodoItem example back to the idiomatic destructured props convention

Closes #965

## What changed

| File | Change |
|------|--------|
| `packages/ui-compiler/src/types.ts` | New `PropsBindingInfo`, `DestructuredPropsInfo` types |
| `packages/ui-compiler/src/analyzers/component-analyzer.ts` | Extracts binding details from `ObjectBindingPattern` |
| `packages/ui-compiler/src/transformers/props-destructuring-transformer.ts` | **New** — the transform |
| `packages/ui-compiler/src/compiler.ts` | Inserts transform at step 2.5 (before reactivity analysis) |
| `packages/ui-compiler/src/__tests__/compiler.test.ts` | Updated diagnostic tests |
| `examples/entity-todo/src/components/todo-item.tsx` | Reverted to destructured props |

## How it works

The transform runs **before** reactivity analysis in the pipeline:

```
Parse → Component analysis → 2.5 PROPS DESTRUCTURING → Reactivity → Signal → Computed → JSX
```

1. Rewrites `function Card({ title }: Props)` → `function Card(__props: Props)`
2. Replaces all body references: `title` → `__props.title`
3. JSX transformer then wraps `__props.xxx` in thunks (`__attr`, `__child`) because they're non-literal expressions — preserving reactivity through the getter chain

## Test plan

- [x] 21 dedicated transform tests covering all patterns (simple, alias, default, rest, shadowing, shorthand property, arrow functions, expression bodies, template literals)
- [x] Updated compiler integration tests for diagnostic behavior
- [x] Full ui-compiler suite passes (404 tests)
- [x] All 67 turbo quality gates pass (lint, typecheck, test, build)
- [ ] Manual E2E verification with entity-todo example

🤖 Generated with [Claude Code](https://claude.com/claude-code)