### PR TITLE
perf(cli): inject modulepreload links for JS chunks in build pipeline

### DIFF
--- a/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
+++ b/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
@@ -264,4 +264,39 @@ describe('buildUI', () => {
     const pluginNames = serverCall.plugins.map((p: { name: string }) => p.name);
     expect(pluginNames).toContain('vertz-ssr-jsx-swap');
   });
+
+  it('should inject modulepreload links for JS chunks in HTML shell', async () => {
+    // Mock client build to return entry + chunks
+    mockBunBuild
+      .mockImplementationOnce(async (opts: { outdir: string }) => {
+        mkdirSync(opts.outdir, { recursive: true });
+        const entryFile = join(opts.outdir, 'entry-client-abc123.js');
+        const chunk1 = join(opts.outdir, 'chunk-def456.js');
+        const chunk2 = join(opts.outdir, 'chunk-ghi789.js');
+        writeFileSync(entryFile, '// entry');
+        writeFileSync(chunk1, '// chunk 1');
+        writeFileSync(chunk2, '// chunk 2');
+        return {
+          success: true,
+          logs: [],
+          outputs: [
+            { path: entryFile, kind: 'entry-point' },
+            { path: chunk1, kind: 'chunk' },
+            { path: chunk2, kind: 'chunk' },
+          ],
+        };
+      })
+      .mockImplementationOnce(async (opts: { outdir: string; entrypoints: string[] }) => {
+        mkdirSync(opts.outdir, { recursive: true });
+        const jsFile = join(opts.outdir, 'app.js');
+        writeFileSync(jsFile, '// server');
+        return { success: true, logs: [], outputs: [{ path: jsFile, kind: 'entry-point' }] };
+      });
+
+    await buildUI(config);
+
+    const html = readFileSync(join(tmpDir, 'dist', 'client', '_shell.html'), 'utf-8');
+    expect(html).toContain('<link rel="modulepreload" href="/assets/chunk-def456.js">');
+    expect(html).toContain('<link rel="modulepreload" href="/assets/chunk-ghi789.js">');
+  });
 });

--- a/packages/cli/src/production-build/ui-build-pipeline.ts
+++ b/packages/cli/src/production-build/ui-build-pipeline.ts
@@ -109,6 +109,7 @@ export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
     // Collect output filenames for HTML injection
     let clientJsPath = '';
     const clientCssPaths: string[] = [];
+    const chunkPaths: string[] = [];
 
     for (const output of clientResult.outputs) {
       const name = output.path.replace(distClient, '');
@@ -116,10 +117,15 @@ export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
         clientJsPath = name;
       } else if (output.path.endsWith('.css')) {
         clientCssPaths.push(name);
+      } else if (output.kind === 'chunk' && output.path.endsWith('.js')) {
+        chunkPaths.push(name);
       }
     }
 
     console.log(`  JS entry: ${clientJsPath}`);
+    for (const chunk of chunkPaths) {
+      console.log(`  JS chunk: ${chunk}`);
+    }
     for (const css of clientCssPaths) {
       console.log(`  CSS: ${css}`);
     }
@@ -146,6 +152,10 @@ export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
       .map((path) => `    <link rel="stylesheet" href="${path}">`)
       .join('\n');
 
+    const modulepreloadLinks = chunkPaths
+      .map((path) => `    <link rel="modulepreload" href="${path}">`)
+      .join('\n');
+
     const html = `<!doctype html>
 <html lang="en">
   <head>
@@ -153,6 +163,7 @@ export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
 ${cssLinks}
+${modulepreloadLinks}
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary

- Adds `<link rel="modulepreload">` tags for all JS chunks in the HTML shell generated by `vertz build`
- Eliminates waterfall loading where the browser discovers chunk dependencies only after executing the entry module
- Related to #1174 (Gap 5: Automatic modulepreload for Route Dependency Graphs)

## Test plan

- [x] New test verifies modulepreload links are injected for chunk outputs
- [x] All existing build pipeline tests pass
- [x] Quality gates clean (test + typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)