### PR TITLE
feat(ui): add italic and list-style CSS shorthands

### DIFF
--- a/packages/ui/src/css/__tests__/token-resolver.test.ts
+++ b/packages/ui/src/css/__tests__/token-resolver.test.ts
@@ -333,6 +333,51 @@ describe('resolveToken', () => {
     });
   });
 
+  describe('font-style keywords', () => {
+    it('resolves italic to font-style: italic', () => {
+      const result = resolveToken({ property: 'italic', value: null, pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'font-style', value: 'italic' }]);
+    });
+
+    it('resolves not-italic to font-style: normal', () => {
+      const result = resolveToken({ property: 'not-italic', value: null, pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'font-style', value: 'normal' }]);
+    });
+  });
+
+  describe('list-style', () => {
+    it('resolves list:none to list-style: none', () => {
+      const result = resolveToken({ property: 'list', value: 'none', pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'list-style', value: 'none' }]);
+    });
+
+    it('resolves list:disc to list-style: disc', () => {
+      const result = resolveToken({ property: 'list', value: 'disc', pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'list-style', value: 'disc' }]);
+    });
+
+    it('resolves list:decimal to list-style: decimal', () => {
+      const result = resolveToken({ property: 'list', value: 'decimal', pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'list-style', value: 'decimal' }]);
+    });
+
+    it('resolves list:inside to list-style-position: inside', () => {
+      const result = resolveToken({ property: 'list', value: 'inside', pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'list-style-position', value: 'inside' }]);
+    });
+
+    it('resolves list:outside to list-style-position: outside', () => {
+      const result = resolveToken({ property: 'list', value: 'outside', pseudo: null });
+      expect(result.declarations).toEqual([{ property: 'list-style-position', value: 'outside' }]);
+    });
+
+    it('throws on invalid list value', () => {
+      expect(() => resolveToken({ property: 'list', value: 'potato', pseudo: null })).toThrow(
+        TokenResolveError,
+      );
+    });
+  });
+
   describe('error cases', () => {
     it('throws on unknown property', () => {
       expect(() => resolveToken({ property: 'xyzzy', value: '4', pseudo: null })).toThrow(

--- a/packages/ui/src/css/token-resolver.ts
+++ b/packages/ui/src/css/token-resolver.ts
@@ -92,6 +92,9 @@ export function resolveToken(parsed: ParsedShorthand): ResolvedStyle {
   if (property === 'ring') {
     return { declarations: resolveRingMulti(value), pseudo };
   }
+  if (property === 'list') {
+    return { declarations: resolveList(value), pseudo };
+  }
 
   // Standard single-mode resolution.
   const resolvedValue = resolveValue(value, mapping.valueType, property);
@@ -339,6 +342,30 @@ function resolveRingMulti(value: string): CSSDeclaration[] {
   }
   // Color token: ring:primary.500 -> outline-color
   return [{ property: 'outline-color', value: resolveColor(value, 'ring') }];
+}
+
+/** List-style type keywords. */
+const LIST_STYLE_KEYWORDS = new Set(['none', 'disc', 'decimal']);
+
+/** List-style position keywords. */
+const LIST_POSITION_KEYWORDS = new Set(['inside', 'outside']);
+
+/**
+ * Resolve `list:value` -- multi-mode:
+ * - Style keywords (none, disc, decimal) -> list-style
+ * - Position keywords (inside, outside) -> list-style-position
+ */
+function resolveList(value: string): CSSDeclaration[] {
+  if (LIST_STYLE_KEYWORDS.has(value)) {
+    return [{ property: 'list-style', value }];
+  }
+  if (LIST_POSITION_KEYWORDS.has(value)) {
+    return [{ property: 'list-style-position', value }];
+  }
+  throw new TokenResolveError(
+    `Invalid list value '${value}'. Use: none, disc, decimal, inside, outside.`,
+    `list:${value}`,
+  );
 }
 
 /** Resolve raw values for properties that need custom mapping (border-width sides, transition, tracking, grid-cols, etc.). */

--- a/packages/ui/src/css/token-tables.ts
+++ b/packages/ui/src/css/token-tables.ts
@@ -90,6 +90,9 @@ export const PROPERTY_MAP: Record<string, PropertyMapping> = {
   tracking: { properties: ['letter-spacing'], valueType: 'raw' },
   decoration: { properties: ['text-decoration'], valueType: 'raw' },
 
+  // List
+  list: { properties: ['list-style'], valueType: 'raw' },
+
   // Ring (outline)
   ring: { properties: ['outline'], valueType: 'ring' },
 
@@ -156,6 +159,10 @@ export const KEYWORD_MAP: Record<string, CSSDeclarationEntry[]> = {
 
   // Flex shrink
   'shrink-0': [{ property: 'flex-shrink', value: '0' }],
+
+  // Font style
+  italic: [{ property: 'font-style', value: 'italic' }],
+  'not-italic': [{ property: 'font-style', value: 'normal' }],
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add `italic` and `not-italic` keyword tokens for `font-style` (#1070)
- Add `list:none`, `list:disc`, `list:decimal` for `list-style` and `list:inside`, `list:outside` for `list-style-position` (#1071)

## Public API Changes

### Additions
- `italic` keyword -> `font-style: italic`
- `not-italic` keyword -> `font-style: normal`
- `list:none` -> `list-style: none`
- `list:disc` -> `list-style: disc`
- `list:decimal` -> `list-style: decimal`
- `list:inside` -> `list-style-position: inside`
- `list:outside` -> `list-style-position: outside`

### Breaking Changes
None.

## Implementation

- Added `italic` and `not-italic` to `KEYWORD_MAP` in `token-tables.ts`
- Added `list` to `PROPERTY_MAP` in `token-tables.ts`
- Added multi-mode `resolveList()` resolver in `token-resolver.ts` (style keywords -> `list-style`, position keywords -> `list-style-position`)
- 7 new tests in `token-resolver.test.ts` (all passing)

## Test Plan

- [x] `bun test packages/ui/src/css/__tests__/token-resolver.test.ts` — 61 tests pass
- [x] `bun test packages/ui/src/__tests__/css-integration.test.ts` — 7 tests pass
- [x] `bun run typecheck` (packages/ui) — clean
- [x] `bunx biome check` — clean
- [x] Pre-push CI (all 69 turbo tasks pass)

Closes #1070
Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)