### PR TITLE
docs: add Claude rule for context stable IDs [#933]

### DIFF
--- a/.claude/rules/context-stable-ids.md
+++ b/.claude/rules/context-stable-ids.md
@@ -1,0 +1,32 @@
+# Manual Stable IDs for @vertz/ui Internal Contexts
+
+## Rule
+
+Every `createContext()` call inside `packages/ui/src/` **must** include a manual `__stableId` string as the second argument:
+
+```ts
+export const RouterContext = createContext<Router>(undefined, '@vertz/ui::RouterContext');
+```
+
+Format: `'@vertz/ui::<ConstName>'`
+
+## Why
+
+Bun's HMR re-evaluates modules on file change. When a module is re-evaluated, `createContext()` creates a new object — breaking identity-based Map lookups in `ContextScope`. The `__stableId` parameter lets the context registry return the existing object instead, preserving Provider/useContext identity across HMR cycles.
+
+## Who needs this
+
+**Only `@vertz/ui` framework-internal contexts.** These are pre-built and shipped in `dist/`, so the dev server plugin never processes them.
+
+**Users don't need manual IDs.** The dev server plugin (`injectContextStableIds` in `@vertz/ui-server`) automatically injects stable IDs into user code at dev time. Any `createContext()` in a user's `.ts`/`.tsx` files gets a stable ID injected transparently.
+
+## Current contexts with manual IDs
+
+- `packages/ui/src/router/router-context.ts` — `RouterContext`
+- `packages/ui/src/router/outlet.ts` — `OutletContext`
+- `packages/ui/src/dialog/dialog-stack.ts` — `DialogStackContext`
+
+## Checklist for adding a new context in @vertz/ui
+
+1. Add `__stableId` as the second argument: `createContext<T>(defaultValue, '@vertz/ui::<Name>')`
+2. Verify HMR works: edit a file in the example app, navigate, confirm no "must be called within Provider" error


### PR DESCRIPTION
## Summary

- Adds a `.claude/rules/context-stable-ids.md` rule documenting that `@vertz/ui`'s internal `createContext()` calls need manual `__stableId` strings for HMR stability
- Explains why **users don't need this** — the dev server plugin (`injectContextStableIds`) handles it automatically for their code
- This replaces the auto-inject build plugin approach from the #933 design — the problem scope is small (3 contexts today) and a rule is simpler than a build pipeline change

## Test plan

- [ ] Verify the rule file renders correctly in `.claude/rules/`
- [ ] No code changes — documentation only

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)