### PR TITLE
feat(schema): make d.uuid().primary() auto-generate UUID v7 by default

### DIFF
--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -207,7 +207,7 @@ export function schemaTemplate(): string {
   return `import { d } from 'vertz/db';
 
 export const tasksTable = d.table('tasks', {
-  id: d.uuid().primary({ generate: 'uuid' }),
+  id: d.uuid().primary(),
   title: d.text(),
   completed: d.boolean().default(false),
   createdAt: d.timestamp().default('now').readOnly(),

--- a/packages/db/src/__tests__/column-generate.test.ts
+++ b/packages/db/src/__tests__/column-generate.test.ts
@@ -21,7 +21,7 @@ describe('Column generate metadata', () => {
   });
 
   // Test 10: d.text().primary()._meta.generate === undefined
-  it('leaves generate undefined when not specified', () => {
+  it('leaves generate undefined when not specified on non-uuid column', () => {
     const col = d.text().primary();
     expect(col._meta.generate).toBeUndefined();
   });
@@ -44,5 +44,29 @@ describe('Column generate metadata', () => {
     expect(col._meta.generate).toBe('uuid');
     expect(col._meta.primary).toBe(true);
     expect(col._meta.hasDefault).toBe(true);
+  });
+
+  it('d.uuid().primary() auto-generates uuid by default', () => {
+    const col = d.uuid().primary();
+    expect(col._meta.generate).toBe('uuid');
+    expect(col._meta.primary).toBe(true);
+    expect(col._meta.hasDefault).toBe(true);
+  });
+
+  it('d.uuid().primary({ generated: false }) opts out of auto-generation', () => {
+    const col = d.uuid().primary({ generated: false });
+    expect(col._meta.generate).toBeUndefined();
+    expect(col._meta.primary).toBe(true);
+    expect(col._meta.hasDefault).toBe(true);
+  });
+
+  it('d.uuid().primary({ generate: "cuid" }) overrides the auto-uuid default', () => {
+    const col = d.uuid().primary({ generate: 'cuid' });
+    expect(col._meta.generate).toBe('cuid');
+  });
+
+  it('d.text().primary() still has no auto-generation', () => {
+    const col = d.text().primary();
+    expect(col._meta.generate).toBeUndefined();
   });
 });

--- a/packages/db/src/schema/column.ts
+++ b/packages/db/src/schema/column.ts
@@ -31,7 +31,7 @@ export interface ColumnBuilder<TType, TMeta extends ColumnMetadata = ColumnMetad
   readonly [PhantomType]: TType;
   readonly _meta: TMeta;
 
-  primary(options?: { generate?: 'cuid' | 'uuid' | 'nanoid' }): ColumnBuilder<
+  primary(options?: { generate?: 'cuid' | 'uuid' | 'nanoid'; generated?: boolean }): ColumnBuilder<
     TType,
     Omit<TMeta, 'primary' | 'hasDefault' | 'generate'> & {
       readonly primary: true;
@@ -122,10 +122,12 @@ function cloneWith(
 function createColumnWithMeta(meta: ColumnMetadata): ColumnBuilder<unknown, ColumnMetadata> {
   const col: ColumnBuilder<unknown, ColumnMetadata> = {
     _meta: meta,
-    primary(options?: { generate?: 'cuid' | 'uuid' | 'nanoid' }) {
+    primary(options?: { generate?: 'cuid' | 'uuid' | 'nanoid'; generated?: boolean }) {
       const meta: Record<string, unknown> = { primary: true, hasDefault: true };
       if (options?.generate) {
         meta.generate = options.generate;
+      } else if (this._meta.sqlType === 'uuid' && options?.generated !== false) {
+        meta.generate = 'uuid';
       }
       return cloneWith(this, meta) as ReturnType<ColumnBuilder<unknown, ColumnMetadata>['primary']>;
     },

--- a/packages/server/src/auth/oauth-schema.ts
+++ b/packages/server/src/auth/oauth-schema.ts
@@ -7,7 +7,7 @@
 import { d } from '@vertz/db';
 
 export const oauthAccountsTable = d.table('oauth_accounts', {
-  id: d.uuid().primary({ generate: 'uuid' }),
+  id: d.uuid().primary(),
   userId: d.uuid(),
   provider: d.text(),
   providerId: d.text(),

--- a/packages/server/src/auth/schema.ts
+++ b/packages/server/src/auth/schema.ts
@@ -7,7 +7,7 @@
 import { d } from '@vertz/db';
 
 export const sessionsTable = d.table('sessions', {
-  id: d.uuid().primary({ generate: 'uuid' }),
+  id: d.uuid().primary(),
   userId: d.uuid(),
   refreshTokenHash: d.text(),
   previousRefreshHash: d.text().nullable(),


### PR DESCRIPTION
## Summary

- `d.uuid().primary()` now auto-sets `generate: 'uuid'` (UUID v7) by default — no explicit option needed
- Opt out with `d.uuid().primary({ generated: false })` for user-supplied UUIDs
- Non-uuid columns (`d.text().primary()`) are unaffected
- Simplified auth schemas and `create-vertz-app` template to use the new default

Closes #1048

## Public API Changes

**Breaking (behavioral):** `d.uuid().primary()` now auto-generates UUID v7. Previously it required `{ generate: 'uuid' }`. Code that called `d.uuid().primary()` and relied on NOT generating IDs will need to add `{ generated: false }`.

**Addition:** `primary()` options now accept `{ generated?: boolean }` for explicit opt-out.

## Test plan

- [x] `d.uuid().primary()` sets `generate: 'uuid'` in metadata
- [x] `d.uuid().primary({ generated: false })` leaves `generate` undefined
- [x] `d.uuid().primary({ generate: 'cuid' })` overrides the default
- [x] `d.text().primary()` still has no auto-generation
- [x] All 1192 `@vertz/db` tests pass
- [x] Typecheck passes for `@vertz/db`, `@vertz/server`, `@vertz/create-vertz-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)