### PR TITLE
fix(db): persist index name in schema snapshot

### DIFF
--- a/packages/db/src/migration/__tests__/snapshot.test.ts
+++ b/packages/db/src/migration/__tests__/snapshot.test.ts
@@ -229,6 +229,25 @@ describe('createSnapshot', () => {
     ]);
   });
 
+  it('captures custom index name in snapshot', () => {
+    const posts = d.table(
+      'posts',
+      {
+        id: d.uuid().primary(),
+        status: d.text(),
+      },
+      {
+        indexes: [d.index('status', { name: 'idx_posts_status_custom' })],
+      },
+    );
+
+    const snapshot = createSnapshot([posts]);
+
+    expect(snapshot.tables.posts.indexes).toEqual([
+      { columns: ['status'], name: 'idx_posts_status_custom' },
+    ]);
+  });
+
   it('captures index type and where in snapshot', () => {
     const posts = d.table(
       'posts',

--- a/packages/db/src/migration/snapshot.ts
+++ b/packages/db/src/migration/snapshot.ts
@@ -142,6 +142,7 @@ export function createSnapshot(entries: (TableDef<ColumnRecord> | ModelDef)[]): 
 
     for (const idx of table._indexes) {
       const snap: IndexSnapshot = { columns: [...idx.columns] };
+      if (idx.name) snap.name = idx.name;
       if (idx.unique) snap.unique = idx.unique;
       if (idx.type) snap.type = idx.type;
       if (idx.where) snap.where = idx.where;


### PR DESCRIPTION
## Summary

- `createSnapshot()` was not copying the `name` field from `IndexDef` into `IndexSnapshot`, causing custom index names to be lost in schema snapshots
- Added `if (idx.name) snap.name = idx.name;` to the snapshot creation loop
- Added test verifying custom index names round-trip through `createSnapshot()`

Closes #977

## Test plan

- [x] New test: `captures custom index name in snapshot` — verifies `d.index('status', { name: 'idx_posts_status_custom' })` produces a snapshot with `name: 'idx_posts_status_custom'`
- [x] All 164 existing migration tests pass
- [x] Typecheck, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)