### PR TITLE
fix(create-vertz): add `create-vertz` package so `bun create vertz` works

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
     "@vertz/compiler",
     "@vertz/core",
     "@vertz/create-vertz-app",
+    "create-vertz",
     "@vertz/db",
     "@vertz/errors",
     "@vertz/fetch",

--- a/.changeset/create-vertz-package.md
+++ b/.changeset/create-vertz-package.md
@@ -1,0 +1,5 @@
+---
+'create-vertz': patch
+---
+
+Add `create-vertz` package so `bun create vertz my-app` works as shown on the landing page

--- a/bun.lock
+++ b/bun.lock
@@ -221,6 +221,16 @@
         "typescript": "^5.7.0",
       },
     },
+    "packages/create-vertz": {
+      "name": "create-vertz",
+      "version": "0.2.12",
+      "bin": {
+        "create-vertz": "./bin/create-vertz.ts",
+      },
+      "dependencies": {
+        "@vertz/create-vertz-app": "workspace:*",
+      },
+    },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
       "version": "0.2.12",
@@ -1132,6 +1142,8 @@
     "contacts-api-example": ["contacts-api-example@workspace:examples/contacts-api"],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "create-vertz": ["create-vertz@workspace:packages/create-vertz"],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/packages/create-vertz/bin/create-vertz.ts
+++ b/packages/create-vertz/bin/create-vertz.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+
+import { resolveOptions, scaffold } from '@vertz/create-vertz-app';
+
+const name = process.argv[2];
+
+try {
+  const resolved = await resolveOptions({ projectName: name });
+
+  console.log(`Creating Vertz app: ${resolved.projectName}`);
+
+  const targetDir = process.cwd();
+  await scaffold(targetDir, resolved);
+
+  console.log(`\n✓ Created ${resolved.projectName}`);
+  console.log(`\nNext steps:`);
+  console.log(`  cd ${resolved.projectName}`);
+  console.log(`  bun install`);
+  console.log(`  bun run dev`);
+} catch (error) {
+  console.error('Error:', error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/packages/create-vertz/package.json
+++ b/packages/create-vertz/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "create-vertz",
+  "version": "0.2.12",
+  "type": "module",
+  "license": "MIT",
+  "description": "Create a new Vertz application — delegates to @vertz/create-vertz-app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "packages/create-vertz"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "bin": {
+    "create-vertz": "./bin/create-vertz.ts"
+  },
+  "files": [
+    "bin"
+  ],
+  "dependencies": {
+    "@vertz/create-vertz-app": "workspace:*"
+  }
+}


### PR DESCRIPTION
## Summary

- The landing page hero CTA shows `bun create vertz my-app`, but `bun create` resolves to a package named `create-vertz` which didn't exist on npm — the command fails with a 404
- Adds a thin `create-vertz` wrapper package that delegates to `@vertz/create-vertz-app`
- Adds `create-vertz` to the changeset fixed version group so it stays in lockstep

## Public API Changes

- **Addition:** `create-vertz` npm package (new) — enables `bun create vertz my-app`

## Test plan

- [x] Verified `bun create vertz my-app` fails without this change (404 on `create-vertz`)
- [x] Verified `bunx @vertz/create-vertz-app my-app` works (existing behavior)
- [x] Tested `create-vertz` bin locally — scaffolds correctly via delegation
- [x] Full CI passed (69/69 tasks: lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)