### PR TITLE
fix(ui-server): clear full require.cache on file change for SSR

### DIFF
--- a/packages/ui-server/src/__tests__/bun-dev-server.test.ts
+++ b/packages/ui-server/src/__tests__/bun-dev-server.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import {
   buildScriptTag,
+  clearSSRRequireCache,
   createBunDevServer,
   createFetchInterceptor,
   createRuntimeErrorDeduplicator,
@@ -697,5 +698,37 @@ describe('createRuntimeErrorDeduplicator', () => {
     dedup.reset();
 
     expect(dedup.shouldLog('Error: foo', 'src/a.tsx', 10)).toBe(true);
+  });
+});
+
+describe('clearSSRRequireCache', () => {
+  it('clears cache entries outside srcDir and entryPath', () => {
+    const fakeKey = '/tmp/outside-project/lib/shared-utils.ts';
+    require.cache[fakeKey] = {} as NodeModule;
+
+    clearSSRRequireCache();
+
+    expect(require.cache[fakeKey]).toBeUndefined();
+  });
+
+  it('returns the number of cache entries cleared', () => {
+    require.cache['/tmp/fake-a.ts'] = {} as NodeModule;
+    require.cache['/tmp/fake-b.ts'] = {} as NodeModule;
+
+    const cleared = clearSSRRequireCache();
+
+    expect(cleared).toBeGreaterThanOrEqual(2);
+  });
+
+  it('clears all entries regardless of path prefix', () => {
+    require.cache['/project/src/app.tsx'] = {} as NodeModule;
+    require.cache['/project/lib/shared.ts'] = {} as NodeModule;
+    require.cache['/other/generated/routes.ts'] = {} as NodeModule;
+
+    clearSSRRequireCache();
+
+    expect(require.cache['/project/src/app.tsx']).toBeUndefined();
+    expect(require.cache['/project/lib/shared.ts']).toBeUndefined();
+    expect(require.cache['/other/generated/routes.ts']).toBeUndefined();
   });
 });

--- a/packages/ui-server/src/bun-dev-server.ts
+++ b/packages/ui-server/src/bun-dev-server.ts
@@ -608,6 +608,20 @@ export function buildScriptTag(
 }
 
 /**
+ * Clear the entire require.cache so SSR module re-import picks up all changes,
+ * including files outside src/ (e.g., generated files, shared libs).
+ *
+ * Returns the number of cache entries cleared.
+ */
+export function clearSSRRequireCache(): number {
+  const keys = Object.keys(require.cache);
+  for (const key of keys) {
+    delete require.cache[key];
+  }
+  return keys.length;
+}
+
+/**
  * Create a unified Bun dev server with SSR + HMR.
  *
  * SSR is always on. HMR always works. No mode toggle needed.
@@ -1494,14 +1508,7 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
           // synchronous context stack used by Provider/useContext. The wrapper
           // is a `.ts` file (no plugin needed) that re-exports from the real
           // entry, keeping the `.tsx` import path clean for the plugin.
-          const cacheKeys = Object.keys(require.cache);
-          let cacheCleared = 0;
-          for (const key of cacheKeys) {
-            if (key.startsWith(srcDir) || key.startsWith(entryPath)) {
-              delete require.cache[key];
-              cacheCleared++;
-            }
-          }
+          const cacheCleared = clearSSRRequireCache();
           logger.log('watcher', 'cache-cleared', { entries: cacheCleared });
           const ssrWrapperPath = resolve(devDir, 'ssr-reload-entry.ts');
           mkdirSync(devDir, { recursive: true });
@@ -1524,12 +1531,7 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
             if (stopped) return;
             await new Promise((r) => setTimeout(r, 500));
             if (stopped) return;
-            const retryKeys = Object.keys(require.cache);
-            for (const key of retryKeys) {
-              if (key.startsWith(srcDir) || key.startsWith(entryPath)) {
-                delete require.cache[key];
-              }
-            }
+            clearSSRRequireCache();
             mkdirSync(devDir, { recursive: true });
             writeFileSync(ssrWrapperPath, `export * from '${entryPath}';\n`);
             try {


### PR DESCRIPTION
## Summary

- Extracted `clearSSRRequireCache()` function that clears the **entire** `require.cache` on file change, not just entries matching `srcDir`/`entryPath` prefixes
- Files outside those prefixes (generated files, shared `lib/` directories) were staying cached, causing SSR to serve stale content

## Public API Changes

None — internal dev server behavior only.

## Test plan

- [x] 3 new tests verifying `clearSSRRequireCache()` clears all cache entries regardless of path prefix
- [x] 60 tests pass in bun-dev-server suite (was 57)
- [x] Full ui-server suite: 443 tests pass

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)