### PR TITLE
fix(ui-server): mock console.error in flaky fast-refresh test

### DIFF
--- a/packages/ui-server/src/__tests__/fast-refresh-runtime.test.ts
+++ b/packages/ui-server/src/__tests__/fast-refresh-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 beforeAll(() => {
@@ -534,6 +534,8 @@ describe('Fast Refresh Runtime', () => {
     });
 
     it('handles factory errors gracefully — keeps old instance', () => {
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
       const factory1 = createFactory('v1');
       __$refreshReg('mod1', 'App', factory1);
 
@@ -553,6 +555,12 @@ describe('Fast Refresh Runtime', () => {
       // Old element should still be in the DOM
       expect(el.isConnected).toBe(true);
       expect(el.textContent).toBe('v1');
+
+      // Verify the error was logged (not swallowed)
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toBe('[vertz-hmr] Error re-mounting App:');
+
+      errorSpy.mockRestore();
     });
 
     it('clears dirty flag after perform', () => {


### PR DESCRIPTION
## Summary

- The fast-refresh runtime test "handles factory errors gracefully" intentionally throws an Error inside a component factory to verify the runtime catches it
- `console.error()` writes the full Error stack to stderr, which Bun's test runner on CI intermittently counts as "1 error" (distinct from test failures), causing exit code 1
- Mock `console.error` in this test and assert it was called with the expected prefix `[vertz-hmr] Error re-mounting App:`

## Public API Changes

None.

## Test plan

- [x] All 659 `@vertz/ui-server` tests pass (0 fail, no error count)
- [x] The `console.error` spy verifies the runtime logs errors (not swallowed)
- [x] Full quality gates pass (test, typecheck, lint)
- [ ] CI should no longer intermittently fail on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)