### PR TITLE
feat(theme-shadcn): add base subpath export to reduce unused JS [#1143]

### DIFF
--- a/.changeset/theme-shadcn-base-export.md
+++ b/.changeset/theme-shadcn-base-export.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Add `@vertz/theme-shadcn/base` subpath export with `configureThemeBase()` for lightweight theme setup without bundling 38 style factories and 30+ component factories.

--- a/packages/create-vertz-app/src/__tests__/scaffold.test.ts
+++ b/packages/create-vertz-app/src/__tests__/scaffold.test.ts
@@ -284,12 +284,12 @@ describe('scaffold', () => {
       expect(content).toContain('import.meta.hot.accept()');
     });
 
-    it('generates src/styles/theme.ts with configureTheme', async () => {
+    it('generates src/styles/theme.ts with configureThemeBase', async () => {
       await scaffold(tempDir, defaultOptions);
 
       const content = await fs.readFile(projectPath('src', 'styles', 'theme.ts'), 'utf-8');
-      expect(content).toContain('configureTheme');
-      expect(content).toContain("from '@vertz/theme-shadcn'");
+      expect(content).toContain('configureThemeBase');
+      expect(content).toContain("from '@vertz/theme-shadcn/base'");
     });
 
     it('generates src/pages/home.tsx with query + form', async () => {

--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -251,10 +251,10 @@ describe('templates', () => {
   });
 
   describe('themeTemplate', () => {
-    it('uses configureTheme from @vertz/theme-shadcn', () => {
+    it('uses configureThemeBase from @vertz/theme-shadcn/base', () => {
       const result = themeTemplate();
-      expect(result).toContain('configureTheme');
-      expect(result).toContain("from '@vertz/theme-shadcn'");
+      expect(result).toContain('configureThemeBase');
+      expect(result).toContain("from '@vertz/theme-shadcn/base'");
     });
   });
 

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -751,12 +751,12 @@ mount(App, {
 }
 
 /**
- * src/styles/theme.ts — configureTheme from @vertz/theme-shadcn
+ * src/styles/theme.ts — configureThemeBase from @vertz/theme-shadcn/base
  */
 export function themeTemplate(): string {
-  return `import { configureTheme } from '@vertz/theme-shadcn';
+  return `import { configureThemeBase } from '@vertz/theme-shadcn/base';
 
-const { theme, globals } = configureTheme({
+const { theme, globals } = configureThemeBase({
   palette: 'zinc',
   radius: 'md',
 });

--- a/packages/theme-shadcn/bunup.config.ts
+++ b/packages/theme-shadcn/bunup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'bunup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/configs.ts'],
+  entry: ['src/index.ts', 'src/configs.ts', 'src/base.ts'],
   dts: true,
 });

--- a/packages/theme-shadcn/package.json
+++ b/packages/theme-shadcn/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./base": {
+      "types": "./dist/base.d.ts",
+      "import": "./dist/base.js"
+    },
     "./configs": {
       "types": "./dist/configs.d.ts",
       "import": "./dist/configs.js"

--- a/packages/theme-shadcn/src/base.ts
+++ b/packages/theme-shadcn/src/base.ts
@@ -1,0 +1,169 @@
+import type { GlobalCSSOutput, Theme } from '@vertz/ui';
+import { defineTheme, globalCss } from '@vertz/ui';
+
+import { deepMergeTokens } from './merge';
+import type { PaletteName } from './tokens';
+import { palettes } from './tokens';
+import type { PaletteTokens } from './types';
+
+/**
+ * Visual style preset. Each style applies different spacing, border-radius,
+ * colors, and visual treatment to all components.
+ *
+ * Currently only 'nova' is implemented. The architecture supports adding
+ * additional styles (e.g., 'default', 'vega', 'maia', 'mira', 'lyra')
+ * in the future — each style factory accepts this parameter.
+ */
+export type ThemeStyle = 'nova';
+
+/** Configuration options for the shadcn theme. */
+export interface ThemeConfig {
+  /** Color palette base. Default: 'zinc'. */
+  palette?: PaletteName;
+  /** Border radius preset. Default: 'md'. */
+  radius?: 'sm' | 'md' | 'lg';
+  /** Visual style preset. Default: 'nova'. */
+  style?: ThemeStyle;
+  /** Token overrides — deep-merged into the selected palette. */
+  overrides?: {
+    tokens?: {
+      colors?: Record<string, Record<string, string> | undefined>;
+    };
+  };
+}
+
+/** Return type of configureThemeBase(). */
+export interface ResolvedThemeBase {
+  /** Theme object for compileTheme(). */
+  theme: Theme;
+  /** Global CSS (reset, typography, radius). Auto-injected via globalCss(). */
+  globals: GlobalCSSOutput;
+}
+
+const RADIUS_VALUES: Record<string, string> = {
+  sm: '0.25rem',
+  md: '0.375rem',
+  lg: '0.5rem',
+};
+
+/**
+ * Configure the shadcn theme base — palette tokens and global CSS only.
+ *
+ * Use this when you only need `{ theme, globals }` without pre-built component
+ * styles or factory functions. This avoids bundling 38 style factories and 30+
+ * component factories (~161 KB) that the full `configureTheme()` from
+ * `@vertz/theme-shadcn` includes.
+ *
+ * For the full theme with styles and components, use `configureTheme()` from
+ * `@vertz/theme-shadcn`.
+ */
+export function configureThemeBase(config?: ThemeConfig): ResolvedThemeBase {
+  const palette = config?.palette ?? 'zinc';
+  const radius = config?.radius ?? 'md';
+  const baseTokens = palettes[palette];
+
+  // Apply token overrides
+  const colorOverrides = config?.overrides?.tokens?.colors ?? {};
+  const mergedTokens: PaletteTokens = deepMergeTokens(baseTokens, colorOverrides);
+
+  // Build theme via defineTheme()
+  const theme = defineTheme({ colors: mergedTokens });
+
+  // Build globals: CSS reset + base typography + radius + native form elements
+  const globals = globalCss({
+    '*, *::before, *::after': {
+      boxSizing: 'border-box',
+      margin: '0',
+      padding: '0',
+      borderWidth: '0',
+      borderStyle: 'solid',
+      borderColor: 'var(--color-border)',
+    },
+    'button, input, select, textarea': {
+      font: 'inherit',
+      color: 'inherit',
+    },
+    ':root': {
+      '--radius': RADIUS_VALUES[radius] ?? '0.375rem',
+    },
+    body: {
+      fontFamily:
+        'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+      lineHeight: '1.5',
+      color: 'var(--color-foreground)',
+      backgroundColor: 'var(--color-background)',
+    },
+    // Native checkbox — styled to match shadcn design tokens so
+    // <input type="checkbox"> looks correct without a custom component.
+    'input[type="checkbox"]': {
+      appearance: 'none',
+      width: '1rem',
+      height: '1rem',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: 'var(--color-input)',
+      borderRadius: '4px',
+      backgroundColor: 'transparent',
+      cursor: 'pointer',
+      flexShrink: '0',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      transition: 'background-color 150ms, border-color 150ms',
+      verticalAlign: 'middle',
+    },
+    'input[type="checkbox"]:checked': {
+      backgroundColor: 'var(--color-primary)',
+      borderColor: 'var(--color-primary)',
+      backgroundImage:
+        "url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e\")",
+      backgroundSize: '100% 100%',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+    },
+    'input[type="checkbox"]:focus-visible': {
+      outline: 'none',
+      borderColor: 'var(--color-ring)',
+      boxShadow: '0 0 0 3px color-mix(in oklch, var(--color-ring) 50%, transparent)',
+    },
+    'input[type="checkbox"]:disabled': {
+      pointerEvents: 'none',
+      opacity: '0.5',
+    },
+    // Native text inputs — styled to match shadcn design tokens so
+    // <input>, <input type="text">, <input type="number">, etc. look
+    // correct without applying a component class.
+    'input:not([type]), input[type="text"], input[type="number"], input[type="email"], input[type="password"], input[type="search"], input[type="tel"], input[type="url"]':
+      {
+        display: 'flex',
+        width: '100%',
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'var(--color-input)',
+        borderRadius: 'var(--radius)',
+        backgroundColor: 'transparent',
+        height: '2rem',
+        paddingLeft: '0.625rem',
+        paddingRight: '0.625rem',
+        paddingTop: '0.25rem',
+        paddingBottom: '0.25rem',
+        fontSize: '0.875rem',
+        lineHeight: '1.25rem',
+        color: 'var(--color-foreground)',
+        transition: 'border-color 150ms, box-shadow 150ms',
+      },
+    'input:not([type]):focus-visible, input[type="text"]:focus-visible, input[type="number"]:focus-visible, input[type="email"]:focus-visible, input[type="password"]:focus-visible, input[type="search"]:focus-visible, input[type="tel"]:focus-visible, input[type="url"]:focus-visible':
+      {
+        outline: '3px solid color-mix(in oklch, var(--color-ring) 50%, transparent)',
+        outlineOffset: '2px',
+        borderColor: 'var(--color-ring)',
+      },
+    'input:not([type]):disabled, input[type="text"]:disabled, input[type="number"]:disabled, input[type="email"]:disabled, input[type="password"]:disabled, input[type="search"]:disabled, input[type="tel"]:disabled, input[type="url"]:disabled':
+      {
+        pointerEvents: 'none',
+        opacity: '0.5',
+      },
+  });
+
+  return { theme, globals };
+}

--- a/packages/theme-shadcn/src/configure.ts
+++ b/packages/theme-shadcn/src/configure.ts
@@ -1,5 +1,4 @@
-import type { GlobalCSSOutput, Theme, VariantFunction } from '@vertz/ui';
-import { defineTheme, globalCss } from '@vertz/ui';
+import type { VariantFunction } from '@vertz/ui';
 import type {
   CheckboxElements,
   CheckboxOptions,
@@ -82,7 +81,6 @@ import type { TableComponents } from './components/table';
 import { createTableComponents } from './components/table';
 import type { TextareaProps } from './components/textarea';
 import { createTextareaComponent } from './components/textarea';
-import { deepMergeTokens } from './merge';
 import {
   createAccordionStyles,
   createAlertDialogStyles,
@@ -128,35 +126,11 @@ import {
   createToggleStyles,
   createTooltipStyles,
 } from './styles';
-import type { PaletteName } from './tokens';
-import { palettes } from './tokens';
-import type { PaletteTokens } from './types';
 
-/**
- * Visual style preset. Each style applies different spacing, border-radius,
- * colors, and visual treatment to all components.
- *
- * Currently only 'nova' is implemented. The architecture supports adding
- * additional styles (e.g., 'default', 'vega', 'maia', 'mira', 'lyra')
- * in the future — each style factory accepts this parameter.
- */
-export type ThemeStyle = 'nova';
+export type { ResolvedThemeBase, ThemeConfig, ThemeStyle } from './base';
 
-/** Configuration options for the shadcn theme. */
-export interface ThemeConfig {
-  /** Color palette base. Default: 'zinc'. */
-  palette?: PaletteName;
-  /** Border radius preset. Default: 'md'. */
-  radius?: 'sm' | 'md' | 'lg';
-  /** Visual style preset. Default: 'nova'. */
-  style?: ThemeStyle;
-  /** Token overrides — deep-merged into the selected palette. */
-  overrides?: {
-    tokens?: {
-      colors?: Record<string, Record<string, string> | undefined>;
-    };
-  };
-}
+import type { ResolvedThemeBase, ThemeConfig } from './base';
+import { configureThemeBase } from './base';
 
 /** Pre-built style definitions returned by configureTheme(). */
 export interface ThemeStyles {
@@ -486,135 +460,23 @@ export interface ThemeComponents {
 }
 
 /** Return type of configureTheme(). */
-export interface ResolvedTheme {
-  /** Theme object for compileTheme(). */
-  theme: Theme;
-  /** Global CSS (reset, typography, radius). Auto-injected via globalCss(). */
-  globals: GlobalCSSOutput;
+export interface ResolvedTheme extends ResolvedThemeBase {
   /** Pre-built style definitions. */
   styles: ThemeStyles;
   /** Component functions — ready-to-use themed elements. */
   components: ThemeComponents;
 }
 
-const RADIUS_VALUES: Record<string, string> = {
-  sm: '0.25rem',
-  md: '0.375rem',
-  lg: '0.5rem',
-};
-
 /**
  * Configure the shadcn theme.
  *
  * Single entry point — selects palette, applies overrides, builds globals, styles, and components.
+ *
+ * For a lightweight alternative that only returns `{ theme, globals }` without
+ * component styles, use `configureThemeBase()` from `@vertz/theme-shadcn/base`.
  */
 export function configureTheme(config?: ThemeConfig): ResolvedTheme {
-  const palette = config?.palette ?? 'zinc';
-  const radius = config?.radius ?? 'md';
-  const baseTokens = palettes[palette];
-
-  // Apply token overrides
-  const colorOverrides = config?.overrides?.tokens?.colors ?? {};
-  const mergedTokens: PaletteTokens = deepMergeTokens(baseTokens, colorOverrides);
-
-  // Build theme via defineTheme()
-  const theme = defineTheme({ colors: mergedTokens });
-
-  // Build globals: CSS reset + base typography + radius + native form elements
-  const globals = globalCss({
-    '*, *::before, *::after': {
-      boxSizing: 'border-box',
-      margin: '0',
-      padding: '0',
-      borderWidth: '0',
-      borderStyle: 'solid',
-      borderColor: 'var(--color-border)',
-    },
-    'button, input, select, textarea': {
-      font: 'inherit',
-      color: 'inherit',
-    },
-    ':root': {
-      '--radius': RADIUS_VALUES[radius] ?? '0.375rem',
-    },
-    body: {
-      fontFamily:
-        'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-      lineHeight: '1.5',
-      color: 'var(--color-foreground)',
-      backgroundColor: 'var(--color-background)',
-    },
-    // Native checkbox — styled to match shadcn design tokens so
-    // <input type="checkbox"> looks correct without a custom component.
-    'input[type="checkbox"]': {
-      appearance: 'none',
-      width: '1rem',
-      height: '1rem',
-      borderWidth: '1px',
-      borderStyle: 'solid',
-      borderColor: 'var(--color-input)',
-      borderRadius: '4px',
-      backgroundColor: 'transparent',
-      cursor: 'pointer',
-      flexShrink: '0',
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      transition: 'background-color 150ms, border-color 150ms',
-      verticalAlign: 'middle',
-    },
-    'input[type="checkbox"]:checked': {
-      backgroundColor: 'var(--color-primary)',
-      borderColor: 'var(--color-primary)',
-      backgroundImage:
-        "url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e\")",
-      backgroundSize: '100% 100%',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-    },
-    'input[type="checkbox"]:focus-visible': {
-      outline: 'none',
-      borderColor: 'var(--color-ring)',
-      boxShadow: '0 0 0 3px color-mix(in oklch, var(--color-ring) 50%, transparent)',
-    },
-    'input[type="checkbox"]:disabled': {
-      pointerEvents: 'none',
-      opacity: '0.5',
-    },
-    // Native text inputs — styled to match shadcn design tokens so
-    // <input>, <input type="text">, <input type="number">, etc. look
-    // correct without applying a component class.
-    'input:not([type]), input[type="text"], input[type="number"], input[type="email"], input[type="password"], input[type="search"], input[type="tel"], input[type="url"]':
-      {
-        display: 'flex',
-        width: '100%',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'var(--color-input)',
-        borderRadius: 'var(--radius)',
-        backgroundColor: 'transparent',
-        height: '2rem',
-        paddingLeft: '0.625rem',
-        paddingRight: '0.625rem',
-        paddingTop: '0.25rem',
-        paddingBottom: '0.25rem',
-        fontSize: '0.875rem',
-        lineHeight: '1.25rem',
-        color: 'var(--color-foreground)',
-        transition: 'border-color 150ms, box-shadow 150ms',
-      },
-    'input:not([type]):focus-visible, input[type="text"]:focus-visible, input[type="number"]:focus-visible, input[type="email"]:focus-visible, input[type="password"]:focus-visible, input[type="search"]:focus-visible, input[type="tel"]:focus-visible, input[type="url"]:focus-visible':
-      {
-        outline: '3px solid color-mix(in oklch, var(--color-ring) 50%, transparent)',
-        outlineOffset: '2px',
-        borderColor: 'var(--color-ring)',
-      },
-    'input:not([type]):disabled, input[type="text"]:disabled, input[type="number"]:disabled, input[type="email"]:disabled, input[type="password"]:disabled, input[type="search"]:disabled, input[type="tel"]:disabled, input[type="url"]:disabled':
-      {
-        pointerEvents: 'none',
-        opacity: '0.5',
-      },
-  });
+  const { theme, globals } = configureThemeBase(config);
 
   // Build style definitions (simple + primitive)
   const buttonStyles = createButton();

--- a/packages/theme-shadcn/src/index.ts
+++ b/packages/theme-shadcn/src/index.ts
@@ -1,8 +1,10 @@
 export type {
   ResolvedTheme,
+  ResolvedThemeBase,
   ThemeComponents,
   ThemeConfig,
   ThemedPrimitives,
+  ThemeStyle,
   ThemeStyles,
 } from './configure';
 export { configureTheme } from './configure';

--- a/plans/reduce-unused-client-js.md
+++ b/plans/reduce-unused-client-js.md
@@ -1,31 +1,51 @@
 # Reduce Unused JS in Client Bundles
 
 **Issue:** [#1143](https://github.com/vertz-dev/vertz/issues/1143)
-**Status:** Draft
+**Status:** In Progress
 
 ## Problem
 
-Lighthouse reports **30.5 KiB unused JavaScript** in the landing page client entry bundle (43% of 70.6 KiB transfer). The framework's client exports aren't being tree-shaken effectively.
+Lighthouse reports **32.5 KiB unused JavaScript** in the landing page client entry bundle (43.7% of 74.4 KiB transfer). The framework's client exports aren't being tree-shaken effectively.
 
 ### Root Cause Analysis
 
-**1. `@vertz/ui-primitives` single-file bundle (primary cause)**
+**1. `@vertz/theme-shadcn` monolithic `configureTheme()` (primary cause)**
 
-The package builds to a single `dist/index.js` (119 KB raw). It contains 30+ headless components (Accordion, Dialog, Select, Tooltip, etc.), but the landing page only imports `Tooltip`. Bun's bundler cannot reliably tree-shake individual component functions from a pre-bundled single file — initialization code, floating-ui setup, and JSX factory calls create implicit side effects that prevent elimination.
+The landing page calls `configureTheme()` but only uses `{ theme, globals }` — the returned `styles` (38 component style factories) and `components` (30+ component wrapper factories) are completely unused. However, `configureTheme()` eagerly imports and instantiates ALL style and component factories. The built `dist/index.js` is 161 KB raw. Since all imports are static at the module level, tree-shaking cannot eliminate unused factories — the function body references everything.
 
-Import chain: `entry-client.ts` → `app.tsx` → `HomePage` → `SchemaFlow`/`GlueCode` → `TokenLines` → `Tooltip` from `@vertz/ui-primitives`.
+Import chain: `entry-client.ts` → `app.tsx` → `theme.ts` → `configureTheme()` from `@vertz/theme-shadcn`.
 
-**2. Eager route imports (secondary cause — deferred)**
+**2. `@vertz/ui-primitives` single-file bundle (resolved — Phase 1)**
+
+Previously the package built to a single `dist/index.js` (119 KB raw). Fixed in PR #1153 by switching to multi-entry build. Single-import ratio dropped from ~100% to 16.1%.
+
+**3. Eager route imports (deferred)**
 
 `app.tsx` imports `ManifestoPage` at the top level. On the `/` route, the ManifestoPage module is loaded but never executed. The router supports lazy loading via `Promise<{ default: () => Node }>`, but **lazy routes do not SSR** — `RouterView` handles promises via `.then()` which doesn't execute before SSR serializes the DOM tree. Since ManifestoPage is content-heavy and benefits from SSR for SEO, converting it to a lazy route would be a regression. This is deferred until SSR Suspense supports async route resolution.
 
-**3. Missing `sideEffects` in some packages (not applicable)**
+**4. Missing `sideEffects` in some packages (not applicable)**
 
 13 of 28 packages lack a `sideEffects` field. However, all 13 are server-side, build-time, or CLI packages — none appear in client bundles. The client-facing packages (`@vertz/ui`, `@vertz/ui-primitives`, `@vertz/core`, `@vertz/schema`, `@vertz/fetch`, `@vertz/icons`, `@vertz/theme-shadcn`) already have correct `sideEffects` declarations.
 
 ## API Surface
 
-### `@vertz/ui-primitives` — no consumer-facing changes
+### `@vertz/theme-shadcn` — new `./base` subpath export
+
+Consumers that only need the theme definition and global CSS (no component styles/factories) import from the lightweight base entry:
+
+```ts
+// Before — pulls in all 38 style factories + 30 component factories (161 KB)
+import { configureTheme } from '@vertz/theme-shadcn';
+const { theme, globals } = configureTheme({ palette: 'zinc', radius: 'md' });
+
+// After — only palette tokens + defineTheme + globalCss (~5 KB)
+import { configureThemeBase } from '@vertz/theme-shadcn/base';
+const { theme, globals } = configureThemeBase({ palette: 'zinc', radius: 'md' });
+```
+
+The full `configureTheme()` from `@vertz/theme-shadcn` remains unchanged — apps that need `styles` and `components` keep using it. Internally, `configureTheme()` calls `configureThemeBase()` to avoid duplication.
+
+### `@vertz/ui-primitives` — no consumer-facing changes (Phase 1, done)
 
 Consumer code stays the same:
 
@@ -47,6 +67,9 @@ The multi-entry build ensures the barrel re-exports resolve to separate chunk fi
 
 ### Rejected Alternatives
 
+- **Lazy property resolution in `configureTheme()`** — Using Proxy or lazy getters for `styles`/`components` properties. Doesn't help because the bundler includes code for getter bodies regardless — tree-shaking operates at the import level, not property access level.
+- **Making `configureTheme()` accept a component list** — `configureTheme({ components: [button, tooltip] })`. Would work but changes the API for all consumers. The `./base` subpath is simpler and non-breaking.
+- **Multi-entry build for theme-shadcn** — Like ui-primitives Phase 1. Wouldn't help because `configureTheme()` imports everything in one function body. Multi-entry only helps when consumers import individual exports from a barrel.
 - **Subpath exports (`@vertz/ui-primitives/tooltip`)** — Would guarantee tree-shaking but forces import path changes on all consumers. Falls back to this if the multi-entry + barrel approach doesn't tree-shake.
 - **Manual chunk splitting in landing build script** — Would only fix the landing page, not all consumers of `@vertz/ui-primitives`.
 - **Dynamic `import()` for Tooltip** — Tooltip is used on the home page (via `TokenLines`), so lazy-loading it would cause layout shift.
@@ -62,11 +85,9 @@ The multi-entry build ensures the barrel re-exports resolve to separate chunk fi
 
 ## Unknowns
 
-1. **Does Bun's bundler tree-shake re-exports from multi-entry barrel files?** — Needs POC verification. If Bun follows the `sideEffects: false` hint and eliminates unused re-exports from `dist/index.js` → `dist/shared/chunk-*.js`, the approach works.
+1. ~~**Does Bun's bundler tree-shake re-exports from multi-entry barrel files?**~~ — **Resolved.** Phase 1 verified that esbuild tree-shakes multi-entry barrels effectively (16.1% ratio). Bun's production bundler was already tree-shaking adequately for ui-primitives.
 
-### Resolution Plan
-- Phase 1 starts with a POC: build `@vertz/ui-primitives` with multi-entry, then build the landing page and measure bundle size.
-- **Fallback:** If Bun doesn't tree-shake barrel re-exports, Phase 1 pivots to subpath exports (`@vertz/ui-primitives/tooltip`, etc.). This is a breaking change to import paths but guarantees tree-shaking. All consumers would need to update imports.
+2. **None remaining for Phase 2.** The `./base` subpath approach is a straightforward module split with no bundler-behavior unknowns.
 
 ## Type Flow Map
 
@@ -76,11 +97,22 @@ No generic type parameters introduced. The changes are purely build-configuratio
 
 ```ts
 describe('Feature: Reduced unused JS in client bundles', () => {
-  describe('Given @vertz/ui-primitives built with multi-entry', () => {
+  describe('Given @vertz/theme-shadcn/base used instead of full configureTheme', () => {
     describe('When building the landing page production bundle', () => {
-      it('Then the entry bundle size is smaller than the single-entry build', () => {
-        // Build landing page with multi-entry ui-primitives
-        // Compare total bundle size vs baseline (70.6 KiB)
+      it('Then the entry bundle is significantly smaller than with full configureTheme', () => {
+        // Build landing page with configureThemeBase
+        // Compare total bundle size vs baseline (74.4 KiB transfer)
+        // Expect substantial reduction (theme-shadcn was 56% of bundle)
+      });
+    });
+  });
+
+  describe('Given a consumer imports from @vertz/theme-shadcn (full)', () => {
+    describe('When using configureTheme()', () => {
+      it('Then styles and components are still available (no regression)', () => {
+        // configureTheme() returns { theme, globals, styles, components }
+        // All 38 style definitions present
+        // All component factories work
       });
     });
   });
@@ -109,30 +141,57 @@ describe('Feature: Reduced unused JS in client bundles', () => {
 
 ## Implementation Plan
 
-### Phase 1: `@vertz/ui-primitives` multi-entry build
+### Phase 1: `@vertz/ui-primitives` multi-entry build (DONE — PR #1153)
 
-Split the single-entry bunup config into per-component entries so the barrel file re-exports from separate chunks. This mirrors the approach already used by `@vertz/ui` (which has 9 entry points producing shared chunks).
+Split the single-entry bunup config into per-component entries so the barrel file re-exports from separate chunks. Single-import ratio dropped from ~100% to 16.1%. Merged and deployed.
+
+### Phase 2: `@vertz/theme-shadcn` base subpath export
+
+Extract the lightweight theme base logic (palette resolution, `defineTheme()`, `globalCss()`) into a separate module so consumers that only need `{ theme, globals }` don't pull in all 38 style factories and 30+ component factories.
+
+**Expected Impact:**
+- Current: 74.4 KiB transfer, 43.7% unused (32.5 KiB wasted)
+- Theme-shadcn contribution: ~41.7 KiB (56% of bundle, 161 KB raw)
+- Base-only estimate: ~5 KiB (palette tokens + defineTheme + globalCss)
+- Expected new bundle: ~37.7 KiB transfer
+- Expected unused JS: well under 25%
 
 **Changes:**
-- `packages/ui-primitives/bunup.config.ts` — Add all component source files as entries alongside the barrel `src/index.ts`
-- Verify `package.json` `exports` map still works (`.` → `dist/index.js` barrel with re-exports to chunks)
-- Build and verify the dist produces separate chunk files per component
-- Build the landing page and measure bundle size reduction
+- `packages/theme-shadcn/src/base.ts` — New module containing `configureThemeBase()`, `ThemeConfig`, `ThemeStyle`, `ResolvedThemeBase`, and `RADIUS_VALUES`. These types/values **move out of** `configure.ts` into `base.ts` to avoid pulling style factory imports. `ResolvedThemeBase` is `{ theme: Theme; globals: GlobalCSSOutput }`. `ResolvedTheme` in `configure.ts` extends `ResolvedThemeBase`.
+- `packages/theme-shadcn/src/configure.ts` — Refactor `configureTheme()` to import and call `configureThemeBase()` from `./base`. Remove duplicated palette/globals logic. Import `ThemeConfig` from `./base`. `ResolvedTheme extends ResolvedThemeBase`.
+- `packages/theme-shadcn/src/index.ts` — Re-export `ThemeConfig` via `configure.ts` (which re-exports from `./base`). No change needed if `configure.ts` re-exports the type.
+- `packages/theme-shadcn/bunup.config.ts` — Add `src/base.ts` as third entry point.
+- `packages/theme-shadcn/package.json` — Add `./base` subpath export: `{ "import": "./dist/base.js", "types": "./dist/base.d.ts" }`.
+- `sites/landing/src/styles/theme.ts` — Change import from `@vertz/theme-shadcn` to `@vertz/theme-shadcn/base`.
+- `packages/create-vertz-app/src/templates/index.ts` — Update scaffolded theme template to import from `@vertz/theme-shadcn/base` (new apps should use the lightweight import by default).
+- `tests/tree-shaking/tree-shaking.test.ts` — Add `@vertz/theme-shadcn` to packages list with alias for `@vertz/theme-shadcn/base` subpath.
 
 **Acceptance Criteria:**
 ```ts
-describe('Given @vertz/ui-primitives built with multi-entry', () => {
-  describe('When a consumer imports only Tooltip', () => {
-    it('Then the bundled output excludes Accordion, Dialog, Select, etc.', () => {
-      // Build a minimal test bundle that imports only Tooltip
-      // Verify bundle size is significantly smaller than 119 KB
+describe('Given @vertz/theme-shadcn/base subpath export', () => {
+  describe('When a consumer imports configureThemeBase from @vertz/theme-shadcn/base', () => {
+    it('Then the bundled output excludes all style factories and component factories', () => {
+      // Build a minimal test bundle that imports only configureThemeBase
+      // Verify bundle is <10% of the full configureTheme bundle
     });
   });
 
-  describe('When a consumer imports from the barrel', () => {
-    it('Then all components are still available', () => {
-      // Import { Tooltip, Dialog, Select } from '@vertz/ui-primitives'
-      // All resolve correctly
+  describe('When a consumer imports configureTheme from @vertz/theme-shadcn', () => {
+    it('Then styles and components are still available (no regression)', () => {
+      // configureTheme() returns { theme, globals, styles, components }
+      // All 38 style definitions present
+    });
+  });
+
+  describe('When building the landing page', () => {
+    it('Then the entry bundle is significantly smaller', () => {
+      // Build landing page with configureThemeBase
+      // Compare vs baseline (74.4 KiB transfer, 43.7% unused)
+    });
+
+    it('Then unused JavaScript is below 25% of total transfer', () => {
+      // Run Lighthouse or coverage analysis on built landing page
+      // Verify unused JS ratio < 25%
     });
   });
 
@@ -144,26 +203,39 @@ describe('Given @vertz/ui-primitives built with multi-entry', () => {
 });
 ```
 
-**POC gate:** After building with multi-entry, build the landing page and compare bundle size. If no meaningful reduction, pivot to subpath exports (see Fallback in Unknowns).
-
 ## Review Sign-offs
 
-### DX Review
+### Phase 1 Reviews (DONE)
+
+#### DX Review
 - **Verdict:** APPROVED
 - Barrel import preserved — zero consumer-facing changes
-- Lazy route pattern matches industry standard but correctly deferred due to SSR gap
-- Phase 3 scope inconsistency resolved (removed)
 
-### Product/Scope Review
-- **Verdict:** APPROVED (after changes)
-- Phase 2 (lazy routes) dropped due to SSR regression risk
-- Phase 3 (sideEffects) dropped — targeted packages don't appear in client bundles
-- Fallback plan added for Bun tree-shaking unknown
-- Quantitative measurement included in Phase 1 POC gate
+#### Product/Scope Review
+- **Verdict:** APPROVED
 
-### Technical Review
-- **Verdict:** APPROVED (after changes)
-- SSR + lazy routes issue resolved by deferring lazy routes entirely
-- `sideEffects` Phase 3 removed — wrong targets
+#### Technical Review
+- **Verdict:** APPROVED
 - Multi-entry build feasible (proven by `@vertz/ui`)
-- POC approach sufficient for Bun tree-shaking unknown
+
+### Phase 2 Reviews
+
+#### DX Review
+- **Verdict:** APPROVED WITH CHANGES (changes addressed)
+- `configureThemeBase` naming is adequate — JSDoc should cross-reference full `configureTheme()`
+- Must update `create-vertz-app` template to use `@vertz/theme-shadcn/base` (added to changes list)
+- No conflict with existing `./configs` subpath
+
+#### Product/Scope Review
+- **Verdict:** APPROVED WITH CHANGES (changes addressed)
+- Added explicit <25% unused JS acceptance criterion
+- Added expected impact estimate (74.4 KiB → ~37.7 KiB)
+- Scope correctly bounded, non-goals correct
+
+#### Technical Review
+- **Verdict:** APPROVED WITH CHANGES (changes addressed)
+- `ThemeConfig`, `ThemeStyle`, `RADIUS_VALUES` must be defined in `base.ts`, not imported from `configure.ts` (addressed in changes list)
+- `ResolvedTheme` should extend `ResolvedThemeBase` for proper type hierarchy (addressed)
+- No circular dependency risk confirmed
+- `sideEffects: false` works correctly with this split confirmed
+- 3 bunup entry points supported confirmed

--- a/reviews/reduce-unused-js/phase-01-multi-entry-build.md
+++ b/reviews/reduce-unused-js/phase-01-multi-entry-build.md
@@ -1,0 +1,134 @@
+# Phase 1: Multi-Entry Build for @vertz/ui-primitives
+
+- **Author:** implementation agent
+- **Reviewer:** adversarial reviewer (claude-opus-4-6)
+- **Commits:** uncommitted working tree changes
+- **Date:** 2026-03-11
+
+## Changes
+
+- `packages/ui-primitives/bunup.config.ts` (modified) — single entry `src/index.ts` replaced with 34 entries (barrel + utils + 32 components)
+- `packages/ui-primitives/package.json` (modified) — `main`, `types`, and `exports` paths updated from `dist/index.js` to `dist/src/index.js`
+- `tests/tree-shaking/tree-shaking.test.ts` (modified) — dist paths fixed for `@vertz/ui-primitives` and `@vertz/ui`, subpath aliases added, formatting cleanup
+
+## CI Status
+
+- [x] 394 ui-primitives tests pass
+- [x] 446 theme-shadcn tests pass
+- [x] Tree-shaking test: `@vertz/ui-primitives` ratio=16.1% (PASS, threshold <50%)
+- [ ] Full `dagger call ci` status unknown — not reported
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [ ] TDD compliance (tests before/alongside implementation) — **see Finding #1**
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc — barrel import preserved, no consumer-facing changes
+
+## Findings
+
+### Finding #1 (Minor): TDD compliance unclear
+
+The tree-shaking test already existed before this PR. The test was modified to fix paths (`dist/index.js` -> `dist/src/index.js`), add subpath aliases, and apply formatting. However, strict TDD requires writing a **failing test first** and then implementing. The sequence appears to have been:
+
+1. Change the build config (implementation)
+2. Fix the test paths to match the new dist structure
+
+This means the test could not have been RED first — it was broken by the implementation and then fixed to match. This is understandable for a build-config-only change where the test harness itself must be updated to locate the new dist output, but it deviates from the letter of the TDD process.
+
+**Verdict:** Acceptable for build-config changes. Not a blocker.
+
+### Finding #2 (Medium): Hardcoded entry list is fragile — new components silently skipped
+
+The `bunup.config.ts` manually lists all 34 entries. When a developer adds a new component (e.g., `src/data-table/data-table.ts`), they must remember to add it to `bunup.config.ts`. If they forget:
+
+- The component still works (it gets bundled into `dist/src/index.js` via the barrel)
+- But it ships as part of the monolithic barrel chunk, defeating tree-shaking for that component
+- No test catches this — the tree-shaking test only checks the aggregate ratio, not per-component isolation
+
+This is a **silent degradation**. The `@vertz/ui` package avoids this problem by having a small, stable set of entries (9 domain-scoped modules), but `@vertz/ui-primitives` has 32 components and will grow.
+
+**Recommendation:** Add a guard test that verifies every directory in `src/` (excluding `__tests__` and `utils/`) has a corresponding entry in `bunup.config.ts`, OR use a glob/dynamic entry list:
+
+```ts
+import { globSync } from 'node:fs';
+const componentEntries = globSync('src/*/index.ts')
+  .concat(globSync('src/*/*.ts'))
+  .filter(f => !f.includes('__tests__'));
+```
+
+**Verdict:** Not a blocker for Phase 1, but should be addressed before merging the final PR to main. The design doc already identifies this package as having 30+ components, and the team actively adds new ones.
+
+### Finding #3 (Informational): Side-effect imports in individual entries
+
+Inspecting the built output of `dist/src/tooltip/tooltip.js`:
+
+```js
+import { Tooltip } from "../../shared/chunk-fjr8m8jz.js";
+import"../../shared/chunk-0mcr52hc.js";  // floating.ts utilities
+import"../../shared/chunk-8y1jf6xr.js";  // id.ts utilities
+```
+
+The bare `import "..."` statements are side-effect-only imports. These exist because bunup/esbuild detected that `chunk-0mcr52hc.js` (floating utils) and `chunk-8y1jf6xr.js` (id utils) have module-level initialization code (e.g., `var counter = 0` in id.ts). This means importing `Tooltip` via its direct entry point still pulls in the floating and id chunks regardless of whether the consumer uses those functions.
+
+This is functionally correct — Tooltip genuinely depends on these utilities. But it's worth noting that the shared chunks create implicit coupling. If a consumer does `import { Tooltip } from '@vertz/ui-primitives'` through the barrel, the bundler resolves to the barrel's re-export, which points to the Tooltip chunk, which pulls floating + id chunks. The `sideEffects: false` in package.json tells the bundler that unused re-exports from the barrel can be eliminated, but the transitive side-effect imports within each component's chunk cannot be — they are genuine dependencies.
+
+The tree-shaking test confirms this works: 32,060B single vs 199,677B full = 16.1%. The ratio demonstrates that the **inter-component** isolation works (Tooltip doesn't pull in Accordion, Dialog, etc.), even if intra-component shared chunks remain.
+
+**Verdict:** Working as designed. No action needed.
+
+### Finding #4 (Low): `@vertz/ui` dist path fix in tree-shaking test is unrelated
+
+The diff changes `@vertz/ui` distEntry from `packages/ui/dist/index.js` to `packages/ui/dist/src/index.js`. This is not related to the `@vertz/ui-primitives` multi-entry change — it fixes a pre-existing incorrect path for `@vertz/ui` (which already uses `dist/src/` as confirmed by its `package.json`). The test was presumably passing before because the alias resolution fell back to the package.json exports field, but the explicit dist path was wrong.
+
+Similarly, the new `SUBPATH_ALIASES` for `@vertz/ui/internals`, `@vertz/core/internals`, and `@vertz/db/sql` fix pre-existing resolution failures that would have caused esbuild to either error or bundle stubs.
+
+**Verdict:** Correct fixes, but they should be called out in the commit message as a separate concern from the `@vertz/ui-primitives` multi-entry change.
+
+### Finding #5 (Informational): No Lighthouse measurement reported
+
+The design doc states the POC gate is: "After building with multi-entry, build the landing page and compare bundle size." The tree-shaking test confirms per-package isolation (16.1% ratio), but the actual Lighthouse metric (30.5 KiB unused JS → target reduction) is not reported in the results provided.
+
+**Verdict:** The tree-shaking test is a stronger, more reproducible signal than a Lighthouse measurement. However, the design doc's acceptance criteria explicitly mention comparing against the 70.6 KiB baseline. This should be verified before closing the issue.
+
+### Finding #6 (None): Breaking changes assessment
+
+Checked the `exports` field:
+- `"."` now maps to `./dist/src/index.js` (was `./dist/index.js`)
+- `"./utils"` now maps to `./dist/src/utils.js` (was `./dist/utils.js`)
+
+The `files` field includes `"dist"` so both old and new paths ship in the published package. Since the `exports` field is the resolution mechanism for modern bundlers and Node.js, and `main`/`types` are updated to match, this is correct. The change is transparent to consumers — they import from `@vertz/ui-primitives` and the `exports` map resolves it.
+
+This is consistent with how `@vertz/ui` already uses `dist/src/` paths.
+
+**Verdict:** No breaking changes. Correct.
+
+### Finding #7 (None): Security
+
+No security concerns. Build configuration changes only. No new dependencies, no user input handling, no network calls.
+
+## Summary
+
+| # | Severity | Finding | Blocker? |
+|---|----------|---------|----------|
+| 1 | Minor | TDD sequence: test fixed after implementation | No |
+| 2 | Medium | Hardcoded entry list is fragile for growing component set | No (but track) |
+| 3 | Info | Side-effect imports in individual entries are expected | No |
+| 4 | Low | `@vertz/ui` path fix and subpath aliases are unrelated to the main change | No |
+| 5 | Info | Lighthouse measurement not yet reported | No |
+| 6 | None | No breaking changes | No |
+| 7 | None | No security issues | No |
+
+## Verdict: APPROVED
+
+The changes deliver what the ticket asks for: `@vertz/ui-primitives` now builds with multi-entry, the barrel re-exports resolve to separate shared chunks, and the tree-shaking test confirms a 16.1% ratio (well under the 50% threshold). All existing tests pass. No consumer-facing API changes.
+
+**Recommended follow-ups (non-blocking):**
+1. Add a guard test for bunup entry list completeness (Finding #2) — prevents silent degradation as new components are added
+2. Run the landing page Lighthouse measurement to close the design doc's POC gate (Finding #5)
+3. Consider splitting the `@vertz/ui` path fix and subpath aliases into a separate commit for clarity (Finding #4)
+
+## Resolution
+
+Pending author response to findings.

--- a/reviews/reduce-unused-js/phase-02-theme-base-export.md
+++ b/reviews/reduce-unused-js/phase-02-theme-base-export.md
@@ -1,0 +1,54 @@
+# Phase 2: theme-shadcn base subpath export
+
+- **Author:** Claude Opus 4.6
+- **Reviewer:** Claude Opus 4.6 (adversarial)
+- **Date:** 2026-03-11
+
+## Changes
+
+- packages/theme-shadcn/src/base.ts (new)
+- packages/theme-shadcn/src/configure.ts (modified)
+- packages/theme-shadcn/src/index.ts (modified)
+- packages/theme-shadcn/bunup.config.ts (modified)
+- packages/theme-shadcn/package.json (modified)
+- sites/landing/src/styles/theme.ts (modified)
+- packages/create-vertz-app/src/templates/index.ts (modified)
+- packages/create-vertz-app/src/templates/__tests__/templates.test.ts (modified)
+- packages/create-vertz-app/src/__tests__/scaffold.test.ts (modified)
+- tests/tree-shaking/tree-shaking.test.ts (modified)
+- plans/reduce-unused-client-js.md (modified)
+
+## CI Status
+
+- [x] `bun run build` passed (theme-shadcn)
+- [x] `bun run typecheck` passed (theme-shadcn, create-vertz-app, landing)
+- [x] `bun run lint` passed
+- [x] Tree-shaking test passed (13.5% ratio)
+- [x] Template tests passed (62/62)
+- [x] Scaffold tests passed (34/34)
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (tests updated for template changes, tree-shaking test extended)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc
+
+## Findings
+
+### Approved
+
+1. **Module split is correct** — `base.ts` imports only lightweight deps (palette tokens, merge, defineTheme, globalCss). Zero style/component factory imports.
+2. **Type chain is clean** — `ResolvedTheme extends ResolvedThemeBase`, types re-exported correctly through the chain.
+3. **All consumers accounted for** — landing page, create-vertz-app template, examples (unchanged, still use full import).
+4. **Build output correct** — `dist/base.js` (100B) re-exports from shared chunk (19KB). Full `dist/index.js` dropped from 161KB to 142KB.
+5. **Bundle reduction verified** — landing page: 293KB → 161KB raw, ~74KB → ~43KB gzipped.
+
+### Minor (non-blocking)
+
+- No dedicated `base.test.ts` unit test. Logic is covered transitively via existing `configure.test.ts` tests + tree-shaking test. Acceptable.
+
+## Resolution
+
+No changes needed.

--- a/sites/landing/src/styles/theme.ts
+++ b/sites/landing/src/styles/theme.ts
@@ -1,7 +1,7 @@
-import { configureTheme } from '@vertz/theme-shadcn';
+import { configureThemeBase } from '@vertz/theme-shadcn/base';
 import { font, type Theme } from '@vertz/ui';
 
-const { theme, globals } = configureTheme({
+const { theme, globals } = configureThemeBase({
   palette: 'zinc',
   radius: 'md',
 });

--- a/tests/tree-shaking/tree-shaking.test.ts
+++ b/tests/tree-shaking/tree-shaking.test.ts
@@ -83,6 +83,11 @@ const PACKAGES: { name: string; singleImport: string; distEntry: string }[] = [
     singleImport: `import { MoonIcon } from '@vertz/icons'; console.log(MoonIcon);`,
     distEntry: 'packages/icons/dist/index.js',
   },
+  {
+    name: '@vertz/theme-shadcn',
+    singleImport: `import { configureThemeBase } from '@vertz/theme-shadcn/base'; console.log(configureThemeBase);`,
+    distEntry: 'packages/theme-shadcn/dist/index.js',
+  },
 ];
 
 /**
@@ -96,6 +101,7 @@ const SUBPATH_ALIASES: Record<string, string> = {
   '@vertz/ui/internals': 'packages/ui/dist/src/internals.js',
   '@vertz/core/internals': 'packages/core/dist/internals.js',
   '@vertz/db/sql': 'packages/db/dist/sql/index.js',
+  '@vertz/theme-shadcn/base': 'packages/theme-shadcn/dist/base.js',
 };
 
 const aliases: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Add `@vertz/theme-shadcn/base` subpath export with `configureThemeBase()` — returns only `{ theme, globals }` without importing 38 style factories and 30+ component factories
- Landing page switches to the lightweight import, dropping the client bundle from **293 KB → 161 KB raw** (~74 KB → ~43 KB gzipped)
- Update `create-vertz-app` template so new apps use the lightweight import by default
- Add `@vertz/theme-shadcn` to tree-shaking test suite (13.5% ratio — well under 50% threshold)

## Public API Changes

### Additions
- `@vertz/theme-shadcn/base` — new subpath export with `configureThemeBase(config?: ThemeConfig): ResolvedThemeBase`
- `ResolvedThemeBase` type — `{ theme: Theme; globals: GlobalCSSOutput }`
- `ResolvedTheme` now extends `ResolvedThemeBase`

### No breaking changes
- `configureTheme()` from `@vertz/theme-shadcn` is unchanged — internally delegates to `configureThemeBase()`

## Context

Follow-up to PR #1153 (ui-primitives multi-entry build). Lighthouse still showed 43.7% unused JS after Phase 1. Root cause analysis revealed `@vertz/theme-shadcn` was 56% of the bundle (161 KB raw) — the landing page calls `configureTheme()` but only uses `{ theme, globals }`, while all 38 style factories and 30+ component factories were eagerly imported.

Design doc: `plans/reduce-unused-client-js.md`

## Test plan

- [x] Tree-shaking test: `@vertz/theme-shadcn` base import is 13.5% of full bundle (50 KB vs 373 KB)
- [x] `bun run build` — theme-shadcn builds with 3 entry points (index, configs, base)
- [x] `bun run typecheck` — theme-shadcn, create-vertz-app, landing all pass
- [x] Template tests pass (62/62)
- [x] Scaffold tests pass (34/34)
- [x] Landing page builds successfully with new import
- [x] All quality gates pass (76/76 turbo tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)