### PR TITLE
Keep router changeset on patch

### DIFF
--- a/.changeset/late-buses-hunt.md
+++ b/.changeset/late-buses-hunt.md
@@ -1,6 +1,6 @@
 ---
 '@vertz/codegen': patch
-'@vertz/ui': minor
+'@vertz/ui': patch
 ---
 
 Generate router module augmentations so `useRouter()` picks up app route types by default after codegen.


### PR DESCRIPTION
## Summary

- change the router changeset so `@vertz/ui` stays on a `patch` release
- avoid accidentally requesting a non-patch version bump for the router work

## Test plan

- [x] Pre-push quality gates passed during push
- [x] Verified `.changeset/late-buses-hunt.md` is the only diff against `main`
