### PR TITLE
feat(integration-tests): add cloudflare runtime adapter coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -316,6 +316,7 @@
         "@happy-dom/global-registrator": "^20.7.0",
         "@mjackson/node-fetch-server": "^0.7.0",
         "@types/node": "^25.3.1",
+        "@vertz/cloudflare": "workspace:^",
         "@vertz/codegen": "workspace:^",
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -328,6 +329,7 @@
         "bun-types": "^1.3.10",
         "happy-dom": "^20.7.0",
         "typescript": "^5.7.0",
+        "vertz": "workspace:^",
         "yaml": "^2.3.0",
       },
     },
@@ -2087,13 +2089,7 @@
 
     "@vertz/cli-runtime/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
-    "@vertz/integration-tests/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
-
     "@vertz/landing-nextjs/wrangler": ["wrangler@4.72.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260310.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260310.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260310.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg=="],
-
-    "@vertz/server/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
-
-    "@vertz/testing/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,6 +8,7 @@
     "test:bun": "RUNTIME=bun bun test",
     "test:node": "RUNTIME=node bun test",
     "test:deno": "RUNTIME=deno bun test",
+    "test:cloudflare": "RUNTIME=cloudflare bun test",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -16,12 +17,14 @@
     "@vertz/codegen": "workspace:^",
     "@vertz/core": "workspace:^",
     "@vertz/errors": "workspace:^",
+    "@vertz/cloudflare": "workspace:^",
     "@vertz/fetch": "workspace:^",
     "@vertz/server": "workspace:^",
     "@vertz/db": "workspace:^",
     "@vertz/schema": "workspace:^",
     "@vertz/theme-shadcn": "workspace:^",
     "@vertz/ui": "workspace:^",
+    "vertz": "workspace:^",
     "@happy-dom/global-registrator": "^20.7.0",
     "bun-types": "^1.3.10",
     "happy-dom": "^20.7.0",

--- a/packages/integration-tests/src/runtime-adapters/cloudflare.test.ts
+++ b/packages/integration-tests/src/runtime-adapters/cloudflare.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { createHandler as directCreateHandler } from '@vertz/cloudflare';
+import { cloudflareAdapter } from './cloudflare';
+import type { ServerHandle } from './types';
+
+describe('vertz/cloudflare meta-package smoke', () => {
+  it('vertz/cloudflare re-exports match @vertz/cloudflare', async () => {
+    const metaPkg = await import('vertz/cloudflare');
+    expect(metaPkg.createHandler).toBe(directCreateHandler);
+  });
+
+  it('vertz/cloudflare exports createHandler as a function', async () => {
+    const metaPkg = await import('vertz/cloudflare');
+    expect(typeof metaPkg.createHandler).toBe('function');
+  });
+
+  it('vertz/cloudflare exports generateNonce as a function', async () => {
+    const metaPkg = await import('vertz/cloudflare');
+    expect(typeof metaPkg.generateNonce).toBe('function');
+  });
+
+  it('vertz/cloudflare exports generateHTMLTemplate as a function', async () => {
+    const metaPkg = await import('vertz/cloudflare');
+    expect(typeof metaPkg.generateHTMLTemplate).toBe('function');
+  });
+});
+
+describe('invalid RUNTIME rejection', () => {
+  it('fails with an explicit error listing supported runtimes including cloudflare', async () => {
+    const proc = Bun.spawn(['bun', '-e', 'await import("./index.ts")'], {
+      cwd: import.meta.dirname,
+      env: { ...process.env, RUNTIME: 'invalid-runtime' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('Unknown RUNTIME: invalid-runtime');
+    expect(stderr).toContain('cloudflare');
+    expect(stderr).toContain('node');
+    expect(stderr).toContain('bun');
+    expect(stderr).toContain('deno');
+  });
+});
+
+describe('Cloudflare runtime adapter', () => {
+  let handle: ServerHandle | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+  });
+
+  it('has name "cloudflare"', () => {
+    expect(cloudflareAdapter.name).toBe('cloudflare');
+  });
+
+  it('creates a server on a random port', async () => {
+    const handler = async () => new Response('ok');
+    handle = await cloudflareAdapter.createServer(handler);
+
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.url).toBe(`http://localhost:${handle.port}`);
+  });
+
+  it('responds to HTTP requests through the Cloudflare handler path', async () => {
+    const handler = async () => new Response('hello from cloudflare');
+    handle = await cloudflareAdapter.createServer(handler);
+
+    const res = await fetch(handle.url);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).toBe('hello from cloudflare');
+  });
+
+  it('stops accepting requests after close', async () => {
+    const handler = async () => new Response('ok');
+    handle = await cloudflareAdapter.createServer(handler);
+    const url = handle.url;
+
+    await handle.close();
+    handle = undefined;
+
+    await expect(fetch(url)).rejects.toThrow();
+  });
+});

--- a/packages/integration-tests/src/runtime-adapters/cloudflare.ts
+++ b/packages/integration-tests/src/runtime-adapters/cloudflare.ts
@@ -1,0 +1,43 @@
+import { createHandler } from '@vertz/cloudflare';
+import type { AppBuilder } from '@vertz/core';
+import type { RuntimeAdapter } from './types';
+
+declare const Bun: {
+  serve(options: { port: number; fetch: (request: Request) => Promise<Response> }): {
+    port: number;
+    stop(closeActiveConnections?: boolean): void;
+  };
+};
+
+interface WorkerExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+}
+
+export const cloudflareAdapter: RuntimeAdapter = {
+  name: 'cloudflare',
+  async createServer(handler) {
+    // Wrap the raw handler as a minimal AppBuilder shape
+    const app = { handler } as unknown as AppBuilder;
+    const worker = createHandler(app);
+
+    // Mock ExecutionContext for local testing
+    const ctx: WorkerExecutionContext = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    };
+
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req: Request) => worker.fetch(req, {}, ctx),
+    });
+
+    return {
+      port: server.port,
+      url: `http://localhost:${server.port}`,
+      close: async () => server.stop(),
+    };
+  },
+};
+
+export const adapter = cloudflareAdapter;

--- a/packages/integration-tests/src/runtime-adapters/index.ts
+++ b/packages/integration-tests/src/runtime-adapters/index.ts
@@ -6,6 +6,7 @@ const adapters: Record<string, () => Promise<{ adapter: RuntimeAdapter }>> = {
   node: () => import('./node'),
   bun: () => import('./bun'),
   deno: () => import('./deno'),
+  cloudflare: () => import('./cloudflare'),
 };
 
 const load = adapters[runtime];


### PR DESCRIPTION
## Summary

- Add `cloudflare` to the shared runtime adapter matrix in `@vertz/integration-tests`
- Implement Cloudflare adapter that wraps `@vertz/cloudflare`'s `createHandler()` through a local Bun server
- Add meta-package smoke coverage verifying `vertz/cloudflare` re-exports match `@vertz/cloudflare`
- Add explicit error coverage for unsupported `RUNTIME` values (now includes `cloudflare` in the error message)
- Add `test:cloudflare` script to integration-tests for parity with other runtimes

Closes #1158

## Public API Changes

None — this is internal test infrastructure only.

## Test plan

- [x] 9 new tests in `cloudflare.test.ts` (adapter lifecycle + meta-package smoke + invalid RUNTIME)
- [x] All 21 runtime adapter tests pass
- [x] `RUNTIME=cloudflare` works through the alias path
- [x] Typecheck passes (`bun run --filter @vertz/integration-tests typecheck`)
- [x] Lint passes
- [x] Pre-push quality gates: 79/79 tasks successful
- [x] Adversarial review: APPROVED (`reviews/package-runtime-hardening/phase-02-runtime-adapters.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)