### PR TITLE
docs(rules): make autonomous phase workflow explicit

### DIFF
--- a/.claude/rules/design-and-planning.md
+++ b/.claude/rules/design-and-planning.md
@@ -51,7 +51,8 @@ Three sign-offs required before implementation:
 - [ ] Design doc updated if deviations occurred
 - [ ] Changeset added
 - [ ] Retrospective written
-- [ ] Human approves PR to main
+- [ ] PR rebased on latest `main`, pushed, and GitHub CI is green
+- [ ] Human approves PR to main (the only human interaction point)
 
 ### Bug Fix
 - **Tier 1** (internal): issue exists → failing test → fix → quality gates → review → changeset

--- a/.claude/rules/local-phase-workflow.md
+++ b/.claude/rules/local-phase-workflow.md
@@ -109,19 +109,29 @@ vertz/reviews/<feature-name>/
 
 When all phases are complete:
 
-1. Push the feature branch to GitHub
-2. Open a single PR: `feat/<feature-name>` → `main`
-3. PR description includes:
+1. Rebase the feature branch on latest `main` to ensure no conflicts
+2. Run full quality gates one final time after rebase (tests, typecheck, lint)
+3. Push the feature branch to GitHub
+4. Open a single PR: `feat/<feature-name>` → `main`
+5. PR description includes:
    - Public API Changes summary (mandatory per `pr-policies.md`)
    - Summary of all phases with links to local review files
    - E2E acceptance test status
-4. **Human (CTO) reviews and approves**
-5. Merge to main
+6. **Monitor GitHub CI** — use `gh pr checks` or `gh run list` to track CI status
+7. If CI fails: diagnose and fix locally, push again, monitor until green
+8. If `main` advances while the PR is open: rebase, re-run quality gates, force-push, monitor CI again
+9. **Only notify the human when CI is fully green and the PR is clean** — the human reviews and merges
 
 ```bash
+git fetch origin main && git rebase origin/main
+bun test && bun run typecheck && bun run lint
 git push -u origin feat/<feature-name>
 gh pr create --title "feat: <Feature Name>" --body "..."
+# Monitor CI
+gh pr checks <pr-number> --watch
 ```
+
+**The entire flow from Phase 1 through CI-green PR is autonomous.** Agents do not pause between phases or after opening the PR. The human's only interaction is reviewing and merging the final PR.
 
 ### 6. After Merge
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -5,8 +5,9 @@
 When assigned a feature with an implementation plan:
 - Execute ALL phases sequentially without waiting for user input
 - Each phase: implement → CI → self-review → fix → CI → next phase
-- Only stop after ALL phases complete and PR is opened to main
-- If blocked (ambiguous requirement, design conflict), ask the user — otherwise keep going
+- After all phases: push → open PR → monitor CI → rebase → ensure green → THEN stop
+- **The human only sees the final PR, already reviewed and CI-green.** Do not ask for input between phases.
+- If blocked (ambiguous requirement, design conflict that agents cannot resolve), ask the user — otherwise keep going
 
 ### Phase Execution
 
@@ -26,12 +27,17 @@ For each phase:
 
 ### After All Phases
 
-1. Push feature branch to origin
-2. Open PR to main with:
+1. Rebase feature branch on latest `main` to ensure it's up-to-date
+2. Run full quality gates one final time after rebase (tests, typecheck, lint)
+3. Push feature branch to origin
+4. Open PR to main with:
    - Public API Changes summary (breaking / deferred / additions vs design doc)
    - Summary of all phases
    - E2E acceptance test status
-3. **STOP** — wait for human review and approval
+5. **Monitor GitHub CI** — check PR status using `gh pr checks` or `gh run list`
+6. If CI fails on GitHub: diagnose, fix locally, push, and monitor again. Repeat until green.
+7. If `main` has advanced since the PR was opened: rebase, re-run quality gates, force-push, monitor CI again.
+8. **STOP only when GitHub CI is green and the PR is ready for review** — notify the human that the PR is ready for their review and manual merge.
 
 ## Branch Naming
 


### PR DESCRIPTION
## Summary

Clarified and strengthened the autonomous development workflow to ensure agents execute all phases without interruption and only stop when the final PR is ready for human review.

- Explicit GitHub CI monitoring, fix, and rebase steps after opening PR
- Agents push → open PR → monitor → fix → ensure green before notifying human
- Human's only interaction point is reviewing and merging the final PR
- Updated Definition of Done with CI green requirement

## Test plan

- Review the three updated rule files for clarity and completeness
- Verify the workflow sequence makes sense: no pauses between phases or after PR opening
- Confirm autonomy statement is clear: "The human only sees the final PR, already reviewed and CI-green"