### PR TITLE
fix(ui-primitives): align sideEffects metadata with shared-chunk build [#1160]

### DIFF
--- a/.changeset/fix-ui-primitives-tree-shaking.md
+++ b/.changeset/fix-ui-primitives-tree-shaking.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Fix `sideEffects` metadata to declare shared chunks as side-effectful, eliminating `ignored-bare-import` warnings during tree-shaking. Add regression test that fails on these warnings.

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -48,5 +48,7 @@
   "engines": {
     "node": ">=22"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./dist/shared/*.js"
+  ]
 }

--- a/tests/tree-shaking/tree-shaking.test.ts
+++ b/tests/tree-shaking/tree-shaking.test.ts
@@ -109,7 +109,12 @@ const aliases: Record<string, string> = {
   ...Object.fromEntries(Object.entries(SUBPATH_ALIASES).map(([k, v]) => [k, path.join(ROOT, v)])),
 };
 
-async function bundleSize(code: string, name: string): Promise<number> {
+interface BundleResult {
+  size: number;
+  warnings: esbuild.Message[];
+}
+
+async function bundleWithWarnings(code: string, name: string): Promise<BundleResult> {
   const entry = path.join(TMP, `${name}.ts`);
   fs.writeFileSync(entry, code);
   const result = await esbuild.build({
@@ -124,7 +129,12 @@ async function bundleSize(code: string, name: string): Promise<number> {
     alias: aliases,
     minify: false,
   });
-  return result.outputFiles[0].contents.byteLength;
+  return { size: result.outputFiles[0].contents.byteLength, warnings: result.warnings };
+}
+
+async function bundleSize(code: string, name: string): Promise<number> {
+  const { size } = await bundleWithWarnings(code, name);
+  return size;
 }
 
 beforeAll(() => {
@@ -164,4 +174,20 @@ describe('tree-shaking', () => {
       ).toBeLessThan(MAX_RATIO);
     });
   }
+});
+
+describe('tree-shaking warnings', () => {
+  it('@vertz/ui-primitives — single import builds without ignored-bare-import warnings', async () => {
+    const pkg = PACKAGES.find((p) => p.name === '@vertz/ui-primitives');
+    if (!pkg) throw new Error('missing @vertz/ui-primitives in PACKAGES');
+    const safeName = pkg.name.replace(/[/@]/g, '_');
+    const { warnings } = await bundleWithWarnings(pkg.singleImport, `warn-${safeName}`);
+
+    const bareImportWarnings = warnings.filter((w) => w.id === 'ignored-bare-import');
+
+    expect(
+      bareImportWarnings,
+      `Expected no ignored-bare-import warnings but got ${bareImportWarnings.length}`,
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Changed `sideEffects: false` → `["./dist/shared/*.js"]` in `@vertz/ui-primitives` to match the emitted multi-entry build structure
- Added tree-shaking regression test that asserts zero `ignored-bare-import` esbuild warnings
- Single-import bundle ratio: 16.1% → 16.3% (negligible, well under 50% threshold)

## Public API Changes

None. Internal packaging metadata only.

## Test plan

- [x] New test: `@vertz/ui-primitives — single import builds without ignored-bare-import warnings`
- [x] Existing tree-shaking ratio tests still pass (all 9 packages)
- [x] Typecheck passes
- [x] Lint passes

Fixes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)