### PR TITLE
chore(ci): exclude Next.js sites from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build packages
-        run: bunx turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example'
+        run: bunx turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel'
 
       - name: Run tests with coverage
         env:

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "lint:fix": "biome check --fix packages/",
     "format": "biome format packages/",
     "format:fix": "biome format --fix packages/",
-    "ci": "turbo run lint build typecheck test --filter='!@vertz-examples/*' --filter='!entity-todo-example' && turbo run build typecheck test --filter='@vertz-examples/task-manager'",
-    "ci:affected": "turbo run lint build typecheck test --filter=...[origin/main] --filter='!@vertz-examples/*' --filter='!entity-todo-example' && turbo run build typecheck test --filter='@vertz-examples/task-manager'",
+    "ci": "turbo run lint build typecheck test --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' && turbo run build typecheck test --filter='@vertz-examples/task-manager'",
+    "ci:affected": "turbo run lint build typecheck test --filter=...[origin/main] --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' && turbo run build typecheck test --filter='@vertz-examples/task-manager'",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "bun run build && bash scripts/publish.sh",
     "postinstall": "if [ \"$(git rev-parse --git-dir 2>/dev/null)\" = \"$(git rev-parse --git-common-dir 2>/dev/null)\" ]; then lefthook install || true; fi",
     "test:tree-shaking": "bun test tests/tree-shaking/tree-shaking.test.ts",
-    "build": "turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example'"
+    "build": "turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel'"
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.3.0",


### PR DESCRIPTION
## Summary

- Exclude `@vertz/landing-nextjs` and `@vertz/landing-nextjs-vercel` from the CI pipeline
- These are benchmarking sites using Next.js tooling — their build failures block unrelated PRs

## Changes

Added `--filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel'` to:
- `ci` script (root package.json)
- `ci:affected` script (root package.json)
- `build` script (root package.json)
- Coverage job's build step (`.github/workflows/ci.yml`)

## Public API Changes

None.

## Test plan

- [x] Local pre-push quality gates pass (76 tasks)
- [x] `@vertz/landing` (Bun-based site) is still included in CI
- [x] Only the Next.js benchmark clones are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)