### PR TITLE
fix(compiler): unwrap type wrappers in isFunctionDef check

### DIFF
--- a/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
@@ -469,6 +469,39 @@ describe('ReactivityAnalyzer', () => {
     expect(findVar(result?.variables, 'doubled')?.kind).toBe('computed');
   });
 
+  it('classifies parenthesized arrow function as static', () => {
+    const [result] = analyze(`
+      function Counter() {
+        let count = 0;
+        const fn = (() => count * 2);
+        return <div>{fn}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'fn')?.kind).toBe('static');
+  });
+
+  it('classifies type-asserted arrow function as static', () => {
+    const [result] = analyze(`
+      function Counter() {
+        let count = 0;
+        const fn = (() => count * 2) as () => number;
+        return <div>{fn}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'fn')?.kind).toBe('static');
+  });
+
+  it('classifies satisfies-wrapped arrow function as static', () => {
+    const [result] = analyze(`
+      function Counter() {
+        let count = 0;
+        const fn = (() => count * 2) satisfies () => number;
+        return <div>{fn}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'fn')?.kind).toBe('static');
+  });
+
   it('still classifies value expression reading signal as computed (regression)', () => {
     const [result] = analyze(`
       function Counter() {

--- a/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
@@ -178,9 +178,11 @@ export class ReactivityAnalyzer {
         const name = decl.getName();
         // Check if the initializer is a function definition (arrow function or function expression).
         // Function defs are stable references — they should never be wrapped in computed().
+        // Unwrap type wrappers (parenthesized, as, satisfies) to find the underlying node.
+        const unwrappedInit = init ? unwrapTypeWrappers(init) : undefined;
         const isFunctionDef =
-          init?.isKind(SyntaxKind.ArrowFunction) === true ||
-          init?.isKind(SyntaxKind.FunctionExpression) === true;
+          unwrappedInit?.isKind(SyntaxKind.ArrowFunction) === true ||
+          unwrappedInit?.isKind(SyntaxKind.FunctionExpression) === true;
         const { refs: deps, propertyAccesses } = init
           ? collectDeps(init)
           : { refs: [] as string[], propertyAccesses: new Map<string, Set<string>>() };
@@ -485,4 +487,26 @@ function collectDeclaredNames(bodyNode: Node): Set<string> {
     }
   }
   return names;
+}
+
+/**
+ * Unwrap TypeScript syntax wrappers to find the underlying expression.
+ * Peels through ParenthesizedExpression, AsExpression, SatisfiesExpression,
+ * and TypeAssertion nodes to expose the actual initializer kind.
+ */
+function unwrapTypeWrappers(node: Node): Node {
+  let current = node;
+  while (true) {
+    if (current.isKind(SyntaxKind.ParenthesizedExpression)) {
+      current = current.getExpression();
+    } else if (current.isKind(SyntaxKind.AsExpression)) {
+      current = current.getExpression();
+    } else if (current.isKind(SyntaxKind.SatisfiesExpression)) {
+      current = current.getExpression();
+    } else if (current.isKind(SyntaxKind.TypeAssertionExpression)) {
+      current = current.getExpression();
+    } else {
+      return current;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes edge case found by adversarial review on PR #992: the `isFunctionDef` check only inspected the direct initializer AST node, missing arrow functions wrapped in:

- `ParenthesizedExpression`: `const fn = (() => x)`
- `AsExpression`: `const fn = (() => x) as Type`
- `SatisfiesExpression`: `const fn = (() => x) satisfies Type`
- `TypeAssertion`: `const fn = <Type>(() => x)`

Adds `unwrapTypeWrappers()` helper that peels through these wrappers before checking for `ArrowFunction` or `FunctionExpression`.

Refs #988

## Test plan

- [x] 3 new tests: parenthesized, type-asserted, satisfies-wrapped arrow functions
- [x] All 439 ui-compiler tests pass
- [x] 67 turborepo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)