### PR TITLE
docs(plans): add package runtime hardening plan

### DIFF
--- a/MAP.md
+++ b/MAP.md
@@ -177,6 +177,8 @@
 
 | Doc | Status | Description |
 |-----|--------|-------------|
+| [Package Distribution & Runtime Hardening](plans/package-runtime-hardening.md) | 📋 Draft | Cross-package hardening for package exports, runtime coverage, CI/task inputs, auth integrity, and CLI/compiler integration. |
+| [Package Distribution & Runtime Hardening Implementation](plans/package-runtime-hardening-implementation.md) | 📋 Draft | Vertical-slice implementation plan for package/runtime hardening. |
 | [Design Inventory](plans/DESIGN-INVENTORY.md) | ✅ Done | 91 documents catalogued |
 | [Release Automation](plans/release-automation.md) | 📋 Draft | Release workflow |
 | [Turborepo Migration](plans/turborepo-migration.md) | 📋 Draft | Build migration |

--- a/plans/package-runtime-hardening-implementation.md
+++ b/plans/package-runtime-hardening-implementation.md
@@ -1,0 +1,291 @@
+# Package Distribution & Runtime Hardening — Implementation Plan
+
+**Design doc:** [plans/package-runtime-hardening.md](./package-runtime-hardening.md)
+**Package focus:** `vertz`, `@vertz/ui-primitives`, `@vertz/create-vertz-app`, `@vertz/cloudflare`, `@vertz/integration-tests`, `@vertz/server`, `@vertz/db`, `@vertz/cli`
+
+---
+
+## Architecture Decisions
+
+| Area | Decision | Why |
+|---|---|---|
+| Meta-package exports | `vertz/*` points at built `dist/**` JS and `.d.ts`, not source `.ts` | Published packages must run under standard Node resolution |
+| Task invalidation | Turbo task inputs include `src/**`, `tests/**`, `__tests__/**`, `bin/**`, and other package-local executable inputs | CI/cache correctness is more important than overly optimistic cache hits |
+| Scaffold package gates | `@vertz/create-vertz-app` exposes `build`, `test`, and `typecheck` like other published packages | Prevents silent CI blind spots |
+| Runtime coverage | Cloudflare uses the shared `RuntimeAdapter` contract instead of bespoke one-off tests | Keeps runtime parity visible in one place |
+| Auth integrity | Multi-statement auth plan writes require a transaction-capable DB boundary before server changes land | Prevents partial writes on PostgreSQL |
+| UI build integration | CLI `build-ui` stage should call a real `@vertz/ui-compiler` contract, not own bundling outright | Closes the seam without over-scoping the phase |
+
+---
+
+## Dependency Map
+
+```txt
+Phase 1: Release correctness foundation
+  |
+  +--> Phase 2: Runtime adapter coverage
+  |
+  +--> Phase 3: Auth/Postgres integrity
+  |
+  '--> Phase 4: UI packaging + CLI compiler integration
+```
+
+- **Phase 1** is the first vertical slice and the hard prerequisite for the others.
+- **Phase 2** depends on Phase 1 because the meta-package/runtime contract must be stable first.
+- **Phase 3** can start after Phase 1.
+- **Phase 4** can start after Phase 1 and the CLI integration POC.
+
+---
+
+## Phase 1: Release Correctness Foundation
+
+**Goal:** make published packages and repo gates truthful before deeper runtime work.
+
+**What it implements**
+
+- move `vertz/*` exports to built artifacts
+- add build output and typecheck coverage for the `vertz` meta-package
+- expand Turbo task inputs so test-only changes invalidate cache
+- add `test` and `typecheck` scripts to `@vertz/create-vertz-app`
+
+### Files
+
+- `packages/vertz/package.json`
+- `packages/vertz/tsconfig.json`
+- `packages/vertz/__tests__/subpath-exports.test.ts`
+- `packages/vertz/src/*.ts`
+- `packages/create-vertz-app/package.json`
+- `packages/create-vertz-app/src/__tests__/*`
+- `turbo.json`
+
+### TDD cycles
+
+1. **RED:** Node consumer import of `vertz/server` fails because exports point to `.ts`
+   **GREEN:** build `vertz` subpath artifacts and update exports to `dist/**`
+
+2. **RED:** `vertz` subpath type surface drifts from the underlying packages
+   **GREEN:** add type-level smoke coverage for representative subpaths
+
+3. **RED:** changing `packages/cloudflare/tests/handler.test.ts` or `packages/vertz/__tests__/subpath-exports.test.ts` does not invalidate Turbo `test`
+   **GREEN:** widen Turbo `test` inputs
+
+4. **RED:** `@vertz/create-vertz-app` cannot run standard `test` / `typecheck`
+   **GREEN:** add scripts and wire them into package validation
+
+### Integration acceptance
+
+- Integration test: Node 22 runs a minimal `vertz/server` consumer without TS loader hacks
+- Type integration: `vertz/server`, `vertz/schema`, and `vertz/cloudflare` resolve through typecheck
+- Cache correctness test: editing an out-of-`src` test file causes the package `test` task to rerun
+- Package gate: `cd packages/create-vertz-app && bun run test && bun run typecheck` succeeds
+
+### Phase gate
+
+- `bun test packages/vertz/__tests__/subpath-exports.test.ts`
+- `cd packages/create-vertz-app && bun run test`
+- `cd packages/create-vertz-app && bun run typecheck`
+- `bun run --filter vertz test`
+- `bunx biome check packages/vertz packages/create-vertz-app turbo.json`
+
+### Review artifact
+
+- `reviews/package-runtime-hardening/phase-01-release-correctness.md`
+
+---
+
+## Phase 2: Runtime Adapter Coverage
+
+**Goal:** validate that supported runtime surfaces are actually symmetric.
+
+**What it implements**
+
+- add a Cloudflare runtime adapter to the integration harness
+- add runtime smoke tests for `@vertz/cloudflare` and `vertz/cloudflare`
+- ensure runtime selection rejects unsupported values cleanly
+
+### Files
+
+- `packages/integration-tests/src/runtime-adapters/index.ts`
+- `packages/integration-tests/src/runtime-adapters/cloudflare.ts`
+- `packages/integration-tests/src/runtime-adapters/cloudflare.test.ts`
+- `packages/integration-tests/src/runtime-adapters/types.ts`
+- `packages/integration-tests/package.json`
+- `packages/cloudflare/tests/handler.test.ts`
+- `packages/vertz/__tests__/subpath-exports.test.ts`
+
+### TDD cycles
+
+1. **RED:** `RUNTIME=cloudflare` is rejected as unknown
+   **GREEN:** add `cloudflare` to the adapter map and contract
+
+2. **RED:** Cloudflare adapter can compile but not satisfy the shared runtime harness
+   **GREEN:** implement the thinnest compliant adapter/harness
+
+3. **RED:** `vertz/cloudflare` re-export path is not exercised in runtime tests
+   **GREEN:** add smoke coverage through the meta-package surface
+
+4. **RED:** unsupported runtime values fail unclearly
+   **GREEN:** tighten error expectations and coverage
+
+### Integration acceptance
+
+- Integration test: Cloudflare adapter serves a request through the shared runtime contract
+- Integration test: `vertz/cloudflare` matches `@vertz/cloudflare` at runtime
+- Integration test: invalid `RUNTIME` values fail with an explicit error
+
+### Phase gate
+
+- `bun test packages/integration-tests/src/runtime-adapters`
+- `bun test packages/cloudflare/tests/handler.test.ts`
+- `bun test packages/vertz/__tests__/subpath-exports.test.ts`
+- `bun run --filter @vertz/integration-tests typecheck`
+- `bunx biome check packages/integration-tests/src/runtime-adapters packages/cloudflare/tests`
+
+### Review artifact
+
+- `reviews/package-runtime-hardening/phase-02-runtime-adapters.md`
+
+---
+
+## Phase 3: Auth/Postgres Integrity
+
+**Goal:** remove the known transactional correctness gap in auth plan writes.
+
+**What it implements**
+
+- introduce or expose a transaction-capable DB boundary for auth plan operations
+- update `AuthDbClient` / `DbPlanStore` to perform plan + override changes atomically
+- close the SQLite-only assumption in auth plan persistence
+- add failure-injection tests for PostgreSQL behavior
+
+### Files
+
+- `packages/db/src/core/db-provider.ts`
+- `packages/db/src/client/*`
+- `packages/server/src/auth/db-types.ts`
+- `packages/server/src/auth/db-plan-store.ts`
+- `packages/server/src/auth/__tests__/plan-store.test.ts`
+- `packages/server/src/auth/__tests__/shared-plan-store.tests.ts`
+- `packages/integration-tests/src/**/auth-*.test.ts`
+
+### TDD cycles
+
+1. **RED:** forced failure between plan upsert and override clear leaves partially applied auth state
+   **GREEN:** wrap the write path in a transaction
+
+2. **RED:** PostgreSQL auth path cannot access the required transaction surface
+   **GREEN:** expose the minimal transaction boundary from `@vertz/db`
+
+3. **RED:** rollback path still leaks intermediate changes
+   **GREEN:** add rollback coverage and tighten store behavior
+
+4. **RED:** type-level auth DB contract does not flow through updated store surface
+   **GREEN:** add type regression coverage for the new boundary
+
+### Integration acceptance
+
+- Integration test: PostgreSQL failure injection rolls back plan + override mutation
+- Integration test: successful plan change still clears overrides as designed
+- Type test: transaction-capable auth DB surface compiles end-to-end
+
+### Phase gate
+
+- `bun test packages/server/src/auth/__tests__/plan-store.test.ts`
+- `bun test packages/server/src/auth/__tests__/shared-plan-store.tests.ts`
+- `bun run --filter @vertz/server typecheck`
+- `bun run --filter @vertz/db typecheck`
+- `bunx biome check packages/server/src/auth packages/db/src`
+
+### Review artifact
+
+- `reviews/package-runtime-hardening/phase-03-auth-postgres-integrity.md`
+
+---
+
+## Phase 4: UI Packaging + CLI Compiler Integration
+
+**Goal:** close the remaining performance and integration seams exposed by the audit.
+
+**What it implements**
+
+- make `@vertz/ui-primitives` metadata match its emitted shared-chunk build
+- add tree-shaking regression coverage for the package metadata choice
+- replace the CLI `build-ui` placeholder with a real `@vertz/ui-compiler` integration path
+
+### Files
+
+- `packages/ui-primitives/package.json`
+- `packages/ui-primitives/bunup.config.ts`
+- `packages/ui-primitives/src/__tests__/*`
+- `tests/tree-shaking/tree-shaking.test.ts`
+- `packages/cli/src/pipeline/orchestrator.ts`
+- `packages/cli/src/pipeline/__tests__/*`
+- `packages/ui-compiler/src/*`
+
+### TDD cycles
+
+1. **RED:** tree-shaking regression test emits ignored-bare-import warnings for `@vertz/ui-primitives`
+   **GREEN:** align build output and `sideEffects` metadata
+
+2. **RED:** importing a single primitive regresses bundle ratio after metadata fix
+   **GREEN:** preserve the existing bundle-size thresholds while removing unsafe warnings
+
+3. **RED:** CLI `build-ui` stage reports success without invoking compiler work
+   **GREEN:** wire the thinnest real `ui-compiler` contract into the stage
+
+4. **RED:** CLI pipeline tests still accept placeholder behavior
+   **GREEN:** update pipeline assertions to require real compiler interaction
+
+### Integration acceptance
+
+- Tree-shaking test: `@vertz/ui-primitives` single-import bundle passes without ignored-bare-import warnings
+- CLI integration test: `build-ui` fails when compiler work fails and succeeds when compiler output is produced
+- Cross-package test: CLI uses `@vertz/ui-compiler` through a stable contract
+
+### Phase gate
+
+- `bun run test:tree-shaking`
+- `bun test packages/cli/src/pipeline`
+- `bun run --filter @vertz/cli typecheck`
+- `bun run --filter @vertz/ui-primitives typecheck`
+- `bun run --filter @vertz/ui-compiler typecheck`
+- `bunx biome check packages/cli/src/pipeline packages/ui-primitives packages/ui-compiler`
+
+### Review artifact
+
+- `reviews/package-runtime-hardening/phase-04-ui-packaging-and-cli.md`
+
+---
+
+## Developer Walkthrough
+
+Write this walkthrough as a failing integration spec in Phase 1 and keep it green through all later phases.
+
+1. Start from a clean Node 22 project.
+2. Install `vertz`.
+3. Create `server.mjs` with `import { createServer } from 'vertz/server'` and a minimal schema import from `vertz/schema`.
+4. Run the file with Node and confirm the import surface works without a TS loader.
+5. In a minimal UI app, import `Tooltip` from `@vertz/ui-primitives`, build the app, and confirm the bundle completes without ignored-bare-import warnings.
+6. In the repo, run the runtime adapter suite with `RUNTIME=cloudflare` and confirm a request succeeds through the Cloudflare adapter path.
+7. In an auth integration test against PostgreSQL, simulate a mid-transaction failure and confirm the tenant plan state remains unchanged.
+8. Run `vertz build` and confirm the UI stage performs real compiler work rather than returning a placeholder success.
+
+---
+
+## Phase Review Rules
+
+- After each phase, run the full required gates for the changed packages plus any integration tests listed above.
+- A different bot reviews the phase and writes the corresponding file under `reviews/package-runtime-hardening/`.
+- If a phase reveals a design deviation:
+  - public package/import behavior changes -> josh re-approves
+  - scope/timeline expands materially -> pm re-approves
+  - internal-only implementation detail -> mike decides whether the design doc needs updating
+
+---
+
+## Suggested Execution Order
+
+1. Finish Phase 1 first. It gives immediate end-to-end value and makes later validation trustworthy.
+2. Run the Cloudflare and CLI POCs before Phase 2 / Phase 4.
+3. Execute Phases 2 and 3 in parallel if bandwidth allows.
+4. Finish with Phase 4 once packaging and runtime correctness are stable.

--- a/plans/package-runtime-hardening.md
+++ b/plans/package-runtime-hardening.md
@@ -1,0 +1,190 @@
+# Design Doc: Package Distribution & Runtime Hardening
+
+**Status:** Draft
+**Author:** mike
+**Feature:** Package Distribution & Runtime Hardening
+
+## 1. API Surface
+
+This feature is cross-cutting, but it still changes developer-visible behavior in concrete ways.
+
+### 1.1 `vertz/*` subpath imports resolve to built JavaScript
+
+Consumer code stays the same:
+
+```ts
+import { createServer } from 'vertz/server';
+import { s } from 'vertz/schema';
+```
+
+After this change:
+
+- the published `vertz` meta-package points subpath exports at built JS artifacts, not raw `.ts` source files
+- Node 22 consumers do not need a TypeScript-aware loader to import `vertz/server`
+- types still resolve through the same subpath surface
+
+### 1.2 `@vertz/ui-primitives` barrel imports remain stable but become packaging-safe
+
+Consumer code stays the same:
+
+```ts
+import { Tooltip } from '@vertz/ui-primitives';
+```
+
+After this change:
+
+- bundlers no longer warn that shared chunks can be dropped incorrectly
+- the package metadata matches the actual emitted build structure
+- tree-shaking remains effective without relying on unsafe `sideEffects` claims
+
+### 1.3 Scaffold packages participate in the same quality gates as the rest of the repo
+
+Scaffold package behavior stays the same for consumers:
+
+```bash
+bunx @vertz/create-vertz-app my-app
+```
+
+After this change:
+
+- `@vertz/create-vertz-app` exposes `test` and `typecheck` scripts
+- repo-level CI and local phase gates can validate it consistently
+- package-local test files are no longer invisible to the standard workflow
+
+### 1.4 Runtime adapter coverage includes Cloudflare
+
+The integration harness gains a first-class Cloudflare runtime target alongside Node, Bun, and Deno.
+
+```bash
+RUNTIME=cloudflare bun test packages/integration-tests/src/runtime-adapters
+```
+
+After this change:
+
+- `@vertz/cloudflare` is exercised through the same adapter contract as the other runtimes
+- `vertz/cloudflare` re-export behavior is covered by runtime-level smoke tests
+- runtime adapter drift is caught before release
+
+### 1.5 Auth plan persistence becomes atomic across supported databases
+
+Developer-facing auth API stays the same:
+
+```ts
+await planStore.assignPlan('org-1', 'pro');
+```
+
+After this change:
+
+- multi-statement auth plan mutations are transactional on PostgreSQL
+- the auth layer no longer relies on SQLite-only write serialization assumptions
+- failure injection leaves plan state unchanged instead of partially applied
+
+### 1.6 The CLI build pipeline closes the `ui-compiler` integration gap
+
+The developer command stays the same:
+
+```bash
+vertz build
+```
+
+After this change:
+
+- the UI build stage no longer returns a placeholder success without compiler work
+- the CLI and `@vertz/ui-compiler` share a real contract instead of a TODO seam
+- component-level build optimizations become available through the first-party build path
+
+## 2. Manifesto Alignment
+
+**Predictability over convenience:** publishing raw `.ts` through `vertz/*` works only in toolchains that quietly transpile dependencies. That is convenient for the repo and unpredictable for users.
+
+**Compile-time over runtime:** package exports, task inputs, and runtime adapter contracts should fail in CI before users discover them in production.
+
+**Explicit over implicit:** `sideEffects`, `exports`, task inputs, and transaction boundaries are packaging contracts. They must describe reality, not optimistic intent.
+
+**LLM-first:** this work reduces invisible seams that agents guess wrong today: whether `vertz/server` is runnable under Node, whether a test file change invalidates Turbo cache, whether `vertz build` actually invokes the UI compiler, and whether runtime adapters are symmetric.
+
+## 3. Non-Goals
+
+- Redesigning the public `vertz` API surface beyond fixing distribution correctness
+- Replacing Bun as the primary toolchain for scaffolders or package builds
+- Rewriting the full Cloudflare adapter architecture
+- Reworking the entire auth subsystem beyond transactional integrity for plan persistence
+- General package-docs cleanup for every workspace package in this pass
+- Broad UI runtime optimization unrelated to the audited packaging/build gaps
+
+## 4. Unknowns
+
+1. **Cloudflare integration harness shape** — **Needs POC**
+   - We need the smallest reliable local runtime for adapter tests.
+   - Candidate directions: contract-level worker simulation, Miniflare/workerd-based execution, or a narrower adapter conformance layer.
+
+2. **Transaction surface for auth plan writes** — **Discussion-resolvable, possibly POC**
+   - If `DatabaseClient` already exposes enough internals for a safe transaction helper, we should reuse it.
+   - If not, we may need a small transaction abstraction at the `@vertz/db` boundary before touching auth stores.
+
+3. **CLI ↔ `ui-compiler` integration boundary** — **Needs POC**
+   - The CLI currently delegates the UI stage to Vite.
+   - We need to confirm the thinnest compiler invocation that improves correctness/perf without accidentally owning the entire app bundling story in one pass.
+
+## 5. POC Results
+
+No POCs completed yet.
+
+Required POCs before implementation:
+
+- Cloudflare runtime adapter harness POC
+- CLI `ui-compiler` stage integration POC
+
+## 6. Type Flow Map
+
+This feature is mostly packaging/runtime hardening. It does not introduce a major new public generic surface, but it does create type flow that must be verified end-to-end.
+
+### 6.1 Meta-package subpath typing
+
+```txt
+packages/vertz/package.json exports -> dist subpath entry -> dist .d.ts -> consumer import('vertz/server')
+```
+
+Acceptance criteria:
+
+- `vertz/server` resolves to built JS at runtime
+- `vertz/server` resolves to the correct `.d.ts` surface at typecheck time
+
+### 6.2 Runtime adapter selection
+
+```txt
+RUNTIME literal -> runtime-adapters/index.ts -> selected adapter module -> RuntimeAdapter contract -> integration test harness
+```
+
+Acceptance criteria:
+
+- adding `cloudflare` extends the adapter union cleanly
+- positive and negative coverage exists for runtime selection
+
+### 6.3 Transaction-capable auth DB boundary
+
+```txt
+Database transaction surface -> AuthDbClient -> DbPlanStore.assignPlan() -> auth access/session evaluation
+```
+
+Acceptance criteria:
+
+- auth plan writes compile against the transaction-capable DB boundary
+- failure-path tests prove the boundary reaches the consumer-observable auth result
+
+## 7. E2E Acceptance Tests
+
+1. **Meta-package runtime:** in a clean Node 22 project, `import { createServer } from 'vertz/server'` runs without a TypeScript loader.
+2. **Meta-package typing:** a `.test-d.ts` or integration typecheck proves `vertz/server`, `vertz/schema`, and `vertz/cloudflare` expose the same public types as the underlying packages.
+3. **Turbo correctness:** changing only a test outside `src/` invalidates the cached `test` task and reruns the package tests.
+4. **Scaffolder gates:** `@vertz/create-vertz-app` participates in repo-level `test` and `typecheck` workflows.
+5. **Cloudflare runtime:** the integration runtime harness can boot a Vertz handler through the Cloudflare adapter and serve a request successfully.
+6. **UI package metadata:** a single-import bundle of `@vertz/ui-primitives` completes without ignored-bare-import side-effect warnings.
+7. **Auth integrity:** when a forced failure occurs mid-plan-assignment on PostgreSQL, the tenant’s plan/override state remains atomic.
+8. **CLI integration:** `vertz build` exercises a real `ui-compiler` stage instead of returning a placeholder success.
+
+## 8. Review Sign-Offs Needed
+
+- **DX:** josh reviews the consumer-facing package/import behavior and CLI/build ergonomics.
+- **Product/Scope:** pm reviews the scope split, especially the decision to keep this narrowly on audited hardening items.
+- **Technical Feasibility:** one engineer reviews the transaction boundary, Cloudflare harness, and packaging/build changes.


### PR DESCRIPTION
## Summary

- Adds design doc for package distribution & runtime hardening (`plans/package-runtime-hardening.md`)
- Adds 4-phase implementation plan (`plans/package-runtime-hardening-implementation.md`)
- Updates `MAP.md` with links to both documents

The design doc covers cross-cutting hardening for: meta-package exports (vertz/*), runtime adapter coverage (Cloudflare), auth/Postgres transactional integrity, UI packaging metadata, and CLI compiler integration.

The implementation plan splits this into 4 vertical phases:
1. **Release correctness foundation** — fix vertz/* exports, Turbo task inputs, scaffold gates
2. **Runtime adapter coverage** — Cloudflare adapter in integration harness
3. **Auth/Postgres integrity** — atomic plan writes with transaction boundary
4. **UI packaging + CLI compiler integration** — sideEffects metadata, real compiler stage

## Public API Changes

No public API changes — this PR adds planning documents only.

## Test plan

- [x] No code changes, only markdown docs
- [x] Quality gates pass (all cached, no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)