### PR TITLE
fix(codegen): wire create() through OptimisticHandler [#1008]

### DIFF
--- a/.changeset/create-mutation-bus.md
+++ b/.changeset/create-mutation-bus.md
@@ -1,0 +1,5 @@
+---
+'@vertz/codegen': patch
+---
+
+Wire create() mutations through OptimisticHandler for MutationEventBus emission, enabling automatic list query revalidation after entity creation

--- a/examples/entity-todo/src/components/todo-form.tsx
+++ b/examples/entity-todo/src/components/todo-form.tsx
@@ -18,10 +18,10 @@ const styles = css({
 });
 
 export interface TodoFormProps {
-  onSuccess: (todo: TodosResponse) => void;
+  onSuccess?: (todo: TodosResponse) => void;
 }
 
-export function TodoForm({ onSuccess }: TodoFormProps) {
+export function TodoForm({ onSuccess }: TodoFormProps = {}) {
   const todoForm = form(api.todos.create, {
     onSuccess,
     resetOnSuccess: true,

--- a/examples/entity-todo/src/pages/todo-list.tsx
+++ b/examples/entity-todo/src/pages/todo-list.tsx
@@ -4,7 +4,7 @@
  * Demonstrates:
  * - query() with descriptor-based data fetching
  * - queryMatch() for exclusive-state pattern matching (loading/error/data)
- * - Automatic optimistic updates — no refetch callbacks needed for toggle/delete
+ * - Automatic optimistic updates — no refetch callbacks needed for any CRUD operation
  * - ListTransition for animated list item enter/exit
  */
 
@@ -46,14 +46,9 @@ const pageStyles = css({
 export function TodoListPage() {
   const todosQuery = query(api.todos.list());
 
-  // Create still needs a refetch since the new entity's ID isn't in the query index yet
-  const handleCreate = (_todo: TodosResponse) => {
-    todosQuery.refetch();
-  };
-
   return (
     <div class={pageStyles.container} data-testid="todo-list-page">
-      <TodoForm onSuccess={handleCreate} />
+      <TodoForm />
 
       <div class={pageStyles.listContainer} style={todosQuery.revalidating ? 'opacity: 0.6' : ''}>
         {queryMatch(todosQuery, {

--- a/packages/codegen/src/generators/__tests__/client-generator.test.ts
+++ b/packages/codegen/src/generators/__tests__/client-generator.test.ts
@@ -197,6 +197,32 @@ describe('ClientGenerator', () => {
       expect(clientFile?.content).toContain(': undefined');
     });
 
+    it('passes optimistic handler for create-only entity', () => {
+      const ir = createBasicIR([
+        {
+          entityName: 'todo',
+          operations: [
+            {
+              kind: 'create',
+              method: 'POST',
+              path: '/todo',
+              operationId: 'createTodo',
+              inputSchema: 'CreateTodoInput',
+              outputSchema: 'TodoResponse',
+            },
+          ],
+          actions: [],
+        },
+      ]);
+
+      const files = generator.generate(ir, { outputDir: '.vertz', options: {} });
+      const clientFile = files.find((f) => f.path === 'client.ts');
+
+      expect(clientFile?.content).toContain('optimistic?: OptimisticHandler | false');
+      expect(clientFile?.content).toContain('createTodoSdk(client, optimistic)');
+      expect(clientFile?.content).toContain('createOptimisticHandler(getEntityStore())');
+    });
+
     it('does not pass optimistic handler when entity has no mutations', () => {
       const ir = createBasicIR([
         {

--- a/packages/codegen/src/generators/__tests__/entity-sdk-generator.test.ts
+++ b/packages/codegen/src/generators/__tests__/entity-sdk-generator.test.ts
@@ -221,6 +221,10 @@ describe('EntitySdkGenerator', () => {
 
     expect(userFile?.content).toContain('client.get<ListResponse<unknown>>');
     expect(userFile?.content).toContain('(body: unknown)');
+    expect(userFile?.content).toContain('createMutationDescriptor');
+    expect(userFile?.content).toContain(
+      "import { type FetchClient, type ListResponse, type OptimisticHandler, createDescriptor, createMutationDescriptor } from '@vertz/fetch'",
+    );
   });
 
   it('generates index file re-exporting all entity SDKs', () => {
@@ -587,6 +591,33 @@ describe('EntitySdkGenerator', () => {
         'createTodoSdk(client: FetchClient, optimistic?: OptimisticHandler)',
       );
       expect(todoFile?.content).toContain('type OptimisticHandler');
+    });
+
+    it('uses createMutationDescriptor for create operations', () => {
+      const ir = createBasicIR([
+        {
+          entityName: 'todo',
+          operations: [
+            {
+              kind: 'create',
+              method: 'POST',
+              path: '/todo',
+              operationId: 'createTodo',
+              inputSchema: 'CreateTodoInput',
+              outputSchema: 'TodoResponse',
+            },
+          ],
+          actions: [],
+        },
+      ]);
+
+      const files = generator.generate(ir, { outputDir: '.vertz', options: {} });
+      const todoFile = files.find((f) => f.path === 'entities/todo.ts');
+
+      expect(todoFile?.content).toContain('createMutationDescriptor');
+      expect(todoFile?.content).toContain("entityType: 'todo'");
+      expect(todoFile?.content).toContain("kind: 'create'");
+      expect(todoFile?.content).toContain('optimistic');
     });
 
     it('SDK function does not accept optimistic handler when no mutations', () => {

--- a/packages/codegen/src/generators/client-generator.ts
+++ b/packages/codegen/src/generators/client-generator.ts
@@ -25,7 +25,9 @@ export class ClientGenerator implements Generator {
   private generateClient(ir: CodegenIR): GeneratedFile {
     const entities = ir.entities ?? [];
     const hasMutations = entities.some((e) =>
-      e.operations.some((op) => op.kind === 'update' || op.kind === 'delete'),
+      e.operations.some(
+        (op) => op.kind === 'create' || op.kind === 'update' || op.kind === 'delete',
+      ),
     );
     const manifest = generateRelationManifest(entities);
     const hasRelations = manifest.some((entry) => Object.keys(entry.schema).length > 0);
@@ -98,7 +100,7 @@ export class ClientGenerator implements Generator {
         const pascal = toPascalCase(entity.entityName);
         const camel = toCamelCase(entity.entityName);
         const entityHasMutations = entity.operations.some(
-          (op) => op.kind === 'update' || op.kind === 'delete',
+          (op) => op.kind === 'create' || op.kind === 'update' || op.kind === 'delete',
         );
         if (entityHasMutations) {
           lines.push(`    ${camel}: create${pascal}Sdk(client, optimistic),`);

--- a/packages/codegen/src/generators/entity-sdk-generator.ts
+++ b/packages/codegen/src/generators/entity-sdk-generator.ts
@@ -58,7 +58,7 @@ export class EntitySdkGenerator implements Generator {
     const hasTypes = entity.operations.some((op) => op.outputSchema || op.inputSchema);
     const hasListOp = entity.operations.some((op) => op.kind === 'list');
     const hasMutationOp = entity.operations.some(
-      (op) => op.kind === 'update' || op.kind === 'delete',
+      (op) => op.kind === 'create' || op.kind === 'update' || op.kind === 'delete',
     );
     if (hasTypes) {
       const typeImports = new Set<string>();
@@ -73,6 +73,10 @@ export class EntitySdkGenerator implements Generator {
       lines.push(
         `import type { ${[...typeImports].join(', ')} } from '../types/${entity.entityName}';`,
       );
+    }
+
+    const needsFetchImport = hasTypes || hasMutationOp || hasListOp;
+    if (needsFetchImport) {
       const fetchImportParts: string[] = ['type FetchClient'];
       if (hasListOp) fetchImportParts.push('type ListResponse');
       if (hasMutationOp) fetchImportParts.push('type OptimisticHandler');
@@ -120,7 +124,7 @@ export class EntitySdkGenerator implements Generator {
             const schemaVarName = `${(op.inputSchema ?? 'createInput').charAt(0).toLowerCase()}${(op.inputSchema ?? 'createInput').slice(1)}Schema`;
             lines.push(`    create: Object.assign(`);
             lines.push(
-              `      (body: ${inputType}) => createDescriptor('POST', '${op.path}', () => client.post<${outputType}>('${op.path}', body)),`,
+              `      (body: ${inputType}) => createMutationDescriptor('POST', '${op.path}', () => client.post<${outputType}>('${op.path}', body), { entityType: '${entity.entityName}', kind: 'create' as const, body }, optimistic),`,
             );
             lines.push(`      {`);
             lines.push(`        url: '${op.path}',`);
@@ -131,7 +135,7 @@ export class EntitySdkGenerator implements Generator {
           } else {
             lines.push(`    create: Object.assign(`);
             lines.push(
-              `      (body: ${inputType}) => createDescriptor('POST', '${op.path}', () => client.post<${outputType}>('${op.path}', body)),`,
+              `      (body: ${inputType}) => createMutationDescriptor('POST', '${op.path}', () => client.post<${outputType}>('${op.path}', body), { entityType: '${entity.entityName}', kind: 'create' as const, body }, optimistic),`,
             );
             lines.push(`      { url: '${op.path}', method: 'POST' as const },`);
             lines.push(`    ),`);


### PR DESCRIPTION
## Summary

- Wire `create()` mutations through `createMutationDescriptor` instead of plain `createDescriptor`, enabling automatic list query revalidation via `MutationEventBus` after entity creation
- Fix `client-generator.ts` to include `'create'` in mutation detection (both top-level and per-entity checks)
- Fix `entity-sdk-generator.ts` to emit `@vertz/fetch` import even when schemas are unresolved but mutation ops exist
- Remove manual `refetch()` from entity-todo example — no longer needed

## Public API Changes

### Behavioral
- Generated `create()` SDK methods now return `MutationDescriptor` instead of `QueryDescriptor`. Both implement `PromiseLike<Result<T, E>>` — no type-level break for `await` or `form()` consumers.
- After a successful `create()`, all active queries for the same entity type auto-revalidate via the `MutationEventBus`. Consumers with manual `refetch()` in `onSuccess` will see double-fetches (acceptable pre-v1).

Closes #1008

## Test plan

- [x] New test: create-only entity uses `createMutationDescriptor` with entity metadata
- [x] New test: create-only entity wires optimistic handler in client generator
- [x] Updated test: schema-less create ops verify `@vertz/fetch` import is still generated
- [x] All 202 codegen tests passing
- [x] Typecheck clean
- [x] Pre-push CI: 72/72 tasks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)