### PR TITLE
feat(server): add rules.public shorthand for entity access

### DIFF
--- a/packages/server/src/auth/__tests__/rules.test.ts
+++ b/packages/server/src/auth/__tests__/rules.test.ts
@@ -81,6 +81,17 @@ describe('rules builders', () => {
     });
   });
 
+  describe('rules.public', () => {
+    it('is a frozen object with type "public"', () => {
+      expect(rules.public).toEqual({ type: 'public' });
+      expect(Object.isFrozen(rules.public)).toBe(true);
+    });
+
+    it('is a constant (same reference every time)', () => {
+      expect(rules.public).toBe(rules.public);
+    });
+  });
+
   describe('rules.user markers', () => {
     it('has id marker', () => {
       expect(rules.user.id).toEqual({ __marker: 'user.id' });

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -2236,6 +2236,7 @@ export type {
   AuthenticatedRule,
   EntitlementRule,
   FvaRule,
+  PublicRule,
   RoleRule,
   UserMarker,
   WhereRule,

--- a/packages/server/src/auth/rules.ts
+++ b/packages/server/src/auth/rules.ts
@@ -38,12 +38,17 @@ export interface AuthenticatedRule {
   readonly type: 'authenticated';
 }
 
+export interface PublicRule {
+  readonly type: 'public';
+}
+
 export interface FvaRule {
   readonly type: 'fva';
   readonly maxAge: number;
 }
 
 export type AccessRule =
+  | PublicRule
   | RoleRule
   | EntitlementRule
   | WhereRule
@@ -70,6 +75,9 @@ const userMarkers = {
 // ============================================================================
 
 export const rules = {
+  /** Endpoint is public — no authentication required */
+  public: Object.freeze({ type: 'public' }) as PublicRule,
+
   /** User has at least one of the specified roles (OR) */
   role(...roleNames: string[]): RoleRule {
     return { type: 'role', roles: Object.freeze([...roleNames]) };

--- a/packages/server/src/entity/__tests__/access-enforcer.test.ts
+++ b/packages/server/src/entity/__tests__/access-enforcer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { EntityForbiddenError } from '@vertz/errors';
+import { rules } from '../../auth/rules';
 import { enforceAccess } from '../access-enforcer';
 import type { BaseContext, EntityContext } from '../types';
 
@@ -119,6 +120,32 @@ describe('Feature: enforceAccess', () => {
         };
 
         const result = await enforceAccess('login', { login: () => true }, baseCtx);
+        expect(result.ok).toBe(true);
+      });
+    });
+  });
+
+  describe('Given access rule is rules.public', () => {
+    describe('When enforceAccess is called', () => {
+      it('Then returns ok(undefined) (always allows)', async () => {
+        const ctx = stubCtx({ userId: null });
+
+        const result = await enforceAccess('list', { list: rules.public }, ctx);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.data).toBeUndefined();
+        }
+      });
+    });
+
+    describe('When enforceAccess is called without authentication', () => {
+      it('Then still returns ok(undefined)', async () => {
+        const ctx = stubCtx({
+          userId: null,
+          authenticated: () => false,
+        });
+
+        const result = await enforceAccess('list', { list: rules.public }, ctx);
         expect(result.ok).toBe(true);
       });
     });

--- a/packages/server/src/entity/access-enforcer.ts
+++ b/packages/server/src/entity/access-enforcer.ts
@@ -9,6 +9,7 @@ import type { AccessRule, BaseContext } from './types';
  *
  * - No rule defined → deny (deny by default)
  * - Rule is false → operation is disabled
+ * - Rule is { type: 'public' } → always allow
  * - Rule is a function → evaluate and deny if returns false
  */
 export async function enforceAccess(
@@ -32,10 +33,14 @@ export async function enforceAccess(
   }
 
   // Function rule — evaluate
-  const allowed = await rule(ctx, row ?? {});
-  if (!allowed) {
-    return err(new EntityForbiddenError(`Access denied for operation "${operation}"`));
+  if (typeof rule === 'function') {
+    const allowed = await rule(ctx, row ?? {});
+    if (!allowed) {
+      return err(new EntityForbiddenError(`Access denied for operation "${operation}"`));
+    }
+    return ok(undefined);
   }
 
+  // Public rule — always allow
   return ok(undefined);
 }

--- a/packages/server/src/entity/types.ts
+++ b/packages/server/src/entity/types.ts
@@ -1,4 +1,5 @@
 import type { ModelDef, RelationDef, SchemaLike, TableDef } from '@vertz/db';
+import type { PublicRule } from '../auth/rules';
 import type { EntityOperations } from './entity-operations';
 
 // ---------------------------------------------------------------------------
@@ -55,6 +56,7 @@ export interface EntityContext<
 // allows actions to share the same AccessRule type.
 export type AccessRule =
   | false
+  | PublicRule
   | ((ctx: BaseContext, row: Record<string, unknown>) => boolean | Promise<boolean>);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `rules.public` as a frozen `{ type: 'public' }` constant for marking entity operations as publicly accessible
- Extends the entity `AccessRule` type to accept `PublicRule` alongside `false` and function rules
- Updates `enforceAccess` to always-allow when it encounters a `PublicRule`
- Exports `PublicRule` type from `@vertz/server`

## Public API Changes

### Additions
- `rules.public` — a pre-built access rule constant meaning "this endpoint is public" (equivalent to `() => true` but self-documenting)
- `PublicRule` type export — `{ readonly type: 'public' }`

### Usage
```ts
import { entity, rules } from '@vertz/server';

export const todos = entity('todos', {
  model: todosModel,
  access: {
    list:   rules.public,
    create: rules.authenticated(),
    update: rules.authenticated(),
    delete: rules.authenticated(),
  },
});
```

## Test plan
- [x] `rules.public` is a frozen object with `{ type: 'public' }`
- [x] `rules.public` returns the same reference (constant, not factory)
- [x] `enforceAccess` returns `ok(undefined)` for `rules.public` even with `userId: null`
- [x] `enforceAccess` returns `ok(undefined)` for `rules.public` with `authenticated: () => false`
- [x] All existing enforcer tests still pass (function rules, false, undefined)
- [x] TypeScript typecheck passes
- [x] Biome lint passes

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)