### PR TITLE
feat(ui): expose typed field names on form() (#1051)

### DIFF
--- a/packages/ui/src/form/__tests__/form.test-d.ts
+++ b/packages/ui/src/form/__tests__/form.test-d.ts
@@ -166,6 +166,25 @@ form(mockSdk);
 const plainWithSchema = form(mockSdk, { schema: metaSchema });
 void plainWithSchema;
 
+// ─── 13b. fields — typed field names for compile-time input validation ──
+
+// fields.name should be typed as the string literal 'name'
+const _fieldName: 'name' = userForm.fields.name;
+void _fieldName;
+
+// fields.email should be typed as the string literal 'email'
+const _fieldEmail: 'email' = userForm.fields.email;
+void _fieldEmail;
+
+// Accessing a non-existent field should be a type error
+// @ts-expect-error - 'nonExistent' is not a key of UserBody
+userForm.fields.nonExistent;
+
+// Assigning to wrong literal should be a type error
+// @ts-expect-error - fields.name is 'name', not 'email'
+const _wrongLiteral: 'email' = userForm.fields.name;
+void _wrongLiteral;
+
 // ─── 14. No attrs() method ────────────────────────────────────────
 
 // @ts-expect-error - attrs() no longer exists on FormInstance

--- a/packages/ui/src/form/__tests__/form.test.ts
+++ b/packages/ui/src/form/__tests__/form.test.ts
@@ -549,6 +549,32 @@ describe('form', () => {
     });
   });
 
+  describe('fields', () => {
+    it('fields.<name> returns the field name as a string', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      expect(f.fields.title).toBe('title');
+      expect(f.fields.name).toBe('name');
+      expect(f.fields.email).toBe('email');
+    });
+
+    it('fields returns the same object on repeated access', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      expect(f.fields).toBe(f.fields);
+    });
+  });
+
   describe('per-field setValue and reset', () => {
     it('field.setValue() updates value and dirty through form proxy', () => {
       const sdk = mockSdkMethod({

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -36,12 +36,16 @@ export type ReservedFormNames =
   | 'reset'
   | 'setFieldError'
   | 'submit'
+  | 'fields'
   | '__bindElement';
 
 export type { FieldState };
 
 /** Mapped type providing FieldState for each field in TBody. */
 export type FieldAccessors<TBody> = { [K in keyof TBody]: FieldState<TBody[K]> };
+
+/** Mapped type providing typed field name strings for compile-time input validation. */
+export type FieldNames<TBody> = { readonly [K in keyof TBody & string]: K };
 
 /** Base properties available on every form instance. */
 export interface FormBaseProperties<TBody> {
@@ -54,6 +58,7 @@ export interface FormBaseProperties<TBody> {
   submitting: Signal<boolean>;
   dirty: ReadonlySignal<boolean>;
   valid: ReadonlySignal<boolean>;
+  fields: FieldNames<TBody>;
   __bindElement: (el: HTMLFormElement) => void;
 }
 
@@ -247,6 +252,12 @@ export function form<TBody, TResult>(
     submitting,
     dirty,
     valid,
+    fields: new Proxy(Object.create(null) as Record<string, string>, {
+      get(_target, prop) {
+        if (typeof prop === 'string') return prop;
+        return undefined;
+      },
+    }),
     __bindElement: (el: HTMLFormElement) => {
       boundElement = el;
       el.addEventListener('input', handleInputOrChange);

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -1,6 +1,7 @@
 export type { FieldState } from './field-state';
 export { createFieldState } from './field-state';
 export type {
+  FieldNames,
   FormInstance,
   FormOptions,
   SdkMethod,

--- a/packages/ui/src/form/public.ts
+++ b/packages/ui/src/form/public.ts
@@ -8,6 +8,7 @@
 export type { FieldState } from './field-state';
 export { createFieldState } from './field-state';
 export type {
+  FieldNames,
   FormInstance,
   FormOptions,
   SdkMethod,


### PR DESCRIPTION
## Summary

- Add `fields` property to `form()` return type that provides typed field name strings for compile-time validation of `<input name>` attributes
- `todoForm.fields.title` returns `'title'` as a string literal type, enabling autocomplete and catching typos/renames at compile time
- `todoForm.fields.nonExistent` produces a TypeScript error

## Public API Changes

### Additions
- `FormInstance<TBody, TResult>.fields` -- new property of type `FieldNames<TBody>`
- `FieldNames<TBody>` -- new exported mapped type: `{ readonly [K in keyof TBody & string]: K }`
- `'fields'` added to `ReservedFormNames` (field name `fields` on a schema will now produce a conflict error)

### No breaking changes
Existing `form()` usage is unaffected. `fields` is additive.

## Test plan

- [x] Type-level tests (`.test-d.ts`): positive literal types for `fields.name` and `fields.email`
- [x] Type-level tests: `@ts-expect-error` on `fields.nonExistent` (non-existent key)
- [x] Type-level tests: `@ts-expect-error` on wrong literal assignment (`'email' = fields.name`)
- [x] Runtime tests: `fields.<name>` returns the field name string
- [x] Runtime tests: `fields` returns the same object on repeated access (identity stability)
- [x] All existing form tests pass (36 total)
- [x] Full CI pipeline: lint, typecheck, build, test (69 tasks)

Closes #1051

Generated with [Claude Code](https://claude.com/claude-code)