### PR TITLE
docs: API reference content and SDK documentation

### DIFF
--- a/packages/docs/api-reference/fetch/sdk.mdx
+++ b/packages/docs/api-reference/fetch/sdk.mdx
@@ -1,0 +1,198 @@
+---
+title: Generated SDK
+description: "API reference for the generated typed client — entity methods, Result type, and query/form integration"
+---
+
+The Vertz codegen produces a fully typed SDK from your entity and service definitions. Every method returns a `Result` — no thrown exceptions for HTTP errors. SDK methods plug directly into `query()` and `form()`.
+
+## Creating the client
+
+```ts
+import { createClient } from '.vertz/generated/client';
+
+const api = createClient({
+  baseURL: '/api',
+});
+```
+
+The codegen generates `createClient()` based on your entity definitions. Each entity becomes a property on the client with typed CRUD methods.
+
+## Entity methods
+
+```ts
+// List — returns QueryDescriptor, works with query()
+api.tasks.list({ status: 'todo' })
+
+// Get by ID
+api.tasks.get('task-123')
+
+// Create — works with form()
+api.tasks.create
+
+// Update
+api.tasks.update
+
+// Delete
+api.tasks.delete('task-123')
+
+// Custom actions (if defined on the entity)
+api.tasks.archive('task-123', { reason: 'Sprint complete' })
+```
+
+### Read methods return QueryDescriptor
+
+Calling `.list()` or `.get()` returns a `QueryDescriptor` — not a raw Promise. This descriptor carries the fetch function, a deterministic cache key, and entity metadata. Pass it directly to `query()`:
+
+```tsx
+import { query } from '@vertz/ui/query';
+
+function TaskList() {
+  const tasks = query(api.tasks.list());
+
+  return (
+    <div>
+      {tasks.loading && <p>Loading...</p>}
+      {tasks.data?.items.map((task) => (
+        <div key={task.id}>{task.title}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+Two components calling `api.tasks.list({ status: 'todo' })` share the same cache entry — the cache key is derived from the HTTP method, path, and sorted query parameters.
+
+### Mutation methods work with form()
+
+Pass a mutation method (`.create`, `.update`) to `form()`. The codegen attaches the entity's validation schema to the method metadata, so `form()` picks it up automatically:
+
+```tsx
+import { form } from '@vertz/ui/form';
+
+function CreateTaskForm({ onSuccess }: { onSuccess: () => void }) {
+  const taskForm = form(api.tasks.create, { onSuccess });
+
+  return (
+    <form action={taskForm.action} method={taskForm.method} onSubmit={taskForm.onSubmit}>
+      <input name="title" />
+      {taskForm.title.error && <span>{taskForm.title.error}</span>}
+      <button type="submit" disabled={taskForm.submitting}>Create</button>
+    </form>
+  );
+}
+```
+
+---
+
+## Result type
+
+Every SDK method returns `Result<T, FetchError>` — a discriminated union, never a thrown exception.
+
+```ts
+type Result<T, E> = { ok: true; data: T } | { ok: false; error: E };
+```
+
+### Checking results
+
+```ts
+const result = await api.tasks.get('task-123');
+
+if (result.ok) {
+  console.log(result.data.title); // typed as Task
+} else {
+  console.log(result.error.status); // typed as FetchError
+}
+```
+
+### Error status codes
+
+When `result.ok` is `false`, `result.error` has a `status` property matching the HTTP response:
+
+| Status | Error class |
+|--------|-------------|
+| 400 | `BadRequestError` |
+| 401 | `UnauthorizedError` |
+| 403 | `ForbiddenError` |
+| 404 | `NotFoundError` |
+| 409 | `ConflictError` |
+| 422 | `UnprocessableEntityError` |
+| 429 | `RateLimitError` |
+| 500 | `InternalServerError` |
+| 503 | `ServiceUnavailableError` |
+
+### Handling errors in SDK calls
+
+```ts
+const result = await api.tasks.get('nonexistent');
+
+if (!result.ok) {
+  switch (result.error.status) {
+    case 404:
+      console.log('Task not found');
+      break;
+    case 401:
+      redirectToLogin();
+      break;
+  }
+}
+```
+
+<Warning>
+SDK methods never throw for HTTP errors. Always check `result.ok` before accessing `result.data`. If you `await` a QueryDescriptor directly (outside of `query()`), you get a `Result` back — not the data directly.
+</Warning>
+
+---
+
+## QueryDescriptor vs await
+
+A QueryDescriptor is `PromiseLike` — you can await it directly for one-off calls. But for reactive UI, always use `query()`:
+
+```ts
+// One-off call (e.g., in a loader or event handler) — returns Result
+const result = await api.tasks.get('task-123');
+if (result.ok) { /* ... */ }
+
+// Reactive UI — use query() for automatic updates
+const task = query(api.tasks.get('task-123'));
+// task.data, task.loading, task.error are reactive
+```
+
+---
+
+## List responses
+
+List endpoints return `ListResponse<T>`:
+
+```ts
+interface ListResponse<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  nextCursor: string | null;
+  hasNextPage: boolean;
+}
+```
+
+```tsx
+const tasks = query(api.tasks.list({ limit: 20 }));
+
+// tasks.data is typed as ListResponse<Task>
+const { items, total, hasNextPage } = tasks.data;
+```
+
+---
+
+## Invalidation
+
+After a mutation, invalidate related queries to trigger a refetch:
+
+```ts
+import { invalidate } from '@vertz/ui/query';
+
+async function handleDelete(taskId: string) {
+  const result = await api.tasks.delete(taskId);
+  if (result.ok) {
+    invalidate('task-list');
+  }
+}
+```

--- a/packages/docs/api-reference/ui/compiler-plugin.mdx
+++ b/packages/docs/api-reference/ui/compiler-plugin.mdx
@@ -1,4 +1,0 @@
----
-title: Compiler Plugin
-description: "API reference for the vertz/ui-compiler Bun plugin"
----

--- a/packages/docs/api-reference/ui/context.mdx
+++ b/packages/docs/api-reference/ui/context.mdx
@@ -2,3 +2,147 @@
 title: Context
 description: "API reference for createContext(), useContext(), and Provider"
 ---
+
+Context provides dependency injection for components. Create a context, wrap a subtree with a Provider, and read it with `useContext()`. No prop threading required.
+
+## createContext()
+
+Create a context object that can hold a typed value.
+
+```ts
+import { createContext } from '@vertz/ui';
+
+interface SettingsValue {
+  theme: string;
+  locale: string;
+}
+
+const SettingsContext = createContext<SettingsValue>();
+```
+
+### Signature
+
+```ts
+function createContext<T>(defaultValue?: T): Context<T>
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `defaultValue` | `T` | Value returned by `useContext()` when no Provider is active |
+
+### Returns
+
+`Context<T>` — an object with a `Provider` method for providing values and internal state for `useContext()` lookups.
+
+---
+
+## useContext()
+
+Read the current value from the nearest Provider in the component tree.
+
+```tsx
+import { useContext } from '@vertz/ui';
+
+function SettingsPanel() {
+  const settings = useContext(SettingsContext);
+  return <div>Theme: {settings.theme}</div>;
+}
+```
+
+### Signature
+
+```ts
+function useContext<T>(ctx: Context<T>): T | undefined
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ctx` | `Context<T>` | The context to read from |
+
+### Returns
+
+The current context value from the nearest Provider, the default value if no Provider is active, or `undefined` if neither exists.
+
+---
+
+## Provider
+
+Provide a value to all descendants. Two usage patterns are supported:
+
+### JSX usage
+
+```tsx
+function App() {
+  const settings = { theme: 'dark', locale: 'en' };
+
+  return (
+    <SettingsContext.Provider value={settings}>
+      <SettingsPanel />
+    </SettingsContext.Provider>
+  );
+}
+```
+
+### Callback usage
+
+```ts
+SettingsContext.Provider({ theme: 'dark', locale: 'en' }, () => {
+  // Everything rendered here sees the provided value
+  renderApp();
+});
+```
+
+---
+
+## Pattern: typed accessor hook
+
+Always create a `use*` wrapper that throws on missing Provider. This gives consumers a clear error instead of silent `undefined`.
+
+```tsx
+import { createContext, useContext } from '@vertz/ui';
+
+interface AuthValue {
+  user: { id: string; name: string };
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthValue>();
+
+export function useAuth(): AuthValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be called within AuthContext.Provider');
+  return ctx;
+}
+```
+
+```tsx
+function UserMenu() {
+  const { user, logout } = useAuth();
+  return (
+    <div>
+      <span>{user.name}</span>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+```
+
+---
+
+## Types
+
+```ts
+interface Context<T> {
+  Provider(value: T, fn: () => void): void;
+  Provider(props: ProviderJsxProps<T>): HTMLElement;
+}
+
+interface ProviderJsxProps<T> {
+  value: T;
+  children: (() => unknown) | unknown;
+}
+```

--- a/packages/docs/api-reference/ui/css.mdx
+++ b/packages/docs/api-reference/ui/css.mdx
@@ -1,4 +1,228 @@
 ---
 title: CSS
-description: "API reference for css(), variants(), and the design token system"
+description: "API reference for css(), variants(), and globalCss()"
 ---
+
+Vertz provides scoped, utility-driven styling with `css()` for component styles, `variants()` for parameterized variants, and `globalCss()` for resets and base styles.
+
+## css()
+
+Define scoped style blocks. Returns an object with class name strings keyed by block name.
+
+```tsx
+import { css } from '@vertz/ui/css';
+
+const styles = css({
+  card: ['bg:white', 'rounded:lg', 'shadow:md', 'p:6'],
+  title: ['font:xl', 'font:bold', 'text:gray.900'],
+});
+
+// styles.card → 'card_a1b2c3' (scoped class name)
+// styles.title → 'title_a1b2c3'
+// styles.css → compiled CSS string (non-enumerable)
+
+function TaskCard() {
+  return (
+    <div class={styles.card}>
+      <h2 class={styles.title}>Task</h2>
+    </div>
+  );
+}
+```
+
+### Signature
+
+```ts
+function css<T extends CSSInput>(
+  input: T,
+  filePath?: string
+): CSSOutput<T>
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `input` | `CSSInput` | Object mapping block names to arrays of style entries |
+| `filePath` | `string` | Used internally by the compiler for scoping |
+
+### Returns
+
+`CSSOutput<T>` — object with each block name mapped to its scoped class name string, plus a non-enumerable `css` property containing the compiled CSS.
+
+### Style entries
+
+Each style entry in the array can be:
+
+| Type | Example | Description |
+|------|---------|-------------|
+| Shorthand string | `'bg:white'` | Utility shorthand expanded to CSS |
+| Nested selector | `{ '&:hover': ['bg:gray.100'] }` | Pseudo-classes, media queries, child selectors |
+| Raw declaration | `{ property: 'grid-template', value: '1fr auto' }` | Escape hatch for arbitrary CSS |
+
+```tsx
+const styles = css({
+  button: [
+    'bg:primary.600',
+    'text:white',
+    'rounded:md',
+    'px:4',
+    'py:2',
+    { '&:hover': ['bg:primary.700'] },
+    { '&:disabled': ['opacity:50', 'cursor:not-allowed'] },
+  ],
+});
+```
+
+---
+
+## variants()
+
+Create a typed variant function for component styling with multiple visual states.
+
+```tsx
+import { variants } from '@vertz/ui/css';
+
+const button = variants({
+  base: ['inline-flex', 'items:center', 'rounded:md', 'font:medium'],
+  variants: {
+    intent: {
+      primary: ['bg:primary.600', 'text:white'],
+      danger: ['bg:danger.500', 'text:white'],
+      ghost: ['bg:transparent', 'text:gray.700'],
+    },
+    size: {
+      sm: ['text:xs', 'px:3', 'py:1.5'],
+      md: ['text:sm', 'px:4', 'py:2'],
+      lg: ['text:base', 'px:6', 'py:3'],
+    },
+  },
+  defaultVariants: { intent: 'primary', size: 'md' },
+});
+
+// button() → 'btn_a1b2c3 primary_a1b2c3 md_a1b2c3'
+// button({ intent: 'danger', size: 'sm' }) → 'btn_a1b2c3 danger_a1b2c3 sm_a1b2c3'
+
+function SubmitButton() {
+  return <button class={button({ intent: 'primary', size: 'lg' })}>Save</button>;
+}
+```
+
+### Signature
+
+```ts
+function variants<V extends VariantDefinitions>(
+  config: VariantsConfig<V>
+): VariantFunction<V>
+```
+
+### VariantsConfig
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `base` | `StyleEntry[]` | Base styles applied to all variants |
+| `variants` | `V` | Object mapping variant names to their options (each option maps to style entries) |
+| `defaultVariants` | `Partial<V>` | Default variant selections when not specified |
+| `compoundVariants` | `CompoundVariant<V>[]` | Styles applied when specific variant combinations are active |
+
+### Returns
+
+`VariantFunction<V>` — a callable function that accepts variant props and returns a class name string. Also has a `.css` property with the compiled CSS.
+
+### Compound variants
+
+```tsx
+const badge = variants({
+  base: ['rounded:full', 'px:2', 'py:0.5', 'font:xs'],
+  variants: {
+    color: {
+      blue: ['bg:blue.100', 'text:blue.800'],
+      red: ['bg:red.100', 'text:red.800'],
+    },
+    outlined: {
+      true: ['bg:transparent', 'border:1'],
+      false: [],
+    },
+  },
+  compoundVariants: [
+    { color: 'blue', outlined: true, css: ['border:blue.300', 'text:blue.700'] },
+    { color: 'red', outlined: true, css: ['border:red.300', 'text:red.700'] },
+  ],
+  defaultVariants: { color: 'blue', outlined: false },
+});
+```
+
+---
+
+## globalCss()
+
+Define global styles — resets, base typography, body defaults. Properties use camelCase, converted to kebab-case in output.
+
+```ts
+import { globalCss } from '@vertz/ui/css';
+
+const reset = globalCss({
+  '*': { margin: '0', padding: '0', boxSizing: 'border-box' },
+  body: { fontFamily: 'system-ui, sans-serif', lineHeight: '1.5' },
+  'a': { textDecoration: 'none', color: 'inherit' },
+});
+
+// reset.css → compiled global CSS string
+```
+
+### Signature
+
+```ts
+function globalCss(input: GlobalCSSInput): GlobalCSSOutput
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `input` | `Record<string, Record<string, string>>` | Object mapping selectors to CSS declarations |
+
+### Returns
+
+`GlobalCSSOutput` — object with a `css` property containing the compiled CSS string.
+
+---
+
+## Types
+
+```ts
+type CSSInput = Record<string, StyleEntry[]>;
+
+type CSSOutput<T extends CSSInput> = {
+  readonly [K in keyof T & string]: string;
+} & { readonly css: string };
+
+type StyleEntry = string | Record<string, StyleValue[]>;
+type StyleValue = string | RawDeclaration;
+
+interface RawDeclaration {
+  property: string;
+  value: string;
+}
+
+type GlobalCSSInput = Record<string, Record<string, string>>;
+interface GlobalCSSOutput {
+  css: string;
+}
+
+interface VariantsConfig<V extends VariantDefinitions> {
+  base: StyleEntry[];
+  variants: V;
+  defaultVariants?: { [K in keyof V]?: keyof V[K] };
+  compoundVariants?: CompoundVariant<V>[];
+}
+
+interface VariantFunction<V extends VariantDefinitions> {
+  (props?: VariantProps<V>): string;
+  css: string;
+}
+
+type VariantProps<V extends VariantDefinitions> = {
+  [K in keyof V]?: keyof V[K];
+};
+```

--- a/packages/docs/api-reference/ui/form.mdx
+++ b/packages/docs/api-reference/ui/form.mdx
@@ -2,3 +2,138 @@
 title: Form
 description: "API reference for form() — type-safe form handling with validation"
 ---
+
+`form()` creates a type-safe form instance bound to a [generated SDK](/api-reference/fetch/sdk) mutation method. It provides reactive field state, schema validation, progressive enhancement attributes (`action`, `method`), and per-field error tracking.
+
+The SDK method carries the validation schema in its metadata, so `form()` picks it up automatically — the `Result` type is handled internally. When the mutation returns `{ ok: false }`, field errors are extracted and mapped to the form fields.
+
+## form()
+
+```tsx
+import { form } from '@vertz/ui/form';
+
+function CreateTaskForm({ onSuccess }: { onSuccess: () => void }) {
+  const taskForm = form(api.tasks.create, {
+    onSuccess,
+  });
+
+  return (
+    <form action={taskForm.action} method={taskForm.method} onSubmit={taskForm.onSubmit}>
+      <input name="title" />
+      {taskForm.title.error && <span>{taskForm.title.error}</span>}
+
+      <textarea name="description" />
+      {taskForm.description.error && <span>{taskForm.description.error}</span>}
+
+      <button type="submit" disabled={taskForm.submitting}>Create</button>
+    </form>
+  );
+}
+```
+
+### Signature
+
+```ts
+function form<TBody, TResult>(
+  sdkMethod: SdkMethod<TBody, TResult>,
+  options?: FormOptions<TBody, TResult>
+): FormInstance<TBody, TResult>
+```
+
+---
+
+## FormInstance
+
+The returned instance has two kinds of properties: reserved form properties and per-field accessors.
+
+### Form properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `action` | `string` | URL for the form's `action` attribute (progressive enhancement) |
+| `method` | `string` | HTTP method for the form's `method` attribute |
+| `onSubmit` | `(e: Event) => Promise<void>` | Submit handler — validates, then calls the SDK method |
+| `submitting` | `boolean` | `true` while the submission is in flight |
+| `dirty` | `boolean` | `true` if any field has been modified |
+| `valid` | `boolean` | `true` if all fields pass validation |
+| `reset()` | `() => void` | Reset all fields to initial values |
+| `submit()` | `(formData?: FormData) => Promise<void>` | Programmatic submit |
+| `setFieldError()` | `(field: string, message: string) => void` | Set a custom error on a field |
+
+### Per-field accessors
+
+Access any field by name on the form instance (e.g., `taskForm.title`). Each field is a `FieldState`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `value` | `T` | Current field value |
+| `error` | `string \| undefined` | Validation error message |
+| `dirty` | `boolean` | `true` if the field has been modified |
+| `touched` | `boolean` | `true` if the field has been interacted with |
+| `pristine` | `boolean` | `true` if the field has not been modified |
+| `setTouched()` | `(touched: boolean) => void` | Mark the field as touched |
+| `validate()` | `(value: T) => void` | Manually trigger validation |
+
+---
+
+## FormOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `schema` | `FormSchema<TBody>` | — | Validation schema (auto-inferred from SDK metadata when available) |
+| `initial` | `Partial<TBody> \| () => Partial<TBody>` | — | Initial field values |
+| `onSuccess` | `(result: TResult) => void` | — | Callback after successful submission |
+| `onError` | `(errors: Record<string, string>) => void` | — | Callback on validation or submission error |
+| `resetOnSuccess` | `boolean` | `false` | Reset fields after successful submission |
+
+---
+
+## Progressive enhancement
+
+The `action` and `method` properties enable the form to work without JavaScript. When JS is available, `onSubmit` intercepts the submission and handles it client-side with validation.
+
+```tsx
+<form action={taskForm.action} method={taskForm.method} onSubmit={taskForm.onSubmit}>
+  {/* Works with and without JS */}
+</form>
+```
+
+---
+
+## Types
+
+```ts
+interface FormOptions<TBody, TResult> {
+  schema?: FormSchema<TBody>;
+  initial?: Partial<TBody> | (() => Partial<TBody>);
+  onSuccess?: (result: TResult) => void;
+  onError?: (errors: Record<string, string>) => void;
+  resetOnSuccess?: boolean;
+}
+
+type FormInstance<TBody, TResult> = {
+  action: string;
+  method: string;
+  onSubmit: (e: Event) => Promise<void>;
+  reset: () => void;
+  setFieldError: (field: keyof TBody & string, message: string) => void;
+  submit: (formData?: FormData) => Promise<void>;
+  submitting: boolean;
+  dirty: boolean;
+  valid: boolean;
+} & { [K in keyof TBody]: FieldState<TBody[K]> }
+
+interface FieldState<T = unknown> {
+  value: T;
+  error: string | undefined;
+  dirty: boolean;
+  touched: boolean;
+  pristine: boolean;
+  setTouched: (touched: boolean) => void;
+  validate: (value: T) => void;
+}
+
+interface FormSchema<T> {
+  parse(data: unknown): { ok: true; data: T } | { ok: false; error: unknown };
+}
+```

--- a/packages/docs/api-reference/ui/jsx-runtime.mdx
+++ b/packages/docs/api-reference/ui/jsx-runtime.mdx
@@ -1,4 +1,0 @@
----
-title: JSX Runtime
-description: "API reference for the vertz/ui JSX runtime"
----

--- a/packages/docs/api-reference/ui/query.mdx
+++ b/packages/docs/api-reference/ui/query.mdx
@@ -2,3 +2,139 @@
 title: Query
 description: "API reference for query() — data fetching and caching"
 ---
+
+`query()` creates a reactive data-fetching primitive. Pass it a SDK method call and it returns reactive properties (`data`, `loading`, `error`) that auto-update in the DOM. It supports SSR data pre-fetching and integrates with the entity store for cross-component cache invalidation.
+
+## query()
+
+Pass a generated SDK method call. The cache key and types are inferred automatically from the SDK:
+
+```tsx
+import { query } from '@vertz/ui/query';
+
+function TaskList() {
+  const tasks = query(api.tasks.list());
+
+  return (
+    <div>
+      {tasks.loading && <p>Loading...</p>}
+      {tasks.error && <p>Error: {tasks.error.message}</p>}
+      {tasks.data?.items.map((task) => (
+        <div key={task.id}>{task.title}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+SDK methods return a `QueryDescriptor` — an object that carries the fetch function, a deterministic cache key, and entity metadata. `query()` unwraps the `Result` for you: if the SDK call succeeds, `data` gets the value; if it fails, `error` gets the error. See the [Generated SDK](/api-reference/fetch/sdk) reference for details on how SDK methods and the `Result` type work.
+
+### Signature
+
+```ts
+function query<T, E>(
+  descriptor: QueryDescriptor<T, E>,
+  options?: Omit<QueryOptions<T>, 'key'>
+): QueryResult<T, E>
+```
+
+---
+
+## QueryResult
+
+The returned object has reactive properties that auto-update in the DOM — the compiler handles reactivity for you.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `data` | `T \| undefined` | Resolved data, or `undefined` while loading |
+| `loading` | `boolean` | `true` during the initial fetch |
+| `revalidating` | `boolean` | `true` during background refetch (stale-while-revalidate) |
+| `error` | `E \| undefined` | Error from the last failed fetch |
+| `refetch()` | `() => void` | Re-execute the query (shows loading state) |
+| `revalidate()` | `() => void` | Background refetch (keeps current data visible) |
+| `dispose()` | `() => void` | Cancel the query and clean up subscriptions |
+
+<Note>
+`refetch()` resets `data` to `undefined` and shows loading state. `revalidate()` keeps the current data visible while fetching fresh data in the background (stale-while-revalidate pattern).
+</Note>
+
+---
+
+## QueryOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `key` | `string` | — | Cache key (auto-inferred from SDK descriptors) |
+| `initialData` | `T` | — | Initial data to use before the first fetch completes |
+| `enabled` | `boolean` | `true` | When `false`, the query doesn't execute |
+| `debounce` | `number` | — | Debounce interval in ms before executing |
+| `cache` | `CacheStore<T>` | — | Custom cache store |
+| `ssrTimeout` | `number` | — | Max time to wait for the query during SSR (ms) |
+| `refetchInterval` | `number \| false \| (data, iteration) => number \| false` | `false` | Polling interval in ms, or a function for dynamic intervals |
+
+---
+
+## invalidate()
+
+Force all queries with a matching key to refetch.
+
+```ts
+import { invalidate } from '@vertz/ui/query';
+
+// After a mutation succeeds, invalidate the list
+const result = await api.tasks.create({ title: 'New task' });
+if (result.ok) {
+  invalidate('task-list');
+}
+```
+
+### Signature
+
+```ts
+function invalidate(key: string): void
+```
+
+---
+
+## SSR support
+
+Queries execute during SSR automatically. The server waits for queries to resolve (up to `ssrTimeout`), serializes the data, and the client hydrates without re-fetching.
+
+```tsx
+const tasks = query(api.tasks.list(), { ssrTimeout: 500 });
+// Server: waits up to 500ms for data, injects into HTML
+// Client: hydrates with server data, no loading flash
+```
+
+---
+
+## Types
+
+```ts
+interface QueryOptions<T> {
+  initialData?: T;
+  debounce?: number;
+  enabled?: boolean;
+  key?: string;
+  cache?: CacheStore<T>;
+  ssrTimeout?: number;
+  refetchInterval?: number | false | ((data: T | undefined, iteration: number) => number | false);
+}
+
+interface QueryResult<T, E = unknown> {
+  readonly data: T | undefined;
+  readonly loading: boolean;
+  readonly revalidating: boolean;
+  readonly error: E | undefined;
+  refetch: () => void;
+  revalidate: () => void;
+  dispose: () => void;
+}
+
+interface CacheStore<T> {
+  get(key: string): T | undefined;
+  set(key: string, value: T): void;
+  has(key: string): boolean;
+  clear(): void;
+}
+```

--- a/packages/docs/api-reference/ui/reactivity.mdx
+++ b/packages/docs/api-reference/ui/reactivity.mdx
@@ -1,0 +1,119 @@
+---
+title: Reactivity
+description: "API reference for Vertz reactivity — let, const, and the compiler-driven model"
+---
+
+Vertz reactivity is compiler-driven. You write plain `let` and `const` — the compiler makes them reactive. There are no hooks, no dependency arrays, and no special imports for component state.
+
+## State with `let`
+
+Declare mutable state with `let`. The compiler transforms it into a reactive value that updates the DOM when it changes.
+
+```tsx
+function Counter() {
+  let count = 0;
+
+  return (
+    <button onClick={() => { count++; }}>
+      Clicked {count} times
+    </button>
+  );
+}
+```
+
+That's it. When `count` changes, only the text node updates — no re-render of the entire component.
+
+## Derived values with `const`
+
+Derive values with `const` expressions. The compiler tracks their dependencies and recomputes them when needed.
+
+```tsx
+function TaskSummary({ tasks }: { tasks: Task[] }) {
+  let statusFilter = 'all';
+
+  const filtered = statusFilter === 'all'
+    ? tasks
+    : tasks.filter((t) => t.status === statusFilter);
+
+  const summary = `${filtered.length} tasks`;
+
+  return (
+    <div>
+      <select onChange={(e) => { statusFilter = e.target.value; }}>
+        <option value="all">All</option>
+        <option value="done">Done</option>
+      </select>
+      <p>{summary}</p>
+    </div>
+  );
+}
+```
+
+When `statusFilter` changes, `filtered` and `summary` recompute, and only the affected DOM nodes update.
+
+## What the compiler does
+
+The compiler transforms your code at build time. You never see or interact with the output — this is purely an implementation detail:
+
+| You write | Compiler handles |
+|-----------|-----------------|
+| `let count = 0` | Reactive state that tracks reads and notifies on write |
+| `const doubled = count * 2` | Lazy derived value that recomputes when dependencies change |
+| `<span>{count}</span>` | Fine-grained DOM binding that updates only the text node |
+| `<div class={isActive ? 'on' : 'off'}>` | Reactive attribute binding |
+
+## Rules
+
+- Use `let` for values that change. Use `const` for values derived from other values.
+- Mutations in event handlers (`onClick`, `onInput`, etc.) trigger updates automatically.
+- You don't need to import anything for component-level reactivity.
+
+---
+
+## Low-level APIs
+
+<Warning>
+These APIs are implementation details. You should not need them in normal component code. They exist for library authors, custom stores, and non-component contexts (e.g., a shared state module outside of any component).
+</Warning>
+
+### batch()
+
+Group multiple state changes into a single update flush. Useful in async callbacks or store logic where multiple values change at once.
+
+```ts
+import { batch } from '@vertz/ui';
+
+function resetForm() {
+  batch(() => {
+    name = '';
+    email = '';
+    status = 'idle';
+  });
+  // DOM updates once, not three times
+}
+```
+
+#### Signature
+
+```ts
+function batch(fn: () => void): void
+```
+
+Nested `batch()` calls are supported — only the outermost batch triggers the flush.
+
+### untrack()
+
+Read a reactive value without creating a dependency. Rarely needed — only useful when you intentionally want to skip reactivity for a specific read.
+
+```ts
+import { untrack } from '@vertz/ui';
+
+// Inside a derived expression, read `count` without subscribing to it
+const label = `${title}: ${untrack(() => count)}`;
+```
+
+#### Signature
+
+```ts
+function untrack<T>(fn: () => T): T
+```

--- a/packages/docs/api-reference/ui/router.mdx
+++ b/packages/docs/api-reference/ui/router.mdx
@@ -2,3 +2,255 @@
 title: Router
 description: "API reference for defineRoutes(), createRouter(), RouterView, and Link"
 ---
+
+The Vertz router provides type-safe, file-system-free routing with loaders, nested layouts, and search param parsing. Route paths are inferred from your route map — typos in `navigate()` calls are caught at compile time.
+
+## defineRoutes()
+
+Define your route map. The `const` modifier preserves literal path types for type-safe navigation.
+
+```ts
+import { defineRoutes } from '@vertz/ui/router';
+
+const routes = defineRoutes({
+  '/': {
+    component: () => HomePage(),
+  },
+  '/tasks': {
+    component: () => TaskListPage(),
+    loader: async () => {
+      const res = await taskApi.list();
+      return res.ok ? res.data : [];
+    },
+  },
+  '/tasks/:id': {
+    component: () => TaskDetailPage(),
+    params: { id: (v) => Number(v) },
+  },
+});
+```
+
+### Signature
+
+```ts
+function defineRoutes<const T extends Record<string, RouteConfigLike>>(
+  map: T
+): TypedRoutes<T>
+```
+
+### RouteConfig
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `component` | `() => Node \| Promise<{ default: () => Node }>` | Component to render (supports lazy imports) |
+| `loader` | `(ctx: { params, signal }) => Promise<T> \| T` | Data loader — runs before the component renders |
+| `errorComponent` | `(error: Error) => Node` | Fallback component when loader fails |
+| `params` | `ParamSchema` | Parse and validate route params (`:id` → `number`) |
+| `searchParams` | `SearchParamSchema` | Parse and validate search/query params |
+| `children` | `RouteDefinitionMap` | Nested routes (rendered via `Outlet`) |
+
+---
+
+## createRouter()
+
+Create a router instance from a route definition.
+
+```ts
+import { createRouter, defineRoutes } from '@vertz/ui/router';
+
+const routes = defineRoutes({ /* ... */ });
+const router = createRouter(routes);
+```
+
+### Signature
+
+```ts
+function createRouter<T extends Record<string, RouteConfigLike>>(
+  routes: TypedRoutes<T>,
+  initialUrl?: string,
+  options?: RouterOptions
+): Router<T>
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `routes` | `TypedRoutes<T>` | Compiled route list from `defineRoutes()` |
+| `initialUrl` | `string` | Override URL (used in SSR to set the server request URL) |
+| `options` | `RouterOptions` | Configuration for server navigation and prefetching |
+
+### RouterOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `serverNav` | `boolean \| { timeout?: number }` | `false` | Enable server-side navigation (SSR prefetch on navigate) |
+
+### Router\<T\>
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `current` | `RouteMatch \| null` | Current matched route (reactive) |
+| `loaderData` | `unknown[]` | Data from the matched route's loader (reactive) |
+| `loaderError` | `Error \| null` | Error from the loader, if any (reactive) |
+| `searchParams` | `Record<string, unknown>` | Parsed search params (reactive) |
+| `navigate(url, options?)` | `(url: RoutePaths<T>, options?) => Promise<void>` | Navigate to a route — type-safe path |
+| `revalidate()` | `() => Promise<void>` | Re-run the current route's loader |
+| `dispose()` | `() => void` | Clean up the router |
+
+---
+
+## RouterView
+
+Renders the component matched by the current route.
+
+```tsx
+import { createRouter, defineRoutes, RouterView } from '@vertz/ui/router';
+
+const routes = defineRoutes({ /* ... */ });
+const router = createRouter(routes);
+
+function App() {
+  return (
+    <div>
+      <nav>...</nav>
+      <RouterView router={router} fallback={() => <div>Page not found</div>} />
+    </div>
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `router` | `Router` | Router instance |
+| `fallback` | `() => Node` | Component to render when no route matches |
+
+---
+
+## Outlet
+
+Renders nested child routes inside a layout component. Must be used within a component rendered by `RouterView`.
+
+```tsx
+const routes = defineRoutes({
+  '/dashboard': {
+    component: () => DashboardLayout(),
+    children: {
+      '/': { component: () => DashboardHome() },
+      '/settings': { component: () => DashboardSettings() },
+    },
+  },
+});
+
+function DashboardLayout() {
+  return (
+    <div class={styles.layout}>
+      <Sidebar />
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+```
+
+---
+
+## useRouter()
+
+Access the router instance from any component in the tree. Must be called within `RouterContext.Provider` (set up automatically by `RouterView`).
+
+```tsx
+import { useRouter } from '@vertz/ui/router';
+import type { InferRouteMap } from '@vertz/ui';
+
+function TaskCard({ taskId }: { taskId: string }) {
+  const router = useRouter<InferRouteMap<typeof routes>>();
+
+  const handleClick = () => {
+    router.navigate(`/tasks/${taskId}`);
+  };
+
+  return <div onClick={handleClick}>...</div>;
+}
+```
+
+### Signature
+
+```ts
+function useRouter<T extends Record<string, RouteConfigLike>>(): UnwrapSignals<Router<T>>
+```
+
+The generic parameter gives you type-safe `navigate()` calls — only valid paths from your route map are accepted.
+
+---
+
+## useParams()
+
+Read the current route's parsed parameters.
+
+```tsx
+import { useParams } from '@vertz/ui/router';
+
+function TaskDetailPage() {
+  const { id } = useParams<'/tasks/:id'>();
+  // id is typed based on the path pattern
+  return <div>Task {id}</div>;
+}
+```
+
+### Signature
+
+```ts
+function useParams<TPath extends string>(): ExtractParams<TPath>
+```
+
+When a `params` schema is defined on the route config, `useParams()` returns the parsed values (e.g., `id` as `number` instead of `string`).
+
+---
+
+## createLink()
+
+Create a Link component factory bound to a router's state. Used internally — most apps use the Link component via `RouterView` setup.
+
+```tsx
+import { createLink } from '@vertz/ui/router';
+
+const Link = createLink(router.current, (url) => router.navigate(url));
+```
+
+### LinkProps
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `href` | `string` | Target URL |
+| `children` | `string \| (() => Node)` | Link content |
+| `activeClass` | `string` | CSS class applied when the link matches the current route |
+| `className` | `string` | Base CSS class |
+| `prefetch` | `'hover'` | Prefetch route data on hover |
+
+---
+
+## Types
+
+```ts
+interface RouteMatch {
+  params: Record<string, string>;
+  parsedParams?: Record<string, unknown>;
+  route: CompiledRoute;
+  matched: MatchedRoute[];
+  searchParams: URLSearchParams;
+  search: Record<string, unknown>;
+}
+
+interface NavigateOptions {
+  replace?: boolean;
+}
+
+type RoutePaths<T extends Record<string, RouteConfigLike>> = keyof T & string;
+type ExtractParams<TPath extends string> = /* extracted param object */;
+type InferRouteMap<T> = T extends TypedRoutes<infer R> ? R : T;
+type TypedRoutes<T> = CompiledRoute[] & { readonly __routes: T };
+```

--- a/packages/docs/api-reference/ui/signals.mdx
+++ b/packages/docs/api-reference/ui/signals.mdx
@@ -1,4 +1,0 @@
----
-title: Signals
-description: "API reference for signal(), computed(), effect(), and watch()"
----

--- a/packages/docs/api-reference/ui/ssr-handler.mdx
+++ b/packages/docs/api-reference/ui/ssr-handler.mdx
@@ -1,4 +1,0 @@
----
-title: SSR Handler
-description: "API reference for createSSRHandler() from vertz/ui-server"
----

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -96,10 +96,13 @@
       {
         "groups": [
           {
+            "group": "Generated SDK",
+            "pages": ["api-reference/fetch/sdk"]
+          },
+          {
             "group": "vertz/ui",
             "pages": [
-              "api-reference/ui/jsx-runtime",
-              "api-reference/ui/signals",
+              "api-reference/ui/reactivity",
               "api-reference/ui/css",
               "api-reference/ui/router",
               "api-reference/ui/query",
@@ -107,14 +110,6 @@
               "api-reference/ui/context",
               "api-reference/ui/mount"
             ]
-          },
-          {
-            "group": "vertz/ui-server",
-            "pages": ["api-reference/ui/ssr-handler"]
-          },
-          {
-            "group": "vertz/ui-compiler",
-            "pages": ["api-reference/ui/compiler-plugin"]
           }
         ],
         "tab": "API Reference"


### PR DESCRIPTION
## Summary

- Write full content for 6 API reference stub pages: **reactivity**, **css**, **router**, **query**, **form**, **context**
- Add new **Generated SDK** page documenting the `Result` type, `QueryDescriptor`, and SDK integration with `query()`/`form()`
- Remove 4 internal-only pages that exposed implementation details users should never configure: `jsx-runtime`, `signals`, `ssr-handler`, `compiler-plugin`
- Replace "Signals" page with "Reactivity" — leads with `let`/`const` DX, pushes `batch()`/`untrack()` to a clearly-marked low-level section
- Update `query`/`form` pages to reference the SDK and `Result` pattern instead of raw fetch

### Key decisions

- **Signals are an implementation detail** — the API reference never teaches users to import `signal()` or `computed()`. Reactivity is presented as `let` for state, `const` for derived values.
- **Internal APIs removed** — `createSSRHandler`, `createVertzBunPlugin`, `createBunDevServer`, and JSX runtime internals are not documented because the CLI handles all of that. Exposing them would mislead both users and LLMs.
- **SDK-first data fetching** — `query()` and `form()` docs lead with generated SDK usage and the `Result<T, E>` pattern, not raw `fetch()` calls.

## Test plan

- [x] `npx mintlify validate` passes
- [x] All pre-push quality gates pass (lint, typecheck, test, build)
- [ ] Visual review of rendered docs on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)