### PR TITLE
feat(ui,ui-server,cli): static pre-rendering build pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -535,6 +535,7 @@
       },
       "devDependencies": {
         "@resvg/resvg-js": "^2.6.2",
+        "@vertz/cli": "workspace:*",
         "@vertz/ui-compiler": "workspace:*",
         "bun-types": "^1.3.9",
         "satori": "^0.25.0",
@@ -1166,7 +1167,7 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
+    "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -2054,6 +2055,8 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@happy-dom/global-registrator/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
+
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -2082,19 +2085,15 @@
 
     "@vertz/cli/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "@vertz/codegen/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@vertz/cli-runtime/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
-    "@vertz/compiler/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
-
-    "@vertz/core/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
-
-    "@vertz/fetch/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@vertz/integration-tests/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "@vertz/landing-nextjs/wrangler": ["wrangler@4.72.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260310.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260310.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260310.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg=="],
 
-    "@vertz/landing-nextjs-vercel/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@vertz/server/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
-    "@vertz/ui-compiler/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@vertz/testing/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -2105,6 +2104,10 @@
     "bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "happy-dom/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
+
+    "jest-worker/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -82,7 +82,7 @@ describe('validateBuildOutputs', () => {
     const result = validateBuildOutputs(projectRoot, 'ui-only');
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('dist/client/index.html');
+      expect(result.error.message).toContain('dist/client/_shell.html');
     }
   });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -61,9 +61,11 @@ export function validateBuildOutputs(projectRoot: string, appType: AppType): Res
   }
 
   if (appType === 'ui-only' || appType === 'full-stack') {
+    // Check for _shell.html (new) or index.html (legacy) as SSR template
+    const shellHtml = join(projectRoot, 'dist', 'client', '_shell.html');
     const clientHtml = join(projectRoot, 'dist', 'client', 'index.html');
-    if (!existsSync(clientHtml)) {
-      missing.push('dist/client/index.html');
+    if (!existsSync(shellHtml) && !existsSync(clientHtml)) {
+      missing.push('dist/client/_shell.html');
     }
 
     const ssrModule = discoverSSRModule(projectRoot);
@@ -184,7 +186,10 @@ async function startUIOnly(
   if (!ssrModulePath) {
     return err(new Error('No SSR module found in dist/server/. Run "vertz build" first.'));
   }
-  const templatePath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  // Prefer _shell.html (new), fall back to index.html (legacy)
+  const shellPath = resolve(projectRoot, 'dist', 'client', '_shell.html');
+  const legacyPath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  const templatePath = existsSync(shellPath) ? shellPath : legacyPath;
   const template = readFileSync(templatePath, 'utf-8');
 
   let ssrModule: import('@vertz/ui-server/ssr').SSRModule;
@@ -217,11 +222,20 @@ async function startUIOnly(
       const url = new URL(req.url);
       const pathname = url.pathname;
 
-      // Serve static files from dist/client/
+      // Nav pre-fetch always goes through SSR (for query discovery)
+      if (req.headers.get('x-vertz-nav') === '1') {
+        return ssrHandler(req);
+      }
+
+      // Serve static assets (JS, CSS, images)
       const staticResponse = serveStaticFile(clientDir, pathname);
       if (staticResponse) return staticResponse;
 
-      // Everything else → SSR
+      // Check for pre-rendered HTML
+      const prerenderResponse = servePrerenderHTML(clientDir, pathname);
+      if (prerenderResponse) return prerenderResponse;
+
+      // Fallback: runtime SSR
       return ssrHandler(req);
     },
   });
@@ -266,7 +280,10 @@ async function startFullStack(
   if (!ssrModulePath) {
     return err(new Error('No SSR module found in dist/server/. Run "vertz build" first.'));
   }
-  const templatePath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  // Prefer _shell.html (new), fall back to index.html (legacy)
+  const shellPath = resolve(projectRoot, 'dist', 'client', '_shell.html');
+  const legacyPath = resolve(projectRoot, 'dist', 'client', 'index.html');
+  const templatePath = existsSync(shellPath) ? shellPath : legacyPath;
   const template = readFileSync(templatePath, 'utf-8');
 
   let ssrModule: import('@vertz/ui-server/ssr').SSRModule;
@@ -303,11 +320,20 @@ async function startFullStack(
         return apiHandler(req);
       }
 
-      // Static files
+      // Nav pre-fetch always goes through SSR (for query discovery)
+      if (req.headers.get('x-vertz-nav') === '1') {
+        return ssrHandler(req);
+      }
+
+      // Static assets
       const staticResponse = serveStaticFile(clientDir, pathname);
       if (staticResponse) return staticResponse;
 
-      // SSR fallback
+      // Pre-rendered HTML
+      const prerenderResponse = servePrerenderHTML(clientDir, pathname);
+      if (prerenderResponse) return prerenderResponse;
+
+      // Runtime SSR fallback
       return ssrHandler(req);
     },
   });
@@ -336,6 +362,34 @@ export function discoverInlineCSS(projectRoot: string): Record<string, string> |
     result[`/assets/${file}`] = content;
   }
   return result;
+}
+
+/**
+ * Serve pre-rendered HTML for a route.
+ * Checks for dist/client/<pathname>/index.html or dist/client/index.html for /.
+ * Returns null if no pre-rendered file exists.
+ */
+export function servePrerenderHTML(clientDir: string, pathname: string): Response | null {
+  const htmlPath =
+    pathname === '/'
+      ? resolve(clientDir, 'index.html')
+      : resolve(clientDir, `${pathname.replace(/^\//, '')}/index.html`);
+
+  // Path traversal guard
+  if (!htmlPath.startsWith(clientDir)) return null;
+
+  // Skip _shell.html — that's the SSR template, not a pre-rendered page
+  if (htmlPath.endsWith('/_shell.html')) return null;
+
+  const file = Bun.file(htmlPath);
+  if (!file.size) return null;
+
+  return new Response(file, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
 }
 
 /**

--- a/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
+++ b/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
@@ -27,6 +27,19 @@ vi.mock('@vertz/ui-server/bun-plugin', () => {
   };
 });
 
+// Mock @vertz/ui-server/ssr to prevent the real SSR module from installing a DOM shim.
+// The real `discoverRoutes` calls `ssrRenderToString` → `installDomShim()` which sets a
+// fake `window` on globalThis. If `resolveAppFactory` throws (because the test's mock
+// Bun.build writes a non-module file), the DOM shim remains installed and pollutes
+// subsequent test files (e.g., pglite tests that check `window.encodeURIComponent`).
+vi.mock('@vertz/ui-server/ssr', () => {
+  return {
+    discoverRoutes: async () => [],
+    filterPrerenderableRoutes: (patterns: string[]) => patterns,
+    prerenderRoutes: async () => [],
+  };
+});
+
 // We need to mock Bun.build since we can't run the real bundler in tests
 const mockBunBuild = vi.fn();
 
@@ -113,7 +126,7 @@ describe('buildUI', () => {
     expect(result.durationMs).toBeGreaterThan(0);
 
     // Verify output structure
-    expect(existsSync(join(tmpDir, 'dist', 'client', 'index.html'))).toBe(true);
+    expect(existsSync(join(tmpDir, 'dist', 'client', '_shell.html'))).toBe(true);
     expect(existsSync(join(tmpDir, 'dist', 'client', 'assets'))).toBe(true);
     expect(existsSync(join(tmpDir, 'dist', 'server'))).toBe(true);
   });
@@ -137,7 +150,7 @@ describe('buildUI', () => {
   it('should generate HTML with hashed JS script tag', async () => {
     await buildUI(config);
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).toContain('crossorigin');
     expect(html).toContain('.js"></script>');
     expect(html).not.toContain('entry-client.ts');
@@ -146,28 +159,28 @@ describe('buildUI', () => {
   it('should generate HTML with CSS link tags', async () => {
     await buildUI(config);
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).toContain('<link rel="stylesheet" href="/assets/vertz.css">');
   });
 
   it('should generate HTML with default title', async () => {
     await buildUI(config);
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).toContain('<title>Vertz App</title>');
   });
 
   it('should generate HTML with custom title', async () => {
     await buildUI({ ...config, title: 'My Todo App' });
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).toContain('<title>My Todo App</title>');
   });
 
   it('should generate valid HTML structure', async () => {
     await buildUI(config);
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).toContain('<!doctype html>');
     expect(html).toContain('<div id="app"></div>');
     expect(html).toContain('<meta charset="UTF-8"');
@@ -177,7 +190,7 @@ describe('buildUI', () => {
   it('should not contain any dev-only artifacts in HTML', async () => {
     await buildUI(config);
 
-    const html = readFileSync(join(tmpDir, 'dist', 'client', 'index.html'), 'utf-8');
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
     expect(html).not.toContain('fast-refresh-runtime');
     expect(html).not.toContain('Fast Refresh runtime');
     expect(html).not.toContain('./public/');

--- a/packages/cli/src/production-build/ui-build-pipeline.ts
+++ b/packages/cli/src/production-build/ui-build-pipeline.ts
@@ -14,7 +14,7 @@
  */
 
 import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 // Minimal ambient declaration for Bun APIs used by this module.
 // The CLI runs under Bun at runtime; these declarations let tsc validate
@@ -56,7 +56,15 @@ export interface UIBuildResult {
 export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
   const startTime = performance.now();
 
-  const { projectRoot, clientEntry, serverEntry, outputDir, minify, sourcemap, title = 'Vertz App' } = config;
+  const {
+    projectRoot,
+    clientEntry,
+    serverEntry,
+    outputDir,
+    minify,
+    sourcemap,
+    title = 'Vertz App',
+  } = config;
   const distDir = resolve(projectRoot, outputDir);
   const distClient = resolve(distDir, 'client');
   const distServer = resolve(distDir, 'server');
@@ -152,7 +160,7 @@ ${cssLinks}
   </body>
 </html>`;
 
-    writeFileSync(resolve(distClient, 'index.html'), html);
+    writeFileSync(resolve(distClient, '_shell.html'), html);
 
     // ── 4. Copy public/ → dist/client/ ────────────────────────────
     const publicDir = resolve(projectRoot, 'public');
@@ -207,6 +215,69 @@ ${cssLinks}
     }
 
     console.log('  Server entry: dist/server/app.js');
+
+    // ── 6. Static pre-rendering ──────────────────────────────────
+    console.log('📄 Pre-rendering routes...');
+
+    const { discoverRoutes, filterPrerenderableRoutes, prerenderRoutes } = await import(
+      '@vertz/ui-server/ssr'
+    );
+
+    // Discover SSR module entry
+    const ssrEntryPath = resolve(distServer, 'app.js');
+    let ssrModule: import('@vertz/ui-server/ssr').SSRModule;
+    try {
+      ssrModule = await import(ssrEntryPath);
+    } catch (error) {
+      console.log('  ⚠ Could not import SSR module for pre-rendering, skipping.');
+      console.log(`    ${error instanceof Error ? error.message : String(error)}`);
+      const durationMs = performance.now() - startTime;
+      console.log('\n✅ UI build complete (without pre-rendering)!');
+      console.log(`  Client: ${distClient}/`);
+      console.log(`  Server: ${distServer}/`);
+      return { success: true, durationMs };
+    }
+
+    // Discover routes
+    let allPatterns: string[];
+    try {
+      allPatterns = await discoverRoutes(ssrModule);
+    } catch (error) {
+      console.log('  ⚠ Route discovery failed, skipping pre-rendering.');
+      console.log(`    ${error instanceof Error ? error.message : String(error)}`);
+      const durationMs = performance.now() - startTime;
+      console.log('\n✅ UI build complete (without pre-rendering)!');
+      console.log(`  Client: ${distClient}/`);
+      console.log(`  Server: ${distServer}/`);
+      return { success: true, durationMs };
+    }
+    if (allPatterns.length === 0) {
+      console.log('  No routes discovered (app may not use createRouter).');
+    } else {
+      console.log(`  Discovered ${allPatterns.length} route(s): ${allPatterns.join(', ')}`);
+
+      // Filter to pre-renderable routes
+      const prerenderableRoutes = filterPrerenderableRoutes(allPatterns);
+      console.log(`  Pre-rendering ${prerenderableRoutes.length} static route(s)...`);
+
+      if (prerenderableRoutes.length > 0) {
+        // Pre-render each route
+        const results = await prerenderRoutes(ssrModule, html, {
+          routes: prerenderableRoutes,
+        });
+
+        // Write pre-rendered HTML files
+        for (const result of results) {
+          const outPath =
+            result.path === '/'
+              ? resolve(distClient, 'index.html')
+              : resolve(distClient, `${result.path.replace(/^\//, '')}/index.html`);
+          mkdirSync(dirname(outPath), { recursive: true });
+          writeFileSync(outPath, result.html);
+          console.log(`  ✓ ${result.path} → ${outPath.replace(distClient, 'dist/client')}`);
+        }
+      }
+    }
 
     // ── Done ──────────────────────────────────────────────────────
     const durationMs = performance.now() - startTime;

--- a/packages/ui-server/src/__tests__/prerender.test.ts
+++ b/packages/ui-server/src/__tests__/prerender.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'bun:test';
+import { createRouter, defineRoutes } from '@vertz/ui';
+import { installDomShim } from '../dom-shim';
+import { discoverRoutes, filterPrerenderableRoutes, prerenderRoutes } from '../prerender';
+
+installDomShim();
+
+describe('discoverRoutes', () => {
+  it('discovers all route patterns from an SSR module', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/': { component: () => document.createElement('div') },
+          '/about': { component: () => document.createElement('div') },
+          '/users/:id': { component: () => document.createElement('div') },
+        });
+        const router = createRouter(routes);
+        // Access current.value to trigger lazy route discovery (as RouterView would)
+        router.current.value;
+        const el = document.createElement('div');
+        el.textContent = 'App';
+        return el;
+      },
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/');
+    expect(patterns).toContain('/about');
+    expect(patterns).toContain('/users/:id');
+  });
+
+  it('discovers nested route patterns as full paths', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/docs': {
+            component: () => document.createElement('div'),
+            children: {
+              '/': { component: () => document.createElement('div') },
+              '/:slug': { component: () => document.createElement('div') },
+            },
+          },
+        });
+        const router = createRouter(routes);
+        // Access current.value to trigger lazy route discovery (as RouterView would)
+        router.current.value;
+        return document.createElement('div');
+      },
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/docs');
+    expect(patterns).toContain('/docs/:slug');
+  });
+
+  it('returns empty array when app has no router', async () => {
+    const module = {
+      default: () => {
+        return document.createElement('div');
+      },
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toEqual([]);
+  });
+});
+
+describe('filterPrerenderableRoutes', () => {
+  it('excludes routes with :param segments', () => {
+    const result = filterPrerenderableRoutes([
+      '/',
+      '/about',
+      '/users/:id',
+      '/posts/:slug/comments',
+    ]);
+
+    expect(result).toContain('/');
+    expect(result).toContain('/about');
+    expect(result).not.toContain('/users/:id');
+    expect(result).not.toContain('/posts/:slug/comments');
+  });
+
+  it('excludes routes with * wildcard', () => {
+    const result = filterPrerenderableRoutes(['/', '/files/*']);
+
+    expect(result).toContain('/');
+    expect(result).not.toContain('/files/*');
+  });
+
+  it('excludes routes with prerender: false via compiledRoutes lookup', () => {
+    const routes = defineRoutes({
+      '/': { component: () => document.createElement('div') },
+      '/dashboard': { component: () => document.createElement('div'), prerender: false },
+      '/about': { component: () => document.createElement('div') },
+    });
+
+    const result = filterPrerenderableRoutes(['/', '/dashboard', '/about'], routes);
+
+    expect(result).toContain('/');
+    expect(result).toContain('/about');
+    expect(result).not.toContain('/dashboard');
+  });
+
+  it('returns all static routes when no compiledRoutes provided', () => {
+    const result = filterPrerenderableRoutes(['/', '/about', '/pricing']);
+
+    expect(result).toEqual(['/', '/about', '/pricing']);
+  });
+});
+
+describe('prerenderRoutes', () => {
+  const template = `<!doctype html>
+<html>
+  <head>
+    <title>Test</title>
+    <link rel="stylesheet" href="/assets/vertz.css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/assets/entry.js"></script>
+  </body>
+</html>`;
+
+  it('pre-renders a single route into the template', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/': { component: () => document.createElement('div') },
+          '/about': {
+            component: () => {
+              const el = document.createElement('div');
+              el.textContent = 'About Page';
+              return el;
+            },
+          },
+        });
+        createRouter(routes);
+        // The router match determines what renders
+        const el = document.createElement('div');
+        el.textContent = 'About Page';
+        return el;
+      },
+    };
+
+    const results = await prerenderRoutes(module, template, {
+      routes: ['/about'],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.path).toBe('/about');
+    expect(results[0]!.html).toContain('About Page');
+    expect(results[0]!.html).toContain('<script type="module" src="/assets/entry.js">');
+    expect(results[0]!.html).toContain('<link rel="stylesheet" href="/assets/vertz.css">');
+  });
+
+  it('pre-renders multiple routes sequentially', async () => {
+    let renderCount = 0;
+    const module = {
+      default: () => {
+        renderCount++;
+        const el = document.createElement('div');
+        el.textContent = `Render ${renderCount}`;
+        return el;
+      },
+    };
+
+    const results = await prerenderRoutes(module, template, {
+      routes: ['/', '/about'],
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.path).toBe('/');
+    expect(results[1]!.path).toBe('/about');
+  });
+
+  it('does not inject inline CSS (avoids duplication with linked CSS)', async () => {
+    const module = {
+      default: () => {
+        const el = document.createElement('div');
+        el.textContent = 'No inline CSS';
+        return el;
+      },
+    };
+
+    const results = await prerenderRoutes(module, template, {
+      routes: ['/'],
+    });
+
+    // Should NOT have <style data-vertz-css> tags (CSS is linked, not inlined)
+    expect(results[0]!.html).not.toContain('<style data-vertz-css>');
+    // Should still have the original CSS link
+    expect(results[0]!.html).toContain('<link rel="stylesheet" href="/assets/vertz.css">');
+  });
+
+  it('throws PrerenderError when SSR render fails for a route', async () => {
+    const module = {
+      default: () => {
+        throw new Error('loader fetch failed');
+      },
+    };
+
+    await expect(prerenderRoutes(module, template, { routes: ['/pricing'] })).rejects.toThrow(
+      /Pre-render failed for \/pricing/,
+    );
+  });
+});

--- a/packages/ui-server/src/__tests__/ssr-render.test.ts
+++ b/packages/ui-server/src/__tests__/ssr-render.test.ts
@@ -753,3 +753,72 @@ describe('per-request isolation', () => {
     expect(result2.css).toContain('font-family: system-ui');
   });
 });
+
+describe('ssrRenderToString discoveredRoutes', () => {
+  it('includes discoveredRoutes when app creates a router', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/': { component: () => document.createElement('div') },
+          '/about': { component: () => document.createElement('div') },
+          '/users/:id': { component: () => document.createElement('div') },
+        });
+        const router = createRouter(routes);
+        // Access current.value to trigger lazy route discovery (as RouterView would)
+        router.current.value;
+        const el = document.createElement('div');
+        el.textContent = 'App';
+        return el;
+      },
+    };
+
+    const result = await ssrRenderToString(module, '/');
+
+    expect(result.discoveredRoutes).toBeDefined();
+    expect(result.discoveredRoutes).toContain('/');
+    expect(result.discoveredRoutes).toContain('/about');
+    expect(result.discoveredRoutes).toContain('/users/:id');
+  });
+
+  it('returns empty discoveredRoutes when app has no router', async () => {
+    const module = {
+      default: () => {
+        const el = document.createElement('div');
+        el.textContent = 'No router';
+        return el;
+      },
+    };
+
+    const result = await ssrRenderToString(module, '/');
+
+    // discoveredRoutes should be undefined or empty when no router is created
+    expect(result.discoveredRoutes ?? []).toEqual([]);
+  });
+
+  it('discovers nested route patterns as full paths', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/docs': {
+            component: () => document.createElement('div'),
+            children: {
+              '/': { component: () => document.createElement('div') },
+              '/:slug': { component: () => document.createElement('div') },
+            },
+          },
+        });
+        const router = createRouter(routes);
+        // Access current.value to trigger lazy route discovery (as RouterView would)
+        router.current.value;
+        const el = document.createElement('div');
+        el.textContent = 'Docs';
+        return el;
+      },
+    };
+
+    const result = await ssrRenderToString(module, '/');
+
+    expect(result.discoveredRoutes).toContain('/docs');
+    expect(result.discoveredRoutes).toContain('/docs/:slug');
+  });
+});

--- a/packages/ui-server/src/prerender.ts
+++ b/packages/ui-server/src/prerender.ts
@@ -1,0 +1,132 @@
+/**
+ * Static pre-rendering pipeline.
+ *
+ * Discovers routes from an SSR module and pre-renders them to HTML
+ * at build time. Used by `vertz build` to generate static HTML files.
+ */
+
+import type { CompiledRoute } from '@vertz/ui';
+import type { SSRModule, SSRRenderResult } from './ssr-render';
+import { ssrRenderToString } from './ssr-render';
+import { injectIntoTemplate } from './template-inject';
+
+export interface PrerenderResult {
+  /** The route path that was pre-rendered. */
+  path: string;
+  /** The complete HTML string. */
+  html: string;
+}
+
+export interface PrerenderOptions {
+  /** Route paths to pre-render. */
+  routes: string[];
+  /** CSP nonce for inline scripts. */
+  nonce?: string;
+}
+
+/**
+ * Discover all route patterns from an SSR module.
+ *
+ * Renders `/` to trigger `createRouter()`, which registers route patterns
+ * with the SSR context. Returns the discovered patterns (including dynamic).
+ */
+export async function discoverRoutes(module: SSRModule): Promise<string[]> {
+  const result = await ssrRenderToString(module, '/');
+  return result.discoveredRoutes ?? [];
+}
+
+/**
+ * Filter route patterns to only pre-renderable ones.
+ *
+ * Excludes:
+ * - Routes with `:param` segments
+ * - Routes with `*` wildcard
+ * - Routes with `prerender: false` (looked up in compiledRoutes)
+ */
+export function filterPrerenderableRoutes(
+  patterns: string[],
+  compiledRoutes?: CompiledRoute[],
+): string[] {
+  return patterns.filter((pattern) => {
+    // Skip dynamic segments
+    if (pattern.includes(':') || pattern.includes('*')) return false;
+    // Skip routes with prerender: false
+    if (compiledRoutes) {
+      const route = findCompiledRoute(compiledRoutes, pattern);
+      if (route?.prerender === false) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Pre-render a list of routes into complete HTML strings.
+ *
+ * Routes are rendered sequentially (not in parallel) because the DOM shim
+ * uses process-global `document`/`window`. Concurrent renders would interleave.
+ *
+ * CSS is deliberately NOT injected as inline `<style>` tags — the template
+ * already has `<link>` tags pointing to the CSS files. This avoids duplication.
+ *
+ * @throws Error if any route fails to render (with hint about `prerender: false`)
+ */
+export async function prerenderRoutes(
+  module: SSRModule,
+  template: string,
+  options: PrerenderOptions,
+): Promise<PrerenderResult[]> {
+  const results: PrerenderResult[] = [];
+
+  for (const routePath of options.routes) {
+    let renderResult: SSRRenderResult;
+    try {
+      renderResult = await ssrRenderToString(module, routePath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Pre-render failed for ${routePath}\n` +
+          `  ${message}\n` +
+          '  Hint: If this route requires runtime data, add `prerender: false` to its route config.',
+      );
+    }
+
+    // Inject HTML into template, passing empty CSS to avoid duplication
+    // (template already has <link> to CSS files)
+    const html = injectIntoTemplate(
+      template,
+      renderResult.html,
+      /* css: */ '',
+      renderResult.ssrData,
+      options.nonce,
+      renderResult.headTags || undefined,
+    );
+
+    results.push({ path: routePath, html });
+  }
+
+  return results;
+}
+
+/** Find a compiled route by pattern (recursive through children). */
+function findCompiledRoute(
+  routes: CompiledRoute[],
+  pattern: string,
+  prefix = '',
+): CompiledRoute | undefined {
+  for (const route of routes) {
+    const fullPattern = joinPatterns(prefix, route.pattern);
+    if (fullPattern === pattern) return route;
+    if (route.children) {
+      const found = findCompiledRoute(route.children, pattern, fullPattern);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** Join parent and child route patterns. */
+function joinPatterns(parent: string, child: string): string {
+  if (!parent || parent === '/') return child;
+  if (child === '/') return parent;
+  return `${parent.replace(/\/$/, '')}/${child.replace(/^\//, '')}`;
+}

--- a/packages/ui-server/src/ssr-handler.ts
+++ b/packages/ui-server/src/ssr-handler.ts
@@ -12,7 +12,7 @@ import { compileTheme, type FontFallbackMetrics, type PreloadItem } from '@vertz
 import { escapeAttr } from './html-serializer';
 import type { SSRModule } from './ssr-render';
 import { ssrRenderToString, ssrStreamNavQueries } from './ssr-render';
-import { safeSerialize } from './ssr-streaming-runtime';
+import { injectIntoTemplate } from './template-inject';
 
 export interface SSRHandlerOptions {
   /** The loaded SSR module (import('./dist/server/index.js')) */
@@ -45,48 +45,6 @@ export interface SSRHandlerOptions {
   modulepreload?: string[];
   /** Cache-Control header for HTML responses. Omit or undefined = no header (safe default). */
   cacheControl?: string;
-}
-
-/**
- * Inject SSR output into the HTML template.
- *
- * Replaces <!--ssr-outlet--> or <div id="app"> content with rendered HTML,
- * injects CSS before </head>, and ssrData before </body>.
- */
-function injectIntoTemplate(
-  template: string,
-  appHtml: string,
-  appCss: string,
-  ssrData: Array<{ key: string; data: unknown }>,
-  nonce?: string,
-  headTags?: string,
-): string {
-  // Inject app HTML: try <!--ssr-outlet--> first, then <div id="app">
-  let html: string;
-  if (template.includes('<!--ssr-outlet-->')) {
-    html = template.replace('<!--ssr-outlet-->', appHtml);
-  } else {
-    html = template.replace(/(<div[^>]*id="app"[^>]*>)([\s\S]*?)(<\/div>)/, `$1${appHtml}$3`);
-  }
-
-  // Inject head tags (e.g., font preloads) before CSS
-  if (headTags) {
-    html = html.replace('</head>', `${headTags}\n</head>`);
-  }
-
-  // Inject CSS before </head>
-  if (appCss) {
-    html = html.replace('</head>', `${appCss}\n</head>`);
-  }
-
-  // Inject SSR data for client-side hydration before </body>
-  if (ssrData.length > 0) {
-    const nonceAttr = nonce != null ? ` nonce="${nonce}"` : '';
-    const ssrDataScript = `<script${nonceAttr}>window.__VERTZ_SSR_DATA__=${safeSerialize(ssrData)};</script>`;
-    html = html.replace('</body>', `${ssrDataScript}\n</body>`);
-  }
-
-  return html;
 }
 
 /**

--- a/packages/ui-server/src/ssr-render.ts
+++ b/packages/ui-server/src/ssr-render.ts
@@ -83,6 +83,8 @@ export interface SSRRenderResult {
   ssrData: Array<{ key: string; data: unknown }>;
   /** Font preload link tags for injection into <head>. */
   headTags: string;
+  /** Route patterns discovered by createRouter() during SSR (for build-time pre-rendering). */
+  discoveredRoutes?: string[];
 }
 
 export interface SSRDiscoverResult {
@@ -264,7 +266,13 @@ export async function ssrRenderToString(
             }))
           : [];
 
-      return { html, css, ssrData, headTags: themePreloadTags };
+      return {
+        html,
+        css,
+        ssrData,
+        headTags: themePreloadTags,
+        discoveredRoutes: ctx.discoveredRoutes,
+      };
     } finally {
       clearGlobalSSRTimeout();
     }

--- a/packages/ui-server/src/ssr/index.ts
+++ b/packages/ui-server/src/ssr/index.ts
@@ -6,7 +6,10 @@
  * bundling vite, rollup, esbuild, lightningcss, and fsevents.
  */
 
+export type { PrerenderOptions, PrerenderResult } from '../prerender';
+export { discoverRoutes, filterPrerenderableRoutes, prerenderRoutes } from '../prerender';
 export type { SSRHandlerOptions } from '../ssr-handler';
 export { createSSRHandler } from '../ssr-handler';
 export type { SSRDiscoverResult, SSRModule, SSRRenderResult } from '../ssr-render';
 export { ssrDiscoverQueries, ssrRenderToString } from '../ssr-render';
+export { injectIntoTemplate } from '../template-inject';

--- a/packages/ui-server/src/template-inject.ts
+++ b/packages/ui-server/src/template-inject.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared HTML template injection utility.
+ *
+ * Used by both the production SSR handler (runtime) and the pre-render pipeline (build-time).
+ */
+
+import { safeSerialize } from './ssr-streaming-runtime';
+
+/**
+ * Inject SSR output into the HTML template.
+ *
+ * Replaces <!--ssr-outlet--> or <div id="app"> content with rendered HTML,
+ * injects CSS before </head>, and ssrData before </body>.
+ */
+export function injectIntoTemplate(
+  template: string,
+  appHtml: string,
+  appCss: string,
+  ssrData: Array<{ key: string; data: unknown }>,
+  nonce?: string,
+  headTags?: string,
+): string {
+  // Inject app HTML: try <!--ssr-outlet--> first, then <div id="app">
+  let html: string;
+  if (template.includes('<!--ssr-outlet-->')) {
+    html = template.replace('<!--ssr-outlet-->', appHtml);
+  } else {
+    html = template.replace(/(<div[^>]*id="app"[^>]*>)([\s\S]*?)(<\/div>)/, `$1${appHtml}$3`);
+  }
+
+  // Inject head tags (e.g., font preloads) before CSS
+  if (headTags) {
+    html = html.replace('</head>', `${headTags}\n</head>`);
+  }
+
+  // Inject CSS before </head>
+  if (appCss) {
+    html = html.replace('</head>', `${appCss}\n</head>`);
+  }
+
+  // Inject SSR data for client-side hydration before </body>
+  if (ssrData.length > 0) {
+    const nonceAttr = nonce != null ? ` nonce="${nonce}"` : '';
+    const ssrDataScript = `<script${nonceAttr}>window.__VERTZ_SSR_DATA__=${safeSerialize(ssrData)};</script>`;
+    html = html.replace('</body>', `${ssrDataScript}\n</body>`);
+  }
+
+  return html;
+}

--- a/packages/ui/src/router/__tests__/define-routes.test.ts
+++ b/packages/ui/src/router/__tests__/define-routes.test.ts
@@ -180,6 +180,38 @@ describe('defineRoutes with params schema', () => {
   });
 });
 
+describe('defineRoutes with prerender', () => {
+  test('propagates prerender: false to CompiledRoute', () => {
+    const routes = defineRoutes({
+      '/': { component: () => document.createElement('div') },
+      '/dashboard': { component: () => document.createElement('div'), prerender: false },
+    });
+    expect(routes[0]?.prerender).toBeUndefined();
+    expect(routes[1]?.prerender).toBe(false);
+  });
+
+  test('propagates prerender: true to CompiledRoute', () => {
+    const routes = defineRoutes({
+      '/about': { component: () => document.createElement('div'), prerender: true },
+    });
+    expect(routes[0]?.prerender).toBe(true);
+  });
+
+  test('propagates prerender to nested children', () => {
+    const routes = defineRoutes({
+      '/docs': {
+        component: () => document.createElement('div'),
+        children: {
+          '/': { component: () => document.createElement('div') },
+          '/api': { component: () => document.createElement('div'), prerender: false },
+        },
+      },
+    });
+    expect(routes[0]?.children?.[0]?.prerender).toBeUndefined();
+    expect(routes[0]?.children?.[1]?.prerender).toBe(false);
+  });
+});
+
 describe('matchRoute with params schema', () => {
   const uuidSchema: ParamSchema<{ id: string }> = {
     parse(raw) {

--- a/packages/ui/src/router/__tests__/navigate.test.ts
+++ b/packages/ui/src/router/__tests__/navigate.test.ts
@@ -972,4 +972,56 @@ describe('createRouter SSR', () => {
     router.current.notify();
     router.searchParams.notify();
   });
+
+  test('SSR router writes discoveredRoutes lazily on first getter access', () => {
+    const ctx = enableTestSSR(createTestSSRContext('/'));
+    const routes = defineRoutes({
+      '/': { component: () => document.createElement('div') },
+      '/about': { component: () => document.createElement('div') },
+      '/users/:id': { component: () => document.createElement('div') },
+    });
+    const router = createRouter(routes);
+
+    // Not set at createRouter() time — deferred to getter access
+    expect(ctx.discoveredRoutes).toBeUndefined();
+
+    // Trigger lazy discovery
+    router.current.value;
+
+    expect(ctx.discoveredRoutes).toBeDefined();
+    expect(ctx.discoveredRoutes).toContain('/');
+    expect(ctx.discoveredRoutes).toContain('/about');
+    expect(ctx.discoveredRoutes).toContain('/users/:id');
+  });
+
+  test('SSR router discovers nested children as full paths', () => {
+    const ctx = enableTestSSR(createTestSSRContext('/'));
+    const routes = defineRoutes({
+      '/docs': {
+        component: () => document.createElement('div'),
+        children: {
+          '/': { component: () => document.createElement('div') },
+          '/:slug': { component: () => document.createElement('div') },
+        },
+      },
+    });
+    const router = createRouter(routes);
+
+    // Trigger lazy discovery
+    router.current.value;
+
+    expect(ctx.discoveredRoutes).toContain('/docs');
+    expect(ctx.discoveredRoutes).toContain('/docs/:slug');
+  });
+
+  test('SSR router does not write discoveredRoutes without SSR context', () => {
+    disableTestSSR();
+    const routes = defineRoutes({
+      '/': { component: () => document.createElement('div') },
+    });
+    // In browser environment (no SSR context), no discoveredRoutes
+    const router = createRouter(routes, '/');
+    // Just verify it doesn't crash — no context to inspect
+    expect(router.current.value).not.toBeNull();
+  });
 });

--- a/packages/ui/src/router/define-routes.ts
+++ b/packages/ui/src/router/define-routes.ts
@@ -35,6 +35,8 @@ export interface RouteConfig<
   searchParams?: SearchParamSchema<TSearch>;
   /** Nested child routes. */
   children?: RouteDefinitionMap;
+  /** Whether to pre-render this route at build time (default: true for static routes). */
+  prerender?: boolean;
 }
 
 /** A map of path patterns to route configs (user input format). */
@@ -61,6 +63,7 @@ export interface RouteConfigLike {
   params?: ParamSchema<unknown>;
   searchParams?: SearchParamSchema<unknown>;
   children?: Record<string, RouteConfigLike>;
+  prerender?: boolean;
 }
 
 /**
@@ -96,6 +99,8 @@ export interface CompiledRoute {
   searchParams?: RouteConfig['searchParams'];
   /** Compiled children. */
   children?: CompiledRoute[];
+  /** Whether to pre-render this route at build time (default: true for static routes). */
+  prerender?: boolean;
 }
 
 /** A single matched route entry in the matched chain. */
@@ -145,6 +150,7 @@ export function defineRoutes<const T extends Record<string, RouteConfigLike>>(
       loader: config.loader as CompiledRoute['loader'],
       params: config.params,
       pattern,
+      prerender: config.prerender,
       searchParams: config.searchParams,
     };
 

--- a/packages/ui/src/router/navigate.ts
+++ b/packages/ui/src/router/navigate.ts
@@ -8,7 +8,13 @@
 import { signal } from '../runtime/signal';
 import type { Signal } from '../runtime/signal-types';
 import { getSSRContext } from '../ssr/ssr-render-context';
-import type { RouteConfigLike, RouteDefinitionMap, RouteMatch, TypedRoutes } from './define-routes';
+import type {
+  CompiledRoute,
+  RouteConfigLike,
+  RouteDefinitionMap,
+  RouteMatch,
+  TypedRoutes,
+} from './define-routes';
 import { matchRoute } from './define-routes';
 import { executeLoaders } from './loader';
 import type { ExtractParams, RoutePattern } from './params';
@@ -190,19 +196,38 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
   // The current/searchParams use SSR-aware getters so that module-level
   // routers (created once at import time) return per-request route matches
   // when accessed inside ssrStorage.run() during SSR rendering.
+  //
+  // Route discovery is deferred to getter access (not module-level) because
+  // createRouter() may run at import time, outside any SSR context. The
+  // getters run during rendering, inside ssrStorage.run(), where the context
+  // is available.
   if (isSSR || typeof window === 'undefined') {
     const ssrUrl = initialUrl ?? ssrCtx?.url ?? '/';
     const fallbackMatch = matchRoute(routes, ssrUrl);
+
+    /** Register route patterns with SSR context for build-time discovery. */
+    function registerRoutesForDiscovery(ctx: NonNullable<typeof ssrCtx>): void {
+      if (!ctx.discoveredRoutes) {
+        ctx.discoveredRoutes = collectRoutePatterns(routes);
+      }
+    }
+
     return {
       current: {
         get value(): RouteMatch | null {
           const ctx = getSSRContext();
-          if (ctx) return matchRoute(routes, ctx.url);
+          if (ctx) {
+            registerRoutesForDiscovery(ctx);
+            return matchRoute(routes, ctx.url);
+          }
           return fallbackMatch;
         },
         peek(): RouteMatch | null {
           const ctx = getSSRContext();
-          if (ctx) return matchRoute(routes, ctx.url);
+          if (ctx) {
+            registerRoutesForDiscovery(ctx);
+            return matchRoute(routes, ctx.url);
+          }
           return fallbackMatch;
         },
         notify() {},
@@ -267,7 +292,12 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
   const current = {
     get value(): RouteMatch | null {
       const ctx = getSSRContext();
-      if (ctx) return matchRoute(routes, ctx.url);
+      if (ctx) {
+        if (!ctx.discoveredRoutes) {
+          ctx.discoveredRoutes = collectRoutePatterns(routes);
+        }
+        return matchRoute(routes, ctx.url);
+      }
       return _current.value;
     },
     set value(v: RouteMatch | null) {
@@ -275,7 +305,12 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
     },
     peek(): RouteMatch | null {
       const ctx = getSSRContext();
-      if (ctx) return matchRoute(routes, ctx.url);
+      if (ctx) {
+        if (!ctx.discoveredRoutes) {
+          ctx.discoveredRoutes = collectRoutePatterns(routes);
+        }
+        return matchRoute(routes, ctx.url);
+      }
       return _current.peek();
     },
     notify() {
@@ -481,4 +516,24 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
     revalidate,
     searchParams,
   } as Router<T>;
+}
+
+/** Recursively collect all route patterns, concatenating parent + child paths. */
+function collectRoutePatterns(routes: CompiledRoute[], prefix = ''): string[] {
+  const patterns: string[] = [];
+  for (const route of routes) {
+    const fullPattern = joinPatterns(prefix, route.pattern);
+    patterns.push(fullPattern);
+    if (route.children) {
+      patterns.push(...collectRoutePatterns(route.children, fullPattern));
+    }
+  }
+  return patterns;
+}
+
+/** Join parent and child route patterns, handling trailing/leading slashes. */
+function joinPatterns(parent: string, child: string): string {
+  if (!parent || parent === '/') return child;
+  if (child === '/') return parent;
+  return `${parent.replace(/\/$/, '')}/${child.replace(/^\//, '')}`;
 }

--- a/packages/ui/src/ssr/ssr-render-context.ts
+++ b/packages/ui/src/ssr/ssr-render-context.ts
@@ -36,6 +36,11 @@ export interface SSRRenderContext {
    * Keyed by CompiledRoute object identity.
    */
   resolvedComponents?: Map<object, () => Node>;
+  /**
+   * Route patterns discovered by createRouter() during SSR.
+   * Used by the build pipeline to discover which routes to pre-render.
+   */
+  discoveredRoutes?: string[];
 }
 
 type SSRContextResolver = () => SSRRenderContext | undefined;

--- a/plans/static-prerender-build.md
+++ b/plans/static-prerender-build.md
@@ -1,0 +1,502 @@
+# Plan: Static Pre-rendering in `vertz build`
+
+**Status:** Draft (Rev 2 — post-review)
+**Priority:** P1
+**Owner:** TBD
+
+## Problem
+
+Building a production-ready Vertz site requires a 290-line custom build script. The landing site (`sites/landing/scripts/build.ts`) manually orchestrates: Bun.build, CSS extraction, dev server spawning, SSR fetching, dev script stripping, HTML injection, and output writing. None of this is reusable.
+
+`vertz build` already handles the **dynamic SSR** path well — it produces `dist/client/` (HTML shell + assets) and `dist/server/` (SSR module), and `vertz start` serves pages with runtime SSR. But there's no **static export** path — pre-rendering routes to standalone HTML files deployable to any CDN without a runtime server.
+
+This violates multiple manifesto principles:
+
+- **"One command. Full stack. Running."** — but only if you write hundreds of lines of build glue
+- **"Convention over configuration"** — but users must hand-wire the entire production pipeline
+- **"AI agents are first-class users"** — an LLM can't reliably produce the landing site's build script from scratch
+
+### The gap
+
+| What exists | What's missing |
+|---|---|
+| `vertz build` → HTML shell + SSR module | Pre-rendering routes to complete static HTML |
+| `ssrRenderToString(module, url)` | Route discovery (which URLs to pre-render) |
+| `buildUI()` client + server bundling | Wiring SSR render into the build pipeline |
+| `createSSRHandler` for runtime SSR | Injecting SSR output into template at build time |
+| Landing site build script (manual) | Framework-level equivalent (automatic) |
+
+## API Surface
+
+### For static sites (landing pages, docs)
+
+Zero config. `vertz build` detects static routes and pre-renders them.
+
+```bash
+vertz build
+```
+
+Output:
+
+```
+dist/client/
+├── _shell.html             # SSR template (used by vertz start for dynamic routes)
+├── index.html              # pre-rendered /
+├── manifesto/
+│   └── index.html          # pre-rendered /manifesto
+├── pricing/
+│   └── index.html          # pre-rendered /pricing
+├── assets/
+│   ├── entry-client-[hash].js
+│   ├── chunk-[hash].js     # lazy route chunks
+│   └── vertz.css
+└── public/
+    └── ...
+```
+
+Deploy anywhere: `wrangler deploy`, `vercel deploy`, `netlify deploy`, or any static host.
+
+### For SaaS apps (dynamic + static routes)
+
+Pre-rendering is an optimization. SaaS apps always require `vertz start` for runtime SSR of authenticated/dynamic routes. Pre-rendered pages are served from disk to avoid redundant SSR computation for pages that don't change per-request.
+
+```ts
+// src/app.tsx — no config needed, the framework figures it out
+const routes = defineRoutes({
+  '/':           { component: () => import('./pages/home') },        // static ✓
+  '/pricing':    { component: () => import('./pages/pricing') },     // static ✓
+  '/login':      { component: () => import('./pages/login') },       // static ✓
+  '/dashboard':  { component: () => import('./pages/dashboard') },   // static ✓
+  '/users/:id':  { component: () => import('./pages/user-detail') }, // dynamic — needs server
+  '/posts/*':    { component: () => import('./pages/post') },        // dynamic — needs server
+});
+```
+
+```bash
+vertz build
+# Pre-renders: /, /pricing, /login, /dashboard
+# Skips: /users/:id, /posts/* (dynamic segments)
+
+vertz start
+# Serves pre-rendered HTML for /, /pricing, /login, /dashboard (from disk)
+# Runtime SSR for /users/:id, /posts/* (on-the-fly)
+# Nav pre-fetch (X-Vertz-Nav: 1) still goes through query discovery for all routes
+```
+
+### Route discovery — zero config
+
+Routes are discovered automatically. The build:
+
+1. Imports the built SSR module (`dist/server/app.js`)
+2. Runs Pass 1 of SSR render for `/` — this executes `createRouter(defineRoutes({...}))`, which registers the route patterns
+3. Extracts all route patterns from the router (recursive walk of nested children)
+4. Filters to pre-renderable routes (no `:param`, no `*`, no `prerender: false`)
+5. SSR-renders each route and writes the complete HTML
+
+No config file. No route manifest. No `getStaticPaths()`. The framework reads the routes the developer already defined.
+
+### Opt-out for specific routes
+
+For cases where a static route shouldn't be pre-rendered (e.g., it requires auth at render time, or its loader needs a runtime API):
+
+```ts
+const routes = defineRoutes({
+  '/':          { component: () => import('./pages/home') },
+  '/dashboard': { component: () => import('./pages/dashboard'), prerender: false },
+});
+```
+
+The `prerender` property is added to `RouteConfig`, `RouteConfigLike`, and carried through to `CompiledRoute`.
+
+### Loader behavior during pre-rendering
+
+Route loaders **run during pre-rendering** — they are part of SSR. This means:
+
+- A route with a loader that calls `fetch('/api/pricing')` will execute that fetch at build time
+- If the API isn't available at build time, the loader throws and **the build fails** with a clear error:
+  ```
+  ✗ Pre-render failed for /pricing
+    Loader error: fetch failed (ECONNREFUSED localhost:3000)
+    Hint: If this route requires runtime data, add `prerender: false` to its route config.
+  ```
+- Developers opt out with `prerender: false` for routes whose loaders need runtime APIs
+
+This aligns with "if it builds, it works" — a successful build guarantees all pre-rendered pages are complete.
+
+## How it works internally
+
+### Current `buildUI` pipeline (steps 1-5 unchanged)
+
+1. **Client build** → `Bun.build()` with Vertz plugin → `dist/client/assets/`
+2. **CSS extraction** → component `css()` calls → `dist/client/assets/vertz.css`
+3. **HTML shell** → programmatic template → `dist/client/_shell.html`
+4. **Public assets** → copy `public/` → `dist/client/`
+5. **Server build** → SSR module → `dist/server/app.js`
+
+Note: Step 3 writes to `_shell.html` (not `index.html`) to avoid conflict with the pre-rendered root route.
+
+### New step 6: Static pre-rendering
+
+6. **Import SSR module** → `import('dist/server/app.js')`
+7. **Discover routes** → render `/`, intercept `createRouter()`, extract patterns via recursive walk
+8. **Filter pre-renderable** → exclude `:param` and `*` patterns, respect `prerender: false`
+9. **Render each route** → `ssrRenderToString(module, routePath)` for each (sequentially — see "Sequential rendering" below)
+10. **Inject into template** → use shared `injectIntoTemplate()` utility, passing empty string for CSS (template already has `<link>` to `vertz.css`)
+11. **Write per-route HTML** → `dist/client/index.html` for `/`, `dist/client/about/index.html` for `/about`, etc.
+
+The pre-rendering reuses `ssrRenderToString` directly — no dev server spawning, no HTTP fetching, no dev script stripping. The SSR module is already built for Bun; we just import and call it.
+
+### Shell vs pre-rendered `index.html`
+
+- The HTML shell (SSR template) is written to `dist/client/_shell.html`
+- The pre-rendered root (`/`) is written to `dist/client/index.html`
+- `vertz start` loads `_shell.html` as the SSR template for dynamic routes
+- For a fully static site (no dynamic routes), `_shell.html` is unused but harmless
+- Pre-rendered `/` overwrites the previous `index.html` location — the pre-rendered version is strictly better (has content AND the client JS bundle)
+
+### CSS handling
+
+The client build (step 2) extracts all component CSS into `vertz.css`. The HTML template already contains `<link rel="stylesheet" href="/assets/vertz.css">`.
+
+During pre-rendering, `ssrRenderToString()` also returns CSS from `collectCSS()`. To avoid duplication (inline `<style>` tags on top of the linked file), the pre-render pipeline passes an **empty string** for the CSS parameter when calling `injectIntoTemplate()`:
+
+```ts
+injectIntoTemplate(template, appHtml, /* css: */ '', ssrData, nonce, headTags)
+```
+
+This ensures pre-rendered pages reference the CSS file via `<link>` (cacheable by the browser) rather than duplicating CSS inline.
+
+### `vertz start` serving pre-rendered HTML
+
+The `fetch` handler in `start.ts` gains a new early check before the SSR fallback:
+
+```ts
+async fetch(req) {
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+
+  // Nav pre-fetch still goes through SSR query discovery (even for pre-rendered routes)
+  if (req.headers.get('x-vertz-nav') === '1') {
+    return ssrHandler(req);
+  }
+
+  // Serve static assets (JS, CSS, images)
+  const staticResponse = serveStaticFile(clientDir, pathname);
+  if (staticResponse) return staticResponse;
+
+  // Check for pre-rendered HTML: /about → dist/client/about/index.html
+  const prerenderResponse = servePrerenderHTML(clientDir, pathname);
+  if (prerenderResponse) return prerenderResponse;
+
+  // Fallback: runtime SSR (dynamic routes, or routes with prerender: false)
+  return ssrHandler(req);
+}
+```
+
+`servePrerenderHTML` checks for `dist/client/<pathname>/index.html` (or `dist/client/index.html` for `/`). It serves with `Cache-Control: public, max-age=0, must-revalidate` (pre-rendered HTML should be fresh on each deploy, unlike hashed assets which are immutable).
+
+### Sequential rendering
+
+Routes are rendered sequentially, not in parallel. This is a deliberate constraint:
+
+The DOM shim (`installDomShim()`) sets process-global `document` and `window`. Concurrent SSR renders would interleave DOM operations on the shared `document.head` (e.g., `<style>` injection). While `ssrStorage` (AsyncLocalStorage) isolates the SSR *context* per-render, the DOM globals are not isolated.
+
+For a typical site with 5-20 static routes at ~200-500ms per render, this adds 1-10 seconds to build time — acceptable. Parallel rendering is a future optimization that requires per-render DOM isolation.
+
+## Route discovery mechanism
+
+### Approach: SSR context interception (zero-config)
+
+`createRouter()` already reads the SSR context for URL matching. We extend it to *write* the route patterns back:
+
+```ts
+// In createRouter(), when SSR context exists:
+const ssrCtx = getSSRContext();
+if (ssrCtx) {
+  // Register all route patterns for discovery (recursive walk of nested children)
+  ssrCtx.discoveredRoutes = collectRoutePatterns(routes);
+}
+
+/** Recursively collect all route patterns, concatenating parent + child paths. */
+function collectRoutePatterns(routes: CompiledRoute[], prefix = ''): string[] {
+  const patterns: string[] = [];
+  for (const route of routes) {
+    const fullPattern = joinPatterns(prefix, route.pattern);
+    patterns.push(fullPattern);
+    if (route.children) {
+      patterns.push(...collectRoutePatterns(route.children, fullPattern));
+    }
+  }
+  return patterns;
+}
+
+/** Join parent and child route patterns, handling trailing/leading slashes. */
+function joinPatterns(parent: string, child: string): string {
+  if (!parent || parent === '/') return child;
+  if (child === '/') return parent;
+  return `${parent.replace(/\/$/, '')}/${child.replace(/^\//, '')}`;
+}
+```
+
+The build pipeline:
+1. Creates an SSR context with `url: '/'`
+2. Calls `ssrRenderToString(module, '/')` — which runs the app
+3. Reads `ctx.discoveredRoutes` after render
+4. Has the complete route pattern list (flat, with full paths)
+
+This is zero-config, works with any router definition, handles nested routes, and requires minimal changes to `createRouter()`.
+
+### Filtering pre-renderable routes
+
+```ts
+function filterPrerenderableRoutes(
+  patterns: string[],
+  compiledRoutes: CompiledRoute[],
+): string[] {
+  return patterns.filter(pattern => {
+    // Skip dynamic segments
+    if (pattern.includes(':') || pattern.includes('*')) return false;
+    // Skip routes with prerender: false
+    const route = findCompiledRoute(compiledRoutes, pattern);
+    if (route?.prerender === false) return false;
+    return true;
+  });
+}
+```
+
+### Rejected alternatives
+
+- **Static analysis of route definitions** — parse `defineRoutes({...})` at build time. Brittle — breaks with computed keys, dynamic imports, spread operators. Not recommended.
+- **Explicit route manifest export** — require the app to export a route list. Adds boilerplate. Not the default path.
+
+## Manifesto Alignment
+
+| Principle | How this design aligns |
+|---|---|
+| **One way to do things** | `vertz build` handles both static and dynamic. No separate `export` command. No manual build scripts. |
+| **Convention over configuration** | Static routes pre-rendered by default. No config file needed. |
+| **AI agents are first-class** | An LLM can produce a deployable site with `defineRoutes()` + `vertz build`. No build script knowledge needed. |
+| **If it builds, it works** | Pre-render failure = build failure. A successful build guarantees all pre-rendered pages are complete and correct. |
+| **Production-ready by default** | Pre-rendering is the default, not an opt-in. Static routes get the performance benefit automatically. |
+| **Performance is not optional** | Pre-rendered HTML = zero server compute, instant TTFB from CDN edge. |
+
+## Non-Goals
+
+- **Full static site generator (SSG) with content pipeline** — this is route pre-rendering, not a content framework. No markdown processing, no content collections, no build-time data fetching from CMS APIs.
+- **Incremental Static Regeneration (ISR)** — on-demand re-rendering at the edge. Future work.
+- **Dynamic route pre-rendering** (`/users/:id`) — requires knowing the parameter space (like Next.js `getStaticPaths`). Deferred. `vertz start` handles these with runtime SSR.
+- **Per-route head/meta customization in the build** — SEO meta tags are a component-level concern (e.g., a `<Head>` component), not a build concern.
+- **Adapter-specific output optimization** — the `dist/client/` structure works as-is for static hosts (Cloudflare Workers Sites, Vercel static, Netlify). Per-platform optimizations (edge functions, serverless) are a separate concern.
+- **Additional static paths config** (`additionalPaths` in `vertz.config.ts`) — pre-rendering CMS-driven paths not in the router requires a `getStaticPaths`-like mechanism. Deferred to the dynamic route pre-rendering design.
+- **Parallel route rendering** — requires per-render DOM isolation (the current DOM shim uses process globals). Future optimization.
+
+## Unknowns
+
+### 1. SSR module import in build context
+
+**Question:** Can we `import()` the built SSR module (`dist/server/app.js`) from within the `vertz build` process?
+
+**Resolution approach:** POC — the module is built with `target: 'bun'` and externals `['@vertz/ui', '@vertz/ui-server', '@vertz/ui-primitives']`. The build process runs under Bun, so externals resolve from `node_modules`.
+
+**Risk:** Low. `vertz start` already does exactly this — `startUIOnly` imports `dist/server/app.js` and passes it to `createSSRHandler`. The pre-render pipeline does the same thing at build time.
+
+### 2. Hydration mismatch for pre-rendered pages
+
+**Question:** Pre-rendered HTML is produced at build time. The client hydrates at request time. Components that render differently based on `Date.now()`, `Math.random()`, or request-time data will produce hydration mismatches.
+
+**Resolution:** This is a known constraint shared by all SSG frameworks (Next.js, Astro, etc.). The existing Vertz hydration system is tolerant (cursor-based DOM walking, skips mismatches). The pre-render pipeline doesn't introduce new mismatch risks — it produces the same HTML as runtime SSR would. Routes with request-time dependencies should use `prerender: false`.
+
+## Type Flow Map
+
+No new generics introduced. The pre-render pipeline operates on `SSRModule` (existing type from `@vertz/ui-server`) and `CompiledRoute` (existing type from `@vertz/ui`). The only type change is adding `prerender?: boolean` to `RouteConfig`/`RouteConfigLike`/`CompiledRoute` — a simple optional boolean, no generic flow needed.
+
+## E2E Acceptance Test
+
+### Test 1: Static site (landing page pattern)
+
+```ts
+describe('Feature: vertz build pre-renders static routes', () => {
+  describe('Given a UI app with two static routes (/ and /about)', () => {
+    describe('When running vertz build', () => {
+      it('Then dist/client/index.html contains SSR content for /', () => {
+        // HTML contains the homepage component's rendered output
+        // Not just an empty <div id="app"></div> shell
+      });
+      it('Then dist/client/about/index.html contains SSR content for /about', () => {
+        // HTML contains the about page's rendered output
+      });
+      it('Then dist/client/_shell.html exists as the SSR template', () => {
+        // Contains empty <div id="app"></div> for runtime SSR
+      });
+      it('Then both pre-rendered files include the client JS bundle script tag', () => {
+        // <script type="module" src="/assets/entry-client-[hash].js">
+      });
+      it('Then both pre-rendered files reference CSS via <link>, not inline <style>', () => {
+        // <link rel="stylesheet" href="/assets/vertz.css">
+        // No duplicate <style data-vertz-css> tags
+      });
+    });
+  });
+
+  describe('Given a UI app with a dynamic route (/users/:id)', () => {
+    describe('When running vertz build', () => {
+      it('Then /users/:id is NOT pre-rendered (no dist/client/users/ directory)', () => {});
+      it('Then dist/client/_shell.html exists for runtime SSR fallback', () => {});
+    });
+  });
+
+  describe('Given a UI app with prerender: false on a static route', () => {
+    describe('When running vertz build', () => {
+      it('Then the route is NOT pre-rendered', () => {});
+    });
+  });
+
+  describe('Given a route whose loader throws during pre-rendering', () => {
+    describe('When running vertz build', () => {
+      it('Then the build fails with a clear error message', () => {
+        // "✗ Pre-render failed for /pricing"
+        // "Hint: add prerender: false to its route config"
+      });
+    });
+  });
+});
+```
+
+### Test 2: Hybrid app — vertz start serves both pre-rendered and dynamic
+
+```ts
+describe('Feature: vertz start serves pre-rendered and dynamic pages', () => {
+  describe('Given a built app with pre-rendered / and /about, and dynamic /users/:id', () => {
+    describe('When GET /about is requested', () => {
+      it('Then responds with the pre-rendered HTML from disk', () => {
+        // Response content matches dist/client/about/index.html
+        // No ssrRenderToString call — served as static file
+      });
+    });
+    describe('When GET /users/123 is requested (dynamic route)', () => {
+      it('Then responds with runtime SSR output', () => {
+        // Falls back to ssrRenderToString using _shell.html as template
+      });
+    });
+    describe('When GET /about with X-Vertz-Nav: 1 header is requested', () => {
+      it('Then responds with SSE query data (not the pre-rendered HTML)', () => {
+        // Nav pre-fetch bypasses static serving for query discovery
+      });
+    });
+  });
+});
+```
+
+### Test 3: Route discovery
+
+```ts
+describe('Feature: Route discovery from SSR module', () => {
+  describe('Given routes: / (static), /about (static), /users/:id (dynamic)', () => {
+    describe('When the build discovers routes', () => {
+      it('Then discovers ["/", "/about", "/users/:id"]', () => {});
+      it('Then filters to pre-renderable: ["/", "/about"]', () => {});
+      it('Then excludes dynamic: ["/users/:id"]', () => {});
+    });
+  });
+
+  describe('Given nested routes: /docs with children / and /:slug', () => {
+    describe('When the build discovers routes', () => {
+      it('Then discovers ["/docs", "/docs/:slug"]', () => {});
+      it('Then pre-renders /docs but not /docs/:slug', () => {});
+    });
+  });
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Route Discovery + `prerender` Type
+
+**Goal:** `createRouter()` registers route patterns with the SSR context. The `prerender` opt-out property is available on route configs.
+
+**Changes:**
+- `packages/ui/src/router/define-routes.ts` — add `prerender?: boolean` to `RouteConfig`, `RouteConfigLike`, and `CompiledRoute`. Propagate in `defineRoutes()`.
+- `packages/ui/src/ssr/ssr-render-context.ts` — add `discoveredRoutes?: string[]` to `SSRRenderContext`
+- `packages/ui/src/router/navigate.ts` — in `createRouter()`, when SSR context exists, call `collectRoutePatterns()` (recursive walk) and write to `ssrCtx.discoveredRoutes`
+- `packages/ui-server/src/ssr-render.ts` — include `discoveredRoutes` in `SSRRenderResult`
+
+**Acceptance criteria:**
+```ts
+describe('Given an SSR render of an app with defineRoutes', () => {
+  describe('When ssrRenderToString is called', () => {
+    it('Then the render result includes discoveredRoutes with all patterns', () => {});
+    it('Then nested children patterns are included as full paths (e.g., /docs/:slug)', () => {});
+    it('Then dynamic patterns (:param, *) are included (filtering is the caller\'s job)', () => {});
+  });
+});
+
+describe('Given a route with prerender: false', () => {
+  it('Then CompiledRoute.prerender is false', () => {});
+  it('Then TypeScript accepts prerender: false in defineRoutes()', () => {});
+});
+```
+
+### Phase 2: Pre-render Pipeline + CLI Integration
+
+**Goal:** `vertz build` automatically pre-renders static routes after the UI build.
+
+**Changes:**
+- `packages/ui-server/src/template-inject.ts` — extract `injectIntoTemplate()` from `ssr-handler.ts` into a shared utility. Export from `@vertz/ui-server/ssr` barrel.
+- `packages/ui-server/src/ssr-handler.ts` — import `injectIntoTemplate` from the new shared location (no behavior change)
+- `packages/ui-server/src/prerender.ts` — new module, exported from `@vertz/ui-server/ssr`:
+  - `discoverRoutes(module)` — render `/`, extract `discoveredRoutes`
+  - `filterPrerenderableRoutes(patterns, routes)` — exclude `:param`, `*`, and `prerender: false`
+  - `prerenderRoutes(module, template, options)` — render each route sequentially, inject into template (with empty CSS string to avoid duplication), return per-route HTML
+- `packages/cli/src/production-build/ui-build-pipeline.ts`:
+  - Step 3: write shell to `dist/client/_shell.html` (instead of `index.html`)
+  - New step 6: import SSR module from `dist/server/app.js`, call `prerenderRoutes()`, write HTML files to `dist/client/`
+  - Build failure if any route's SSR render throws (with hint about `prerender: false`)
+  - Build summary lists pre-rendered routes
+- `packages/cli/src/commands/start.ts`:
+  - New `servePrerenderHTML(clientDir, pathname)` function: checks `dist/client/<pathname>/index.html`
+  - Load SSR template from `_shell.html` (not `index.html`)
+  - `X-Vertz-Nav` requests bypass pre-rendered HTML (go through SSR handler for query discovery)
+  - Pre-rendered HTML served with `Cache-Control: public, max-age=0, must-revalidate`
+
+**Acceptance criteria:**
+```ts
+describe('Given a Vertz UI app with static and dynamic routes', () => {
+  describe('When running vertz build', () => {
+    it('Then pre-rendered HTML files are written to dist/client/', () => {});
+    it('Then dist/client/_shell.html exists as the SSR template', () => {});
+    it('Then the build summary lists pre-rendered routes', () => {});
+    it('Then pre-rendered HTML references CSS via <link>, not inline', () => {});
+    it('Then a route whose loader throws fails the build with a hint', () => {});
+  });
+  describe('When running vertz start after build', () => {
+    it('Then pre-rendered routes are served from static HTML', () => {});
+    it('Then dynamic routes fall back to runtime SSR using _shell.html', () => {});
+    it('Then X-Vertz-Nav requests go through SSR handler (not static)', () => {});
+  });
+});
+```
+
+### Phase 3: Dogfood — Migrate Landing Site
+
+**Goal:** Replace `sites/landing/scripts/build.ts` with `vertz build`.
+
+**Changes:**
+- `sites/landing/package.json` — change `"build"` script to `vertz build`
+- `sites/landing/scripts/build.ts` — delete (or keep for OG image generation only)
+- `sites/landing/wrangler.toml` — update `directory` to `./dist/client`
+- Verify the landing site builds and deploys correctly
+
+**Acceptance criteria:**
+- `vertz build` in `sites/landing/` produces the same output as the custom build script
+- `vertz.dev` and `vertz.dev/manifesto` serve correct pre-rendered HTML
+- No custom build script needed (except OG image generation, which is site-specific)
+
+### Future work (not in scope)
+
+- **Dynamic route pre-rendering** — `getStaticPaths()` equivalent for `:param` routes. This also subsumes the `additionalPaths` config concept.
+- **Per-route metadata** — `<Head>` component for title/meta tags per page
+- **Build hooks** — pre-build/post-build hooks for custom steps (OG images, sitemaps, etc.)
+- **Adapter output** — Cloudflare/Vercel/Netlify-specific output optimization
+- **Incremental builds** — only re-render changed routes
+- **Parallel route rendering** — requires per-render DOM isolation (current DOM shim uses process globals)
+- **Build dry-run** — `vertz build --dry-run` to list discovered routes without rendering

--- a/sites/landing/package.json
+++ b/sites/landing/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/dev-server.ts",
-    "build": "bun run scripts/build.ts",
+    "build": "vertz build",
+    "build:og": "bun run scripts/og-images.ts",
     "deploy": "bun run build && bunx wrangler deploy",
     "typecheck": "tsc --noEmit"
   },
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",
+    "@vertz/cli": "workspace:*",
     "@vertz/ui-compiler": "workspace:*",
     "bun-types": "^1.3.9",
     "satori": "^0.25.0",

--- a/sites/landing/wrangler.toml
+++ b/sites/landing/wrangler.toml
@@ -3,7 +3,7 @@ compatibility_date = "2025-01-01"
 workers_dev = true
 
 [assets]
-directory = "./dist"
+directory = "./dist/client"
 not_found_handling = "single-page-application"
 
 [[routes]]


### PR DESCRIPTION
## Summary

- Add static pre-rendering to `vertz build`: discovers routes via SSR, filters to static-only patterns, and writes pre-rendered HTML files to `dist/client/`
- Route discovery is lazy (on first `router.current.value` access during SSR render) to support module-level routers created outside SSR context
- Migrate landing site to use `vertz build` — both `/` and `/manifesto` are pre-rendered to static HTML
- Extract `injectIntoTemplate()` into shared module and add `prerender.ts` with `discoverRoutes`, `filterPrerenderableRoutes`, `prerenderRoutes`
- CLI `start` command serves pre-rendered HTML files before falling back to runtime SSR

## Test plan

- [x] 14 SSR router tests pass (lazy route discovery)
- [x] 11 prerender tests pass (discover, filter, render)
- [x] 27 SSR render tests pass (discoveredRoutes in render result)
- [x] 425 CLI tests pass (including build pipeline + start command)
- [x] Landing site builds with `vertz build` — discovers 2 routes, pre-renders both
- [x] Full quality gates pass (79/79 turbo tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)