### PR TITLE
refactor(db): move tenant scoping from column-level to model-level [#955]

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -82,8 +82,7 @@ d.textArray()               // TEXT[] → string[]
 d.integerArray()            // INTEGER[] → number[]
 d.enum('status', ['active', 'inactive'])  // ENUM → 'active' | 'inactive'
 
-// Multi-tenancy
-d.tenant(orgsTable)         // UUID FK to tenant root → string
+// Multi-tenancy — see d.model() options below
 ```
 
 ### Column Modifiers
@@ -476,11 +475,15 @@ const orgsTable = d.table('organizations', {
 const usersTable = d.table('users', {
   id: d.uuid().primary(),
   email: d.email(),
-  orgId: d.tenant(orgsTable),  // scopes this table to a tenant
+  orgId: d.uuid(),
 });
 
 const orgsModel = d.model(orgsTable);
-const usersModel = d.model(usersTable);
+const usersModel = d.model(
+  usersTable,
+  { organization: d.ref.one(() => orgsTable, 'orgId') },
+  { tenant: 'organization' },  // scopes this model to a tenant via relation
+);
 
 const tenantGraph = computeTenantGraph({ organizations: orgsModel, users: usersModel });
 

--- a/packages/db/src/__tests__/_type-helpers.ts
+++ b/packages/db/src/__tests__/_type-helpers.ts
@@ -14,9 +14,7 @@ export type Expect<T extends true> = T;
 
 /** True if A and B are exactly the same type. */
 export type Equal<A, B> =
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-    ? true
-    : false;
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 /** True if A extends B (structural subtype). */
 export type Extends<A, B> = [A] extends [B] ? true : false;

--- a/packages/db/src/__tests__/column-metadata.test-d.ts
+++ b/packages/db/src/__tests__/column-metadata.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'bun:test';
-import type { Equal, Expect, HasKey, Not } from './_type-helpers';
 import { d } from '../d';
+import type { Equal, Expect, HasKey, Not } from './_type-helpers';
 
 // ---------------------------------------------------------------------------
 // Column-type-specific metadata — type-level tests

--- a/packages/db/src/__tests__/crud-id-generation.test.ts
+++ b/packages/db/src/__tests__/crud-id-generation.test.ts
@@ -1,6 +1,6 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { unwrap } from '@vertz/schema';
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { createDb } from '../client';
 import { d } from '../d';
 
@@ -94,9 +94,7 @@ describe('CRUD ID Generation', () => {
 
   // Test 17: create() with user-provided ID — explicit ID used, not overwritten
   it('respects user-provided ID', async () => {
-    const user = unwrap(
-      await db.usersCuid.create({ data: { id: 'my-custom-id', name: 'Dave' } }),
-    );
+    const user = unwrap(await db.usersCuid.create({ data: { id: 'my-custom-id', name: 'Dave' } }));
     expect(user.id).toBe('my-custom-id');
     expect(user.name).toBe('Dave');
   });

--- a/packages/db/src/__tests__/database-client-types.test-d.ts
+++ b/packages/db/src/__tests__/database-client-types.test-d.ts
@@ -1,8 +1,8 @@
 import { describe, it } from 'bun:test';
-import type { Equal, Expect, Extends, HasKey, IsFunction } from './_type-helpers';
 import type { DatabaseClient, ModelDelegate } from '../client/database';
 import { d } from '../d';
 import type { ModelEntry } from '../schema/inference';
+import type { Equal, Expect, Extends, HasKey, IsFunction } from './_type-helpers';
 
 // ---------------------------------------------------------------------------
 // Fixture: minimal schema with relations

--- a/packages/db/src/__tests__/database-types.test-d.ts
+++ b/packages/db/src/__tests__/database-types.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, it } from 'bun:test';
-import type { Equal, Expect, Extends, HasKey, IsFunction, Not } from './_type-helpers';
 import type { DatabaseClient } from '../client/database';
 import { d } from '../d';
 import type {
@@ -9,6 +8,7 @@ import type {
   ModelEntry,
   UpdateInput,
 } from '../schema/inference';
+import type { Equal, Expect, Extends, HasKey, IsFunction, Not } from './_type-helpers';
 
 // ---------------------------------------------------------------------------
 // Fixture: minimal schema with relations
@@ -23,7 +23,7 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
   email: d.email().unique().is('sensitive'),
   passwordHash: d.text().is('hidden'),

--- a/packages/db/src/__tests__/db-integration.e2e.test.ts
+++ b/packages/db/src/__tests__/db-integration.e2e.test.ts
@@ -1,6 +1,6 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { unwrap } from '@vertz/schema';
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { createDb } from '../client/database';
 import { createDbProvider } from '../core/db-provider';
 import { d } from '../d';

--- a/packages/db/src/__tests__/e2e.test.ts
+++ b/packages/db/src/__tests__/e2e.test.ts
@@ -1,6 +1,6 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { unwrap } from '@vertz/schema';
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { createDb } from '../client/database';
 import { d } from '../d';
 import type { QueryFn } from '../query/executor';
@@ -19,7 +19,7 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
   email: d.email().unique().is('sensitive'),
   passwordHash: d.text().is('hidden'),
@@ -61,7 +61,13 @@ const featureFlags = d
 
 const models = {
   organizations: d.model(organizations),
-  users: d.model(users),
+  users: d.model(
+    users,
+    {
+      organization: d.ref.one(() => organizations, 'organizationId'),
+    },
+    { tenant: 'organization' },
+  ),
   posts: d.model(posts, {
     author: d.ref.one(() => users, 'authorId'),
     comments: d.ref.many(() => comments, 'postId'),
@@ -631,14 +637,14 @@ describe('E2E Acceptance Test (db-018)', () => {
     it('computes tenant graph correctly', () => {
       const graph = db._internals.tenantGraph;
 
-      // organizations is the root (users have d.tenant(organizations))
+      // organizations is the root (users model has { tenant: 'organization' })
       expect(graph.root).toBe('organizations');
 
-      // users is directly scoped (has d.tenant(organizations))
+      // users is directly scoped (has { tenant: 'organization' })
       expect(graph.directlyScoped).toContain('users');
 
-      // posts references users -> indirectly scoped
-      // comments references posts -> indirectly scoped
+      // posts references users via relation -> indirectly scoped
+      // comments references posts via relation -> indirectly scoped
       expect(graph.indirectlyScoped).toContain('posts');
       expect(graph.indirectlyScoped).toContain('comments');
 

--- a/packages/db/src/__tests__/id-generators.test.ts
+++ b/packages/db/src/__tests__/id-generators.test.ts
@@ -33,7 +33,7 @@ describe('ID Generators', () => {
   // Test 5: 1000 calls per strategy produce 1000 unique values
   it('generates unique IDs for each strategy', { timeout: 15_000 }, () => {
     const strategies: Array<'cuid' | 'uuid' | 'nanoid'> = ['cuid', 'uuid', 'nanoid'];
-    
+
     for (const strategy of strategies) {
       const ids = new Set<string>();
       for (let i = 0; i < 1000; i++) {

--- a/packages/db/src/__tests__/integration-postgres-regression.test.ts
+++ b/packages/db/src/__tests__/integration-postgres-regression.test.ts
@@ -6,8 +6,8 @@
  * no breaking changes were introduced during SQLite dialect implementation.
  */
 
-import { PGlite } from '@electric-sql/pglite';
 import { describe, expect, it } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
 import { createDb } from '../client/database';
 import { d } from '../d';
 

--- a/packages/db/src/__tests__/integration-sqlite.test.ts
+++ b/packages/db/src/__tests__/integration-sqlite.test.ts
@@ -6,8 +6,8 @@
  * works correctly.
  */
 
-import { unwrap } from '@vertz/schema';
 import { describe, expect, it, mock } from 'bun:test';
+import { unwrap } from '@vertz/schema';
 import { createDb } from '../client/database';
 import type { D1Database, D1PreparedStatement } from '../client/sqlite-driver';
 import { d } from '../d';

--- a/packages/db/src/__tests__/postgres-integration.test.ts
+++ b/packages/db/src/__tests__/postgres-integration.test.ts
@@ -9,9 +9,9 @@
  * Unique identifiers per test group prevent cross-test collisions.
  */
 
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { unwrap } from '@vertz/schema';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { createDb } from '../client/database';
 import { d } from '../d';
 import type { QueryFn } from '../query/executor';
@@ -30,7 +30,7 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
   email: d.email().unique().is('sensitive'),
   passwordHash: d.text().is('hidden'),

--- a/packages/db/src/__tests__/prisma-style-api.test.ts
+++ b/packages/db/src/__tests__/prisma-style-api.test.ts
@@ -1,5 +1,5 @@
-import { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
 import { createDb } from '../client/database';
 import { d } from '../d';
 import type { QueryFn } from '../query/executor';

--- a/packages/db/src/__tests__/type-errors.test-d.ts
+++ b/packages/db/src/__tests__/type-errors.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, it } from 'bun:test';
-import type { Equal, Expect } from './_type-helpers';
 import { d } from '../d';
 import type { FilterType, SelectOption } from '../schema/inference';
 import type {
@@ -8,6 +7,7 @@ import type {
   InvalidRelation,
   ValidateKeys,
 } from '../types/branded-errors';
+import type { Equal, Expect } from './_type-helpers';
 
 // ---------------------------------------------------------------------------
 // Fixture tables
@@ -66,7 +66,9 @@ describe('InvalidFilterType branded type', () => {
 describe('InvalidRelation branded type', () => {
   it('produces readable relation error', () => {
     type Err = InvalidRelation<'bogus', 'author, comments'>;
-    type _t1 = Expect<Equal<Err, "ERROR: Relation 'bogus' does not exist. Available relations: author, comments.">>;
+    type _t1 = Expect<
+      Equal<Err, "ERROR: Relation 'bogus' does not exist. Available relations: author, comments.">
+    >;
   });
 });
 

--- a/packages/db/src/adapters/d1-adapter.ts
+++ b/packages/db/src/adapters/d1-adapter.ts
@@ -6,9 +6,9 @@
  */
 
 import type { DbDriver } from '../client/driver';
-import type { TableDef, ColumnRecord } from '../schema/table';
+import type { ColumnRecord, TableDef } from '../schema/table';
 import type { EntityDbAdapter } from '../types/adapter';
-import { generateCreateTableSql, generateIndexSql, BaseSqlAdapter } from './sql-utils';
+import { BaseSqlAdapter, generateCreateTableSql, generateIndexSql } from './sql-utils';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -89,13 +89,13 @@ export class D1Adapter<T extends ColumnRecord> extends BaseSqlAdapter<T> {
 
 /**
  * Create a D1 EntityDbAdapter from a schema and D1 binding.
- * 
- * NOTE: For production D1 deployments, migrations should be run via 
+ *
+ * NOTE: For production D1 deployments, migrations should be run via
  * `wrangler d1 migrations apply` during deployment, NOT at runtime.
  * Set `migrations.autoApply = false` or omit the migrations option for production.
  */
 export function createD1Adapter<T extends ColumnRecord>(
-  options: D1AdapterOptions<T>
+  options: D1AdapterOptions<T>,
 ): EntityDbAdapter {
   const { schema, d1, migrations } = options;
 

--- a/packages/db/src/adapters/sqlite-adapter.ts
+++ b/packages/db/src/adapters/sqlite-adapter.ts
@@ -9,9 +9,9 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { DbDriver } from '../client/driver';
-import type { TableDef, ColumnRecord } from '../schema/table';
+import type { ColumnRecord, TableDef } from '../schema/table';
 import type { EntityDbAdapter } from '../types/adapter';
-import { generateCreateTableSql, generateIndexSql, BaseSqlAdapter } from './sql-utils';
+import { BaseSqlAdapter, generateCreateTableSql, generateIndexSql } from './sql-utils';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -81,8 +81,8 @@ export function createSqliteDriver(dbPath: string): DbDriver {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       throw new Error(
         `Failed to create SQLite database at "${dbPath}". ` +
-        `Please ensure the directory exists and you have write permissions. ` +
-        `Error: ${errorMessage}`
+          `Please ensure the directory exists and you have write permissions. ` +
+          `Error: ${errorMessage}`,
       );
     }
   }
@@ -130,7 +130,7 @@ export class SqliteAdapter<T extends ColumnRecord> extends BaseSqlAdapter<T> {
  * Create a SQLite EntityDbAdapter from a schema.
  */
 export async function createSqliteAdapter<T extends ColumnRecord>(
-  options: SqliteAdapterOptions<T>
+  options: SqliteAdapterOptions<T>,
 ): Promise<EntityDbAdapter> {
   const { schema, dbPath, dataDir, migrations } = options;
 

--- a/packages/db/src/cli/__tests__/migrate-deploy.test.ts
+++ b/packages/db/src/cli/__tests__/migrate-deploy.test.ts
@@ -1,5 +1,5 @@
-import { unwrap } from '@vertz/errors';
 import { describe, expect, it, mock } from 'bun:test';
+import { unwrap } from '@vertz/errors';
 import type { MigrationFile, MigrationQueryFn } from '../../migration';
 import { migrateDeploy } from '../migrate-deploy';
 
@@ -83,9 +83,7 @@ describe('migrateDeploy', () => {
         throw new Error('relation "_vertz_migrations" does not exist');
       });
 
-      const result = unwrap(
-        await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }),
-      );
+      const result = unwrap(await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }));
 
       expect(result.dryRun).toBe(true);
       expect(result.applied).toEqual(['0001_init.sql', '0002_add_users.sql']);
@@ -127,9 +125,7 @@ describe('migrateDeploy', () => {
         throw new Error('Unexpected SQL in dry-run mode');
       });
 
-      const result = unwrap(
-        await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }),
-      );
+      const result = unwrap(await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }));
 
       expect(result.dryRun).toBe(true);
       expect(result.applied).toEqual(['0002_add_users.sql']);
@@ -175,9 +171,7 @@ describe('migrateDeploy', () => {
         return { rows: [], rowCount: 0 };
       });
 
-      const result = unwrap(
-        await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }),
-      );
+      const result = unwrap(await migrateDeploy({ queryFn, migrationFiles: files, dryRun: true }));
 
       expect(result.dryRun).toBe(true);
       expect(result.applied).toEqual([]);

--- a/packages/db/src/client/__tests__/createDb-dialect.test.ts
+++ b/packages/db/src/client/__tests__/createDb-dialect.test.ts
@@ -13,7 +13,7 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
 });
 

--- a/packages/db/src/client/__tests__/database.test.ts
+++ b/packages/db/src/client/__tests__/database.test.ts
@@ -13,20 +13,20 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
   email: d.email(),
 });
 
 const projects = d.table('projects', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
 });
 
 const tasks = d.table('tasks', {
   id: d.uuid().primary(),
-  projectId: d.uuid().references('projects', 'id'),
+  projectId: d.uuid(),
   title: d.text(),
 });
 
@@ -66,11 +66,25 @@ describe('createDb', () => {
     const db = createDb({
       url: 'postgres://localhost:5432/test',
       models: {
-        organizations: { table: organizations, relations: {} },
-        users: { table: users, relations: {} },
-        projects: { table: projects, relations: {} },
-        tasks: { table: tasks, relations: {} },
-        featureFlags: { table: featureFlags, relations: {} },
+        organizations: d.model(organizations),
+        users: d.model(
+          users,
+          {
+            organization: d.ref.one(() => organizations, 'organizationId'),
+          },
+          { tenant: 'organization' },
+        ),
+        projects: d.model(
+          projects,
+          {
+            organization: d.ref.one(() => organizations, 'organizationId'),
+          },
+          { tenant: 'organization' },
+        ),
+        tasks: d.model(tasks, {
+          project: d.ref.one(() => projects, 'projectId'),
+        }),
+        featureFlags: d.model(featureFlags),
       },
     });
 
@@ -88,9 +102,15 @@ describe('createDb', () => {
     createDb({
       url: 'postgres://localhost:5432/test',
       models: {
-        organizations: { table: organizations, relations: {} },
-        users: { table: users, relations: {} },
-        auditLogs: { table: auditLogs, relations: {} },
+        organizations: d.model(organizations),
+        users: d.model(
+          users,
+          {
+            organization: d.ref.one(() => organizations, 'organizationId'),
+          },
+          { tenant: 'organization' },
+        ),
+        auditLogs: d.model(auditLogs),
       },
       log: logFn,
     });
@@ -104,9 +124,15 @@ describe('createDb', () => {
     createDb({
       url: 'postgres://localhost:5432/test',
       models: {
-        organizations: { table: organizations, relations: {} },
-        users: { table: users, relations: {} },
-        featureFlags: { table: featureFlags, relations: {} },
+        organizations: d.model(organizations),
+        users: d.model(
+          users,
+          {
+            organization: d.ref.one(() => organizations, 'organizationId'),
+          },
+          { tenant: 'organization' },
+        ),
+        featureFlags: d.model(featureFlags),
       },
       log: logFn,
     });

--- a/packages/db/src/client/__tests__/result-errors.test.ts
+++ b/packages/db/src/client/__tests__/result-errors.test.ts
@@ -13,14 +13,14 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
   email: d.email().unique(),
 });
 
 const _projects = d.table('projects', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
 });
 

--- a/packages/db/src/client/__tests__/sqlite-value-converter.test.ts
+++ b/packages/db/src/client/__tests__/sqlite-value-converter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { toSqliteValue, fromSqliteValue } from '../sqlite-value-converter';
+import { fromSqliteValue, toSqliteValue } from '../sqlite-value-converter';
 
 describe('toSqliteValue', () => {
   it('converts true to 1', () => {

--- a/packages/db/src/client/__tests__/tenant-graph.test.ts
+++ b/packages/db/src/client/__tests__/tenant-graph.test.ts
@@ -4,6 +4,7 @@ import { computeTenantGraph } from '../tenant-graph';
 
 // ---------------------------------------------------------------------------
 // Test schema: multi-tenant SaaS
+// Tenant scoping is declared at the model level via { tenant: 'relationName' }
 // ---------------------------------------------------------------------------
 
 const organizations = d.table('organizations', {
@@ -13,26 +14,26 @@ const organizations = d.table('organizations', {
 
 const users = d.table('users', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
-  email: d.email(),
+  email: d.text(),
 });
 
 const projects = d.table('projects', {
   id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
+  organizationId: d.uuid(),
   name: d.text(),
 });
 
 const tasks = d.table('tasks', {
   id: d.uuid().primary(),
-  projectId: d.uuid().references('projects', 'id'),
+  projectId: d.uuid(),
   title: d.text(),
 });
 
 const comments = d.table('comments', {
   id: d.uuid().primary(),
-  taskId: d.uuid().references('tasks', 'id'),
+  taskId: d.uuid(),
   body: d.text(),
 });
 
@@ -57,19 +58,37 @@ const auditLogs = d.table('audit_logs', {
 describe('computeTenantGraph', () => {
   it('identifies the tenant root table', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      users: { table: users, relations: {} },
+      organizations: d.model(organizations),
+      users: d.model(
+        users,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
     };
 
     const graph = computeTenantGraph(registry);
     expect(graph.root).toBe('organizations');
   });
 
-  it('identifies directly scoped tables (those with d.tenant())', () => {
+  it('identifies directly scoped tables (those with { tenant } option)', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      users: { table: users, relations: {} },
-      projects: { table: projects, relations: {} },
+      organizations: d.model(organizations),
+      users: d.model(
+        users,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      projects: d.model(
+        projects,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
     };
 
     const graph = computeTenantGraph(registry);
@@ -78,11 +97,19 @@ describe('computeTenantGraph', () => {
     expect(graph.directlyScoped).not.toContain('organizations');
   });
 
-  it('identifies indirectly scoped tables (via references to directly scoped)', () => {
+  it('identifies indirectly scoped tables (via relations to directly scoped)', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      projects: { table: projects, relations: {} },
-      tasks: { table: tasks, relations: {} },
+      organizations: d.model(organizations),
+      projects: d.model(
+        projects,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      tasks: d.model(tasks, {
+        project: d.ref.one(() => projects, 'projectId'),
+      }),
     };
 
     const graph = computeTenantGraph(registry);
@@ -91,10 +118,20 @@ describe('computeTenantGraph', () => {
 
   it('traverses multi-hop indirect tenant paths', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      projects: { table: projects, relations: {} },
-      tasks: { table: tasks, relations: {} },
-      comments: { table: comments, relations: {} },
+      organizations: d.model(organizations),
+      projects: d.model(
+        projects,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      tasks: d.model(tasks, {
+        project: d.ref.one(() => projects, 'projectId'),
+      }),
+      comments: d.model(comments, {
+        task: d.ref.one(() => tasks, 'taskId'),
+      }),
     };
 
     const graph = computeTenantGraph(registry);
@@ -104,8 +141,8 @@ describe('computeTenantGraph', () => {
 
   it('identifies shared tables', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      featureFlags: { table: featureFlags, relations: {} },
+      organizations: d.model(organizations),
+      featureFlags: d.model(featureFlags),
     };
 
     const graph = computeTenantGraph(registry);
@@ -115,13 +152,19 @@ describe('computeTenantGraph', () => {
 
   it('returns tables without tenant path and not shared as unscoped', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      users: { table: users, relations: {} },
-      auditLogs: { table: auditLogs, relations: {} },
+      organizations: d.model(organizations),
+      users: d.model(
+        users,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      auditLogs: d.model(auditLogs),
     };
 
     const graph = computeTenantGraph(registry);
-    // auditLogs has no tenant column, no references to scoped tables, and is not shared
+    // auditLogs has no tenant relation, no relation to scoped tables, and is not shared
     expect(graph.directlyScoped).not.toContain('auditLogs');
     expect(graph.indirectlyScoped).not.toContain('auditLogs');
     expect(graph.shared).not.toContain('auditLogs');
@@ -129,9 +172,21 @@ describe('computeTenantGraph', () => {
 
   it('root table is not in directlyScoped or indirectlyScoped', () => {
     const registry = {
-      organizations: { table: organizations, relations: {} },
-      users: { table: users, relations: {} },
-      projects: { table: projects, relations: {} },
+      organizations: d.model(organizations),
+      users: d.model(
+        users,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      projects: d.model(
+        projects,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
     };
 
     const graph = computeTenantGraph(registry);
@@ -139,14 +194,81 @@ describe('computeTenantGraph', () => {
     expect(graph.indirectlyScoped).not.toContain('organizations');
   });
 
-  it('returns null root when no tenant columns exist', () => {
+  it('throws when multiple tenant declarations point to different roots', () => {
+    const otherRoot = d.table('other_root', {
+      id: d.uuid().primary(),
+      name: d.text(),
+    });
+
+    const registry = {
+      organizations: d.model(organizations),
+      otherRoot: d.model(otherRoot),
+      users: d.model(
+        users,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+        },
+        { tenant: 'organization' },
+      ),
+      projects: d.model(
+        projects,
+        {
+          other: d.ref.one(() => otherRoot, 'organizationId'),
+        },
+        { tenant: 'other' },
+      ),
+    };
+
+    expect(() => computeTenantGraph(registry)).toThrow('Conflicting tenant roots');
+  });
+
+  it('throws when _tenant references a non-existent relation', () => {
+    const registry = {
+      organizations: d.model(organizations),
+      users: {
+        table: users,
+        relations: {},
+        _tenant: 'organization', // relation doesn't exist
+        schemas: d.model(users).schemas,
+      },
+    };
+
+    expect(() => computeTenantGraph(registry)).toThrow('tenant relation "organization" not found');
+  });
+
+  it('resolves indirect scoping via ref.many', () => {
+    const tags = d.table('tags', {
+      id: d.uuid().primary(),
+      name: d.text(),
+    });
+
+    const registry = {
+      organizations: d.model(organizations),
+      projects: d.model(
+        projects,
+        {
+          organization: d.ref.one(() => organizations, 'organizationId'),
+          tags: d.ref.many(() => tags, 'projectId'),
+        },
+        { tenant: 'organization' },
+      ),
+      tags: d.model(tags, {
+        project: d.ref.one(() => projects, 'projectId'),
+      }),
+    };
+
+    const graph = computeTenantGraph(registry);
+    expect(graph.indirectlyScoped).toContain('tags');
+  });
+
+  it('returns null root when no tenant options exist', () => {
     const standalone = d.table('standalone', {
       id: d.uuid().primary(),
       name: d.text(),
     });
 
     const registry = {
-      standalone: { table: standalone, relations: {} },
+      standalone: d.model(standalone),
     };
 
     const graph = computeTenantGraph(registry);

--- a/packages/db/src/client/database.ts
+++ b/packages/db/src/client/database.ts
@@ -428,8 +428,8 @@ const RESERVED_MODEL_NAMES = new Set(['query', 'close', 'isHealthy', '_internals
  * Each model in the registry becomes a property on the returned client
  * with all CRUD methods typed for that specific model.
  *
- * Computes the tenant graph at creation time from d.tenant() metadata,
- * traversing references to find indirect tenant paths.
+ * Computes the tenant graph at creation time from model-level { tenant }
+ * options, traversing relations to find indirect tenant paths.
  * Logs notices for tables without tenant paths and not .shared().
  *
  * When `url` is provided and `_queryFn` is NOT provided, creates a real

--- a/packages/db/src/client/sqlite-value-converter.ts
+++ b/packages/db/src/client/sqlite-value-converter.ts
@@ -28,7 +28,10 @@ export function fromSqliteValue(value: unknown, columnType: string): unknown {
       return false;
     }
   }
-  if ((columnType === 'timestamp' || columnType === 'timestamp with time zone') && typeof value === 'string') {
+  if (
+    (columnType === 'timestamp' || columnType === 'timestamp with time zone') &&
+    typeof value === 'string'
+  ) {
     return new Date(value);
   }
   return value;

--- a/packages/db/src/client/tenant-graph.ts
+++ b/packages/db/src/client/tenant-graph.ts
@@ -1,4 +1,4 @@
-import type { ColumnBuilder, ColumnMetadata } from '../schema/column';
+import type { RelationDef } from '../schema/relation';
 import type { ColumnRecord, TableDef } from '../schema/table';
 
 // ---------------------------------------------------------------------------
@@ -6,13 +6,13 @@ import type { ColumnRecord, TableDef } from '../schema/table';
 // ---------------------------------------------------------------------------
 
 export interface TenantGraph {
-  /** The tenant root table name (e.g., "organizations"). Null if no tenant columns exist. */
+  /** The tenant root table key (e.g., "organizations"). Null if no tenant declarations exist. */
   readonly root: string | null;
-  /** Tables with a direct d.tenant() column pointing to the root. */
+  /** Model keys with a direct { tenant } declaration pointing to the root. */
   readonly directlyScoped: readonly string[];
-  /** Tables reachable from directly scoped tables via .references() chains. */
+  /** Model keys reachable from scoped models via relation chains. */
   readonly indirectlyScoped: readonly string[];
-  /** Tables marked with .shared(). */
+  /** Model keys whose tables are marked with .shared(). */
   readonly shared: readonly string[];
 }
 
@@ -20,27 +20,31 @@ export interface TenantGraph {
 // Registry types (subset of what createDb receives)
 // ---------------------------------------------------------------------------
 
-interface TableRegistryEntry {
+interface ModelRegistryEntry {
   readonly table: TableDef<ColumnRecord>;
-  readonly relations: Record<string, unknown>;
+  readonly relations: Record<string, RelationDef>;
+  readonly _tenant?: string | null;
 }
 
-type TableRegistry = Record<string, TableRegistryEntry>;
+type ModelRegistry = Record<string, ModelRegistryEntry>;
 
 // ---------------------------------------------------------------------------
 // computeTenantGraph
 // ---------------------------------------------------------------------------
 
 /**
- * Analyzes a table registry to compute the tenant scoping graph.
+ * Analyzes a model registry to compute the tenant scoping graph.
  *
- * 1. Finds the tenant root — the table that tenant columns point to.
- * 2. Classifies tables as directly scoped (has d.tenant()), indirectly scoped
- *    (references a scoped table via .references()), or shared (.shared()).
- * 3. Tables that are none of the above are unscoped — the caller should
+ * Fully relation-derived — reads _tenant from model options and follows
+ * relation chains for indirect scoping. Does NOT scan column metadata.
+ *
+ * 1. Finds the tenant root — the table that tenant relations point to.
+ * 2. Classifies models as directly scoped (has { tenant } option),
+ *    indirectly scoped (has a relation to a scoped model), or shared (.shared()).
+ * 3. Models that are none of the above are unscoped — the caller should
  *    log a notice for those.
  */
-export function computeTenantGraph(registry: TableRegistry): TenantGraph {
+export function computeTenantGraph(registry: ModelRegistry): TenantGraph {
   const entries = Object.entries(registry);
 
   // Build a map of table name -> registry key for lookup
@@ -49,7 +53,7 @@ export function computeTenantGraph(registry: TableRegistry): TenantGraph {
     tableNameToKey.set(entry.table._name, key);
   }
 
-  // Step 1: Find tenant root and directly scoped tables
+  // Step 1: Find tenant root, directly scoped, and shared models
   let root: string | null = null;
   const directlyScoped: string[] = [];
   const shared: string[] = [];
@@ -61,26 +65,32 @@ export function computeTenantGraph(registry: TableRegistry): TenantGraph {
       continue;
     }
 
-    // Check columns for tenant marker
-    const columns = entry.table._columns;
-    for (const colKey of Object.keys(columns)) {
-      const col = columns[colKey] as ColumnBuilder<unknown, ColumnMetadata>;
-      if (col._meta.isTenant && col._meta.references) {
-        // This table is directly scoped
-        if (!directlyScoped.includes(key)) {
-          directlyScoped.push(key);
+    // Check for tenant option
+    if (entry._tenant) {
+      const tenantRel = entry.relations[entry._tenant] as RelationDef | undefined;
+      if (!tenantRel) {
+        throw new Error(
+          `Model "${key}": tenant relation "${entry._tenant}" not found in relations`,
+        );
+      }
+      if (!directlyScoped.includes(key)) {
+        directlyScoped.push(key);
+      }
+      // The referenced table is the tenant root
+      const rootTableName = tenantRel._target()._name;
+      const rootKey = tableNameToKey.get(rootTableName);
+      if (rootKey) {
+        if (root !== null && root !== rootKey) {
+          throw new Error(
+            `Conflicting tenant roots: "${root}" and "${rootKey}". All tenant declarations must point to the same root table.`,
+          );
         }
-        // The referenced table is the tenant root
-        const rootTableName = col._meta.references.table;
-        const rootKey = tableNameToKey.get(rootTableName);
-        if (rootKey && root === null) {
-          root = rootKey;
-        }
+        root = rootKey;
       }
     }
   }
 
-  // Step 2: Find indirectly scoped tables via .references() chains
+  // Step 2: Find indirectly scoped models via relation chains
   // Build a set of table names that are scoped (root + directly scoped)
   const scopedTableNames = new Set<string>();
   if (root !== null) {
@@ -99,7 +109,7 @@ export function computeTenantGraph(registry: TableRegistry): TenantGraph {
   const indirectlyScoped: string[] = [];
   const indirectlyScopedNames = new Set<string>();
 
-  // Iteratively resolve indirect scoping until no new tables are found
+  // Iteratively resolve indirect scoping until no new models are found
   let changed = true;
   while (changed) {
     changed = false;
@@ -114,19 +124,15 @@ export function computeTenantGraph(registry: TableRegistry): TenantGraph {
         continue;
       }
 
-      // Check if any column references a scoped or indirectly scoped table
-      const columns = entry.table._columns;
-      for (const colKey of Object.keys(columns)) {
-        const col = columns[colKey] as ColumnBuilder<unknown, ColumnMetadata>;
-        if (col._meta.references && !col._meta.isTenant) {
-          const refTable = col._meta.references.table;
-          if (scopedTableNames.has(refTable) || indirectlyScopedNames.has(refTable)) {
-            indirectlyScoped.push(key);
-            indirectlyScopedNames.add(entry.table._name);
-            scopedTableNames.add(entry.table._name);
-            changed = true;
-            break;
-          }
+      // Check if any relation targets a scoped or indirectly scoped table
+      for (const rel of Object.values(entry.relations)) {
+        const targetTableName = (rel as RelationDef)._target()._name;
+        if (scopedTableNames.has(targetTableName) || indirectlyScopedNames.has(targetTableName)) {
+          indirectlyScoped.push(key);
+          indirectlyScopedNames.add(entry.table._name);
+          scopedTableNames.add(entry.table._name);
+          changed = true;
+          break;
         }
       }
     }

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -6,12 +6,11 @@ import type {
   FormatMeta,
   JsonbValidator,
   SerialMeta,
-  TenantMeta,
   VarcharMeta,
 } from './schema/column';
-import { createColumn, createSerialColumn, createTenantColumn } from './schema/column';
+import { createColumn, createSerialColumn } from './schema/column';
 import type { ModelEntry } from './schema/inference';
-import type { ModelDef } from './schema/model';
+import type { ModelDef, ModelOptions } from './schema/model';
 import { createModel } from './schema/model';
 import type { SchemaLike } from './schema/model-schemas';
 import type { ManyRelationDef, RelationDef } from './schema/relation';
@@ -56,7 +55,6 @@ export const d: {
     name: TName,
     schema: EnumSchemaLike<TValues>,
   ): ColumnBuilder<TValues[number], EnumMeta<TName, TValues>>;
-  tenant(targetTable: TableDef<ColumnRecord>): ColumnBuilder<string, TenantMeta>;
   table<TColumns extends ColumnRecord>(
     name: string,
     columns: TColumns,
@@ -85,6 +83,11 @@ export const d: {
   model<TTable extends TableDef<ColumnRecord>, TRelations extends Record<string, RelationDef>>(
     table: TTable,
     relations: TRelations,
+  ): ModelDef<TTable, TRelations>;
+  model<TTable extends TableDef<ColumnRecord>, TRelations extends Record<string, RelationDef>>(
+    table: TTable,
+    relations: TRelations,
+    options: ModelOptions<TRelations>,
   ): ModelDef<TTable, TRelations>;
 } = {
   uuid: () => createColumn<string, DefaultMeta<'uuid'>>('uuid'),
@@ -134,7 +137,6 @@ export const d: {
       enumValues: values,
     });
   },
-  tenant: (targetTable: TableDef<ColumnRecord>) => createTenantColumn(targetTable._name),
   table: <TColumns extends ColumnRecord>(name: string, columns: TColumns, options?: TableOptions) =>
     createTable(name, columns, options),
   index: (columns: string | string[]) => createIndex(columns),
@@ -148,6 +150,9 @@ export const d: {
     table,
     relations,
   }),
-  model: (table: TableDef<ColumnRecord>, relations: Record<string, RelationDef> = {}) =>
-    createModel(table, relations),
+  model: (
+    table: TableDef<ColumnRecord>,
+    relations: Record<string, RelationDef> = {},
+    options?: ModelOptions<Record<string, RelationDef>>,
+  ) => createModel(table, relations, options),
 };

--- a/packages/db/src/dialect/__tests__/postgres-dialect.test.ts
+++ b/packages/db/src/dialect/__tests__/postgres-dialect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { PostgresDialect, defaultPostgresDialect } from '../postgres';
+import { defaultPostgresDialect, PostgresDialect } from '../postgres';
 
 describe('PostgresDialect', () => {
   const dialect = new PostgresDialect();

--- a/packages/db/src/dialect/__tests__/sqlite-dialect.test.ts
+++ b/packages/db/src/dialect/__tests__/sqlite-dialect.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'bun:test';
-import { SqliteDialect, defaultSqliteDialect } from '../sqlite';
+import { describe, expect, it } from 'bun:test';
+import { defaultSqliteDialect, SqliteDialect } from '../sqlite';
 
 describe('SqliteDialect', () => {
   const dialect = new SqliteDialect();

--- a/packages/db/src/dialect/index.ts
+++ b/packages/db/src/dialect/index.ts
@@ -1,3 +1,3 @@
+export { defaultPostgresDialect, PostgresDialect } from './postgres';
+export { defaultSqliteDialect, SqliteDialect } from './sqlite';
 export type { ColumnTypeMeta, Dialect, IdStrategy } from './types';
-export { PostgresDialect, defaultPostgresDialect } from './postgres';
-export { SqliteDialect, defaultSqliteDialect } from './sqlite';

--- a/packages/db/src/dialect/postgres.ts
+++ b/packages/db/src/dialect/postgres.ts
@@ -38,9 +38,7 @@ export class PostgresDialect implements Dialect {
       case 'json':
         return 'JSONB';
       case 'decimal':
-        return meta?.precision
-          ? `NUMERIC(${meta.precision},${meta.scale ?? 0})`
-          : 'NUMERIC';
+        return meta?.precision ? `NUMERIC(${meta.precision},${meta.scale ?? 0})` : 'NUMERIC';
       case 'varchar':
         return meta?.length ? `VARCHAR(${meta.length})` : 'VARCHAR';
       case 'enum':

--- a/packages/db/src/id/generators.ts
+++ b/packages/db/src/id/generators.ts
@@ -1,14 +1,18 @@
 import { createId } from '@paralleldrive/cuid2';
-import { v7 as uuidv7 } from 'uuid';
 import { nanoid } from 'nanoid';
+import { v7 as uuidv7 } from 'uuid';
 
 export type IdStrategy = 'cuid' | 'uuid' | 'nanoid';
 
 export function generateId(strategy: IdStrategy): string {
   switch (strategy) {
-    case 'cuid': return createId();
-    case 'uuid': return uuidv7();
-    case 'nanoid': return nanoid();
-    default: throw new Error(`Unknown ID generation strategy: ${strategy}`);
+    case 'cuid':
+      return createId();
+    case 'uuid':
+      return uuidv7();
+    case 'nanoid':
+      return nanoid();
+    default:
+      throw new Error(`Unknown ID generation strategy: ${strategy}`);
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -135,7 +135,6 @@ export type {
   FormatMeta,
   InferColumnType,
   JsonbValidator,
-  TenantMeta,
   VarcharMeta,
 } from './schema/column';
 export { defineAnnotations } from './schema/define-annotations';
@@ -154,7 +153,7 @@ export type {
   SelectOption,
   UpdateInput,
 } from './schema/inference';
-export type { ModelDef } from './schema/model';
+export type { ModelDef, ModelOptions } from './schema/model';
 export type { ModelSchemas, SchemaLike } from './schema/model-schemas';
 export { createRegistry } from './schema/registry';
 export type { RelationDef } from './schema/relation';

--- a/packages/db/src/migration/__tests__/auto-migrate.test.ts
+++ b/packages/db/src/migration/__tests__/auto-migrate.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { autoMigrate } from '../auto-migrate';
-import type { SchemaSnapshot } from '../snapshot';
-import type { MigrationQueryFn } from '../runner';
-import { createSnapshot } from '../snapshot';
-import { d } from '../../d';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { d } from '../../d';
+import { autoMigrate } from '../auto-migrate';
+import type { MigrationQueryFn } from '../runner';
+import type { SchemaSnapshot } from '../snapshot';
+import { createSnapshot } from '../snapshot';
 
 describe('auto-migrate', () => {
   let tmpDir: string;
@@ -47,8 +47,10 @@ describe('auto-migrate', () => {
       });
 
       // Should have created history table and the users table
-      const createHistoryQuery = db.queries.find(q => q.sql.includes('_vertz_migrations'));
-      const createTableQuery = db.queries.find(q => q.sql.includes('CREATE TABLE') && q.sql.includes('users'));
+      const createHistoryQuery = db.queries.find((q) => q.sql.includes('_vertz_migrations'));
+      const createTableQuery = db.queries.find(
+        (q) => q.sql.includes('CREATE TABLE') && q.sql.includes('users'),
+      );
 
       expect(createHistoryQuery).toBeDefined();
       expect(createTableQuery).toBeDefined();
@@ -68,7 +70,9 @@ describe('auto-migrate', () => {
       });
 
       // Should only create history table, no table creations
-      const createTableQueries = db.queries.filter(q => q.sql.includes('CREATE TABLE') && !q.sql.includes('_vertz_migrations'));
+      const createTableQueries = db.queries.filter(
+        (q) => q.sql.includes('CREATE TABLE') && !q.sql.includes('_vertz_migrations'),
+      );
       expect(createTableQueries).toHaveLength(0);
     });
   });
@@ -103,7 +107,9 @@ describe('auto-migrate', () => {
       });
 
       // Should only query the migrations history table (no new migrations applied)
-      const migrationInserts = db.queries.filter(q => q.sql.includes('INSERT INTO "_vertz_migrations"'));
+      const migrationInserts = db.queries.filter((q) =>
+        q.sql.includes('INSERT INTO "_vertz_migrations"'),
+      );
       expect(migrationInserts).toHaveLength(0);
     });
   });
@@ -146,7 +152,7 @@ describe('auto-migrate', () => {
       });
 
       // Should have generated ALTER TABLE for the new column
-      const alterTableQueries = db.queries.filter(q => q.sql.includes('ALTER TABLE'));
+      const alterTableQueries = db.queries.filter((q) => q.sql.includes('ALTER TABLE'));
       expect(alterTableQueries.length).toBeGreaterThan(0);
     });
 
@@ -185,7 +191,9 @@ describe('auto-migrate', () => {
       });
 
       // Should have created the posts table
-      const createPostsQuery = db.queries.find(q => q.sql.includes('CREATE TABLE') && q.sql.includes('posts'));
+      const createPostsQuery = db.queries.find(
+        (q) => q.sql.includes('CREATE TABLE') && q.sql.includes('posts'),
+      );
       expect(createPostsQuery).toBeDefined();
     });
   });
@@ -233,9 +241,9 @@ describe('auto-migrate', () => {
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Warning: Destructive change detected'),
       );
-      expect(consoleWarnSpy.mock.calls.some(call => 
-        call[0]?.includes('column_removed')
-      )).toBe(true);
+      expect(consoleWarnSpy.mock.calls.some((call) => call[0]?.includes('column_removed'))).toBe(
+        true,
+      );
 
       console.warn = originalWarn;
     });
@@ -276,9 +284,9 @@ describe('auto-migrate', () => {
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Warning: Destructive change detected'),
       );
-      expect(consoleWarnSpy.mock.calls.some(call => 
-        call[0]?.includes('table_removed')
-      )).toBe(true);
+      expect(consoleWarnSpy.mock.calls.some((call) => call[0]?.includes('table_removed'))).toBe(
+        true,
+      );
 
       console.warn = originalWarn;
     });

--- a/packages/db/src/migration/__tests__/sql-generator-dialect.test.ts
+++ b/packages/db/src/migration/__tests__/sql-generator-dialect.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { defaultPostgresDialect, defaultSqliteDialect } from '../../dialect';
-import { generateMigrationSql, generateRollbackSql } from '../sql-generator';
 import type { DiffChange } from '../differ';
+import { generateMigrationSql, generateRollbackSql } from '../sql-generator';
 
 describe('generateMigrationSql with PostgresDialect (regression)', () => {
   it('CREATE TABLE with PostgresDialect produces Postgres types', () => {
@@ -17,9 +17,27 @@ describe('generateMigrationSql with PostgresDialect (regression)', () => {
           _name: 'users',
           columns: {
             id: { type: 'UUID', nullable: false, primary: true, unique: false, default: undefined },
-            name: { type: 'TEXT', nullable: false, primary: false, unique: false, default: undefined },
-            isActive: { type: 'BOOLEAN', nullable: true, primary: false, unique: false, default: undefined },
-            createdAt: { type: 'TIMESTAMPTZ', nullable: false, primary: false, unique: false, default: undefined },
+            name: {
+              type: 'TEXT',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
+            isActive: {
+              type: 'BOOLEAN',
+              nullable: true,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
+            createdAt: {
+              type: 'TIMESTAMPTZ',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
           },
           foreignKeys: [],
           indexes: [],
@@ -29,7 +47,7 @@ describe('generateMigrationSql with PostgresDialect (regression)', () => {
     };
 
     const sql = generateMigrationSql(changes, ctx, defaultPostgresDialect);
-    
+
     expect(sql).toContain('"id" UUID NOT NULL');
     expect(sql).toContain('"is_active" BOOLEAN');
     expect(sql).toContain('"created_at" TIMESTAMPTZ NOT NULL');
@@ -50,9 +68,27 @@ describe('generateMigrationSql with SqliteDialect', () => {
           _name: 'users',
           columns: {
             id: { type: 'UUID', nullable: false, primary: true, unique: false, default: undefined },
-            name: { type: 'TEXT', nullable: false, primary: false, unique: false, default: undefined },
-            isActive: { type: 'BOOLEAN', nullable: true, primary: false, unique: false, default: undefined },
-            createdAt: { type: 'TIMESTAMPTZ', nullable: false, primary: false, unique: false, default: undefined },
+            name: {
+              type: 'TEXT',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
+            isActive: {
+              type: 'BOOLEAN',
+              nullable: true,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
+            createdAt: {
+              type: 'TIMESTAMPTZ',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
           },
           foreignKeys: [],
           indexes: [],
@@ -62,7 +98,7 @@ describe('generateMigrationSql with SqliteDialect', () => {
     };
 
     const sql = generateMigrationSql(changes, ctx, defaultSqliteDialect);
-    
+
     // SQLite maps UUID -> TEXT, BOOLEAN -> INTEGER, TIMESTAMPTZ -> TEXT
     expect(sql).toContain('"id" TEXT NOT NULL');
     expect(sql).toContain('"is_active" INTEGER');
@@ -83,7 +119,13 @@ describe('generateMigrationSql with SqliteDialect', () => {
           columns: {
             id: { type: 'TEXT', nullable: false, primary: true, unique: false, default: undefined },
             // Column type matches the enum name so it's detected as an enum
-            status: { type: 'post_status', nullable: false, primary: false, unique: false, default: undefined },
+            status: {
+              type: 'post_status',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
           },
           foreignKeys: [],
           indexes: [],
@@ -95,9 +137,9 @@ describe('generateMigrationSql with SqliteDialect', () => {
     };
 
     const sql = generateMigrationSql(changes, ctx, defaultSqliteDialect);
-    
+
     // SQLite should use CHECK constraint for enum values
-    expect(sql).toContain('CHECK("status" IN (\'draft\', \'published\', \'archived\'))');
+    expect(sql).toContain("CHECK(\"status\" IN ('draft', 'published', 'archived'))");
   });
 
   it('CREATE INDEX is identical for both dialects', () => {
@@ -140,7 +182,13 @@ describe('generateMigrationSql with PostgresDialect', () => {
           _name: 'posts',
           columns: {
             id: { type: 'TEXT', nullable: false, primary: true, unique: false, default: undefined },
-            status: { type: 'post_status', nullable: false, primary: false, unique: false, default: undefined },
+            status: {
+              type: 'post_status',
+              nullable: false,
+              primary: false,
+              unique: false,
+              default: undefined,
+            },
           },
           foreignKeys: [],
           indexes: [],
@@ -152,10 +200,10 @@ describe('generateMigrationSql with PostgresDialect', () => {
     };
 
     const sql = generateMigrationSql(changes, ctx, defaultPostgresDialect);
-    
+
     // Postgres should create enum type
     expect(sql).toContain('CREATE TYPE "post_status" AS ENUM');
-    expect(sql).toContain('\'draft\', \'published\', \'archived\'');
+    expect(sql).toContain("'draft', 'published', 'archived'");
   });
 });
 
@@ -183,7 +231,7 @@ describe('generateMigrationSql backward compatibility', () => {
 
     // Should work without the dialect parameter (defaults to PostgresDialect)
     const sql = generateMigrationSql(changes, ctx);
-    
+
     expect(sql).toContain('"id" UUID NOT NULL');
   });
 });

--- a/packages/db/src/migration/sql-generator.ts
+++ b/packages/db/src/migration/sql-generator.ts
@@ -1,6 +1,6 @@
-import { camelToSnake } from '../sql/casing';
 import type { Dialect } from '../dialect';
 import { defaultPostgresDialect } from '../dialect';
+import { camelToSnake } from '../sql/casing';
 import type { DiffChange } from './differ';
 import type { ColumnSnapshot, TableSnapshot } from './snapshot';
 
@@ -39,7 +39,10 @@ function isEnumType(col: ColumnSnapshot, enums?: Record<string, string[]>): bool
 /**
  * Get enum values for a column type.
  */
-function getEnumValues(col: ColumnSnapshot, enums?: Record<string, string[]>): string[] | undefined {
+function getEnumValues(
+  col: ColumnSnapshot,
+  enums?: Record<string, string[]>,
+): string[] | undefined {
   if (!enums) return undefined;
   for (const [enumName, values] of Object.entries(enums)) {
     if (col.type.toLowerCase() === enumName.toLowerCase() || col.type === enumName) {
@@ -60,11 +63,11 @@ function columnDef(
 ): string {
   const snakeName = camelToSnake(name);
   const isEnum = isEnumType(col, enums);
-  
+
   // Map the column type using dialect
   let sqlType: string;
   let checkConstraint: string | undefined;
-  
+
   if (isEnum && dialect.name === 'sqlite') {
     // SQLite: use TEXT with CHECK constraint for enums
     sqlType = dialect.mapColumnType('text');
@@ -75,7 +78,7 @@ function columnDef(
     }
   } else {
     // Use dialect's type mapping
-    // For backward compatibility: 
+    // For backward compatibility:
     // - PostgresDialect with lowercase types preserves them as-is
     // - SQLiteDialect always applies mapping (uuid->TEXT, boolean->INTEGER, etc.)
     // - Uppercase types are normalized and mapped via dialect
@@ -180,8 +183,8 @@ export function generateMigrationSql(
               if (enumValues && enumValues.length > 0) {
                 // Check if we already emitted this enum type
                 const enumSnakeName = camelToSnake(col.type);
-                const alreadyEmitted = statements.some(
-                  (s) => s.includes(`CREATE TYPE "${enumSnakeName}"`),
+                const alreadyEmitted = statements.some((s) =>
+                  s.includes(`CREATE TYPE "${enumSnakeName}"`),
                 );
                 if (!alreadyEmitted) {
                   const valuesStr = enumValues.map((v) => `'${escapeSqlString(v)}'`).join(', ');

--- a/packages/db/src/query/__tests__/aggregate.test.ts
+++ b/packages/db/src/query/__tests__/aggregate.test.ts
@@ -1,5 +1,5 @@
-import { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
 import { createDb } from '../../client/database';
 import { d } from '../../d';
 import type { ModelEntry } from '../../schema/inference';

--- a/packages/db/src/query/__tests__/crud.test.ts
+++ b/packages/db/src/query/__tests__/crud.test.ts
@@ -1,5 +1,5 @@
-import { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
 import { createDb } from '../../client/database';
 import { d } from '../../d';
 import type { ModelEntry } from '../../schema/inference';

--- a/packages/db/src/query/__tests__/relation-loader.test.ts
+++ b/packages/db/src/query/__tests__/relation-loader.test.ts
@@ -1,6 +1,6 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { unwrap } from '@vertz/schema';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { createDb } from '../../client/database';
 import { d } from '../../d';
 import type { ModelEntry } from '../../schema/inference';

--- a/packages/db/src/schema/__tests__/column.test-d.ts
+++ b/packages/db/src/schema/__tests__/column.test-d.ts
@@ -196,20 +196,6 @@ describe('type-level negative tests', () => {
   });
 });
 
-describe('d.tenant() type inference', () => {
-  it('d.tenant() infers string', () => {
-    const orgs = d.table('orgs', { id: d.uuid().primary() });
-    const col = d.tenant(orgs);
-    type _t1 = Expect<Equal<InferColumnType<typeof col>, string>>;
-  });
-
-  it('d.tenant().nullable() infers string | null', () => {
-    const orgs = d.table('orgs', { id: d.uuid().primary() });
-    const col = d.tenant(orgs).nullable();
-    type _t1 = Expect<Equal<InferColumnType<typeof col>, string | null>>;
-  });
-});
-
 describe('metadata type-level tracking', () => {
   it('.primary() sets primary to true in metadata type', () => {
     const col = d.uuid().primary();

--- a/packages/db/src/schema/__tests__/column.test.ts
+++ b/packages/db/src/schema/__tests__/column.test.ts
@@ -127,12 +127,12 @@ describe('chainable builders', () => {
     expect(col._meta.defaultValue).toBe(true);
   });
 
-  it('.is(\'sensitive\') adds sensitive to _annotations', () => {
+  it(".is('sensitive') adds sensitive to _annotations", () => {
     const col = d.email().is('sensitive');
     expect(col._meta._annotations.sensitive).toBe(true);
   });
 
-  it('.is(\'hidden\') adds hidden to _annotations', () => {
+  it(".is('hidden') adds hidden to _annotations", () => {
     const col = d.text().is('hidden');
     expect(col._meta._annotations.hidden).toBe(true);
   });
@@ -212,54 +212,9 @@ describe('d.jsonb<T>({ validator })', () => {
   });
 });
 
-describe('d.tenant()', () => {
-  it('creates a uuid column with isTenant: true and references metadata', () => {
-    const organizations = d.table('organizations', {
-      id: d.uuid().primary(),
-      name: d.text(),
-    });
-
-    const col = d.tenant(organizations);
-    expect(col._meta.sqlType).toBe('uuid');
-    expect(col._meta.isTenant).toBe(true);
-    expect(col._meta.references).toEqual({ table: 'organizations', column: 'id' });
-  });
-
-  it('defaults other metadata flags to false/null', () => {
-    const orgs = d.table('orgs', {
-      id: d.uuid().primary(),
-    });
-
-    const col = d.tenant(orgs);
-    expect(col._meta.primary).toBe(false);
-    expect(col._meta.unique).toBe(false);
-    expect(col._meta.nullable).toBe(false);
-    expect(col._meta.hasDefault).toBe(false);
-    expect(col._meta._annotations).toEqual({});
-    expect(col._meta.check).toBeNull();
-  });
-
-  it('supports chaining modifiers after d.tenant()', () => {
-    const orgs = d.table('orgs', {
-      id: d.uuid().primary(),
-    });
-
-    const col = d.tenant(orgs).nullable();
-    expect(col._meta.isTenant).toBe(true);
-    expect(col._meta.nullable).toBe(true);
-    expect(col._meta.references).toEqual({ table: 'orgs', column: 'id' });
-  });
-});
-
-describe('isTenant metadata on regular columns', () => {
-  it('defaults isTenant to false on regular columns', () => {
-    const col = d.uuid();
-    expect(col._meta.isTenant).toBe(false);
-  });
-
-  it('defaults isTenant to false on serial columns', () => {
-    const col = d.serial();
-    expect(col._meta.isTenant).toBe(false);
+describe('d.tenant() removed', () => {
+  it('d.tenant no longer exists on the d namespace', () => {
+    expect('tenant' in d).toBe(false);
   });
 });
 

--- a/packages/db/src/schema/__tests__/model.test-d.ts
+++ b/packages/db/src/schema/__tests__/model.test-d.ts
@@ -19,6 +19,56 @@ const users = d.table('users', {
 const usersModel = d.model(users);
 
 // ---------------------------------------------------------------------------
+// _tenant — model-level tenant option
+// ---------------------------------------------------------------------------
+
+const orgs = d.table('organizations', {
+  id: d.uuid().primary(),
+  name: d.text(),
+});
+
+const employees = d.table('employees', {
+  id: d.uuid().primary(),
+  organizationId: d.uuid(),
+  name: d.text(),
+});
+
+describe('ModelDef._tenant type', () => {
+  it('is string | null', () => {
+    const model = d.model(
+      employees,
+      {
+        organization: d.ref.one(() => orgs, 'organizationId'),
+      },
+      { tenant: 'organization' },
+    );
+
+    type _t1 = Expect<Extends<typeof model._tenant, string | null>>;
+  });
+
+  it('is string | null when no options provided', () => {
+    type _t1 = Expect<Extends<typeof usersModel._tenant, string | null>>;
+  });
+
+  it('rejects invalid relation names in tenant option', () => {
+    const relations = { organization: d.ref.one(() => orgs, 'organizationId') };
+    // @ts-expect-error — 'nonexistent' is not a key of the relations record
+    d.model(employees, relations, { tenant: 'nonexistent' });
+  });
+
+  it('accepts valid relation names in tenant option', () => {
+    // Should compile without error
+    d.model(
+      employees,
+      {
+        organization: d.ref.one(() => orgs, 'organizationId'),
+      },
+      { tenant: 'organization' },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // schemas.response — type excludes hidden columns
 // ---------------------------------------------------------------------------
 
@@ -104,10 +154,15 @@ describe('ModelDef schemas.createInput required vs optional', () => {
     type CreateType = Unwrap<ReturnType<typeof usersModel.schemas.createInput.parse>>;
 
     // Should compile: role is optional (has default 'viewer'), omitting it is valid
-    type _t1 = Expect<Extends<{
-      email: string;
-      name: string;
-      passwordHash: string;
-    }, CreateType>>;
+    type _t1 = Expect<
+      Extends<
+        {
+          email: string;
+          name: string;
+          passwordHash: string;
+        },
+        CreateType
+      >
+    >;
   });
 });

--- a/packages/db/src/schema/__tests__/model.test.ts
+++ b/packages/db/src/schema/__tests__/model.test.ts
@@ -168,6 +168,48 @@ describe('Feature: d.model() and derived schemas', () => {
     });
   });
 
+  describe('Given a model with tenant option', () => {
+    const orgsTable = d.table('organizations', {
+      id: d.uuid().primary(),
+      name: d.text(),
+    });
+
+    const employeesTable = d.table('employees', {
+      id: d.uuid().primary(),
+      organizationId: d.uuid(),
+      name: d.text(),
+    });
+
+    describe('When calling d.model(table) without relations or options', () => {
+      it('Then ._tenant defaults to null', () => {
+        const model = d.model(usersTable);
+        expect(model._tenant).toBeNull();
+      });
+    });
+
+    describe('When calling d.model(table, relations) without options', () => {
+      it('Then ._tenant defaults to null', () => {
+        const model = d.model(employeesTable, {
+          organization: d.ref.one(() => orgsTable, 'organizationId'),
+        });
+        expect(model._tenant).toBeNull();
+      });
+    });
+
+    describe('When calling d.model(table, relations, { tenant }) with a valid relation name', () => {
+      it('Then ._tenant equals the relation name', () => {
+        const model = d.model(
+          employeesTable,
+          {
+            organization: d.ref.one(() => orgsTable, 'organizationId'),
+          },
+          { tenant: 'organization' },
+        );
+        expect(model._tenant).toBe('organization');
+      });
+    });
+  });
+
   describe('Given a table and relations', () => {
     const postsTable = d.table('posts', {
       id: d.uuid().primary(),

--- a/packages/db/src/schema/__tests__/registry.test-d.ts
+++ b/packages/db/src/schema/__tests__/registry.test-d.ts
@@ -180,7 +180,9 @@ describe('createRegistry() types', () => {
     type _t3 = Expect<Equal<typeof models.comments.table, typeof comments>>;
 
     // Relation types are preserved
-    type _t4 = Expect<Extends<typeof models.posts.relations.author, RelationDef<typeof users, 'one'>>>;
+    type _t4 = Expect<
+      Extends<typeof models.posts.relations.author, RelationDef<typeof users, 'one'>>
+    >;
   });
 
   it('tables without relations get empty relations object', () => {

--- a/packages/db/src/schema/__tests__/table.test-d.ts
+++ b/packages/db/src/schema/__tests__/table.test-d.ts
@@ -193,60 +193,6 @@ describe('$update', () => {
 });
 
 // ---------------------------------------------------------------------------
-// d.tenant() -- type-level tests
-// ---------------------------------------------------------------------------
-
-const organizations = d.table('organizations', {
-  id: d.uuid().primary(),
-  name: d.text(),
-});
-
-const tenantUsers = d.table('tenant_users', {
-  id: d.uuid().primary(),
-  organizationId: d.tenant(organizations),
-  name: d.text(),
-});
-
-describe('d.tenant() type inference', () => {
-  it('tenant column infers as string (UUID type)', () => {
-    type TUser = typeof tenantUsers.$infer;
-    type _t1 = Expect<Equal<TUser['organizationId'], string>>;
-  });
-
-  it('tenant column carries isTenant: true in metadata type', () => {
-    const _isTenant: typeof tenantUsers._columns.organizationId._meta.isTenant = true;
-    // @ts-expect-error -- isTenant is true on a tenant column, false should not be assignable
-    const _notTenant: typeof tenantUsers._columns.organizationId._meta.isTenant = false;
-    void _isTenant;
-    void _notTenant;
-  });
-
-  it('tenant column carries references metadata in type', () => {
-    type Refs = typeof tenantUsers._columns.organizationId._meta.references;
-    type _t1 = Expect<Equal<Refs, { readonly table: string; readonly column: string }>>;
-  });
-
-  it('non-tenant columns have isTenant: false in metadata type', () => {
-    const _notTenant: typeof tenantUsers._columns.name._meta.isTenant = false;
-    // @ts-expect-error -- isTenant is false on a regular column, true should not be assignable
-    const _isTenant: typeof tenantUsers._columns.name._meta.isTenant = true;
-    void _notTenant;
-    void _isTenant;
-  });
-
-  it('tenant column is required in $insert (no default)', () => {
-    type TInsert = typeof tenantUsers.$insert;
-
-    // organizationId is required -- no default on a tenant column
-    const _valid: TInsert = {
-      organizationId: 'org-uuid',
-      name: 'Alice',
-    };
-    void _valid;
-  });
-});
-
-// ---------------------------------------------------------------------------
 // .shared() -- metadata flag
 // ---------------------------------------------------------------------------
 

--- a/packages/db/src/schema/__tests__/table.test.ts
+++ b/packages/db/src/schema/__tests__/table.test.ts
@@ -70,42 +70,6 @@ describe('table options', () => {
   });
 });
 
-describe('d.tenant() in table definition', () => {
-  it('tenant column metadata is accessible from the table definition', () => {
-    const organizations = d.table('organizations', {
-      id: d.uuid().primary(),
-      name: d.text(),
-    });
-
-    const users = d.table('users', {
-      id: d.uuid().primary(),
-      organizationId: d.tenant(organizations),
-      name: d.text(),
-    });
-
-    const orgIdMeta = users._columns.organizationId._meta;
-    expect(orgIdMeta.sqlType).toBe('uuid');
-    expect(orgIdMeta.isTenant).toBe(true);
-    expect(orgIdMeta.references).toEqual({ table: 'organizations', column: 'id' });
-  });
-
-  it('non-tenant columns in the same table have isTenant false', () => {
-    const organizations = d.table('organizations', {
-      id: d.uuid().primary(),
-      name: d.text(),
-    });
-
-    const users = d.table('users', {
-      id: d.uuid().primary(),
-      organizationId: d.tenant(organizations),
-      name: d.text(),
-    });
-
-    expect(users._columns.id._meta.isTenant).toBe(false);
-    expect(users._columns.name._meta.isTenant).toBe(false);
-  });
-});
-
 describe('.shared()', () => {
   it('sets the shared metadata flag on a table', () => {
     const featureFlags = d

--- a/packages/db/src/schema/column.ts
+++ b/packages/db/src/schema/column.ts
@@ -11,7 +11,6 @@ export interface ColumnMetadata {
   readonly _annotations: Record<string, true>;
   readonly isReadOnly: boolean;
   readonly isAutoUpdate: boolean;
-  readonly isTenant: boolean;
   readonly references: { readonly table: string; readonly column: string } | null;
   readonly check: string | null;
   readonly defaultValue?: unknown;
@@ -88,7 +87,6 @@ export type DefaultMeta<TSqlType extends string> = {
   readonly _annotations: {};
   readonly isReadOnly: false;
   readonly isAutoUpdate: false;
-  readonly isTenant: false;
   readonly references: null;
   readonly check: null;
 };
@@ -197,7 +195,6 @@ function defaultMeta<TSqlType extends string>(sqlType: TSqlType): DefaultMeta<TS
     _annotations: {},
     isReadOnly: false,
     isAutoUpdate: false,
-    isTenant: false,
     references: null,
     check: null,
   };
@@ -222,7 +219,6 @@ export type SerialMeta = {
   readonly _annotations: {};
   readonly isReadOnly: false;
   readonly isAutoUpdate: false;
-  readonly isTenant: false;
   readonly references: null;
   readonly check: null;
 };
@@ -237,38 +233,7 @@ export function createSerialColumn(): ColumnBuilder<number, SerialMeta> {
     _annotations: {},
     isReadOnly: false,
     isAutoUpdate: false,
-    isTenant: false,
     references: null,
     check: null,
   }) as ColumnBuilder<number, SerialMeta>;
-}
-
-export type TenantMeta = {
-  readonly sqlType: 'uuid';
-  readonly primary: false;
-  readonly unique: false;
-  readonly nullable: false;
-  readonly hasDefault: false;
-  readonly _annotations: {};
-  readonly isReadOnly: false;
-  readonly isAutoUpdate: false;
-  readonly isTenant: true;
-  readonly references: { readonly table: string; readonly column: string };
-  readonly check: null;
-};
-
-export function createTenantColumn(targetTableName: string): ColumnBuilder<string, TenantMeta> {
-  return createColumnWithMeta({
-    sqlType: 'uuid',
-    primary: false,
-    unique: false,
-    nullable: false,
-    hasDefault: false,
-    _annotations: {},
-    isReadOnly: false,
-    isAutoUpdate: false,
-    isTenant: true,
-    references: { table: targetTableName, column: 'id' },
-    check: null,
-  }) as ColumnBuilder<string, TenantMeta>;
 }

--- a/packages/db/src/schema/model.ts
+++ b/packages/db/src/schema/model.ts
@@ -23,6 +23,20 @@ export interface ModelDef<
   readonly table: TTable;
   readonly relations: TRelations;
   readonly schemas: ModelSchemas<TTable>;
+  readonly _tenant: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// ModelOptions — optional config for d.model()
+// ---------------------------------------------------------------------------
+
+export interface ModelOptions<TRelations extends Record<string, RelationDef>> {
+  /**
+   * The relation that defines the tenant boundary for this model.
+   * Must reference a key in the relations record. The referenced relation's
+   * target table is the tenant root.
+   */
+  readonly tenant?: Extract<keyof TRelations, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -32,10 +46,15 @@ export interface ModelDef<
 export function createModel<
   TTable extends TableDef<ColumnRecord>,
   TRelations extends Record<string, RelationDef> = Record<string, never>,
->(table: TTable, relations?: TRelations): ModelDef<TTable, TRelations> {
+>(
+  table: TTable,
+  relations?: TRelations,
+  options?: ModelOptions<TRelations>,
+): ModelDef<TTable, TRelations> {
   return {
     table,
     relations: (relations ?? {}) as TRelations,
     schemas: deriveSchemas(table),
+    _tenant: options?.tenant ?? null,
   };
 }

--- a/packages/db/src/sql/__tests__/dialect-regression.test.ts
+++ b/packages/db/src/sql/__tests__/dialect-regression.test.ts
@@ -36,7 +36,9 @@ describe('buildInsert with PostgresDialect (regression)', () => {
       defaultPostgresDialect,
     );
 
-    expect(result.sql).toBe('INSERT INTO "users" ("id", "created_at") VALUES ($1, NOW()) RETURNING *');
+    expect(result.sql).toBe(
+      'INSERT INTO "users" ("id", "created_at") VALUES ($1, NOW()) RETURNING *',
+    );
     expect(result.params).toEqual(['123']);
   });
 

--- a/packages/db/src/sql/__tests__/pglite-integration.test.ts
+++ b/packages/db/src/sql/__tests__/pglite-integration.test.ts
@@ -1,5 +1,5 @@
-import { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
 import { buildDelete } from '../delete';
 import { buildInsert } from '../insert';
 import { buildSelect } from '../select';

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -34,7 +34,9 @@ describe('buildInsert with SqliteDialect', () => {
       sqliteDialect,
     );
 
-    expect(result.sql).toBe('INSERT INTO "users" ("id", "created_at") VALUES (?, datetime(\'now\')) RETURNING *');
+    expect(result.sql).toBe(
+      'INSERT INTO "users" ("id", "created_at") VALUES (?, datetime(\'now\')) RETURNING *',
+    );
     expect(result.params).toEqual(['123']);
   });
 
@@ -121,7 +123,9 @@ describe('buildUpdate with SqliteDialect', () => {
       sqliteDialect,
     );
 
-    expect(result.sql).toBe('UPDATE "users" SET "updated_at" = datetime(\'now\') WHERE "id" = ? RETURNING *');
+    expect(result.sql).toBe(
+      'UPDATE "users" SET "updated_at" = datetime(\'now\') WHERE "id" = ? RETURNING *',
+    );
     expect(result.params).toEqual(['123']);
   });
 });
@@ -155,9 +159,7 @@ describe('buildWhere with SqliteDialect', () => {
       sqliteDialect,
     );
 
-    expect(result.sql).toBe(
-      '"age" > ? AND "age" <= ? AND "name" LIKE ? AND "status" IN (?, ?)',
-    );
+    expect(result.sql).toBe('"age" > ? AND "age" <= ? AND "name" LIKE ? AND "status" IN (?, ?)');
     expect(result.params).toEqual([18, 65, '%alice%', 'active', 'pending']);
   });
 
@@ -179,45 +181,31 @@ describe('buildWhere with SqliteDialect', () => {
 describe('SQLite feature guards', () => {
   it('throws descriptive error for arrayContains with SqliteDialect', () => {
     expect(() =>
-      buildWhere(
-        { tags: { arrayContains: ['admin'] } },
-        0,
-        undefined,
-        sqliteDialect,
-      ),
-    ).toThrow('Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite');
+      buildWhere({ tags: { arrayContains: ['admin'] } }, 0, undefined, sqliteDialect),
+    ).toThrow(
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+    );
   });
 
   it('throws descriptive error for arrayContainedBy with SqliteDialect', () => {
     expect(() =>
-      buildWhere(
-        { tags: { arrayContainedBy: ['admin'] } },
-        0,
-        undefined,
-        sqliteDialect,
-      ),
-    ).toThrow('Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite');
+      buildWhere({ tags: { arrayContainedBy: ['admin'] } }, 0, undefined, sqliteDialect),
+    ).toThrow(
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+    );
   });
 
   it('throws descriptive error for arrayOverlaps with SqliteDialect', () => {
     expect(() =>
-      buildWhere(
-        { tags: { arrayOverlaps: ['admin'] } },
-        0,
-        undefined,
-        sqliteDialect,
-      ),
-    ).toThrow('Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite');
+      buildWhere({ tags: { arrayOverlaps: ['admin'] } }, 0, undefined, sqliteDialect),
+    ).toThrow(
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+    );
   });
 
   it('throws descriptive error for JSONB path operator with SqliteDialect', () => {
     expect(() =>
-      buildWhere(
-        { 'metadata->role': { eq: 'admin' } },
-        0,
-        undefined,
-        sqliteDialect,
-      ),
+      buildWhere({ 'metadata->role': { eq: 'admin' } }, 0, undefined, sqliteDialect),
     ).toThrow('JSONB path operators (->>, ->) are not supported on SQLite');
   });
 

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -14,8 +14,8 @@
  * Column names are converted from camelCase to snake_case.
  */
 
-import { type CasingOverrides, camelToSnake } from './casing';
 import { type Dialect, defaultPostgresDialect } from '../dialect';
+import { type CasingOverrides, camelToSnake } from './casing';
 
 export interface WhereResult {
   readonly sql: string;

--- a/packages/schema/src/schemas/__tests__/from-db-enum.test.ts
+++ b/packages/schema/src/schemas/__tests__/from-db-enum.test.ts
@@ -16,7 +16,7 @@ describe('s.fromDbEnum', () => {
         hasDefault: false,
         sensitive: false,
         hidden: false,
-        isTenant: false,
+
         references: null,
         check: null,
       },
@@ -41,7 +41,7 @@ describe('s.fromDbEnum', () => {
         hasDefault: false,
         sensitive: false,
         hidden: false,
-        isTenant: false,
+
         references: null,
         check: null,
       },
@@ -62,7 +62,7 @@ describe('s.fromDbEnum', () => {
         hasDefault: false,
         sensitive: false,
         hidden: false,
-        isTenant: false,
+
         references: null,
         check: null,
       },
@@ -83,7 +83,7 @@ describe('s.fromDbEnum', () => {
         hasDefault: false,
         sensitive: false,
         hidden: false,
-        isTenant: false,
+
         references: null,
         check: null,
       },

--- a/plans/955-move-tenant-to-model.md
+++ b/plans/955-move-tenant-to-model.md
@@ -1,0 +1,387 @@
+# Move Tenant Scoping to Model-Level (d.model)
+
+**Issue:** [#955](https://github.com/vertz-dev/vertz/issues/955)
+**Related:** [#954](https://github.com/vertz-dev/vertz/issues/954) (derive FK from relations — converges with this work)
+**Status:** v2 — revised after adversarial review
+
+## Problem
+
+Tenant scoping is currently defined as a column annotation via `d.tenant()`:
+
+```ts
+const users = d.table('users', {
+  organizationId: d.tenant(organizations),
+  name: d.text(),
+});
+```
+
+This mixes concerns:
+
+1. **Cohesion violation** (internal): `d.tenant(organizations)` bundles three things into one column call: (a) UUID type, (b) FK reference, (c) tenant scoping key. These are at different abstraction levels. The framework maintainer pays for this when `computeTenantGraph` must scan column internals to discover scoping.
+
+2. **Inconsistency with relations** (DX): Relations are defined separately from columns (via `d.model(table, { relations })`). Tenant scoping is a relationship concern — it should follow the same pattern.
+
+3. **Blocks request-level auto-scoping**: Future runtime behavior (inject `tenantId` on the request context → all queries auto-scoped) requires a clean tenant graph derived from explicit declarations, not column metadata scanning. The graph must know the full path from any entity back to the tenant root — through both direct and indirect relations.
+
+## Proposed Direction
+
+Move tenant declaration to `d.model()` as a model-level option that references a relation by name. The column becomes a plain UUID; the model declares which relation is the tenant boundary.
+
+### Before
+
+```ts
+const organizations = d.table('organizations', {
+  id: d.uuid().primary(),
+  name: d.text(),
+});
+
+const users = d.table('users', {
+  id: d.uuid().primary(),
+  organizationId: d.tenant(organizations),
+  name: d.text(),
+});
+
+const usersModel = d.model(users);
+```
+
+### After
+
+```ts
+const organizations = d.table('organizations', {
+  id: d.uuid().primary(),
+  name: d.text(),
+});
+
+const users = d.table('users', {
+  id: d.uuid().primary(),
+  organizationId: d.uuid(),    // plain FK column
+  name: d.text(),
+});
+
+const usersModel = d.model(users, {
+  organization: d.ref.one(() => organizations, 'organizationId'),
+}, { tenant: 'organization' });
+```
+
+The `{ tenant: 'organization' }` option references the relation by name. The model declares: "this model is tenant-scoped via its 'organization' relation."
+
+### Why model-level `{ tenant }` (not `.tenant()` on the relation)
+
+Three options were evaluated:
+
+**Option A: `.tenant()` on the relation** (rejected after adversarial review)
+```ts
+d.ref.one(() => organizations, 'organizationId').tenant()
+```
+Problems:
+- Wrong abstraction level. Tenant scoping is a property of the **model** (how the model's data is partitioned), not of the **relation** (how two tables connect). Compare: `.shared()` lives on the table because "cross-tenant" is a table-level policy. "Scoped by X" is a model-level policy.
+- Type system leak. Adding `.tenant()` to `RelationDef` makes it available on `ref.many` with FK (returns `RelationDef<T, 'many'>`), and on `.through()` chains. Restricting it requires a new `OneRelationDef` type — unnecessary complexity.
+- Blocks future extensibility. Composite tenants (`{ tenant: ['organization', 'region'] }`) or hierarchical scoping have no natural expression on a single relation.
+
+**Option B: Model-level string referencing the FK column** (rejected)
+```ts
+d.model(users, relations, { tenant: 'organizationId' })
+```
+Rejected: Duplicates information (the relation already declares the FK) and references a column name as a string — not type-safe against the model's relations.
+
+**Option C: Model-level string referencing the relation name** (chosen)
+```ts
+d.model(users, {
+  organization: d.ref.one(() => organizations, 'organizationId'),
+}, { tenant: 'organization' })
+```
+- Correct abstraction: "this model is tenant-scoped via its 'organization' relation."
+- Type-safe: `'organization'` is constrained to `keyof TRelations` — typos are compile errors.
+- No duplication: the relation carries the FK and target table; `tenant` just points to which relation.
+- Extensible: composite tenants could become `{ tenant: ['organization', 'region'] }`.
+- Reads naturally alongside `.shared()`: shared is table-level, scoped is model-level. Both are data isolation policies at the appropriate abstraction level.
+
+### Convergence with #954 (Derive FK from Relations)
+
+Issue #954 proposes that `.references()` on columns should be deprecated — relations should be the single source of truth for FK constraints.
+
+After BOTH #955 and #954 land:
+- Columns are pure data types + constraints. No FK metadata, no tenant metadata.
+- Relations are the single source of truth for: FK constraints, eager loading, AND tenant scoping.
+- `computeTenantGraph` reads ENTIRELY from relations — no column scanning at all.
+
+This change takes a critical step: it makes `computeTenantGraph` read both direct AND indirect scoping from relations (see "Indirect scoping from relations" below). This means #954 does not need to land first — the tenant graph is fully relation-derived after this change.
+
+## API Surface
+
+### d.model() — new optional third argument
+
+```ts
+// Current signature (unchanged for 0-arg and 2-arg overloads)
+d.model<TTable>(table: TTable): ModelDef<TTable, {}>;
+d.model<TTable, TRelations>(table: TTable, relations: TRelations): ModelDef<TTable, TRelations>;
+
+// New: 3-arg overload with model options
+d.model<TTable, TRelations>(
+  table: TTable,
+  relations: TRelations,
+  options: ModelOptions<TRelations>,
+): ModelDef<TTable, TRelations>;
+```
+
+### ModelOptions type
+
+```ts
+interface ModelOptions<TRelations extends Record<string, RelationDef>> {
+  /**
+   * The relation that defines the tenant boundary for this model.
+   * Must reference a key in the relations record. The referenced relation's
+   * target table is the tenant root.
+   *
+   * When set, all queries on this model will be automatically scoped to the
+   * current tenant (once request-level auto-scoping is implemented).
+   */
+  readonly tenant?: Extract<keyof TRelations, string>;
+}
+```
+
+The `tenant` value is constrained to `Extract<keyof TRelations, string>` — only valid relation names accepted. Typos are compile-time errors.
+
+### ModelDef — new optional `_tenant` field
+
+```ts
+interface ModelDef<TTable, TRelations> {
+  readonly table: TTable;
+  readonly relations: TRelations;
+  readonly schemas: ModelSchemas<TTable>;
+  readonly _tenant: string | null;  // NEW — the relation name, or null
+}
+```
+
+### RelationDef — unchanged
+
+No changes to `RelationDef`, `ManyRelationDef`, or `createOneRelation`. The relation types stay clean.
+
+### computeTenantGraph — fully relation-derived
+
+Both direct and indirect scoping read from `entry.relations`:
+
+```ts
+// Step 1: Find directly scoped models (those with _tenant set)
+for (const [key, entry] of entries) {
+  if (entry._tenant) {
+    const tenantRel = entry.relations[entry._tenant];
+    // tenantRel._target()._name → tenant root table name
+    // tenantRel._foreignKey → FK column name
+    directlyScoped.push(key);
+    root = tableNameToKey.get(tenantRel._target()._name);
+  }
+}
+
+// Step 2: Find indirectly scoped models (via relation chains)
+// Walk ALL relations (not just tenant ones) to find tables
+// that reference a scoped table.
+for (const [relKey, rel] of Object.entries(entry.relations)) {
+  const targetName = rel._target()._name;
+  if (scopedTableNames.has(targetName)) {
+    // This table is indirectly scoped
+  }
+}
+```
+
+**Key change from v1:** Indirect scoping now also reads from relations instead of column `.references()`. This eliminates the hybrid state (direct from relations, indirect from columns) that the adversarial review flagged as a blocker. The tenant graph is fully derived from the relation layer.
+
+**Implication:** Every table that participates in indirect tenant scoping must have a relation defined for its FK to the scoped table. Without a relation, `computeTenantGraph` cannot see the FK chain. This is consistent with the direction of #954 (relations as the single source of truth for FK relationships).
+
+### Column builder — d.tenant() removed
+
+`d.tenant()` and the `TenantMeta` type are removed. The `isTenant` flag is removed from `ColumnMetadata`.
+
+### .shared() on TableDef — preserved as-is
+
+`.shared()` marks a table as cross-tenant. This is correctly a table-level concern:
+- `.shared()` on the table → "this table's data is NOT partitioned" (table-level policy)
+- `{ tenant: 'relation' }` on the model → "this model's data IS partitioned via this relation" (model-level policy)
+
+Both are data isolation policies at the appropriate abstraction level. `.shared()` doesn't need relations (shared tables have no tenant boundary to reference).
+
+## Manifesto Alignment
+
+- **One way to do things**: Tenant scoping is declared in exactly one place — the `tenant` model option. No duplication between column and model. The full tenant graph (direct + indirect) is derived from a single data source (relations).
+- **Explicit over implicit**: `{ tenant: 'organization' }` is explicit. The developer declares "this model is tenant-scoped via its organization relation." The system doesn't infer it from column names or conventions.
+- **Compile-time over runtime**: The `tenant` option is type-checked against relation keys — a typo is a compile error. The relation itself uses variable references (`() => organizations`), not strings.
+- **Predictability over convenience**: The model declaration tells the full story: columns for data types, relations for relationships, `tenant` for scoping policy. A developer reading the model knows everything about the entity's data behavior.
+
+## Diagnostics and Error Messages
+
+### Warning: Relation to tenant root without `{ tenant }` declaration
+
+When `computeTenantGraph` finds a model with a relation pointing to the tenant root table but no `{ tenant }` option set, it emits a warning:
+
+```
+[vertz/db] Model "invoices" has a relation to tenant root "organizations" via "organizationId"
+but is not declared as tenant-scoped. Add { tenant: 'organization' } to d.model() options,
+or mark the table as .shared() if cross-tenant access is intentional.
+```
+
+This catches the "forgot to add `{ tenant }` " case — currently a silent misconfiguration.
+
+### Warning: Unscoped table (preserved from current behavior)
+
+When a tenant root exists but a model is neither scoped, shared, nor the root itself:
+
+```
+[vertz/db] Table "audit_logs" has no tenant path and is not marked .shared().
+It will not be automatically scoped to a tenant.
+```
+
+## Non-Goals
+
+- **Runtime auto-scoping**: This change moves WHERE tenant is declared and ensures the graph is fully relation-derived. The runtime behavior (auto-filter queries by tenant, auto-inject tenant ID on create) is a separate feature that builds on this foundation.
+- **Multi-tenant root**: Single tenant root only. All `{ tenant }` declarations across models must ultimately point to the same root table. This is the current behavior, preserved.
+- **Table/model unification (#953)**: This design works with the current `d.table()` + `d.model()` two-step. When #953 lands (`.relations()` on table), the model options can be chained similarly.
+
+## Unknowns
+
+No unknowns remaining. All items resolved during adversarial review:
+
+1. **Abstraction level** → Resolved: model-level `{ tenant }` option, not relation-level `.tenant()`.
+2. **Indirect scoping without column `.references()`** → Resolved: `computeTenantGraph` reads both direct and indirect scoping from relations. No column scanning.
+3. **Type restriction (ref.one only)** → Resolved: `tenant` references a relation name, and the type constraint `Extract<keyof TRelations, string>` accepts any relation. The system validates at `computeTenantGraph` time that the referenced relation is `_type: 'one'` (runtime error if a many relation is referenced as tenant). Future: could add type-level constraint to only accept keys whose values are `RelationDef<_, 'one'>`.
+4. **`.tenant()` leaking to ManyRelationDef/through** → Resolved: no `.tenant()` on relations at all. Model option only.
+
+## Type Flow Map
+
+```
+d.model(users, { organization: d.ref.one(() => orgs, 'orgId') }, { tenant: 'organization' })
+  ↓  ModelDef._tenant = 'organization'
+  ↓  ModelDef.relations.organization._target = () => orgs
+createDb({ models: { users: usersModel, tasks: tasksModel, ... } })
+  ↓  computeTenantGraph reads:
+  ↓    - _tenant from each model (direct scoping)
+  ↓    - relations._target()._name from all models (indirect scoping)
+TenantGraph { root: 'organizations', directlyScoped: ['users'], indirectlyScoped: ['tasks'], shared: [...] }
+  ↓  exposed via db._internals.tenantGraph
+Server entity system / request middleware reads tenantGraph for auto-scoping
+  ↓  tenantId injected per-request → all queries scoped automatically
+```
+
+## E2E Acceptance Test
+
+```ts
+// Tenant declared at model level, NOT on column
+const organizations = d.table('organizations', {
+  id: d.uuid().primary(),
+  name: d.text(),
+});
+
+const users = d.table('users', {
+  id: d.uuid().primary(),
+  organizationId: d.uuid(),  // plain column — no .tenant()
+  name: d.text(),
+});
+
+const tasks = d.table('tasks', {
+  id: d.uuid().primary(),
+  userId: d.uuid(),  // plain column — no .references() needed
+  title: d.text(),
+});
+
+const featureFlags = d.table('feature_flags', {
+  id: d.uuid().primary(),
+  name: d.text(),
+}).shared();
+
+const db = createDb({
+  url: 'postgres://...',
+  models: {
+    organizations: d.model(organizations),
+    users: d.model(users, {
+      organization: d.ref.one(() => organizations, 'organizationId'),
+    }, { tenant: 'organization' }),
+    tasks: d.model(tasks, {
+      user: d.ref.one(() => users, 'userId'),
+    }),
+    featureFlags: d.model(featureFlags),
+  },
+});
+
+// Tenant graph computed correctly from relation metadata
+expect(db._internals.tenantGraph.root).toBe('organizations');
+expect(db._internals.tenantGraph.directlyScoped).toContain('users');
+expect(db._internals.tenantGraph.indirectlyScoped).toContain('tasks');
+expect(db._internals.tenantGraph.shared).toContain('featureFlags');
+
+// Type error: tenant must reference a valid relation name
+// @ts-expect-error — 'nonexistent' is not a key of the relations record
+d.model(users, {
+  organization: d.ref.one(() => organizations, 'organizationId'),
+}, { tenant: 'nonexistent' });
+
+// Type error: d.tenant() no longer exists
+// @ts-expect-error — d.tenant removed
+d.tenant(organizations);
+```
+
+## Implementation Phases
+
+### Phase 1: Add `ModelOptions` and `_tenant` to `d.model()` / `ModelDef`
+
+**Changes:**
+- `packages/db/src/schema/model.ts`: Add `ModelOptions<TRelations>` interface with `tenant?: Extract<keyof TRelations, string>`. Add `_tenant: string | null` to `ModelDef`. Update `createModel()` to accept optional third argument.
+- `packages/db/src/d.ts`: Add 3-arg overload for `d.model()`. Pass options through to `createModel()`.
+- `packages/db/src/schema/inference.ts`: Add `_tenant?: string | null` to `ModelEntry` if needed for `computeTenantGraph` compatibility.
+
+**Type-level tests:**
+- `d.model(table, { org: d.ref.one(...) }, { tenant: 'org' })` compiles.
+- `d.model(table, { org: d.ref.one(...) }, { tenant: 'bad' })` → `@ts-expect-error`.
+- `d.model(table)._tenant` is `null`.
+- `d.model(table, { org: d.ref.one(...) }, { tenant: 'org' })._tenant` is `string | null`.
+
+**Integration test:**
+```ts
+const model = d.model(users, {
+  organization: d.ref.one(() => organizations, 'organizationId'),
+}, { tenant: 'organization' });
+expect(model._tenant).toBe('organization');
+expect(model.relations.organization._type).toBe('one');
+```
+
+### Phase 2: Rewrite `computeTenantGraph` to be fully relation-derived
+
+**Changes:**
+- `packages/db/src/client/tenant-graph.ts`:
+  - Update `TableRegistryEntry` to include `_tenant: string | null` and `relations: Record<string, RelationDef>`.
+  - **Step 1 (direct scoping):** Scan entries for `_tenant !== null`. Read the tenant relation's `_target()._name` to find the root table.
+  - **Step 2 (indirect scoping):** Walk ALL relations across ALL entries. For each relation, check if `rel._target()._name` refers to a scoped table. If yes, the current table is indirectly scoped. Fixed-point iteration until no new tables are found.
+  - Remove all column-scanning logic (`col._meta.isTenant`, `col._meta.references`).
+- Update all `tenant-graph.test.ts` tests to use model-level tenant declarations with relations.
+
+**Integration test:** Same test matrix as today (root detection, direct scoping, indirect scoping, multi-hop, shared, unscoped, null root) — all using relation-based declarations.
+
+### Phase 3: Remove `d.tenant()`, `TenantMeta`, and `isTenant` from columns
+
+**Changes:**
+- `packages/db/src/schema/column.ts`: Remove `createTenantColumn()`, `TenantMeta` type. Remove `isTenant` from `ColumnMetadata` and `DefaultMeta`.
+- `packages/db/src/d.ts`: Remove `d.tenant()` from the `d` namespace type and implementation.
+- Update all test files that use `d.tenant()`:
+  - `column.test.ts`, `column.test-d.ts`: Remove `d.tenant()` test section. Add test that `d.tenant` does not exist.
+  - `table.test.ts`, `table.test-d.ts`: Replace `d.tenant(org)` with `d.uuid()` where used.
+  - `e2e.test.ts`: Change `organizationId: d.tenant(organizations)` to `d.uuid()`. Add organization relation with `{ tenant: 'organization' }` to users model.
+  - `prisma-style-api.test.ts`: Same pattern.
+  - `database.test.ts`: Same pattern.
+  - `database-client-types.test-d.ts`, `database-types.test-d.ts`: Update if they reference `isTenant`.
+  - `result-errors.test.ts`, `createDb-dialect.test.ts`: Update if they reference tenant column metadata.
+  - `database-bridge-adapter.test.ts`: Update if needed.
+  - `postgres-integration.test.ts`: Same pattern as e2e.test.ts.
+- `packages/schema/src/__tests__/from-db-enum.test.ts`: Remove stale `isTenant: false` from mock `_meta` objects.
+
+**Integration test:** `d.tenant` is `undefined`. `ColumnMetadata` type has no `isTenant` field.
+
+### Phase 4: Update server package, add diagnostics, final verification
+
+**Changes:**
+- `packages/server/src/__tests__/create-server.test.ts`: Update mock `tenantGraph` in `mockDatabaseClient._internals`.
+- `packages/server/src/entity/__tests__/context.test.ts`, `packages/server/src/service/__tests__/context.test.ts`: Verify tenant context still works (these use `tenantId` on request, not column metadata — likely unchanged).
+- `packages/server/src/entity/__tests__/access-enforcer.test.ts`: Update if it references tenant column metadata.
+- Add the diagnostic warning to `createDb()`: when a relation points to the tenant root but the model has no `{ tenant }`, log a specific warning.
+- Verify `bun test` passes across ALL packages.
+- Verify `bun run typecheck` passes across ALL packages.
+- Run `bun run typecheck --filter @vertz/integration-tests` for cross-package type safety.
+
+**Integration test:** Full E2E acceptance test from above. All quality gates green.


### PR DESCRIPTION
## Summary

- **Remove `d.tenant()` column builder** — tenant scoping is no longer a column-level concern. Removes `TenantMeta`, `createTenantColumn`, and `isTenant` from column metadata.
- **Add model-level `{ tenant }` option** — `d.model(table, relations, { tenant: 'relationName' })` declares which relation defines the tenant boundary. The type system constrains `tenant` to valid relation keys.
- **Rewrite `computeTenantGraph()` to be fully relation-derived** — no longer scans column metadata. Follows relation chains for indirect scoping via fixed-point iteration.
- **Runtime validation** — throws on conflicting tenant roots and missing tenant relations at startup.
- **Update README** with new API examples.

Closes #955

## Test plan

- [x] `computeTenantGraph` — root detection, direct scoping, indirect scoping, multi-hop, shared, unscoped, conflicting roots (throws), missing relation (throws), `ref.many` indirect scoping
- [x] `ModelDef._tenant` type tests — `string | null`, rejects invalid relation names, accepts valid ones
- [x] `d.model()` unit tests — `_tenant` defaults to null, equals relation name with options
- [x] All existing db tests updated (1150 pass, 0 fail)
- [x] Server tests unaffected (367 pass, 0 fail)
- [x] Full quality gates: lint, typecheck, test, build (67/67 turborepo tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)