### PR TITLE
feat(ui): font() default to font-display: swap [#1141]

### DIFF
--- a/.changeset/font-display-swap.md
+++ b/.changeset/font-display-swap.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui': patch
+---
+
+Change font() default font-display from 'optional' to 'swap' for better first-visit font rendering.

--- a/packages/ui/src/css/__tests__/font.test.ts
+++ b/packages/ui/src/css/__tests__/font.test.ts
@@ -13,7 +13,7 @@ describe('font()', () => {
     expect(result.family).toBe('DM Sans');
     expect(result.weight).toBe('100..1000');
     expect(result.style).toBe('normal');
-    expect(result.display).toBe('optional');
+    expect(result.display).toBe('swap');
     expect(result.src).toBe('/fonts/dm-sans.woff2');
     expect(result.fallback).toEqual([]);
     expect(result.subsets).toEqual(['latin']);
@@ -64,7 +64,7 @@ describe('compileFonts()', () => {
     expect(result.fontFaceCss).toContain("font-family: 'DM Sans'");
     expect(result.fontFaceCss).toContain('font-weight: 100 1000');
     expect(result.fontFaceCss).toContain('font-style: normal');
-    expect(result.fontFaceCss).toContain('font-display: optional');
+    expect(result.fontFaceCss).toContain('font-display: swap');
     expect(result.fontFaceCss).toContain("url(/fonts/dm-sans.woff2) format('woff2')");
   });
 

--- a/packages/ui/src/css/font.ts
+++ b/packages/ui/src/css/font.ts
@@ -22,7 +22,7 @@ export interface FontOptions {
   weight: string | number;
   /** Font style. @default 'normal' */
   style?: 'normal' | 'italic';
-  /** Font-display strategy. @default 'optional' */
+  /** Font-display strategy. @default 'swap' */
   display?: 'auto' | 'block' | 'swap' | 'fallback' | 'optional';
   /** URL path(s) for local/self-hosted fonts. */
   src?: string | FontSrc[];
@@ -75,7 +75,7 @@ export function font(family: string, options: FontOptions): FontDescriptor {
     family,
     weight: String(options.weight),
     style: options.style ?? 'normal',
-    display: options.display ?? 'optional',
+    display: options.display ?? 'swap',
     src: options.src,
     fallback: options.fallback ?? [],
     subsets: options.subsets ?? ['latin'],


### PR DESCRIPTION
## Summary

- Change `font()` default `font-display` from `'optional'` to `'swap'`
- `swap` guarantees custom fonts always render (with brief FOUT), better for first visits
- Users can still override with `display: 'optional'` for app-shell use cases

Fixes #1141

## Public API Changes

- **`font()` default behavior**: `font-display` now defaults to `'swap'` instead of `'optional'`. This means fonts will always swap in after loading, rather than being skipped if they don't load within ~100ms. Existing code that explicitly passes `display: 'optional'` is unaffected.

## Test plan

- [x] Updated test expectations for new default value
- [x] All 26 font tests pass
- [x] Typecheck clean
- [x] Full CI (72/72 tasks pass)
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)