### PR TITLE
refactor(compiler): replace hardcoded registry with framework manifest

### DIFF
--- a/packages/ui-compiler/src/__tests__/integration.test.ts
+++ b/packages/ui-compiler/src/__tests__/integration.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { compile } from '../compiler';
+import { loadManifestFromJson } from '../reactivity-manifest';
+import type { ReactivityManifest } from '../types';
 
 describe('Integration Tests', () => {
   it('IT-1B-1: Counter component — let count → signal, {count} → subscription', () => {
@@ -520,6 +522,48 @@ function Counter() {
     // format is a function expression — stable reference, NOT computed
     expect(result.code).not.toContain('computed(() => function');
     expect(result.code).toContain('const format = function()');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // ─── Manifest-based compilation (#989) ──────────────
+
+  it('uses manifest instead of hardcoded registry when manifests are provided', () => {
+    // Manifest says query has 'customProp' as signal property (NOT the default registry values)
+    const manifest = loadManifestFromJson({
+      version: 1,
+      filePath: '@vertz/ui',
+      exports: {
+        query: {
+          kind: 'function',
+          reactivity: {
+            type: 'signal-api',
+            signalProperties: ['customProp'],
+            plainProperties: ['data', 'loading', 'error', 'refetch'],
+          },
+        },
+      },
+    } as ReactivityManifest);
+
+    const result = compile(
+      `
+import { query } from '@vertz/ui';
+
+function TaskList() {
+  const tasks = query('/api/tasks');
+  const x = tasks.customProp ? 'yes' : 'no';
+  const y = tasks.data ? 'yes' : 'no';
+  return <div>{x}{y}</div>;
+}
+    `.trim(),
+      { manifests: { '@vertz/ui': manifest } },
+    );
+
+    // x depends on customProp (signal in manifest) → computed
+    expect(result.code).toContain('computed(() =>');
+    // tasks.customProp should get .value (it's a signal property per manifest)
+    expect(result.code).toContain('tasks.customProp.value');
+    // tasks.data is plain in this manifest → should NOT get .value
+    expect(result.code).not.toContain('tasks.data.value');
     expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/ui-compiler/src/__tests__/reactivity-manifest.test.ts
+++ b/packages/ui-compiler/src/__tests__/reactivity-manifest.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @file Tests for reactivity manifest loading and integration.
+ */
+import { describe, expect, it } from 'bun:test';
+import { loadFrameworkManifest, loadManifestFromJson } from '../reactivity-manifest';
+import type { ReactivityManifest } from '../types';
+
+describe('reactivity-manifest', () => {
+  describe('loadManifestFromJson', () => {
+    it('converts JSON arrays to Sets for signal-api exports', () => {
+      const json: ReactivityManifest = {
+        version: 1,
+        filePath: '@vertz/ui',
+        exports: {
+          query: {
+            kind: 'function',
+            reactivity: {
+              type: 'signal-api',
+              signalProperties: ['data', 'loading', 'error'],
+              plainProperties: ['refetch'],
+            },
+          },
+        },
+      };
+      const loaded = loadManifestFromJson(json);
+      const queryExport = loaded.exports.query;
+      expect(queryExport.kind).toBe('function');
+      expect(queryExport.reactivity.type).toBe('signal-api');
+      if (queryExport.reactivity.type === 'signal-api') {
+        expect(queryExport.reactivity.signalProperties).toBeInstanceOf(Set);
+        expect(queryExport.reactivity.signalProperties).toEqual(
+          new Set(['data', 'loading', 'error']),
+        );
+        expect(queryExport.reactivity.plainProperties).toBeInstanceOf(Set);
+        expect(queryExport.reactivity.plainProperties).toEqual(new Set(['refetch']));
+      }
+    });
+
+    it('converts fieldSignalProperties when present', () => {
+      const json: ReactivityManifest = {
+        version: 1,
+        filePath: '@vertz/ui',
+        exports: {
+          form: {
+            kind: 'function',
+            reactivity: {
+              type: 'signal-api',
+              signalProperties: ['submitting'],
+              plainProperties: ['action'],
+              fieldSignalProperties: ['value', 'error'],
+            },
+          },
+        },
+      };
+      const loaded = loadManifestFromJson(json);
+      const formExport = loaded.exports.form;
+      if (formExport.reactivity.type === 'signal-api') {
+        expect(formExport.reactivity.fieldSignalProperties).toBeInstanceOf(Set);
+        expect(formExport.reactivity.fieldSignalProperties).toEqual(new Set(['value', 'error']));
+      }
+    });
+
+    it('passes through non-signal-api exports unchanged', () => {
+      const json: ReactivityManifest = {
+        version: 1,
+        filePath: '@vertz/ui',
+        exports: {
+          useContext: {
+            kind: 'function',
+            reactivity: { type: 'reactive-source' },
+          },
+          signal: {
+            kind: 'function',
+            reactivity: { type: 'signal' },
+          },
+        },
+      };
+      const loaded = loadManifestFromJson(json);
+      expect(loaded.exports.useContext.reactivity.type).toBe('reactive-source');
+      expect(loaded.exports.signal.reactivity.type).toBe('signal');
+    });
+
+    it('warns and falls back to unknown for unsupported version', () => {
+      const json = {
+        version: 999,
+        filePath: 'test',
+        exports: {
+          foo: { kind: 'function', reactivity: { type: 'static' } },
+        },
+      } as unknown as ReactivityManifest;
+      const loaded = loadManifestFromJson(json);
+      expect(loaded.exports.foo.reactivity.type).toBe('unknown');
+    });
+  });
+
+  describe('loadFrameworkManifest', () => {
+    it('loads the @vertz/ui framework manifest', () => {
+      const manifest = loadFrameworkManifest();
+      expect(manifest.version).toBe(1);
+      expect(manifest.filePath).toBe('@vertz/ui');
+    });
+
+    it('includes query with correct signal properties', () => {
+      const manifest = loadFrameworkManifest();
+      const q = manifest.exports.query;
+      expect(q.kind).toBe('function');
+      expect(q.reactivity.type).toBe('signal-api');
+      if (q.reactivity.type === 'signal-api') {
+        expect(q.reactivity.signalProperties).toEqual(
+          new Set(['data', 'loading', 'error', 'revalidating']),
+        );
+        expect(q.reactivity.plainProperties).toEqual(new Set(['refetch', 'revalidate', 'dispose']));
+      }
+    });
+
+    it('includes form with fieldSignalProperties', () => {
+      const manifest = loadFrameworkManifest();
+      const f = manifest.exports.form;
+      expect(f.kind).toBe('function');
+      if (f.reactivity.type === 'signal-api') {
+        expect(f.reactivity.fieldSignalProperties).toEqual(
+          new Set(['value', 'error', 'dirty', 'touched']),
+        );
+      }
+    });
+
+    it('includes createLoader', () => {
+      const manifest = loadFrameworkManifest();
+      const cl = manifest.exports.createLoader;
+      expect(cl.kind).toBe('function');
+      expect(cl.reactivity.type).toBe('signal-api');
+    });
+
+    it('includes useContext as reactive-source', () => {
+      const manifest = loadFrameworkManifest();
+      expect(manifest.exports.useContext.reactivity.type).toBe('reactive-source');
+    });
+
+    it('includes signal', () => {
+      const manifest = loadFrameworkManifest();
+      expect(manifest.exports.signal.reactivity.type).toBe('signal');
+    });
+  });
+});

--- a/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
@@ -5,7 +5,7 @@ import {
   isSignalApi,
   type SignalApiConfig,
 } from '../signal-api-registry';
-import type { ComponentInfo, VariableInfo } from '../types';
+import type { ComponentInfo, LoadedReactivityManifest, VariableInfo } from '../types';
 import { findBodyNode } from '../utils';
 
 /**
@@ -18,13 +18,25 @@ import { findBodyNode } from '../utils';
  *         Those `let` vars become signals, and the intermediate consts become computeds.
  */
 export class ReactivityAnalyzer {
-  analyze(sourceFile: SourceFile, component: ComponentInfo): VariableInfo[] {
+  analyze(
+    sourceFile: SourceFile,
+    component: ComponentInfo,
+    manifests?: Record<string, LoadedReactivityManifest>,
+  ): VariableInfo[] {
     const bodyNode = findBodyNode(sourceFile, component);
     if (!bodyNode) return [];
 
     // Build import alias maps for signal APIs and reactive source APIs
-    const { signalApiAliases: importAliases, reactiveSourceAliases } =
-      buildImportAliasMap(sourceFile);
+    const {
+      signalApiAliases: importAliases,
+      reactiveSourceAliases,
+      manifestConfigs,
+    } = buildImportAliasMap(sourceFile, manifests);
+
+    // Resolve signal API config: manifest first, then hardcoded registry
+    const resolveSignalApiConfig = (originalName: string): SignalApiConfig | undefined => {
+      return manifestConfigs.get(originalName) ?? getSignalApiConfig(originalName);
+    };
 
     // Collect all declared variable names to avoid synthetic name collisions
     const declaredNames = collectDeclaredNames(bodyNode);
@@ -97,7 +109,7 @@ export class ReactivityAnalyzer {
               const fnName = callName.getText();
               const originalName = importAliases.get(fnName);
               if (originalName) {
-                signalApiConfig = getSignalApiConfig(originalName);
+                signalApiConfig = resolveSignalApiConfig(originalName);
                 if (signalApiConfig) {
                   let counter = syntheticCounters.get(originalName) ?? 0;
                   syntheticName = `__${originalName}_${counter}`;
@@ -195,7 +207,7 @@ export class ReactivityAnalyzer {
             // Signal API check
             const originalName = importAliases.get(fnName);
             if (originalName) {
-              const config = getSignalApiConfig(originalName);
+              const config = resolveSignalApiConfig(originalName);
               if (config) {
                 signalApiVars.set(name, config);
               }
@@ -391,37 +403,71 @@ function collectDeps(node: Node): {
 }
 
 /**
- * Build maps of imported API names from @vertz/ui.
+ * Build maps of imported API names.
+ *
+ * When manifests are provided, uses them to classify imports from any module.
+ * Falls back to the hardcoded signal API registry for @vertz/ui imports
+ * when no manifest is available for a module.
+ *
  * - signalApiAliases: local name → original name for signal APIs (query, form, etc.)
  * - reactiveSourceAliases: set of local names for reactive source APIs (useContext)
  */
-function buildImportAliasMap(sourceFile: SourceFile): {
+function buildImportAliasMap(
+  sourceFile: SourceFile,
+  manifests?: Record<string, LoadedReactivityManifest>,
+): {
   signalApiAliases: Map<string, string>;
   reactiveSourceAliases: Set<string>;
+  manifestConfigs: Map<string, SignalApiConfig>;
 } {
   const signalApiAliases = new Map<string, string>();
   const reactiveSourceAliases = new Set<string>();
+  const manifestConfigs = new Map<string, SignalApiConfig>();
 
   for (const importDecl of sourceFile.getImportDeclarations()) {
     const moduleSpecifier = importDecl.getModuleSpecifierValue();
-    // Only process imports from @vertz/ui
-    if (moduleSpecifier !== '@vertz/ui') continue;
+    const manifest = manifests?.[moduleSpecifier];
+
+    // If no manifest, only process @vertz/ui via the hardcoded registry
+    if (!manifest && moduleSpecifier !== '@vertz/ui') continue;
 
     const namedImports = importDecl.getNamedImports();
     for (const namedImport of namedImports) {
       const originalName = namedImport.getName();
       const localName = namedImport.getAliasNode()?.getText() ?? originalName;
 
-      if (isSignalApi(originalName)) {
-        signalApiAliases.set(localName, originalName);
-      }
-      if (isReactiveSourceApi(originalName)) {
-        reactiveSourceAliases.add(localName);
+      if (manifest) {
+        // Use manifest to classify
+        const exportInfo = manifest.exports[originalName];
+        if (exportInfo) {
+          const { reactivity } = exportInfo;
+          if (reactivity.type === 'signal-api') {
+            signalApiAliases.set(localName, originalName);
+            // Build SignalApiConfig from manifest shape
+            manifestConfigs.set(originalName, {
+              signalProperties: reactivity.signalProperties,
+              plainProperties: reactivity.plainProperties,
+              ...(reactivity.fieldSignalProperties
+                ? { fieldSignalProperties: reactivity.fieldSignalProperties }
+                : {}),
+            });
+          } else if (reactivity.type === 'reactive-source') {
+            reactiveSourceAliases.add(localName);
+          }
+        }
+      } else {
+        // Fall back to hardcoded registry for @vertz/ui
+        if (isSignalApi(originalName)) {
+          signalApiAliases.set(localName, originalName);
+        }
+        if (isReactiveSourceApi(originalName)) {
+          reactiveSourceAliases.add(localName);
+        }
       }
     }
   }
 
-  return { signalApiAliases, reactiveSourceAliases };
+  return { signalApiAliases, reactiveSourceAliases, manifestConfigs };
 }
 
 /** Collect all declared variable names in a component body. */

--- a/packages/ui-compiler/src/compiler.ts
+++ b/packages/ui-compiler/src/compiler.ts
@@ -70,7 +70,7 @@ export function compile(
   for (const component of components) {
     // 3. Reactivity analysis
     const reactivityAnalyzer = new ReactivityAnalyzer();
-    const variables = reactivityAnalyzer.analyze(sourceFile, component);
+    const variables = reactivityAnalyzer.analyze(sourceFile, component, options.manifests);
 
     const hasSignals = variables.some((v) => v.kind === 'signal');
     const hasComputeds = variables.some((v) => v.kind === 'computed');

--- a/packages/ui-compiler/src/reactivity-manifest.ts
+++ b/packages/ui-compiler/src/reactivity-manifest.ts
@@ -1,0 +1,88 @@
+/**
+ * Reactivity manifest loading utilities.
+ *
+ * Converts JSON manifest files (with string[] arrays) into runtime
+ * representations (with Set<string>) for O(1) lookups.
+ */
+import { resolve } from 'node:path';
+import type {
+  LoadedExportReactivityInfo,
+  LoadedReactivityManifest,
+  LoadedReactivityShape,
+  ReactivityManifest,
+} from './types';
+
+const SUPPORTED_VERSION = 1;
+
+/**
+ * Load and convert a ReactivityManifest from JSON format.
+ * Converts string[] to Set<string> for signal-api properties.
+ * Unsupported versions fall back to treating all exports as unknown.
+ */
+export function loadManifestFromJson(json: ReactivityManifest): LoadedReactivityManifest {
+  if (json.version !== SUPPORTED_VERSION) {
+    const unknownExports: Record<string, LoadedExportReactivityInfo> = {};
+    for (const [name, info] of Object.entries(json.exports)) {
+      unknownExports[name] = {
+        kind: info.kind,
+        reactivity: { type: 'unknown' },
+      };
+    }
+    return {
+      version: SUPPORTED_VERSION,
+      filePath: json.filePath,
+      exports: unknownExports,
+    };
+  }
+
+  const exports: Record<string, LoadedExportReactivityInfo> = {};
+  for (const [name, info] of Object.entries(json.exports)) {
+    exports[name] = {
+      kind: info.kind,
+      reactivity: convertReactivityShape(info.reactivity),
+    };
+  }
+
+  return {
+    version: SUPPORTED_VERSION,
+    filePath: json.filePath,
+    exports,
+  };
+}
+
+function convertReactivityShape(
+  shape: ReactivityManifest['exports'][string]['reactivity'],
+): LoadedReactivityShape {
+  if (shape.type === 'signal-api') {
+    return {
+      type: 'signal-api',
+      signalProperties: toSet(shape.signalProperties),
+      plainProperties: toSet(shape.plainProperties),
+      ...(shape.fieldSignalProperties
+        ? { fieldSignalProperties: toSet(shape.fieldSignalProperties) }
+        : {}),
+    };
+  }
+  return shape as LoadedReactivityShape;
+}
+
+function toSet(value: Set<string> | string[]): Set<string> {
+  return value instanceof Set ? value : new Set(value);
+}
+
+/** Cached framework manifest instance. */
+let cachedFrameworkManifest: LoadedReactivityManifest | null = null;
+
+/**
+ * Load the @vertz/ui framework manifest.
+ * The manifest is loaded once and cached for the process lifetime.
+ */
+export function loadFrameworkManifest(): LoadedReactivityManifest {
+  if (cachedFrameworkManifest) return cachedFrameworkManifest;
+
+  // Resolve relative to this file → up to ui-compiler → up to packages → ui/reactivity.json
+  const manifestPath = resolve(__dirname, '../../ui/reactivity.json');
+  const json = require(manifestPath) as ReactivityManifest;
+  cachedFrameworkManifest = loadManifestFromJson(json);
+  return cachedFrameworkManifest;
+}

--- a/packages/ui-compiler/src/types.ts
+++ b/packages/ui-compiler/src/types.ts
@@ -4,6 +4,8 @@ export interface CompileOptions {
   filename?: string;
   /** Compilation target. 'dom' uses @vertz/ui/internals, 'tui' uses @vertz/tui/internals. */
   target?: 'dom' | 'tui';
+  /** Pre-loaded reactivity manifests keyed by module specifier (e.g., '@vertz/ui'). */
+  manifests?: Record<string, LoadedReactivityManifest>;
 }
 
 /** Severity of a compiler diagnostic. */
@@ -129,6 +131,67 @@ export interface JsxExpressionInfo {
   /** Names of reactive variables referenced. */
   deps: string[];
 }
+
+// ─── Reactivity Manifest Types ──────────────────────────────────────
+
+/** Schema for a per-file reactivity manifest. */
+export interface ReactivityManifest {
+  /** Schema version for forward compatibility. */
+  version: 1;
+  /** The source file path (resolved, absolute) or package name. */
+  filePath: string;
+  /** Exports and their reactivity shapes. */
+  exports: Record<string, ExportReactivityInfo>;
+}
+
+/** Reactivity info for a single export. */
+export interface ExportReactivityInfo {
+  /** What kind of export this is. */
+  kind: 'function' | 'variable' | 'component' | 'class';
+  /** Reactivity shape of this export. */
+  reactivity: ReactivityShape;
+}
+
+/** Reactivity shape of a value or function return. */
+export type ReactivityShape =
+  | { type: 'static' }
+  | { type: 'signal' }
+  | {
+      type: 'signal-api';
+      signalProperties: Set<string> | string[];
+      plainProperties: Set<string> | string[];
+      fieldSignalProperties?: Set<string> | string[];
+    }
+  | { type: 'reactive-source' }
+  | { type: 'unknown' };
+
+/** Loaded manifest with Sets (after JSON deserialization). */
+export interface LoadedReactivityManifest {
+  version: 1;
+  filePath: string;
+  exports: Record<string, LoadedExportReactivityInfo>;
+}
+
+/** Export info with signal-api properties converted to Sets. */
+export interface LoadedExportReactivityInfo {
+  kind: 'function' | 'variable' | 'component' | 'class';
+  reactivity: LoadedReactivityShape;
+}
+
+/** Reactivity shape with all arrays converted to Sets. */
+export type LoadedReactivityShape =
+  | { type: 'static' }
+  | { type: 'signal' }
+  | {
+      type: 'signal-api';
+      signalProperties: Set<string>;
+      plainProperties: Set<string>;
+      fieldSignalProperties?: Set<string>;
+    }
+  | { type: 'reactive-source' }
+  | { type: 'unknown' };
+
+// ─── Mutation Types ─────────────────────────────────────────────────
 
 /** Kinds of in-place mutations on signal variables. */
 export type MutationKind =

--- a/packages/ui/reactivity.json
+++ b/packages/ui/reactivity.json
@@ -1,0 +1,43 @@
+{
+  "exports": {
+    "createLoader": {
+      "kind": "function",
+      "reactivity": {
+        "plainProperties": ["refetch"],
+        "signalProperties": ["data", "loading", "error"],
+        "type": "signal-api"
+      }
+    },
+    "form": {
+      "kind": "function",
+      "reactivity": {
+        "fieldSignalProperties": ["value", "error", "dirty", "touched"],
+        "plainProperties": ["action", "method", "onSubmit", "reset", "setFieldError", "submit"],
+        "signalProperties": ["submitting", "dirty", "valid"],
+        "type": "signal-api"
+      }
+    },
+    "query": {
+      "kind": "function",
+      "reactivity": {
+        "plainProperties": ["refetch", "revalidate", "dispose"],
+        "signalProperties": ["data", "loading", "error", "revalidating"],
+        "type": "signal-api"
+      }
+    },
+    "signal": {
+      "kind": "function",
+      "reactivity": {
+        "type": "signal"
+      }
+    },
+    "useContext": {
+      "kind": "function",
+      "reactivity": {
+        "type": "reactive-source"
+      }
+    }
+  },
+  "filePath": "@vertz/ui",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

- Introduces `ReactivityManifest` type system for describing reactivity shapes of exports
- Creates `packages/ui/reactivity.json` — the framework manifest for `@vertz/ui` APIs (query, form, createLoader, useContext, signal)
- Creates `reactivity-manifest.ts` with loading utilities (JSON `string[]` → `Set<string>` conversion)
- Adds `CompileOptions.manifests` parameter to pass pre-loaded manifests through the compile pipeline
- Refactors `buildImportAliasMap` in ReactivityAnalyzer to consume manifests, with fallback to hardcoded registry

Closes #989

## Key design decisions

- **Backward compatible**: All existing callers that don't provide manifests still work via the hardcoded registry fallback
- **Manifest-first resolution**: `resolveSignalApiConfig()` checks `manifestConfigs` before falling back to `getSignalApiConfig()`
- **Loaded types**: JSON manifests use `string[]` for properties; loaded manifests use `Set<string>` for O(1) lookups
- **Version forward compatibility**: Unsupported manifest versions fall back to treating all exports as `unknown`

## Test plan

- [x] 10 new manifest loading tests (version handling, Set conversion, framework manifest loading)
- [x] 1 new integration test proving manifest overrides hardcoded registry (custom signal properties)
- [x] All 436 ui-compiler tests pass (including all existing signal API tests — backward compat verified)
- [x] Typecheck clean
- [x] Lint/format clean  
- [x] 67 turborepo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)