### PR TITLE
docs(auth): DB-backed auth stores v2 — aligned with access redesign [#1059]

### DIFF
--- a/plans/db-backed-auth-stores.md
+++ b/plans/db-backed-auth-stores.md
@@ -1,17 +1,33 @@
 # DB-Backed Auth Stores
 
 **Issue:** [#1059](https://github.com/vertz-dev/vertz/issues/1059)
-**Status:** Draft — awaiting approval
+**Status:** Draft v2 — updated to align with access redesign (#1069)
+**Supersedes:** Original design doc (PR #1068)
 
 ## Problem
 
 `createAuth()` defaults all stores to in-memory implementations. Data that must survive a server restart (users, sessions, roles, plans) disappears when the process dies. The server already has a `db`, but auth doesn't use it.
 
+## Alignment with Access Redesign
+
+The [access redesign](./access-redesign.md) (#1069) introduces new stores and significantly changes existing ones. This design doc covers the DB persistence layer for **all** access-related stores, not just the original 7. Specifically:
+
+- **PlanStore** — gains add-on support, effective plan computation
+- **WalletStore** — gains scoped keys, batch check, multi-limit
+- **FlagStore** — reclassified from ephemeral to persistent (local DB)
+- **New stores** — OverrideStore, PlanVersionStore, GrandfatheringStore
+
+The access redesign's Phase 6 (Cloud Storage) defines a data residency split:
+- **Local DB** — role assignments, closure table, plan assignments, flags, overrides, add-on assignments
+- **Cloud** — wallet counts, plan version snapshots, grandfathering state, billing events, audit log
+
+This design doc covers the **local DB** stores only. Cloud stores are a separate feature.
+
 ## API Surface
 
 ### Infrastructure lives at the framework root
 
-`db` and `cloud` are framework-level concerns — auth is just one consumer. Tomorrow it could be KV stores, file storage, analytics, etc. Both belong on `createServer()`:
+`db` and `cloud` are framework-level concerns — auth is just one consumer. Both belong on `createServer()`:
 
 ```ts
 import { createDb } from '@vertz/db';
@@ -25,47 +41,91 @@ const db = createDb({
 
 const app = createServer({
   db,                                         // framework-level — all subsystems use it
-  cloud: process.env.VERTZ_CLOUD_KEY,         // framework-level — managed services
+  cloud: process.env.VERTZ_CLOUD_KEY,         // framework-level — managed services (future)
   auth: {                                     // auth-specific config only
     session: { strategy: 'jwt', ttl: '60s' },
     emailPassword: { enabled: true },
   },
+  access: defineAccess({ ... }),              // access control config
   entities: [/* ... */],
 });
 ```
 
-`createServer` owns the infrastructure. Auth, entities, and future services all receive `db` and `cloud` from the server context.
-
 ### How auth receives `db`
 
-`createServer` passes `db` to the internal `createAuth()` call. The developer never passes `db` to auth directly — it flows through the framework:
+`createServer` passes `db` to internal `createAuth()` and wires access stores. The developer never passes `db` to auth directly — it flows through the framework:
 
 ```
-createServer({ db, auth: { ... } })
-  └─ internally: createAuth({ ...auth, db })
-       └─ db present? → DB-backed stores for persistent data
-       └─ db absent?  → in-memory stores (prototyping/testing)
+createServer({ db, auth: { ... }, access: defineAccess({ ... }) })
+  └─ internally:
+       ├─ createAuth({ ...auth, db })
+       │    └─ db present? → DB-backed stores (UserStore, SessionStore, OAuthAccountStore)
+       │    └─ db absent?  → in-memory stores (prototyping/testing)
+       └─ wire access stores with db
+            └─ db present? → DB-backed stores (RoleAssignment, Closure, Plan, Flag, Override)
+            └─ db absent?  → in-memory stores
 ```
+
+### Internal auth config type
+
+`createAuth()` receives an internal extended type that includes `db`. This type is **not** part of the public `AuthConfig` — it's only used inside `createServer`:
+
+```ts
+// Internal only — not exported
+interface InternalAuthConfig extends AuthConfig {
+  db?: DatabaseClient<Record<string, ModelEntry>>;
+}
+```
+
+This avoids polluting the public `AuthConfig` type while still allowing `createAuth()` to auto-select DB stores.
 
 ### Store selection logic
 
 When `db` is provided via `createServer`:
-- **Persistent stores auto-switch to DB**: UserStore, SessionStore, OAuthAccountStore, RoleAssignmentStore, ClosureStore, PlanStore, WalletStore
-- **Ephemeral stores stay in-memory**: RateLimitStore, EmailVerificationStore, PasswordResetStore, MFAStore, FlagStore
-- Explicit store overrides always win: passing `userStore` in auth config uses the custom store
+
+**Auth stores auto-switch to DB:**
+- UserStore, SessionStore, OAuthAccountStore
+
+**Access stores auto-switch to DB (local-DB category from access redesign):**
+- RoleAssignmentStore, ClosureStore, PlanStore, FlagStore, OverrideStore
+
+**Access stores remain in-memory (cloud category — future):**
+- WalletStore → cloud-backed in production, in-memory for dev/test
+- PlanVersionStore → cloud-backed in production, in-memory for dev/test
+- GrandfatheringStore → cloud-backed in production, in-memory for dev/test
+
+**Ephemeral stores stay in-memory always:**
+- RateLimitStore, EmailVerificationStore, PasswordResetStore, MFAStore
 
 When `db` is omitted:
 - All stores default to in-memory (current behavior, for prototyping/testing)
 
-### Vertz Cloud integration (future, not this PR)
+Explicit store overrides always win.
 
-When `cloud` is provided via `createServer`:
-- OAuth providers with no explicit credentials → routed through Vertz Cloud proxy
-- Email operations with no `onSend` → routed through Vertz Cloud email relay
-- KV stores, file storage, etc. → future cloud-managed services
-- Ephemeral stores (rate limiting, etc.) could optionally use cloud-managed Redis
+### Auth model validation
 
-This design doc covers only the `db` wiring. Cloud integration is a separate feature.
+When `createServer` receives both `db` (as `DatabaseClient`) and `auth` config, it validates that auth models are registered — same pattern as entity model validation (lines 143-157 of `create-server.ts`):
+
+```ts
+// Inside createServer, after entity validation:
+if (db && isDatabaseClient(db) && config.auth) {
+  const dbModels = db._internals.models;
+  const requiredAuthModels = [
+    'auth_users', 'auth_sessions', 'auth_oauth_accounts',
+    'auth_role_assignments', 'auth_closure', 'auth_plans',
+    'auth_flags', 'auth_overrides',
+  ];
+  const missing = requiredAuthModels.filter(m => !(m in dbModels));
+  if (missing.length > 0) {
+    throw new Error(
+      `Auth requires models ${missing.map(m => `"${m}"`).join(', ')} in createDb(). ` +
+      `Add authModels to your createDb() call: createDb({ models: { ...authModels, ...yourModels } })`
+    );
+  }
+}
+```
+
+This produces a clear, prescriptive error message instead of inscrutable runtime failures.
 
 ### Auth Models Export
 
@@ -80,39 +140,51 @@ import { authModels } from '@vertz/server';
 //   auth_role_assignments: d.model(authRoleAssignmentsTable),
 //   auth_closure: d.model(authClosureTable),
 //   auth_plans: d.model(authPlansTable),
-//   auth_wallet: d.model(authWalletTable),
+//   auth_flags: d.model(authFlagsTable),
+//   auth_overrides: d.model(authOverridesTable),
 // }
 ```
 
 All auth tables prefixed with `auth_` to avoid collision with user entity tables.
+
+### How auth is exposed on the server instance
+
+`createServer` currently returns `AppBuilder`. To expose `app.auth`, we extend the return type:
+
+```ts
+interface ServerInstance extends AppBuilder {
+  auth: AuthInstance;
+  initialize(): Promise<void>;
+}
+
+export function createServer(config: ServerConfig): ServerInstance;
+```
+
+`initialize()` on `ServerInstance` calls `auth.initialize()` (DDL) plus any future subsystem initialization. This keeps the return type clean and avoids polluting `AppBuilder` in `@vertz/core`.
 
 ### Standalone `createAuth()` still works
 
 For testing or apps that don't use `createServer`:
 
 ```ts
-// Direct usage — pass db explicitly
-const auth = createAuth({
-  session: { strategy: 'jwt', ttl: '60s' },
-  db, // optional — same behavior as when createServer passes it
-});
-
 // No db — fully in-memory (tests, prototyping)
 const auth = createAuth({
   session: { strategy: 'jwt', ttl: '60s' },
 });
 ```
 
+Note: `createAuth({ db })` is intentionally **not supported** as a public API. The only way to wire `db` to auth is through `createServer({ db, auth })`. This enforces "one way to do things".
+
 ### ServerConfig changes
 
 ```ts
-export interface ServerConfig {
+export interface ServerConfig extends Omit<AppConfig, '_entityDbFactory' | 'entities'> {
   db?: DatabaseClient<Record<string, ModelEntry>> | EntityDbAdapter;
   cloud?: string;  // Vertz Cloud API key — future
-  auth?: AuthConfig; // NEW — auth config (without db, stores, etc.)
+  auth?: AuthConfig;
+  access?: AccessDefinition;  // from defineAccess()
   entities?: EntityDefinition[];
   services?: ServiceDefinition[];
-  // ...existing fields
 }
 ```
 
@@ -120,14 +192,43 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 ## Table Schemas
 
+### Dialect-aware DDL
+
+Tables must work on both SQLite and PostgreSQL. The DDL generator uses a dialect abstraction:
+
+| Concept | SQLite | PostgreSQL |
+|---------|--------|------------|
+| Primary key | `TEXT PRIMARY KEY` | `TEXT PRIMARY KEY` |
+| Boolean | `INTEGER NOT NULL DEFAULT 0` | `BOOLEAN NOT NULL DEFAULT false` |
+| Timestamp | `TEXT NOT NULL` | `TIMESTAMPTZ NOT NULL` |
+| Nullable timestamp | `TEXT` | `TIMESTAMPTZ` |
+| Auto-now | Application-side (ISO string) | Application-side (ISO string) |
+| JSON | `TEXT` | `TEXT` (not jsonb — simpler, portable) |
+
+Implementation: A `dialectDDL(dialect)` helper returns the right SQL fragments per type. Each table has one `createTable()` function that uses these fragments.
+
+```ts
+function dialectDDL(dialect: 'sqlite' | 'postgres') {
+  return {
+    boolean: (def: boolean) => dialect === 'sqlite'
+      ? `INTEGER NOT NULL DEFAULT ${def ? 1 : 0}`
+      : `BOOLEAN NOT NULL DEFAULT ${def}`,
+    timestamp: () => dialect === 'sqlite' ? 'TEXT NOT NULL' : 'TIMESTAMPTZ NOT NULL',
+    timestampNullable: () => dialect === 'sqlite' ? 'TEXT' : 'TIMESTAMPTZ',
+    // ...etc
+  };
+}
+```
+
 ### auth_users
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
+| id | text | PK |
 | email | text | unique, indexed |
 | password_hash | text | nullable (OAuth-only users) |
 | role | text | default 'user' |
+| plan | text | nullable — current plan ID |
 | email_verified | boolean | default false |
 | created_at | timestamp | |
 | updated_at | timestamp | |
@@ -136,10 +237,11 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
-| user_id | uuid | indexed |
+| id | text | PK |
+| user_id | text | indexed |
 | refresh_token_hash | text | indexed |
 | previous_refresh_hash | text | nullable |
+| current_tokens | text | nullable, JSON — cached JWT + refresh for grace period |
 | ip_address | text | |
 | user_agent | text | |
 | created_at | timestamp | |
@@ -151,8 +253,8 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
-| user_id | uuid | indexed |
+| id | text | PK |
+| user_id | text | indexed |
 | provider | text | |
 | provider_id | text | |
 | email | text | nullable |
@@ -163,9 +265,9 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
-| user_id | uuid | indexed |
-| resource_type | text | |
+| id | text | PK |
+| user_id | text | indexed |
+| resource_type | text | lowercase entity name |
 | resource_id | text | |
 | role | text | |
 | created_at | timestamp | |
@@ -175,77 +277,125 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
+| id | text | PK |
 | ancestor_type | text | |
 | ancestor_id | text | |
 | descendant_type | text | |
 | descendant_id | text | |
 | depth | integer | |
+| **unique** | | (ancestor_type, ancestor_id, descendant_type, descendant_id) |
 | **index** | | (descendant_type, descendant_id) for getAncestors |
 | **index** | | (ancestor_type, ancestor_id) for getDescendants |
 
 ### auth_plans
 
+Redesigned to support add-ons from the access redesign (Phase 2).
+
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
-| org_id | text | unique, indexed |
+| id | text | PK |
+| tenant_id | text | indexed |
 | plan_id | text | |
 | started_at | timestamp | |
 | expires_at | timestamp | nullable |
-| overrides | text | JSON-serialized Record<string, LimitOverride> |
+| **unique** | | (tenant_id) — one base plan per tenant |
 
-### auth_wallet
+### auth_plan_addons
+
+New table — tracks add-on assignments per tenant.
 
 | Column | Type | Notes |
 |--------|------|-------|
-| id | uuid | PK |
-| org_id | text | |
-| entitlement | text | |
-| period_start | timestamp | |
-| period_end | timestamp | |
-| consumed | integer | default 0 |
+| id | text | PK |
+| tenant_id | text | indexed |
+| addon_id | text | |
+| is_one_off | boolean | default false — one-off add-ons don't reset |
+| quantity | integer | default 1 — stackable one-off purchases |
 | created_at | timestamp | |
+| **index** | | (tenant_id, addon_id) |
+
+### auth_flags
+
+Reclassified from ephemeral to persistent per access redesign data residency.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | text | PK |
+| tenant_id | text | indexed |
+| flag | text | |
+| enabled | boolean | |
+| **unique** | | (tenant_id, flag) |
+
+### auth_overrides
+
+New table — per-tenant feature and limit overrides (access redesign Phase 3).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | text | PK |
+| tenant_id | text | indexed |
+| overrides | text | JSON — `{ features?: string[], limits?: Array<{ key, add?, max? }> }` |
 | updated_at | timestamp | |
-| **unique** | | (org_id, entitlement, period_start) |
+| **unique** | | (tenant_id) |
+
+## Store-to-Table Mapping
+
+| Store | Table(s) | Category | Notes |
+|-------|----------|----------|-------|
+| UserStore | auth_users | Auth | |
+| SessionStore | auth_sessions | Auth | `current_tokens` stored as JSON text |
+| OAuthAccountStore | auth_oauth_accounts | Auth | |
+| RoleAssignmentStore | auth_role_assignments | Access (local) | |
+| ClosureStore | auth_closure | Access (local) | UNIQUE constraint for idempotent addResource |
+| PlanStore | auth_plans + auth_plan_addons | Access (local) | Two tables for base plan + add-ons |
+| FlagStore | auth_flags | Access (local) | Was ephemeral, now persistent |
+| OverrideStore | auth_overrides | Access (local) | New in access redesign |
+| WalletStore | — | Access (cloud) | **Not DB-backed** — cloud or in-memory |
+| PlanVersionStore | — | Access (cloud) | **Not DB-backed** — cloud or in-memory |
+| GrandfatheringStore | — | Access (cloud) | **Not DB-backed** — cloud or in-memory |
 
 ## Manifesto Alignment
 
 ### Explicit over implicit
 - `db` is configured once at the framework level — visible, not hidden
 - Auth models must be explicitly included in `createDb({ models: { ...authModels } })`
+- Missing models produce a prescriptive error at `createServer()` time
 - In-memory fallback only when `db` is absent (prototyping)
 
 ### One way to do things
-- One recommended path: `createServer({ db, auth: { ... } })` — db flows to auth automatically
-- No second config path for db (don't also accept `db` on auth config when using createServer)
+- One path: `createServer({ db, auth: { ... } })` — db flows to auth automatically
+- `createAuth({ db })` is NOT a public API — prevents two competing configuration paths
+- `createAuth()` without db is the only standalone option (for tests)
 
 ### If it builds, it works
 - Auth models are typed via `d.table()` — column types checked at compile time
-- DB-backed stores use the typed query builder
+- Missing model validation at `createServer()` catches misconfig before runtime
 
 ### Convention over configuration
 - Table names, column names, indexes all predefined
 - No config needed beyond passing `db` to `createServer`
+- DB stores auto-selected when `db` is present
 
 ## Non-Goals
 
 - **Custom auth table names** — auth tables are always `auth_*`. Custom naming adds complexity for zero benefit pre-v1.
 - **Migration system** — `initialize()` creates tables if they don't exist. Schema migrations are a future concern (post-v1).
-- **Multi-database support per store** — all auth stores use the same `db`. A store that uses Redis while others use Postgres is out of scope.
-- **Making ephemeral stores DB-backed** — RateLimitStore, EmailVerificationStore, PasswordResetStore, MFAStore, FlagStore stay in-memory. The issue explicitly calls these acceptable as ephemeral.
+- **Cloud-category stores in local DB** — WalletStore, PlanVersionStore, GrandfatheringStore are cloud-backed per the access redesign. When no cloud is configured, they fall back to in-memory, not local DB. This keeps the local DB lean.
 - **Vertz Cloud integration** — `cloud` key is reserved on `ServerConfig` but not implemented in this feature.
 
 ## Unknowns
 
-1. **Does `DatabaseClient` support creating tables at runtime?** The current `createDb()` assumes tables exist. `auth.initialize()` needs to create tables. Need to verify if the query builder supports DDL or if we need raw SQL.
-   - **Resolution**: Needs POC — check if dialect adapters expose a `query()` or `exec()` method for raw DDL.
+1. **Does `DatabaseClient` support creating tables at runtime?**
+   - **Resolution**: Confirmed — `db.query(sql\`CREATE TABLE IF NOT EXISTS ...\`)` works.
 
-2. **JSON column support across dialects** — `auth_plans.overrides` needs JSON storage. PostgreSQL has `jsonb`, SQLite stores JSON as text natively.
-   - **Resolution**: Use `text` column with JSON serialization/deserialization in the store implementation. Avoids dialect-specific column types.
+2. **JSON column support across dialects**
+   - **Resolution**: Use `text` column with JSON serialization/deserialization.
 
-3. **Atomic wallet consume across DB** — `InMemoryWalletStore.consume()` uses an atomic check-and-increment. The DB version needs `UPDATE ... WHERE consumed < limit` or transactions.
-   - **Resolution**: Use `UPDATE auth_wallet SET consumed = consumed + :amount WHERE ... AND consumed + :amount <= :limit` with affected-rows check. Single-statement atomicity, no explicit transaction needed.
+3. **Atomic wallet consume across DB**
+   - **Resolution**: N/A for this doc — wallet is cloud-backed, not local DB.
+
+4. **How does `createServer` return type change?**
+   - **Resolution**: Return `ServerInstance extends AppBuilder` with `.auth` and `.initialize()`. Defined in `@vertz/server`, not `@vertz/core`.
 
 ## POC Results
 
@@ -255,40 +405,15 @@ Note: `auth` on `ServerConfig` is the config object, not an `AuthInstance`. `cre
 
 **What was tried:** Explored `packages/db/src/client/database.ts` and dialect adapters. The `DatabaseClient` exposes a public `query()` method that accepts `SqlFragment` objects created via the `sql` tagged template.
 
-**Result:** DDL is fully supported through `db.query(sql\`CREATE TABLE IF NOT EXISTS ...\`)`. Both PostgreSQL and SQLite dialect adapters route `query()` to their underlying drivers. No raw SQL escape hatch needed — the existing `sql` tagged template handles it.
-
-**Usage in auth:**
-```ts
-await db.query(sql`
-  CREATE TABLE IF NOT EXISTS auth_users (
-    id TEXT PRIMARY KEY,
-    email TEXT UNIQUE NOT NULL,
-    password_hash TEXT,
-    role TEXT NOT NULL DEFAULT 'user',
-    email_verified INTEGER NOT NULL DEFAULT 0,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-  )
-`);
-```
+**Result:** DDL is fully supported through `db.query(sql\`CREATE TABLE IF NOT EXISTS ...\`)`. Both PostgreSQL and SQLite dialect adapters route `query()` to their underlying drivers.
 
 ### 2. JSON Column Support — Text with Serialization
 
-**Resolution confirmed:** Use `text` column type with `JSON.stringify()` on write and `JSON.parse()` on read. This avoids dialect-specific column types (`jsonb` in PostgreSQL vs native text in SQLite). The `auth_plans.overrides` column stores `Record<string, LimitOverride>` as serialized JSON text.
+**Resolution confirmed:** Use `text` column type with `JSON.stringify()` on write and `JSON.parse()` on read.
 
-### 3. Atomic Wallet Consume — Single UPDATE
+### 3. Dialect Detection
 
-**Resolution confirmed:** Use a single `UPDATE` statement with a `WHERE` clause that checks capacity:
-
-```sql
-UPDATE auth_wallet
-SET consumed = consumed + :amount, updated_at = :now
-WHERE org_id = :orgId AND entitlement = :entitlement
-  AND period_start = :periodStart
-  AND consumed + :amount <= :limit
-```
-
-Check `affectedRows` — if 0, the limit was exceeded. Single-statement atomicity, no explicit transaction needed. Both SQLite and PostgreSQL guarantee this.
+The `DatabaseClient` exposes `_internals.dialect` which returns `'sqlite'` or `'postgres'`. The DDL generator reads this to produce the right SQL.
 
 ## Type Flow Map
 
@@ -296,22 +421,23 @@ Check `affectedRows` — if 0, the limit was exceeded. Single-statement atomicit
 authModels (table defs via d.table())
   ↓ spread into createDb({ models: { ...authModels, ...userModels } })
 DatabaseClient<{ auth_users: AuthUserEntry, auth_sessions: ..., ... }>
-  ↓ passed to createServer({ db, auth: { ... } })
-createServer passes db to createAuth internally
-  ↓ createAuth extracts model delegates: db.auth_users, db.auth_sessions, ...
-  ↓ creates DbUserStore(db.auth_users), DbSessionStore(db.auth_sessions), ...
-Each DbXxxStore implements XxxStore interface
-  ↓ used by auth handlers (signUp, signIn, etc.)
-Same async interface as InMemoryXxxStore
+  ↓ passed to createServer({ db, auth: { ... }, access: defineAccess({ ... }) })
+createServer validates auth models are in db (prescriptive error on missing)
+  ↓ createServer creates auth instance internally
+  ↓ db present? → DbUserStore(db), DbSessionStore(db), ...
+  ↓ db absent?  → InMemoryUserStore(), InMemorySessionStore(), ...
+  ↓ access stores wired similarly: DbRoleAssignmentStore(db), DbClosureStore(db), ...
+ServerInstance { auth: AuthInstance, initialize(), ...AppBuilder }
+  ↓ initialize() creates tables via dialect-aware DDL (idempotent)
+  ↓ auth handlers use stores (signUp, signIn, etc.)
+Same async interface for DB and InMemory stores
 ```
-
-No dead generics — `DatabaseClient<TModels>` flows the model types through to store implementations.
 
 ## E2E Acceptance Test
 
 ```ts
 import { createDb } from '@vertz/db';
-import { authModels, createServer } from '@vertz/server';
+import { authModels, createServer, defineAccess } from '@vertz/server';
 
 // 1. Create DB with auth models
 const db = createDb({
@@ -319,43 +445,72 @@ const db = createDb({
   dialect: 'sqlite',
 });
 
-// 2. Create server with db + auth
+// 2. Define access
+const access = defineAccess({
+  entities: {
+    organization: { roles: ['owner', 'admin', 'member'] },
+    project: {
+      roles: ['manager', 'viewer'],
+      inherits: { 'organization:admin': 'manager', 'organization:member': 'viewer' },
+    },
+  },
+  entitlements: {
+    'project:view': { roles: ['viewer', 'manager'] },
+    'project:edit': { roles: ['manager'] },
+  },
+});
+
+// 3. Create server with db + auth + access
 const app = createServer({
   db,
   auth: {
     session: { strategy: 'jwt', ttl: '60s' },
     emailPassword: { enabled: true },
   },
+  access,
 });
 
-// 3. Initialize (creates auth tables)
+// 4. Initialize (creates auth tables — idempotent)
 await app.initialize();
 
-// 4. Sign up persists to DB
+// 5. Sign up persists to DB
 const signUp = await app.auth.api.signUp({
   email: 'test@example.com',
   password: 'Password123!',
 });
 expect(signUp.ok).toBe(true);
 
-// 5. User survives "restart" — create fresh server with same db
+// 6. User survives "restart" — create fresh server with same db
 const app2 = createServer({
   db,
   auth: {
     session: { strategy: 'jwt', ttl: '60s' },
     emailPassword: { enabled: true },
   },
+  access,
 });
 await app2.initialize(); // tables already exist, no-op
 
-// 6. Sign in works with previous user's data
+// 7. Sign in works with previous user's data
 const signIn = await app2.auth.api.signIn({
   email: 'test@example.com',
   password: 'Password123!',
 });
 expect(signIn.ok).toBe(true);
 
-// 7. Standalone createAuth still works (for tests)
+// 8. Role assignments persist across restart
+// (assigned in app1, checked in app2)
+
+// 9. Feature flags persist across restart
+
+// 10. Missing authModels produces prescriptive error
+const badDb = createDb({ models: {}, dialect: 'sqlite' });
+expect(() => createServer({
+  db: badDb,
+  auth: { session: { strategy: 'jwt', ttl: '60s' } },
+})).toThrow(/Auth requires models.*authModels/);
+
+// 11. No db — fully in-memory (standalone createAuth for tests)
 import { createAuth } from '@vertz/server';
 const testAuth = createAuth({
   session: { strategy: 'jwt', ttl: '60s' },
@@ -363,49 +518,121 @@ const testAuth = createAuth({
 });
 ```
 
+## Testing Strategy
+
+### Shared test factories for behavioral parity
+
+Every store with both InMemory and DB implementations shares a test factory:
+
+```ts
+// Example: shared-user-store.tests.ts
+export function userStoreTests(
+  name: string,
+  factory: () => { store: UserStore; cleanup: () => Promise<void> },
+) {
+  describe(`UserStore: ${name}`, () => {
+    let store: UserStore;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(() => {
+      const result = factory();
+      store = result.store;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => { await cleanup(); });
+
+    it('creates and finds user by email', async () => { /* ... */ });
+    it('returns null for unknown email', async () => { /* ... */ });
+    // ... all UserStore behaviors
+  });
+}
+
+// In user-store.test.ts:
+userStoreTests('InMemory', () => ({
+  store: new InMemoryUserStore(),
+  cleanup: async () => {},
+}));
+
+// In db-user-store.test.ts:
+userStoreTests('SQLite', () => ({
+  store: new DbUserStore(testDb),
+  cleanup: async () => { /* truncate tables */ },
+}));
+```
+
+This guarantees DB stores behave identically to in-memory stores.
+
 ## Implementation Phases
 
-### Phase 1: Auth table definitions + DDL support
+### Phase 1: Dialect-aware DDL + auth table definitions
 
-- Define all 7 auth table schemas using `d.table()`
+- Implement `dialectDDL()` helper for SQLite and PostgreSQL
+- Define all 9 auth table schemas (auth_users through auth_overrides)
 - Export `authModels` from `@vertz/server`
 - Implement DDL in `initialize()` — create tables if not exist
-- Acceptance: `auth.initialize()` creates all 7 tables in SQLite
+- Add auth model validation in `createServer()`
+- Acceptance:
+  - `auth.initialize()` creates all 9 tables in SQLite
+  - `auth.initialize()` creates all 9 tables in PostgreSQL
+  - `initialize()` is idempotent (calling twice succeeds)
+  - Missing authModels in createDb() throws prescriptive error
 
-### Phase 2: DbUserStore + DbSessionStore
+### Phase 2: ServerInstance + DbUserStore + DbSessionStore
 
+- Define `ServerInstance` type extending `AppBuilder` with `.auth` and `.initialize()`
 - Implement DB-backed UserStore and SessionStore
-- Wire into `createAuth()` — auto-select DB store when `db` is present
-- Wire `createServer` to pass `db` to auth
-- Acceptance: sign-up → restart → sign-in works (E2E test above)
+- Wire `createServer` to create auth internally and return `ServerInstance`
+- Shared test factory for UserStore (InMemory + DB)
+- Shared test factory for SessionStore (InMemory + DB)
+- Acceptance:
+  - `createServer({ db, auth })` returns `ServerInstance` with `.auth`
+  - sign-up → restart → sign-in works
+  - `current_tokens` persists in session (grace period works)
+  - In-memory path unchanged (no db → same behavior as today)
 
-### Phase 3: DbRoleAssignmentStore + DbClosureStore
+### Phase 3: DbRoleAssignmentStore + DbClosureStore + DbFlagStore
 
-- Implement DB-backed role and closure stores
-- Wire into `createAuth()` access config
-- Acceptance: role assignments and hierarchy lookups persist
+- Implement DB-backed role assignment, closure, and flag stores
+- Wire into access store auto-selection
+- Shared test factories for each
+- Acceptance:
+  - Role assignments persist across restart
+  - Closure table hierarchy queries work with DB
+  - Feature flags persist across restart
+  - `addResource` is idempotent (UNIQUE constraint)
 
-### Phase 4: DbPlanStore + DbWalletStore + DbOAuthAccountStore
+### Phase 4: DbPlanStore + DbOverrideStore + DbOAuthAccountStore
 
-- Implement remaining DB-backed stores
-- Wire into `createAuth()` for plan/wallet/OAuth
-- Acceptance: plan assignments, wallet consumption, OAuth accounts persist
+- Implement DB-backed PlanStore (with add-on support via auth_plan_addons)
+- Implement DB-backed OverrideStore
+- Implement DB-backed OAuthAccountStore
+- Shared test factories for each
+- Acceptance:
+  - Plan assignments + add-ons persist
+  - Overrides persist
+  - OAuth accounts persist
+  - Add-on stacking works (one-off × N)
 
 ### Phase 5: Integration tests + docs update
 
-- Full E2E integration test with all stores
-- Update auth docs to show `createServer({ db, auth })` as the recommended pattern
+- Full E2E integration test with all stores (both SQLite and PostgreSQL)
+- Behavioral parity tests (shared factories) for all stores
+- Update auth docs to show `createServer({ db, auth })` pattern
 - Changeset
 
 ## Definition of Done
 
-- [ ] All 7 DB-backed store implementations
+- [ ] All 8 DB-backed store implementations (UserStore, SessionStore, OAuthAccountStore, RoleAssignmentStore, ClosureStore, PlanStore, FlagStore, OverrideStore)
+- [ ] 9 auth tables with dialect-aware DDL (SQLite + PostgreSQL)
 - [ ] `authModels` exported from `@vertz/server`
-- [ ] `createServer({ db, auth })` auto-wires DB stores
-- [ ] Standalone `createAuth({ db })` still works
-- [ ] Explicit store overrides still work
+- [ ] `createServer({ db, auth })` returns `ServerInstance` with `.auth`
+- [ ] Auth model validation with prescriptive error messages
 - [ ] `initialize()` creates tables (idempotent)
-- [ ] E2E acceptance test passing
-- [ ] All existing auth tests pass (in-memory path unchanged)
+- [ ] Shared test factories proving behavioral parity (InMemory ↔ DB)
+- [ ] Explicit store overrides still work
+- [ ] In-memory fallback unchanged (no db → same behavior)
+- [ ] E2E acceptance test passing (both dialects)
+- [ ] All existing auth tests pass
 - [ ] Docs updated
 - [ ] Changeset added


### PR DESCRIPTION
## Summary

Updated design doc for DB-backed auth stores, addressing all blocker findings from adversarial reviews and aligning with the access redesign (#1069).

**Supersedes** the original design doc from PR #1068.

### Key changes from v1

- **Store interfaces aligned with access redesign** — PlanStore gains add-on support, FlagStore reclassified from ephemeral to persistent, new OverrideStore table added
- **Data residency split** — local DB for hot-path stores (roles, closure, plans, flags, overrides), cloud for high-volume stores (wallet, versioning, grandfathering). Wallet/PlanVersion/Grandfathering are NOT DB-backed.
- **`ServerInstance` return type** — `createServer()` returns `ServerInstance extends AppBuilder` with `.auth` and `.initialize()`, solving the "app.auth doesn't exist" blocker
- **Auth model validation** — `createServer()` validates authModels are in `createDb()`, with prescriptive error message (same pattern as entity model validation)
- **Dialect-aware DDL** — `dialectDDL()` helper for SQLite vs PostgreSQL type differences
- **`InternalAuthConfig`** — `db` passed internally, not on public `AuthConfig` type. Enforces "one way to do things"
- **Shared test factories** — behavioral parity tests ensure DB stores match in-memory stores exactly
- **9 tables** (was 7) — added `auth_flags`, `auth_overrides`, `auth_plan_addons`

### Blockers addressed

| Blocker | Resolution |
|---------|-----------|
| `createServer` has no auth awareness | `ServerInstance` return type with `.auth` |
| `authModels` manual spread footgun | Fail-fast validation with prescriptive error |
| No dialect-aware DDL | `dialectDDL()` helper |
| `AuthConfig` has no `db` field | `InternalAuthConfig` (not exported) |
| Store wiring more complex than described | Explicit wiring diagram for auth vs access stores |
| Missing `plan` column on auth_users | Added |
| Missing `currentTokens` persistence | Added as JSON column on auth_sessions |
| Phase acceptance criteria too vague | Concrete acceptance criteria per phase |

Ref #1059

## Sign-offs needed

- [ ] **DX** — Is the updated API surface intuitive?
- [ ] **Product/scope** — Right scope given access redesign alignment?
- [ ] **Technical** — Can it be built as designed?

🤖 Generated with [Claude Code](https://claude.com/claude-code)