### PR TITLE
chore(examples): use form().fields for typed input names

### DIFF
--- a/examples/entity-todo/src/components/todo-form.tsx
+++ b/examples/entity-todo/src/components/todo-form.tsx
@@ -38,7 +38,7 @@ export function TodoForm({ onSuccess }: TodoFormProps) {
         <div class={styles.inputWrap}>
           <input
             class={inputStyles.base}
-            name="title"
+            name={todoForm.fields.title}
             type="text"
             placeholder="What needs to be done?"
             data-testid="todo-title-input"

--- a/examples/task-manager/src/components/task-form.tsx
+++ b/examples/task-manager/src/components/task-form.tsx
@@ -94,7 +94,7 @@ export function TaskForm({ onSuccess, onCancel }: TaskFormProps) {
         <input
           class={inputStyles.base}
           id="task-title"
-          name="title"
+          name={taskForm.fields.title}
           type="text"
           placeholder="What needs to be done?"
         />
@@ -110,7 +110,7 @@ export function TaskForm({ onSuccess, onCancel }: TaskFormProps) {
         <textarea
           class={formStyles.textarea}
           id="task-description"
-          name="description"
+          name={taskForm.fields.description}
           placeholder="Describe the task in detail..."
         />
         <span class={formStyles.error} data-testid="description-error">
@@ -122,7 +122,7 @@ export function TaskForm({ onSuccess, onCancel }: TaskFormProps) {
         <label class={labelStyles.base} for="task-priority">
           Priority
         </label>
-        <select class={formStyles.select} id="task-priority" name="priority">
+        <select class={formStyles.select} id="task-priority" name={taskForm.fields.priority}>
           <option value="low">Low</option>
           <option value="medium" selected>
             Medium

--- a/packages/docs/api-reference/ui/form.mdx
+++ b/packages/docs/api-reference/ui/form.mdx
@@ -19,10 +19,10 @@ function CreateTaskForm({ onSuccess }: { onSuccess: () => void }) {
 
   return (
     <form action={taskForm.action} method={taskForm.method} onSubmit={taskForm.onSubmit}>
-      <input name="title" />
+      <input name={taskForm.fields.title} />
       {taskForm.title.error && <span>{taskForm.title.error}</span>}
 
-      <textarea name="description" />
+      <textarea name={taskForm.fields.description} />
       {taskForm.description.error && <span>{taskForm.description.error}</span>}
 
       <button type="submit" disabled={taskForm.submitting}>Create</button>

--- a/packages/docs/guides/ui/auth.mdx
+++ b/packages/docs/guides/ui/auth.mdx
@@ -40,10 +40,10 @@ function LoginPage() {
       method={loginForm.method}
       onSubmit={loginForm.onSubmit}
     >
-      <input name="email" type="email" />
+      <input name={loginForm.fields.email} type="email" />
       <span>{loginForm.email.error}</span>
 
-      <input name="password" type="password" />
+      <input name={loginForm.fields.password} type="password" />
       <span>{loginForm.password.error}</span>
 
       <button type="submit" disabled={loginForm.submitting}>
@@ -210,7 +210,7 @@ function LoginPage() {
   if (auth.status === 'mfa_required') {
     return (
       <form onSubmit={mfaForm.onSubmit}>
-        <input name="code" placeholder="Enter 6-digit code" />
+        <input name={mfaForm.fields.code} placeholder="Enter 6-digit code" />
         <span>{mfaForm.code.error}</span>
         <button type="submit" disabled={mfaForm.submitting}>Verify</button>
       </form>
@@ -219,8 +219,8 @@ function LoginPage() {
 
   return (
     <form onSubmit={loginForm.onSubmit}>
-      <input name="email" type="email" />
-      <input name="password" type="password" />
+      <input name={loginForm.fields.email} type="email" />
+      <input name={loginForm.fields.password} type="password" />
       <button type="submit" disabled={loginForm.submitting}>Sign In</button>
     </form>
   );
@@ -248,7 +248,7 @@ function ForgotPasswordPage() {
 
   return (
     <form onSubmit={forgotForm.onSubmit}>
-      <input name="email" type="email" placeholder="Your email" />
+      <input name={forgotForm.fields.email} type="email" placeholder="Your email" />
       <span>{forgotForm.email.error}</span>
       <button type="submit" disabled={forgotForm.submitting}>
         Send Reset Link
@@ -271,8 +271,8 @@ function ResetPasswordPage() {
 
   return (
     <form onSubmit={resetForm.onSubmit}>
-      <input type="hidden" name="token" value={token} />
-      <input name="password" type="password" placeholder="New password" />
+      <input type="hidden" name={resetForm.fields.token} value={token} />
+      <input name={resetForm.fields.password} type="password" placeholder="New password" />
       <span>{resetForm.password.error}</span>
       <button type="submit" disabled={resetForm.submitting}>
         Reset Password
@@ -412,9 +412,9 @@ function AppContent() {
 const signupForm = form(auth.signUp);
 
 <form onSubmit={signupForm.onSubmit}>
-  <input name="email" type="email" />
-  <input name="password" type="password" />
-  <input name="name" />
+  <input name={signupForm.fields.email} type="email" />
+  <input name={signupForm.fields.password} type="password" />
+  <input name={signupForm.fields.name} />
   <button type="submit">Create Account</button>
 </form>
 ```

--- a/packages/docs/guides/ui/forms.mdx
+++ b/packages/docs/guides/ui/forms.mdx
@@ -20,7 +20,7 @@ export function CreateTaskForm({ onSuccess }: CreateTaskFormProps) {
       method={taskForm.method}
       onSubmit={taskForm.onSubmit}
     >
-      <input name="title" placeholder="Task title" />
+      <input name={taskForm.fields.title} placeholder="Task title" />
       {taskForm.title.error && <span>{taskForm.title.error}</span>}
 
       <button type="submit" disabled={taskForm.submitting}>


### PR DESCRIPTION
## Summary

- Replace hardcoded string `name="fieldName"` attributes with typed `name={formVar.fields.fieldName}` across all form examples and documentation
- Updates 5 files: entity-todo example, task-manager example, forms guide, form API reference, and auth guide
- No behavioral changes -- only swaps string literals for the typed `.fields` accessor

Closes #1051

## Public API Changes

None -- documentation and example-only changes.

## Test plan

- [x] `bun run typecheck` passes on both example packages
- [x] Pre-push quality gates pass (69/69 tasks)
- [ ] Verify docs render correctly in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)