### PR TITLE
fix(landing): resolve vertz CLI path for workspace builds

### DIFF
--- a/sites/landing/package.json
+++ b/sites/landing/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/dev-server.ts",
-    "build": "vertz build",
+    "build": "bun node_modules/@vertz/cli/dist/vertz.js build",
     "build:og": "bun run scripts/og-images.ts",
     "deploy": "bun run build && bunx wrangler deploy",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- The `@vertz/landing` build script used bare `vertz build`, but bun workspaces don't create `.bin/` symlinks for workspace packages, causing `command not found` (exit 127) in CI
- Changed to `bun node_modules/@vertz/cli/dist/vertz.js build` — the same pattern used by `@vertz-examples/task-manager`

## Public API Changes
None — internal build script only.

## Test plan
- [ ] CI passes (the `@vertz/landing#build` task that was failing with exit code 127)
- [ ] Release workflow passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)