### PR TITLE
feat(router): schema-based route param parsing and validation [#945]

### DIFF
--- a/.changeset/route-param-schemas.md
+++ b/.changeset/route-param-schemas.md
@@ -1,0 +1,9 @@
+---
+'@vertz/ui': patch
+---
+
+feat(router): schema-based route param parsing and validation
+
+Add `ParamSchema<T>` interface and `params` field to `RouteConfig`. When a route defines a `params` schema, `matchRoute()` validates path params at the routing layer — invalid params result in no match (fallback/404 renders). Valid params are stored as `parsedParams` on `RouteMatch`.
+
+`useParams()` gains a second overload accepting a `Record<string, unknown>` type parameter for typed parsed params: `useParams<{ id: number }>()`.

--- a/packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test-d.ts
+++ b/packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test-d.ts
@@ -1,0 +1,46 @@
+/**
+ * Developer Walkthrough — Route Param Schema Types
+ *
+ * Type-level test using public package imports (@vertz/ui).
+ * Validates cross-package type safety for ParamSchema and useParams overloads.
+ *
+ * @see plans/route-param-schemas.md
+ */
+
+import type { ParamSchema } from '@vertz/ui';
+import { defineRoutes, useParams } from '@vertz/ui';
+
+// ── ParamSchema accepted in route config via public API ─────────────────────
+
+const schema: ParamSchema<{ id: string }> = {
+  parse(raw) {
+    const { id } = raw as { id: string };
+    return { ok: true, data: { id } };
+  },
+};
+
+// Positive: route config with params schema compiles
+defineRoutes({
+  '/tasks/:id': {
+    component: () => document.createElement('div'),
+    params: schema,
+  },
+});
+
+// ── useParams overloads via public API ──────────────────────────────────────
+
+// Overload 1: backward compat — path literal → string params
+const strParams = useParams<'/tasks/:id'>();
+const _id: string = strParams.id;
+void _id;
+
+// @ts-expect-error - 'name' not on ExtractParams<'/tasks/:id'>
+strParams.name;
+
+// Overload 2: parsed type assertion
+const parsedParams = useParams<{ id: string }>();
+const _parsedId: string = parsedParams.id;
+void _parsedId;
+
+// @ts-expect-error - 'name' not on { id: string }
+parsedParams.name;

--- a/packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Developer Walkthrough — Route Param Schemas
+ *
+ * Integration test using public package imports (@vertz/ui) to validate
+ * route param schema parsing at the routing layer.
+ *
+ * @see plans/route-param-schemas.md
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ParamSchema } from '@vertz/ui';
+import { createRouter, defineRoutes } from '@vertz/ui';
+
+describe('Route param schema walkthrough', () => {
+  const uuidSchema: ParamSchema<{ id: string }> = {
+    parse(raw) {
+      const { id } = raw as { id: string };
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(id)) return { ok: false, error: `Invalid UUID: ${id}` };
+      return { ok: true, data: { id } };
+    },
+  };
+
+  const routes = defineRoutes({
+    '/': { component: () => document.createElement('div') },
+    '/tasks/:id': {
+      component: () => document.createElement('div'),
+      params: uuidSchema,
+    },
+    '/items/:id': {
+      component: () => document.createElement('div'),
+      // No params schema — backward compat
+    },
+  });
+
+  it('routes with valid params when schema accepts', () => {
+    const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+    const router = createRouter(routes, `/tasks/${validUuid}`);
+    expect(router.current.value).not.toBeNull();
+    expect(router.current.value!.params).toEqual({ id: validUuid });
+    expect(router.current.value!.parsedParams).toEqual({ id: validUuid });
+    router.dispose();
+  });
+
+  it('rejects route when schema rejects params (returns null match)', () => {
+    const router = createRouter(routes, '/tasks/not-a-uuid');
+    expect(router.current.value).toBeNull();
+    router.dispose();
+  });
+
+  it('routes without schema work unchanged (backward compat)', () => {
+    const router = createRouter(routes, '/items/42');
+    expect(router.current.value).not.toBeNull();
+    expect(router.current.value!.params).toEqual({ id: '42' });
+    expect(router.current.value!.parsedParams).toBeUndefined();
+    router.dispose();
+  });
+
+  it('schema can transform param values', () => {
+    const numSchema: ParamSchema<{ id: number }> = {
+      parse(raw) {
+        const { id } = raw as { id: string };
+        const num = Number(id);
+        if (Number.isNaN(num)) return { ok: false, error: 'not a number' };
+        return { ok: true, data: { id: num } };
+      },
+    };
+
+    const numRoutes = defineRoutes({
+      '/items/:id': {
+        component: () => document.createElement('div'),
+        params: numSchema,
+      },
+    });
+
+    const router = createRouter(numRoutes, '/items/42');
+    expect(router.current.value).not.toBeNull();
+    expect(router.current.value!.params).toEqual({ id: '42' });
+    expect(router.current.value!.parsedParams).toEqual({ id: 42 });
+    router.dispose();
+  });
+
+  it('schema that throws is treated as rejection', () => {
+    const throwingSchema: ParamSchema<{ id: string }> = {
+      parse() {
+        throw new Error('boom');
+      },
+    };
+
+    const throwRoutes = defineRoutes({
+      '/items/:id': {
+        component: () => document.createElement('div'),
+        params: throwingSchema,
+      },
+    });
+
+    const router = createRouter(throwRoutes, '/items/42');
+    expect(router.current.value).toBeNull();
+    router.dispose();
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -111,6 +111,7 @@ export type {
   InferRouteMap,
   LoaderData,
   MatchedRoute,
+  ParamSchema,
   RouteConfig,
   RouteDefinitionMap,
   RouteMatch,

--- a/packages/ui/src/router/__tests__/define-routes.test.ts
+++ b/packages/ui/src/router/__tests__/define-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { ParamSchema } from '../define-routes';
 import { defineRoutes, matchRoute } from '../define-routes';
 
 describe('defineRoutes', () => {
@@ -149,5 +150,141 @@ describe('matchRoute', () => {
     const match = matchRoute(routes, '/users');
     expect(match).not.toBeNull();
     expect(match?.route.errorComponent).toBe(errorComp);
+  });
+});
+
+describe('defineRoutes with params schema', () => {
+  test('stores params schema on compiled route', () => {
+    const schema: ParamSchema<{ id: string }> = {
+      parse(raw) {
+        const { id } = raw as { id: string };
+        return { ok: true, data: { id } };
+      },
+    };
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+        params: schema,
+      },
+    });
+    expect(routes[0]?.params).toBe(schema);
+  });
+
+  test('compiled route has no params schema when not provided', () => {
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+      },
+    });
+    expect(routes[0]?.params).toBeUndefined();
+  });
+});
+
+describe('matchRoute with params schema', () => {
+  const uuidSchema: ParamSchema<{ id: string }> = {
+    parse(raw) {
+      const { id } = raw as { id: string };
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(id)) return { ok: false, error: `Invalid UUID: ${id}` };
+      return { ok: true, data: { id } };
+    },
+  };
+
+  test('sets parsedParams when schema succeeds', () => {
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+        params: uuidSchema,
+      },
+    });
+    const match = matchRoute(routes, '/tasks/550e8400-e29b-41d4-a716-446655440000');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+    expect(match!.parsedParams).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+  });
+
+  test('returns null when schema rejects params', () => {
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+        params: uuidSchema,
+      },
+    });
+    const match = matchRoute(routes, '/tasks/not-a-uuid');
+    expect(match).toBeNull();
+  });
+
+  test('returns null when schema parse() throws', () => {
+    const throwingSchema: ParamSchema<{ id: string }> = {
+      parse() {
+        throw new Error('unexpected');
+      },
+    };
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+        params: throwingSchema,
+      },
+    });
+    const match = matchRoute(routes, '/tasks/123');
+    expect(match).toBeNull();
+  });
+
+  test('no parsedParams when no schema is provided (backward compat)', () => {
+    const routes = defineRoutes({
+      '/tasks/:id': {
+        component: () => document.createElement('div'),
+      },
+    });
+    const match = matchRoute(routes, '/tasks/123');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ id: '123' });
+    expect(match!.parsedParams).toBeUndefined();
+  });
+
+  test('nested route: leaf schema receives all accumulated params', () => {
+    const multiSchema: ParamSchema<{ userId: string; postId: string }> = {
+      parse(raw) {
+        const { userId, postId } = raw as { userId: string; postId: string };
+        if (!userId || !postId) return { ok: false, error: 'missing params' };
+        return { ok: true, data: { userId, postId } };
+      },
+    };
+    const routes = defineRoutes({
+      '/users/:userId': {
+        component: () => document.createElement('div'),
+        children: {
+          '/posts/:postId': {
+            component: () => document.createElement('span'),
+            params: multiSchema,
+          },
+        },
+      },
+    });
+    const match = matchRoute(routes, '/users/alice/posts/42');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ userId: 'alice', postId: '42' });
+    expect(match!.parsedParams).toEqual({ userId: 'alice', postId: '42' });
+  });
+
+  test('schema can transform param values', () => {
+    const numSchema: ParamSchema<{ id: number }> = {
+      parse(raw) {
+        const { id } = raw as { id: string };
+        const num = Number(id);
+        if (Number.isNaN(num)) return { ok: false, error: 'not a number' };
+        return { ok: true, data: { id: num } };
+      },
+    };
+    const routes = defineRoutes({
+      '/items/:id': {
+        component: () => document.createElement('div'),
+        params: numSchema,
+      },
+    });
+    const match = matchRoute(routes, '/items/42');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ id: '42' });
+    expect(match!.parsedParams).toEqual({ id: 42 });
   });
 });

--- a/packages/ui/src/router/__tests__/param-schema.test-d.ts
+++ b/packages/ui/src/router/__tests__/param-schema.test-d.ts
@@ -1,0 +1,82 @@
+/**
+ * Type tests for ParamSchema on route definitions.
+ *
+ * @see plans/route-param-schemas.md
+ */
+
+import type { ParamSchema } from '../define-routes';
+import { defineRoutes } from '../define-routes';
+import { useParams } from '../router-context';
+
+// ── ParamSchema interface ───────────────────────────────────────────────────
+
+// Positive: valid schema compiles
+const validSchema: ParamSchema<{ id: string }> = {
+  parse(raw) {
+    const { id } = raw as { id: string };
+    return { ok: true, data: { id } };
+  },
+};
+void validSchema;
+
+// Positive: schema with non-string parsed values
+const numSchema: ParamSchema<{ id: number }> = {
+  parse(raw) {
+    const { id } = raw as { id: string };
+    return { ok: true, data: { id: Number(id) } };
+  },
+};
+void numSchema;
+
+// ── RouteConfig accepts params ──────────────────────────────────────────────
+
+// Positive: route config with params schema compiles
+defineRoutes({
+  '/tasks/:id': {
+    component: () => document.createElement('div'),
+    params: validSchema,
+  },
+});
+
+// Positive: route config without params schema compiles (backward compat)
+defineRoutes({
+  '/tasks/:id': {
+    component: () => document.createElement('div'),
+  },
+});
+
+// Positive: route config with both params and searchParams
+defineRoutes({
+  '/tasks/:id': {
+    component: () => document.createElement('div'),
+    params: validSchema,
+    searchParams: {
+      parse(raw) {
+        return { ok: true as const, data: raw as { page: string } };
+      },
+    },
+  },
+});
+
+// ── useParams overloads ─────────────────────────────────────────────────────
+
+// Overload 1: path literal → string params (backward compat)
+const strParams = useParams<'/tasks/:id'>();
+const _strId: string = strParams.id;
+void _strId;
+
+// @ts-expect-error - 'name' not on ExtractParams<'/tasks/:id'>
+strParams.name;
+
+// Overload 2: parsed type assertion
+const parsedParams = useParams<{ id: string }>();
+const _parsedId: string = parsedParams.id;
+void _parsedId;
+
+// @ts-expect-error - 'name' not on { id: string }
+parsedParams.name;
+
+// Overload 2 with non-string type
+const numParams = useParams<{ id: number }>();
+const _numId: number = numParams.id;
+void _numId;

--- a/packages/ui/src/router/__tests__/router-context.test.ts
+++ b/packages/ui/src/router/__tests__/router-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { lifecycleEffect } from '../../runtime/signal';
 import { untrack } from '../../runtime/tracking';
+import type { ParamSchema } from '../define-routes';
 import { defineRoutes } from '../define-routes';
 import { createRouter } from '../navigate';
 import { RouterContext, useParams, useRouter } from '../router-context';
@@ -42,6 +43,50 @@ describe('RouterContext + useRouter', () => {
     const router = createRouter(routes, '/tasks/42');
 
     let params: Record<string, string> | undefined;
+    RouterContext.Provider(router, () => {
+      params = useParams();
+    });
+
+    expect(params).toEqual({ id: '42' });
+    router.dispose();
+  });
+
+  test('useParams returns parsedParams when route has a params schema', () => {
+    const numSchema: ParamSchema<{ id: number }> = {
+      parse(raw) {
+        const { id } = raw as { id: string };
+        const num = Number(id);
+        if (Number.isNaN(num)) return { ok: false, error: 'not a number' };
+        return { ok: true, data: { id: num } };
+      },
+    };
+    const routes = defineRoutes({
+      '/items/:id': {
+        component: () => document.createElement('div'),
+        params: numSchema,
+      },
+    });
+    const router = createRouter(routes, '/items/42');
+
+    let params: unknown;
+    RouterContext.Provider(router, () => {
+      params = useParams();
+    });
+
+    // parsedParams is preferred — schema transforms string '42' to number 42
+    expect(params).toEqual({ id: 42 });
+    router.dispose();
+  });
+
+  test('useParams returns raw params when no schema is present', () => {
+    const routes = defineRoutes({
+      '/items/:id': {
+        component: () => document.createElement('div'),
+      },
+    });
+    const router = createRouter(routes, '/items/42');
+
+    let params: unknown;
     RouterContext.Provider(router, () => {
       params = useParams();
     });

--- a/packages/ui/src/router/define-routes.ts
+++ b/packages/ui/src/router/define-routes.ts
@@ -5,16 +5,20 @@
 import { matchPath } from './matcher';
 import type { ExtractParams } from './params';
 
-/** Simple schema interface for search param parsing. */
+/** Schema interface for parsing and validating values (search params, path params). */
 export interface SearchParamSchema<T> {
   parse(data: unknown): { ok: true; data: T } | { ok: false; error: unknown };
 }
+
+/** Schema interface for parsing and validating route path params. */
+export type ParamSchema<T> = SearchParamSchema<T>;
 
 /** A route configuration for a single path. */
 export interface RouteConfig<
   TPath extends string = string,
   TLoaderData = unknown,
   TSearch = unknown,
+  TParams = unknown,
 > {
   /** Component factory (lazy for code splitting). */
   component: () => Node | Promise<{ default: () => Node }>;
@@ -25,6 +29,8 @@ export interface RouteConfig<
   }) => Promise<TLoaderData> | TLoaderData;
   /** Optional error component rendered when loader throws. */
   errorComponent?: (error: Error) => Node;
+  /** Optional path params schema for validation/parsing. */
+  params?: ParamSchema<TParams>;
   /** Optional search params schema for validation/coercion. */
   searchParams?: SearchParamSchema<TSearch>;
   /** Nested child routes. */
@@ -52,6 +58,7 @@ export interface RouteConfigLike {
    */
   loader?(ctx: { params: Record<string, string>; signal: AbortSignal }): unknown;
   errorComponent?: (error: Error) => Node;
+  params?: ParamSchema<unknown>;
   searchParams?: SearchParamSchema<unknown>;
   children?: Record<string, RouteConfigLike>;
 }
@@ -84,6 +91,8 @@ export interface CompiledRoute {
     signal: AbortSignal;
   }) => Promise<unknown> | unknown;
   errorComponent?: RouteConfig['errorComponent'];
+  /** Optional path params schema for validation/parsing. */
+  params?: ParamSchema<unknown>;
   searchParams?: RouteConfig['searchParams'];
   /** Compiled children. */
   children?: CompiledRoute[];
@@ -99,6 +108,8 @@ export interface MatchedRoute {
 export interface RouteMatch {
   /** All params extracted from the full URL path. */
   params: Record<string, string>;
+  /** Parsed params via schema (set when route has a params schema and parse succeeds). */
+  parsedParams?: Record<string, unknown>;
   /** The leaf route config that matched. */
   route: CompiledRoute;
   /** The chain of matched routes from root to leaf (for nested layouts). */
@@ -132,6 +143,7 @@ export function defineRoutes<const T extends Record<string, RouteConfigLike>>(
       component: config.component,
       errorComponent: config.errorComponent,
       loader: config.loader as CompiledRoute['loader'],
+      params: config.params,
       pattern,
       searchParams: config.searchParams,
     };
@@ -165,6 +177,18 @@ export function matchRoute(routes: CompiledRoute[], url: string): RouteMatch | n
   const leaf = matchRouteRecursive(routes, pathname as string, matched, allParams);
   if (!leaf) return null;
 
+  // Parse path params through schema if the leaf route has one
+  let parsedParams: Record<string, unknown> | undefined;
+  if (leaf.params) {
+    try {
+      const parseResult = leaf.params.parse(allParams);
+      if (!parseResult.ok) return null;
+      parsedParams = parseResult.data as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
   // Parse search params through schema if the leaf route has one
   let search: Record<string, unknown> = {};
   // Walk matched routes to find a searchParams schema
@@ -185,6 +209,7 @@ export function matchRoute(routes: CompiledRoute[], url: string): RouteMatch | n
   return {
     matched,
     params: allParams,
+    parsedParams,
     route: leaf,
     search,
     searchParams,

--- a/packages/ui/src/router/index.ts
+++ b/packages/ui/src/router/index.ts
@@ -3,6 +3,7 @@ export type {
   InferRouteMap,
   LoaderData,
   MatchedRoute,
+  ParamSchema,
   RouteConfig,
   RouteConfigLike,
   RouteDefinitionMap,

--- a/packages/ui/src/router/public.ts
+++ b/packages/ui/src/router/public.ts
@@ -11,6 +11,7 @@ export type {
   InferRouteMap,
   LoaderData,
   MatchedRoute,
+  ParamSchema,
   RouteConfig,
   RouteDefinitionMap,
   RouteMatch,

--- a/packages/ui/src/router/router-context.ts
+++ b/packages/ui/src/router/router-context.ts
@@ -23,10 +23,22 @@ export function useRouter<
   return router as UnwrapSignals<Router<T>>;
 }
 
-export function useParams<TPath extends string = string>(): ExtractParams<TPath> {
+/**
+ * Read route params from the current matched route.
+ *
+ * Overload 1: `useParams<'/tasks/:id'>()` — returns `{ id: string }` (backward compat).
+ * Overload 2: `useParams<{ id: number }>()` — returns parsed type assertion
+ *   (reads `parsedParams` when a route has a `params` schema).
+ *
+ * At runtime, both overloads prefer `parsedParams` (schema-parsed) when available,
+ * falling back to raw `params` (string values).
+ */
+export function useParams<TPath extends string = string>(): ExtractParams<TPath>;
+export function useParams<T extends Record<string, unknown>>(): T;
+export function useParams(): unknown {
   const router = useContext(RouterContext);
   if (!router) {
     throw new Error('useParams() must be called within RouterContext.Provider');
   }
-  return (router.current?.params ?? {}) as ExtractParams<TPath>;
+  return router.current?.parsedParams ?? router.current?.params ?? {};
 }

--- a/plans/route-param-schemas.md
+++ b/plans/route-param-schemas.md
@@ -1,0 +1,425 @@
+# Design Doc: Schema-Based Route Param Parsing and Typing
+
+**Status:** Approved (post-adversarial review v2)
+**Author:** mike
+**Feature:** Route param schemas [#945]
+
+---
+
+## 1. API Surface
+
+### 1.1 `ParamSchema<T>` — same interface as `SearchParamSchema<T>`
+
+```ts
+/** Schema interface for parsing and validating route path params. */
+export interface ParamSchema<T> {
+  parse(data: unknown): { ok: true; data: T } | { ok: false; error: unknown };
+}
+```
+
+Intentionally identical to `SearchParamSchema<T>`. Any object with a conforming `parse()` method works — including future `d.object()` schemas from `@vertz/db`.
+
+### 1.2 `RouteConfig` gains a `params` field
+
+```tsx
+import { defineRoutes } from '@vertz/ui';
+
+const routes = defineRoutes({
+  '/tasks/:id': {
+    component: () => TaskDetailPage(),
+    params: {
+      parse(raw) {
+        const { id } = raw as { id: string };
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRegex.test(id)) return { ok: false, error: `Invalid UUID: ${id}` };
+        return { ok: true, data: { id } };
+      },
+    },
+  },
+  '/items/:id': {
+    component: () => ItemDetailPage(),
+    // No params schema — backward compat, raw string params
+  },
+});
+```
+
+The `params` field is optional. Routes without it behave exactly as today.
+
+### 1.3 Parsing at the routing layer
+
+When `matchRoute()` finds a matching route with a `params` schema, it runs `parse()` on the raw string params. **If parsing fails, `matchRoute()` returns `null`** — treating invalid params as "no match." This is the simplest integration: the existing fallback/404 mechanism handles it.
+
+When parsing succeeds, the result is stored in `RouteMatch.parsedParams`:
+
+```ts
+export interface RouteMatch {
+  params: Record<string, string>;           // Raw string params (always present)
+  parsedParams?: Record<string, unknown>;   // Parsed via schema (set when schema succeeds)
+  route: CompiledRoute;
+  matched: MatchedRoute[];
+  searchParams: URLSearchParams;
+  search: Record<string, unknown>;
+}
+```
+
+- Schema succeeds: `parsedParams` is set, match is returned
+- Schema fails: `matchRoute()` returns `null` (no match)
+- Schema `parse()` throws: caught, treated as failure → returns `null`
+- No schema: `parsedParams` is undefined, match returned as before
+
+**Design rationale for returning `null` on failure:**
+The adversarial review (C2) revealed that `RouterView` has **zero existing error handling** — no `errorComponent` rendering for loader errors or anything else. Building `errorComponent` integration from scratch is significant scope. Returning `null` leverages the existing fallback mechanism: invalid params → no match → fallback/404 renders. Custom per-route error rendering for param failures is deferred to a follow-up.
+
+### 1.4 `useParams()` — backward compatible with new overload
+
+```ts
+// Overload 1: path literal → string params (backward compat)
+function useParams<TPath extends string = string>(): ExtractParams<TPath>;
+
+// Overload 2: parsed type assertion → read parsed params
+function useParams<T extends Record<string, unknown>>(): T;
+```
+
+**Backward compat** — existing code unchanged:
+```tsx
+const { id } = useParams<'/tasks/:id'>();
+// id: string — works exactly as before
+```
+
+**New: parsed type assertion** — when route has a param schema:
+```tsx
+const { id } = useParams<{ id: string }>();
+// id: string — reads parsedParams from RouteMatch
+```
+
+**Overload resolution:**
+- `useParams<'/tasks/:id'>()` — `string` literal → overload 1 (extends `string`, not `Record`)
+- `useParams<{ id: string }>()` — object type → overload 2 (extends `Record`, not `string`)
+- `useParams()` — no type param → overload 1 default (`TPath = string`)
+
+**Runtime behavior (shared by both overloads):**
+```ts
+function useParams(): unknown {
+  const router = useContext(RouterContext);
+  if (!router) throw new Error('useParams() must be called within RouterContext.Provider');
+  const match = router.current;
+  return match?.parsedParams ?? match?.params ?? {};
+}
+```
+
+**Documented limitation:** If a developer uses `useParams<{ id: number }>()` on a route that has no `params` schema, the runtime returns `Record<string, string>` but the type says `{ id: number }`. This is an unsound type assertion — same trade-off as the existing `useParams<TPath>()` where passing the wrong path literal produces wrong types. The developer is responsible for matching the type parameter to the route's actual schema.
+
+### 1.5 Nested routes — leaf schema only
+
+For nested routes, only the **leaf route's** `params` schema is used. It receives ALL accumulated params from the full matched chain (parent + child segments). Parent route `params` schemas are ignored during the leaf match.
+
+This matches how `searchParams` currently works: walks matched routes and uses the first schema found.
+
+```tsx
+defineRoutes({
+  '/users/:userId': {
+    component: () => UserLayout(),
+    children: {
+      '/posts/:postId': {
+        component: () => PostDetailPage(),
+        params: postSchema,  // Receives { userId, postId }
+      },
+    },
+  },
+});
+```
+
+### 1.6 Schema requirements
+
+**Schemas must be pure functions.** `parse()` is called during every route match, including popstate (back/forward buttons) and SSR sync. Side effects (database calls, network requests) in `parse()` will execute on every navigation and must be avoided.
+
+## 2. Manifesto Alignment
+
+**Schema is the source of truth:** Extends the "define once, use everywhere" pattern from database tables and API entities to route params. The param schema is the single source of truth for validation.
+
+**Compile-time over runtime:** Invalid params are caught at the routing layer before rendering. Combined with `useParams<TPath>()` type checking, both compile-time (type safety) and runtime (schema validation) enforce correctness.
+
+**Explicit over implicit:** The param schema is explicitly attached to the route config. `useParams()` with a type parameter is an explicit developer assertion.
+
+**One way to do things:** Same schema interface (`parse()` → `{ ok, data/error }`) for both path params and search params.
+
+### Alternatives considered
+
+**`useParams(schema)` runtime argument for type inference:** Passing the schema to `useParams` for type inference. Rejected: the schema argument would be unused at runtime (parsing already happened in `matchRoute`) — passing an argument that's ignored is misleading.
+
+**Separate `useParsedParams<T>()` hook:** A new hook distinct from `useParams`. Rejected: introduces a second way to read params ("one way to do things" violation).
+
+**`matchRoute` returns match with `paramError` field:** Adversarial review C2 revealed `RouterView` has no error handling at all. Adding `paramError` to `RouteMatch` and rendering `errorComponent` requires building error rendering in `RouterView` from scratch — significant scope. Deferred. Returning `null` from `matchRoute` on failure leverages the existing fallback mechanism.
+
+**Passing parsed params to loaders:** Loaders currently receive `Record<string, string>`. Passing `Record<string, unknown>` (parsed params) creates a type lie (adversarial review I7). Deferred — loaders always receive raw string params.
+
+## 3. Non-Goals
+
+- **`RouterView` error component rendering for param failures** — `RouterView` has no existing error handling. Building it is a separate feature. Invalid params → `matchRoute` returns `null` → fallback renders.
+- **Passing parsed params to loaders** — Loaders always receive raw string params. Developers who need parsed values in loaders can re-parse using the schema.
+- **Automatic type inference for `useParams()`** — The parsed type is NOT inferred from the route definition. The developer provides a type parameter assertion.
+- **Schema library integration** — This defines the `ParamSchema<T>` interface. Making `d.object()` conform to it is a separate task.
+- **Search param error handling** — `searchParams` parse failures silently fall back to empty `search`. Unchanged.
+- **Nested route param schema inheritance** — Only leaf route schemas run.
+
+## 4. Unknowns
+
+### 4.1 `CompiledRoute` params storage — **Resolved (discussion)**
+
+`CompiledRoute` already carries `searchParams`. Adding `params?: ParamSchema<unknown>` follows the same pattern. Stored at `defineRoutes()` time, read at `matchRoute()` time.
+
+### 4.2 `RouteConfigLike` constraint — **Resolved (discussion)**
+
+Adding `params?: ParamSchema<unknown>` to `RouteConfigLike` follows the same pattern as `searchParams?: SearchParamSchema<unknown>`. The loose `unknown` generic allows any concrete schema.
+
+### 4.3 `matchRoute` returning `null` on parse failure — **Resolved (design decision)**
+
+When `matchRoute` returns `null` for a URL that pattern-matches but fails param validation, the router treats it identically to "no route matched." The fallback/404 is rendered. This loses the "why" (which param was invalid) but is the simplest integration with zero `RouterView` changes.
+
+The `parse()` call is wrapped in try/catch. If `parse()` throws (instead of returning `{ ok: false }`), the exception is caught and treated as a parse failure → `matchRoute` returns `null`.
+
+## 5. Type Flow Map
+
+```
+RouteConfig.params: ParamSchema<T>
+  |
+defineRoutes<const T>() — stores schema in CompiledRoute.params
+  |
+matchRoute(routes, url)
+  |-- matchPath extracts raw params: Record<string, string>
+  |-- if leaf route has params schema:
+  |     |-- try { schema.parse(rawParams) }
+  |     |-- ok: true  → RouteMatch.parsedParams = data, return match
+  |     |-- ok: false  → return null (no match)
+  |     |-- catch     → return null (no match)
+  |-- no schema → return match (params only, no parsedParams)
+  |
+useParams<TPath>() → ExtractParams<TPath>  (reads parsedParams ?? params)
+useParams<T>()     → T                     (reads parsedParams ?? params)
+```
+
+**Erasure boundary:** `ParamSchema<T>` generic `T` is erased when stored in `CompiledRoute.params: ParamSchema<unknown>`. `useParams<T>()` is a developer assertion.
+
+## 6. E2E Acceptance Test
+
+```ts
+// packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test.ts
+
+import { defineRoutes, matchRoute } from '@vertz/ui';
+import type { ParamSchema } from '@vertz/ui';
+import { describe, expect, it } from 'bun:test';
+
+describe('Route param schema walkthrough', () => {
+  const uuidSchema: ParamSchema<{ id: string }> = {
+    parse(raw) {
+      const { id } = raw as { id: string };
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(id)) return { ok: false, error: `Invalid UUID: ${id}` };
+      return { ok: true, data: { id } };
+    },
+  };
+
+  const routes = defineRoutes({
+    '/': { component: () => document.createElement('div') },
+    '/tasks/:id': {
+      component: () => document.createElement('div'),
+      params: uuidSchema,
+    },
+    '/items/:id': {
+      component: () => document.createElement('div'),
+    },
+  });
+
+  it('parses valid params through schema', () => {
+    const match = matchRoute(routes, '/tasks/550e8400-e29b-41d4-a716-446655440000');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+    expect(match!.parsedParams).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+  });
+
+  it('returns null when schema rejects params', () => {
+    const match = matchRoute(routes, '/tasks/not-a-uuid');
+    expect(match).toBeNull();
+  });
+
+  it('works without schema (backward compat)', () => {
+    const match = matchRoute(routes, '/items/42');
+    expect(match).not.toBeNull();
+    expect(match!.params).toEqual({ id: '42' });
+    expect(match!.parsedParams).toBeUndefined();
+  });
+});
+```
+
+Type-level test:
+
+```ts
+// packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test-d.ts
+
+import type { ParamSchema } from '@vertz/ui';
+import { defineRoutes, useParams } from '@vertz/ui';
+
+// ParamSchema accepted in route config
+const schema: ParamSchema<{ id: string }> = {
+  parse(raw) {
+    const { id } = raw as { id: string };
+    return { ok: true, data: { id } };
+  },
+};
+
+defineRoutes({
+  '/tasks/:id': {
+    component: () => document.createElement('div'),
+    params: schema,
+  },
+});
+
+// Backward compat — path literal → string params
+const strParams = useParams<'/tasks/:id'>();
+const _id: string = strParams.id;
+void _id;
+
+// @ts-expect-error - 'name' not on ExtractParams<'/tasks/:id'>
+strParams.name;
+
+// Parsed type assertion
+const parsedParams = useParams<{ id: string }>();
+const _parsedId: string = parsedParams.id;
+void _parsedId;
+
+// @ts-expect-error - 'name' not on { id: string }
+parsedParams.name;
+```
+
+## 7. Implementation Phases
+
+### Phase 1: Type infrastructure + walkthrough stub
+
+Add `ParamSchema<T>` type. Add `params` field to `RouteConfig`, `RouteConfigLike`, and `CompiledRoute`. Write integration walkthrough test as failing RED stub.
+
+**Acceptance criteria:**
+- `ParamSchema<T>` interface defined
+- `RouteConfig` accepts `params?: ParamSchema<TParams>`
+- `RouteConfigLike` accepts `params?: ParamSchema<unknown>`
+- `CompiledRoute` stores `params?: ParamSchema<unknown>`
+- `defineRoutes()` copies `params` to compiled routes
+- Type test: route config with `params` compiles
+- Type test: `@ts-expect-error` on schema with wrong interface
+- Existing tests pass unchanged (backward compat)
+- Integration walkthrough test written (RED — `matchRoute` doesn't parse yet, `ParamSchema` not exported)
+
+### Phase 2: Runtime parsing in `matchRoute()`
+
+When a matched leaf route has a `params` schema, run `parse()` on raw params. On success, set `parsedParams`. On failure (or throw), return `null`.
+
+**Acceptance criteria:**
+- `matchRoute()` with valid params + schema → match with `parsedParams`
+- `matchRoute()` with invalid params + schema → returns `null`
+- `matchRoute()` with schema that throws → returns `null`
+- `matchRoute()` without schema → match without `parsedParams` (backward compat)
+- Raw `params` always present on successful matches
+- Nested route: leaf schema receives all accumulated params
+- Integration test: valid UUID matches, invalid UUID returns null
+
+### Phase 3: `useParams()` overload
+
+Add `Record<string, unknown>` overload. Runtime reads `parsedParams` when available.
+
+**Acceptance criteria:**
+- `useParams<'/tasks/:id'>()` returns `{ id: string }` (backward compat)
+- `useParams<{ id: string }>()` compiles and returns `{ id: string }`
+- Runtime: returns `parsedParams` when available, falls back to `params`
+- Type test: `@ts-expect-error` on invalid property for both overloads
+- Type test: overload 1 selected for string literals, overload 2 for Record types
+
+### Phase 4: Exports + integration tests + changeset
+
+Export `ParamSchema` from public API. Run full integration walkthrough. Add changeset.
+
+**Acceptance criteria:**
+- `ParamSchema` exported from `@vertz/ui` (public.ts, index.ts)
+- `matchRoute` exported from `@vertz/ui` (verify already exported)
+- Integration runtime test passes (public imports)
+- Integration type test passes (`bun run typecheck --filter @vertz/integration-tests`)
+- All quality gates pass (lint, format, typecheck across all packages)
+- Changeset added (`@vertz/ui` patch)
+
+## 8. Developer Walkthrough
+
+1. **Define a param schema:**
+   ```tsx
+   import type { ParamSchema } from '@vertz/ui';
+
+   const taskParamsSchema: ParamSchema<{ id: string }> = {
+     parse(raw) {
+       const { id } = raw as { id: string };
+       const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+       if (!uuidRegex.test(id)) return { ok: false, error: new Error(`Invalid task ID: ${id}`) };
+       return { ok: true, data: { id } };
+     },
+   };
+   ```
+
+2. **Attach to route definition:**
+   ```tsx
+   import { defineRoutes } from '@vertz/ui';
+
+   export const routes = defineRoutes({
+     '/tasks/:id': {
+       component: () => TaskDetailPage(),
+       params: taskParamsSchema,
+     },
+   });
+   ```
+
+3. **Read params in component:**
+   ```tsx
+   import { useParams } from '@vertz/ui';
+
+   export function TaskDetailPage() {
+     const { id } = useParams<'/tasks/:id'>();
+     // id: string — validated by schema before this code runs
+     // Invalid IDs trigger the fallback/404 — never reach this component
+   }
+   ```
+
+4. **No extra config. No plugins. Same `defineRoutes` call, with an optional `params` field.**
+
+## 9. Files to Modify
+
+| File | Change |
+|------|--------|
+| `packages/ui/src/router/define-routes.ts` | Add `ParamSchema<T>`, add `params` to `RouteConfig`/`RouteConfigLike`/`CompiledRoute`, update `matchRoute()` parsing |
+| `packages/ui/src/router/router-context.ts` | Add `useParams` overload |
+| `packages/ui/src/router/index.ts` | Export `ParamSchema` |
+| `packages/ui/src/router/public.ts` | Export `ParamSchema` |
+| `packages/ui/src/index.ts` | Export `ParamSchema` |
+| `packages/ui/src/router/__tests__/define-routes.test.ts` | Tests for param parsing in `matchRoute` |
+| `packages/ui/src/router/__tests__/router-context.test.ts` | Tests for `useParams` overload |
+| `packages/ui/src/router/__tests__/param-schema.test-d.ts` | Type tests |
+| `packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test.ts` | Runtime integration walkthrough |
+| `packages/integration-tests/src/__tests__/route-param-schema-walkthrough.test-d.ts` | Type integration walkthrough |
+| `.changeset/*.md` | Patch changeset for `@vertz/ui` |
+
+## 10. Adversarial Review Summary
+
+Issues found and how they were addressed:
+
+| Issue | Severity | Resolution |
+|-------|----------|------------|
+| C2: RouterView has no error handling | Critical | Descoped. `matchRoute` returns `null` on failure → existing fallback handles it. |
+| C3: `navigate.ts` loader guard missing | Critical | Not needed — `matchRoute` returns `null`, so `match` is falsy and loaders don't run. |
+| C4: SSR sync hook paramError | Critical | Not needed — SSR calls `matchRoute` which returns `null` on failure. |
+| C1: `useParams` overload type assertion unsound | Critical | Documented limitation. Same trade-off as existing `useParams<TPath>()`. |
+| I1: Nested route schema behavior | Important | Specified: leaf schema only, receives all accumulated params. |
+| I2: `parse()` throwing | Important | Wrapped in try/catch → treated as failure → `null`. |
+| I5: `errorComponent` signature mismatch | Important | Not applicable — `errorComponent` integration descoped. |
+| I7: `executeLoaders` type signature | Important | Descoped — loaders always receive raw string params. |
+| M3: `matchRoute` not in public exports | Minor | Must verify and add to public exports if missing. |
+
+## 11. Follow-up Work (Explicitly Deferred)
+
+- **`RouterView` error component for param failures** — Build `errorComponent` rendering in `RouterView`, add `paramError` to `RouteMatch` instead of returning `null`.
+- **Typed parsed params for loaders** — Pass parsed params to loaders with correct types.
+- **Automatic `useParams` type inference from route map** — Thread param schema type through `TypedRoutes<T>` → `Router<T>` → `useParams`.
+- **`d.object()` conformance** — Make `@vertz/db` schema DSL produce objects conforming to `ParamSchema<T>`.


### PR DESCRIPTION
## Summary

- Adds `ParamSchema<T>` interface (same shape as `SearchParamSchema<T>`) and `params` field to `RouteConfig`
- When a route has a `params` schema, `matchRoute()` validates path params at the routing layer — invalid params return `null` (fallback/404 renders)
- Valid parsed params stored as `parsedParams` on `RouteMatch`, read by `useParams()`
- `useParams()` gains a second overload: `useParams<{ id: number }>()` for typed parsed params
- Fully backward compatible — routes without `params` behave unchanged

## Design Decisions

- **`matchRoute` returns `null` on parse failure** — adversarial review revealed `RouterView` has zero existing error handling, so `errorComponent` rendering was descoped. Invalid params = no match = fallback renders.
- **Schema `parse()` wrapped in try/catch** — thrown errors treated as rejection
- **Loaders always receive raw string params** — avoids type widening issues (deferred)
- **Leaf schema only for nested routes** — receives all accumulated params from parent + child

## Test Plan

- [x] Unit tests: `matchRoute` with valid/invalid/throwing schemas
- [x] Unit tests: `useParams` returns `parsedParams` when available
- [x] Type tests: `ParamSchema` in route config, `useParams` overload resolution
- [x] Integration runtime test: public imports from `@vertz/ui`
- [x] Integration type test: cross-package typecheck
- [x] All pre-push quality gates pass (lint, typecheck, test, build)

## Follow-up Work

- `RouterView` error component rendering for param failures
- Passing parsed params to loaders with correct types
- Automatic `useParams` type inference from route map
- `d.object()` conformance with `ParamSchema<T>`

Closes #945