### PR TITLE
feat(ui,ui-compiler): nested form schemas and dynamic field access (#530)

### DIFF
--- a/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
@@ -11,11 +11,11 @@
 // Uses only public package imports — never relative imports.
 // ===========================================================================
 
+import { describe, expect, it, mock } from 'bun:test';
 import { err, ok } from '@vertz/fetch';
 import { s } from '@vertz/schema';
 import type { FormOptions, SdkMethod, SdkMethodWithMeta } from '@vertz/ui/form';
 import { form, formDataToObject } from '@vertz/ui/form';
-import { describe, expect, it, mock } from 'bun:test';
 
 // ---------------------------------------------------------------------------
 // 1. Mock SDK method — simulates generated SDK output
@@ -34,10 +34,11 @@ interface User {
 
 /** Mock SDK method with url/method metadata (no .meta). */
 function mockSdk(): SdkMethod<CreateUserBody, User> {
-  const fn = async (body: CreateUserBody) => ok<User>({
-    id: 'u-1',
-    ...body,
-  });
+  const fn = async (body: CreateUserBody) =>
+    ok<User>({
+      id: 'u-1',
+      ...body,
+    });
   return Object.assign(fn, { url: '/api/users', method: 'POST' });
 }
 
@@ -47,10 +48,11 @@ function mockSdkWithMeta(): SdkMethodWithMeta<CreateUserBody, User> {
     name: s.string().min(1),
     email: s.string().min(1),
   });
-  const fn = async (body: CreateUserBody) => ok<User>({
-    id: 'u-1',
-    ...body,
-  });
+  const fn = async (body: CreateUserBody) =>
+    ok<User>({
+      id: 'u-1',
+      ...body,
+    });
   return Object.assign(fn, {
     url: '/api/users',
     method: 'POST',
@@ -416,6 +418,112 @@ describe('Form API Developer Walkthrough', () => {
       fd.append('email', 'alice@test.com');
       const obj = formDataToObject(fd);
       expect(obj).toEqual({ name: 'Alice', email: 'alice@test.com' });
+    });
+
+    it('parses dot-paths into nested objects when nested: true', () => {
+      const fd = new FormData();
+      fd.set('name', 'Alice');
+      fd.set('address.street', '123 Main');
+      fd.set('address.city', 'Springfield');
+      const obj = formDataToObject(fd, { nested: true });
+      expect(obj).toEqual({
+        name: 'Alice',
+        address: { street: '123 Main', city: 'Springfield' },
+      });
+    });
+
+    it('preserves flat keys without nested option (backward compat)', () => {
+      const fd = new FormData();
+      fd.set('address.street', '123 Main');
+      const obj = formDataToObject(fd);
+      expect(obj).toEqual({ 'address.street': '123 Main' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3k. Nested field access — chain proxy
+  // -------------------------------------------------------------------------
+
+  describe('Nested field access', () => {
+    const nestedSchema = s.object({
+      name: s.string().min(1),
+      address: s.object({
+        street: s.string().min(1),
+        city: s.string().min(1),
+      }),
+    });
+
+    interface NestedBody {
+      name: string;
+      address: { street: string; city: string };
+    }
+
+    function nestedSdk(): SdkMethod<NestedBody, { id: string }> {
+      const fn = async (_body: NestedBody) => ok<{ id: string }>({ id: 'u-1' });
+      return Object.assign(fn, { url: '/api/users', method: 'POST' });
+    }
+
+    it('supports nested field error access via chain proxy', () => {
+      const f = form(nestedSdk(), { schema: nestedSchema });
+      expect(f.address.street.error.peek()).toBeUndefined();
+      f.address.street.error.value = 'Street is required';
+      expect(f.address.street.error.peek()).toBe('Street is required');
+    });
+
+    it('chain proxy identity is stable (cached)', () => {
+      const f = form(nestedSdk(), { schema: nestedSchema });
+      expect(f.address).toBe(f.address);
+      expect(f.address.street).toBe(f.address.street);
+    });
+
+    it('group-level field state works', () => {
+      const f = form(nestedSdk(), { schema: nestedSchema });
+      f.address.error.value = 'Invalid address';
+      expect(f.address.error.peek()).toBe('Invalid address');
+      // Group-level is independent of leaf-level
+      expect(f.address.street.error.peek()).toBeUndefined();
+    });
+
+    it('setFieldError accepts dot-path strings', () => {
+      const f = form(nestedSdk(), { schema: nestedSchema });
+      f.setFieldError('address.street', 'Street required');
+      expect(f.address.street.error.peek()).toBe('Street required');
+      f.setFieldError('address', 'Invalid address');
+      expect(f.address.error.peek()).toBe('Invalid address');
+    });
+
+    it('validation populates nested field errors via dot-path keys', async () => {
+      const onError = mock();
+      const f = form(nestedSdk(), { schema: nestedSchema, onError });
+      const fd = new FormData();
+      fd.set('name', '');
+      fd.set('address.street', '');
+      fd.set('address.city', '');
+      await f.submit(fd);
+      expect(onError).toHaveBeenCalled();
+      expect(f.name.error.peek()).toBeDefined();
+      expect(f.address.street.error.peek()).toBeDefined();
+      expect(f.address.city.error.peek()).toBeDefined();
+    });
+
+    it('nested initial values are resolved from DeepPartial', () => {
+      const f = form(nestedSdk(), {
+        schema: nestedSchema,
+        initial: { address: { city: 'Springfield' } },
+      });
+      expect(f.address.city.value.peek()).toBe('Springfield');
+      expect(f.address.street.value.peek()).toBeUndefined();
+      expect(f.name.value.peek()).toBeUndefined();
+    });
+
+    it('form-level signals still work with nested fields', () => {
+      const f = form(nestedSdk(), { schema: nestedSchema });
+      expect(f.submitting.peek()).toBe(false);
+      expect(f.dirty.peek()).toBe(false);
+      expect(f.valid.peek()).toBe(true);
+
+      f.setFieldError('address.street', 'Required');
+      expect(f.valid.peek()).toBe(false);
     });
   });
 

--- a/packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts
@@ -162,6 +162,52 @@ describe('JsxAnalyzer', () => {
     expect(result?.[0]?.reactive).toBe(true);
   });
 
+  it('classifies 4-level field signal chain as reactive', () => {
+    const code = `
+      function UserForm() {
+        const taskForm = form({});
+        return <div>{taskForm.address.street.error}</div>;
+      }
+    `;
+    const variables: VariableInfo[] = [
+      {
+        name: 'taskForm',
+        kind: 'static',
+        start: 0,
+        end: 0,
+        signalProperties: new Set(['submitting', 'dirty', 'valid']),
+        plainProperties: new Set(['action', 'method']),
+        fieldSignalProperties: new Set(['error', 'dirty', 'touched', 'value']),
+      },
+    ];
+    const [result] = analyze(code, variables);
+    expect(result?.[0]?.reactive).toBe(true);
+  });
+
+  it('classifies ElementAccessExpression field chain as reactive', () => {
+    const code = `
+      function DynForm() {
+        const taskForm = form({});
+        const field = 'title';
+        return <div>{taskForm[field].error}</div>;
+      }
+    `;
+    const variables: VariableInfo[] = [
+      {
+        name: 'taskForm',
+        kind: 'static',
+        start: 0,
+        end: 0,
+        signalProperties: new Set(['submitting']),
+        plainProperties: new Set(['action']),
+        fieldSignalProperties: new Set(['error', 'dirty', 'touched', 'value']),
+      },
+    ];
+    const [result] = analyze(code, variables);
+    const reactiveExprs = result?.filter((e) => e.reactive);
+    expect(reactiveExprs?.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('classifies bare reactive source identifier as reactive', () => {
     const code = `
       function App() {

--- a/packages/ui-compiler/src/analyzers/jsx-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/jsx-analyzer.ts
@@ -86,7 +86,8 @@ export class JsxAnalyzer {
  *
  * Handles two patterns:
  * - 2-level: `tasks.loading` (root.signalProp)
- * - 3-level: `taskForm.title.error` (root.field.fieldSignalProp)
+ * - N-level (>= 3): `taskForm.title.error`, `taskForm.address.street.error`,
+ *   `taskForm[field].error` (root + intermediates + fieldSignalProp leaf)
  */
 function containsSignalApiPropertyAccess(
   node: Node,
@@ -110,28 +111,57 @@ function containsSignalApiPropertyAccess(
       }
     }
 
-    // 3-level: root.field.fieldSignalProp
-    if (obj.isKind(SyntaxKind.PropertyAccessExpression)) {
-      const innerExpr = obj.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-      const rootExpr = innerExpr.getExpression();
-      const middleProp = innerExpr.getName();
-
-      if (rootExpr.isKind(SyntaxKind.Identifier)) {
-        const rootName = rootExpr.getText();
-        const fieldSignalProps = fieldSignalPropVars.get(rootName);
-        if (!fieldSignalProps) continue;
-
-        // Middle must NOT be a signal property or plain property (it's a field name)
-        const signalProps = signalApiVars.get(rootName);
-        const plainProps = plainPropVars.get(rootName);
-        if (signalProps?.has(middleProp) || plainProps?.has(middleProp)) continue;
-
-        // Leaf must be a field signal property
-        if (fieldSignalProps.has(propName)) {
-          return true;
-        }
+    // N-level (>= 3): Walk up the chain to find the root identifier
+    // Quick check: leaf must be a potential fieldSignalProperty
+    let anyHasLeaf = false;
+    for (const props of fieldSignalPropVars.values()) {
+      if (props.has(propName)) {
+        anyHasLeaf = true;
+        break;
       }
     }
+    if (!anyHasLeaf) continue;
+
+    let current: Node = obj;
+    const intermediateNames: string[] = [];
+    let chainLength = 2; // root + leaf
+
+    while (true) {
+      if (current.isKind(SyntaxKind.PropertyAccessExpression)) {
+        const innerPa = current.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+        intermediateNames.unshift(innerPa.getName());
+        current = innerPa.getExpression();
+        chainLength++;
+      } else if (current.isKind(SyntaxKind.ElementAccessExpression)) {
+        const ea = current.asKindOrThrow(SyntaxKind.ElementAccessExpression);
+        current = ea.getExpression();
+        chainLength++;
+      } else {
+        break;
+      }
+    }
+
+    if (!current.isKind(SyntaxKind.Identifier)) continue;
+    const rootName = current.getText();
+
+    const fieldSignalProps = fieldSignalPropVars.get(rootName);
+    if (!fieldSignalProps) continue;
+    if (chainLength < 3) continue;
+    if (!fieldSignalProps.has(propName)) continue;
+
+    // No intermediate can be a signalProperty or plainProperty
+    const signalProps = signalApiVars.get(rootName);
+    const plainProps = plainPropVars.get(rootName);
+    let intermediateBlocked = false;
+    for (const name of intermediateNames) {
+      if (signalProps?.has(name) || plainProps?.has(name)) {
+        intermediateBlocked = true;
+        break;
+      }
+    }
+    if (intermediateBlocked) continue;
+
+    return true;
   }
   return false;
 }

--- a/packages/ui-compiler/src/transformers/__tests__/signal-transformer.test.ts
+++ b/packages/ui-compiler/src/transformers/__tests__/signal-transformer.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from 'bun:test';
 import MagicString from 'magic-string';
 import { Project, ts } from 'ts-morph';
-import { describe, expect, it } from 'bun:test';
 import { ComponentAnalyzer } from '../../analyzers/component-analyzer';
 import type { VariableInfo } from '../../types';
 import { SignalTransformer } from '../signal-transformer';
@@ -149,5 +149,86 @@ describe('SignalTransformer', () => {
       [formVar],
     );
     expect(result).toContain('taskForm.dirty.value');
+  });
+
+  it('dirty ambiguity: 2-level taskForm.dirty uses Pass 2, 3-level uses Pass 1', () => {
+    // dirty is in BOTH signalProperties and fieldSignalProperties.
+    // 2-level: taskForm.dirty → signalProperty via Pass 2 → .value
+    // 3-level: taskForm.title.dirty → fieldSignalProperty via Pass 1 → .value
+    const result = transform(
+      `function TaskForm() {\n  const taskForm = form({ title: '' });\n  const d = taskForm.dirty;\n  const fd = taskForm.title.dirty;\n  return <div>{d}{fd}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm.dirty.value');
+    expect(result).toContain('taskForm.title.dirty.value');
+    // Neither should be double-transformed
+    expect(result).not.toContain('taskForm.dirty.value.value');
+    expect(result).not.toContain('taskForm.title.dirty.value.value');
+  });
+
+  it('auto-unwraps 4-level chain (root.group.field.signal)', () => {
+    const result = transform(
+      `function UserForm() {\n  const taskForm = form({});\n  const err = taskForm.address.street.error;\n  return <div>{err}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm.address.street.error.value');
+  });
+
+  it('auto-unwraps 5-level chain (root.a.b.c.signal)', () => {
+    const result = transform(
+      `function UserForm() {\n  const taskForm = form({});\n  const v = taskForm.deep.nested.field.value;\n  return <div>{v}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm.deep.nested.field.value.value');
+  });
+
+  it('does NOT double-transform 4-level chain when .value already present', () => {
+    const result = transform(
+      `function UserForm() {\n  const taskForm = form({});\n  const err = taskForm.address.street.error.value;\n  return <div>{err}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm.address.street.error.value');
+    expect(result).not.toContain('taskForm.address.street.error.value.value');
+  });
+
+  it('does NOT transform when leaf is NOT a fieldSignalProperty', () => {
+    const result = transform(
+      `function UserForm() {\n  const taskForm = form({});\n  const x = taskForm.address.street.something;\n  return <div>{x}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).not.toContain('.something.value');
+  });
+
+  it('does NOT transform when intermediate is a signalProperty', () => {
+    const result = transform(
+      `function UserForm() {\n  const taskForm = form({});\n  const x = taskForm.submitting.error;\n  return <div>{x}</div>;\n}`,
+      [formVar],
+    );
+    // submitting is a signalProperty, so this is NOT a field chain
+    expect(result).not.toContain('taskForm.submitting.error.value');
+  });
+
+  it('transforms ElementAccessExpression: form[dynamicField].error', () => {
+    const result = transform(
+      `function DynForm() {\n  const taskForm = form({});\n  const field = 'title';\n  const err = taskForm[field].error;\n  return <div>{err}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm[field].error.value');
+  });
+
+  it('transforms mixed chain: form.items[0].name.error', () => {
+    const result = transform(
+      `function ArrayForm() {\n  const taskForm = form({});\n  const err = taskForm.items[0].name.error;\n  return <div>{err}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm.items[0].name.error.value');
+  });
+
+  it('transforms multiple bracket notations: form[a][b].error', () => {
+    const result = transform(
+      `function DynForm() {\n  const taskForm = form({});\n  const a = 'x';\n  const b = 'y';\n  const err = taskForm[a][b].error;\n  return <div>{err}</div>;\n}`,
+      [formVar],
+    );
+    expect(result).toContain('taskForm[a][b].error.value');
   });
 });

--- a/packages/ui-compiler/src/transformers/signal-transformer.ts
+++ b/packages/ui-compiler/src/transformers/signal-transformer.ts
@@ -147,11 +147,12 @@ function transformReferences(
  * Transform property accesses on signal API variables to auto-unwrap.
  *
  * Handles two patterns:
+ * - N-level field chains (>= 3 segments): `taskForm.title.error` → `.value`,
+ *   `taskForm.address.street.error` → `.value` (root + intermediates + fieldSignalProp leaf)
  * - 2-level: `tasks.data` → `tasks.data.value` (root.signalProp)
- * - 3-level: `taskForm.title.error` → `taskForm.title.error.value` (root.field.fieldSignalProp)
  *
- * 3-level chains are processed first to avoid the inner PropertyAccessExpression
- * being matched as a 2-level check.
+ * N-level chains are processed first (Pass 1) to avoid inner PropertyAccessExpressions
+ * being matched as 2-level chains in Pass 2.
  */
 function transformSignalApiProperties(
   source: MagicString,
@@ -160,61 +161,104 @@ function transformSignalApiProperties(
   plainPropVars: Map<string, Set<string>>,
   fieldSignalPropVars: Map<string, Set<string>>,
 ): void {
-  // Pass 1: Find and transform 3-level chains, track their ranges
-  const threeLevelRanges: Array<{ start: number; end: number }> = [];
+  // Pass 1: Find and transform N-level field signal chains (chain length >= 3), track their ranges
+  const fieldChainRanges: Array<{ start: number; end: number }> = [];
 
   bodyNode.forEachDescendant((node) => {
     if (!node.isKind(SyntaxKind.PropertyAccessExpression)) return;
 
     const outerExpr = node.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-    const middleExpr = outerExpr.getExpression();
     const leafProp = outerExpr.getName();
 
-    // 3-level: outerExpr = middleExpr.leafProp, middleExpr = rootIdent.middleProp
-    if (!middleExpr.isKind(SyntaxKind.PropertyAccessExpression)) return;
+    // Quick check: leaf must be a potential fieldSignalProperty for some variable
+    let anyHasLeaf = false;
+    for (const props of fieldSignalPropVars.values()) {
+      if (props.has(leafProp)) {
+        anyHasLeaf = true;
+        break;
+      }
+    }
+    if (!anyHasLeaf) return;
 
-    const innerExpr = middleExpr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-    const rootExpr = innerExpr.getExpression();
-    const middleProp = innerExpr.getName();
+    // Walk up the chain to find the root identifier, collecting intermediates
+    let current: Node = outerExpr.getExpression();
+    const intermediateNames: string[] = [];
+    let chainLength = 2; // root + leaf
 
-    if (!rootExpr.isKind(SyntaxKind.Identifier)) return;
-    const rootName = rootExpr.getText();
+    while (true) {
+      if (current.isKind(SyntaxKind.PropertyAccessExpression)) {
+        const pa = current.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+        intermediateNames.unshift(pa.getName());
+        current = pa.getExpression();
+        chainLength++;
+      } else if (current.isKind(SyntaxKind.ElementAccessExpression)) {
+        // ElementAccessExpression — opaque intermediate (bracket notation)
+        const ea = current.asKindOrThrow(SyntaxKind.ElementAccessExpression);
+        current = ea.getExpression();
+        chainLength++;
+        // No named property to validate — skip intermediate name check
+      } else {
+        break;
+      }
+    }
 
-    // Root must be a signal API var with fieldSignalProperties
+    // Root must be an identifier
+    if (!current.isKind(SyntaxKind.Identifier)) return;
+    const rootName = current.getText();
+
+    // Root must have fieldSignalProperties
     const fieldSignalProps = fieldSignalPropVars.get(rootName);
     if (!fieldSignalProps) return;
 
-    // Middle must NOT be a signal property or plain property (it's a field name)
-    const signalProps = signalApiVars.get(rootName);
-    const plainProps = plainPropVars.get(rootName);
-    if (signalProps?.has(middleProp) || plainProps?.has(middleProp)) return;
+    // Chain must have >= 3 segments (root + at least one intermediate + leaf)
+    if (chainLength < 3) return;
 
     // Leaf must be a field signal property
     if (!fieldSignalProps.has(leafProp)) return;
+
+    // No intermediate PropertyAccess name can be a signalProperty or plainProperty
+    const signalProps = signalApiVars.get(rootName);
+    const plainProps = plainPropVars.get(rootName);
+    for (const name of intermediateNames) {
+      if (signalProps?.has(name) || plainProps?.has(name)) return;
+    }
 
     // Guard: Check if .value is already present (migration case)
     const parent = outerExpr.getParent();
     if (parent?.isKind(SyntaxKind.PropertyAccessExpression)) {
       const parentProp = parent.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
       if (parentProp.getExpression() === outerExpr && parentProp.getName() === 'value') {
-        threeLevelRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
-        return; // Already has .value, skip transformation
+        fieldChainRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
+        return;
+      }
+    }
+
+    // Guard: If the leaf is 'value' and the sub-chain (without leaf) already ends
+    // with a fieldSignalProperty, the user manually wrote .value — don't double-append.
+    if (leafProp === 'value') {
+      const subExpr = outerExpr.getExpression();
+      if (subExpr.isKind(SyntaxKind.PropertyAccessExpression)) {
+        const subLeaf = subExpr.asKindOrThrow(SyntaxKind.PropertyAccessExpression).getName();
+        if (fieldSignalProps.has(subLeaf)) {
+          fieldChainRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
+          return;
+        }
       }
     }
 
     source.appendLeft(outerExpr.getEnd(), '.value');
-    threeLevelRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
+    fieldChainRanges.push({ start: outerExpr.getStart(), end: outerExpr.getEnd() });
   });
 
-  // Pass 2: Transform 2-level chains, skipping nodes inside 3-level ranges
+  // Pass 2: Transform 2-level chains, skipping nodes inside N-level chain ranges
   bodyNode.forEachDescendant((node) => {
     if (!node.isKind(SyntaxKind.PropertyAccessExpression)) return;
 
     const expr = node.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
 
-    // Skip if this node is inside a 3-level chain range
+    // Skip if this node is inside a field chain range
     const nodeStart = expr.getStart();
-    if (threeLevelRanges.some((r) => nodeStart >= r.start && nodeStart < r.end)) return;
+    if (fieldChainRanges.some((r) => nodeStart >= r.start && nodeStart < r.end)) return;
 
     const objExpr = expr.getExpression();
     const propName = expr.getName();
@@ -231,7 +275,7 @@ function transformSignalApiProperties(
     if (parent?.isKind(SyntaxKind.PropertyAccessExpression)) {
       const parentProp = parent.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
       if (parentProp.getExpression() === expr && parentProp.getName() === 'value') {
-        return; // Already has .value, skip transformation
+        return;
       }
     }
 

--- a/packages/ui/src/form/__tests__/form-data.test.ts
+++ b/packages/ui/src/form/__tests__/form-data.test.ts
@@ -80,4 +80,151 @@ describe('formDataToObject', () => {
 
     expect(result).toEqual({ count: '42', active: 'true' });
   });
+
+  describe('nested dot-path parsing (nested: true)', () => {
+    it('parses "address.street" into { address: { street: value } }', () => {
+      const fd = new FormData();
+      fd.append('address.street', '123 Main St');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({ address: { street: '123 Main St' } });
+    });
+
+    it('parses multiple nested keys into the same parent object', () => {
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('address.street', '123 Main');
+      fd.append('address.city', 'Springfield');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({
+        name: 'Alice',
+        address: { street: '123 Main', city: 'Springfield' },
+      });
+    });
+
+    it('handles deeply nested paths (3+ levels)', () => {
+      const fd = new FormData();
+      fd.append('a.b.c.d', 'deep');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({ a: { b: { c: { d: 'deep' } } } });
+    });
+
+    it('creates arrays for numeric indices', () => {
+      const fd = new FormData();
+      fd.append('items.0.name', 'Widget');
+      fd.append('items.1.name', 'Gadget');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({
+        items: [{ name: 'Widget' }, { name: 'Gadget' }],
+      });
+    });
+
+    it('passes sparse indices through as-is (holes are undefined)', () => {
+      const fd = new FormData();
+      fd.append('items.0.name', 'First');
+      fd.append('items.3.name', 'Fourth');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result.items).toBeArray();
+      const items = result.items as Array<unknown>;
+      expect(items[0]).toEqual({ name: 'First' });
+      expect(items[1]).toBeUndefined();
+      expect(items[2]).toBeUndefined();
+      expect(items[3]).toEqual({ name: 'Fourth' });
+    });
+
+    it('handles mixed object and array nesting', () => {
+      const fd = new FormData();
+      fd.append('order.items.0.product', 'Widget');
+      fd.append('order.items.0.quantity', '5');
+      fd.append('order.items.1.product', 'Gadget');
+      fd.append('order.note', 'Rush order');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({
+        order: {
+          items: [{ product: 'Widget', quantity: '5' }, { product: 'Gadget' }],
+          note: 'Rush order',
+        },
+      });
+    });
+
+    it('preserves flat keys without dots unchanged', () => {
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@example.com');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({ name: 'Alice', email: 'alice@example.com' });
+    });
+
+    it('coercion works with nested paths', () => {
+      const fd = new FormData();
+      fd.append('user.age', '25');
+      fd.append('user.active', 'true');
+
+      const result = formDataToObject(fd, { nested: true, coerce: true });
+
+      expect(result).toEqual({ user: { age: 25, active: true } });
+    });
+  });
+
+  describe('prototype pollution guard (nested: true)', () => {
+    it('ignores __proto__ segments', () => {
+      const fd = new FormData();
+      fd.append('__proto__.isAdmin', 'true');
+      fd.append('name', 'Alice');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({ name: 'Alice' });
+      // Ensure Object.prototype was NOT polluted
+      expect(({} as Record<string, unknown>).isAdmin).toBeUndefined();
+    });
+
+    it('ignores constructor segments', () => {
+      const fd = new FormData();
+      fd.append('constructor.prototype.isAdmin', 'true');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      expect(result).toEqual({});
+    });
+
+    it('ignores prototype as a leaf segment', () => {
+      const fd = new FormData();
+      fd.append('a.prototype', 'value');
+
+      const result = formDataToObject(fd, { nested: true });
+
+      // 'a' is created as intermediate, but 'prototype' value is dropped
+      expect(result).toEqual({ a: {} });
+      expect((result.a as Record<string, unknown>).prototype).toBeUndefined();
+    });
+  });
+
+  describe('backward compatibility (without nested option)', () => {
+    it('preserves dot-containing keys as flat strings', () => {
+      const fd = new FormData();
+      fd.append('address.street', '123 Main');
+      fd.append('address.city', 'Springfield');
+
+      const result = formDataToObject(fd);
+
+      expect(result).toEqual({
+        'address.street': '123 Main',
+        'address.city': 'Springfield',
+      });
+    });
+  });
 });

--- a/packages/ui/src/form/__tests__/form.test-d.ts
+++ b/packages/ui/src/form/__tests__/form.test-d.ts
@@ -200,6 +200,85 @@ userForm.error;
 // @ts-expect-error - handleSubmit() no longer exists on FormInstance
 userForm.handleSubmit;
 
+// ─── 19. Nested field access types ───────────────────────────────────
+
+type NestedBody = { name: string; address: { street: string; city: string } };
+declare const nestedForm: FormInstance<NestedBody, void>;
+
+// Flat field on nested form still works
+const _nestedNameError: Signal<string | undefined> = nestedForm.name.error;
+void _nestedNameError;
+
+// Nested field access: address.street.error
+const _streetError: Signal<string | undefined> = nestedForm.address.street.error;
+void _streetError;
+
+const _cityValue: Signal<string> = nestedForm.address.city.value;
+void _cityValue;
+
+// Group-level field state
+const _addressError: Signal<string | undefined> = nestedForm.address.error;
+void _addressError;
+
+// @ts-expect-error - 'nonexistent' is not a key of address
+nestedForm.address.nonexistent;
+
+// ─── 20. DeepPartial initial values ─────────────────────────────────
+
+const _nestedOpts: FormOptions<NestedBody, void> = {
+  initial: { address: { city: 'Springfield' } }, // partial nested — no name, no street
+};
+void _nestedOpts;
+
+// ─── 21. FieldPath — setFieldError accepts dot-path strings ─────────
+
+nestedForm.setFieldError('name', 'Required');
+nestedForm.setFieldError('address', 'Invalid address');
+nestedForm.setFieldError('address.street', 'Street required');
+nestedForm.setFieldError('address.city', 'City required');
+
+// @ts-expect-error - 'address.nonexistent' is not a valid FieldPath
+nestedForm.setFieldError('address.nonexistent', 'Bad');
+
+// @ts-expect-error - 'foo' is not a valid FieldPath
+nestedForm.setFieldError('foo', 'Bad');
+
+// ─── 22. Array field access types ────────────────────────────────────
+
+type OrderBody = { items: Array<{ product: string; quantity: number }> };
+declare const orderForm: FormInstance<OrderBody, void>;
+
+const _orderItem = orderForm.items[0];
+// biome-ignore lint/style/noNonNullAssertion: type test needs definite access
+const _itemProductError: Signal<string | undefined> = _orderItem!.product.error;
+void _itemProductError;
+
+// biome-ignore lint/style/noNonNullAssertion: type test needs definite access
+const _itemQuantityValue: Signal<number> = _orderItem!.quantity.value;
+void _itemQuantityValue;
+
+// ─── 23. BuiltInObjects are leaf FieldState (no recursion) ───────────
+
+type WithDate = { name: string; createdAt: Date };
+declare const dateForm: FormInstance<WithDate, void>;
+
+const _dateValue: Signal<Date> = dateForm.createdAt.value;
+void _dateValue;
+
+// Date is a leaf — should NOT recurse into Date prototype methods
+const _dateError: Signal<string | undefined> = dateForm.createdAt.error;
+void _dateError;
+
+// ─── 24. Reserved field name collision in nested object ──────────────
+
+type BadNested = { meta: { error: string; name: string } };
+type BadForm = FormInstance<BadNested, void>;
+
+// 'error' in meta conflicts with FieldState.error — type should produce __error
+// @ts-expect-error - meta has __error, accessing .error should fail
+const _badError: Signal<string | undefined> = ({} as BadForm).meta.error;
+void _badError;
+
 // ─── SdkMethod basics (unchanged) ─────────────────────────────────
 
 declare const createUser: SdkMethod<UserBody, UserResult>;

--- a/packages/ui/src/form/__tests__/form.test.ts
+++ b/packages/ui/src/form/__tests__/form.test.ts
@@ -636,6 +636,121 @@ describe('form', () => {
     });
   });
 
+  describe('nested field access', () => {
+    it('nested path returns field accessor with error signal', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      expect(f.address.street.error.peek()).toBeUndefined();
+      f.address.street.error.value = 'Street is required';
+      expect(f.address.street.error.peek()).toBe('Street is required');
+    });
+
+    it('nested chain proxy is cached (same identity)', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      const street1 = f.address.street;
+      const street2 = f.address.street;
+      expect(street1).toBe(street2);
+    });
+
+    it('group-level field state works', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      f.address.error.value = 'Invalid address';
+      expect(f.address.error.peek()).toBe('Invalid address');
+    });
+
+    it('form-level signals still work with chain proxy', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      expect(f.action).toBe('/api/users');
+      expect(f.method).toBe('POST');
+      expect(f.submitting.peek()).toBe(false);
+    });
+
+    it('flat field access still works', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      f.name.error.value = 'Required';
+      expect(f.name.error.peek()).toBe('Required');
+    });
+
+    it('nested initial values are resolved via path traversal', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, {
+        schema: passingSchema(),
+        initial: { address: { city: 'Springfield' } },
+      });
+
+      expect(f.address.city.value.peek()).toBe('Springfield');
+      expect(f.address.street.value.peek()).toBeUndefined();
+    });
+
+    it('setFieldError works with dot-path strings', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+
+      const f = form(sdk, { schema: passingSchema() });
+      f.setFieldError('address.street', 'Street is required');
+      expect(f.address.street.error.peek()).toBe('Street is required');
+    });
+
+    it('validation errors populate nested field states via dot-path keys', async () => {
+      const handler = vi.fn().mockResolvedValue({ id: 1 });
+      const sdk = mockSdkMethod({ url: '/api/users', method: 'POST', handler });
+      const schema: FormSchema<{ name: string; address: { street: string } }> = {
+        parse(_data: unknown) {
+          const error = new Error('Validation failed');
+          (error as Error & { fieldErrors: Record<string, string> }).fieldErrors = {
+            'address.street': 'Required',
+          };
+          return { ok: false as const, error };
+        },
+      };
+
+      const f = form(sdk, { schema });
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('address.street', '');
+      await f.submit(fd);
+
+      expect(f.address.street.error.peek()).toBe('Required');
+    });
+  });
+
   describe('computed dirty and valid', () => {
     it('dirty starts as false', () => {
       const sdk = mockSdkMethod({

--- a/packages/ui/src/form/form-data.ts
+++ b/packages/ui/src/form/form-data.ts
@@ -2,6 +2,8 @@
 export interface FormDataOptions {
   /** When true, coerces numeric strings to numbers and "true"/"false" to booleans. */
   coerce?: boolean;
+  /** When true, parses dot-separated keys into nested objects (e.g., "address.street" → { address: { street: ... } }). */
+  nested?: boolean;
 }
 
 /**
@@ -18,6 +20,7 @@ export function formDataToObject(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   const coerce = options?.coerce ?? false;
+  const nested = options?.nested ?? false;
 
   for (const [key, value] of formData.entries()) {
     // Skip File entries
@@ -25,10 +28,36 @@ export function formDataToObject(
       continue;
     }
 
-    result[key] = coerce ? coerceValue(value) : value;
+    const coerced = coerce ? coerceValue(value) : value;
+    if (nested && key.includes('.')) {
+      setNestedValue(result, key, coerced);
+    } else {
+      result[key] = coerced;
+    }
   }
 
   return result;
+}
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Set a value at a dot-separated path in a nested object. Numeric segments create arrays. */
+function setNestedValue(obj: Record<string, unknown>, dotPath: string, value: unknown): void {
+  const segments = dotPath.split('.');
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]!;
+    if (DANGEROUS_KEYS.has(segment)) return;
+    const nextSegment = segments[i + 1]!;
+    const isNextArray = /^\d+$/.test(nextSegment);
+    if (!(segment in current)) {
+      current[segment] = isNextArray ? [] : {};
+    }
+    current = current[segment] as Record<string, unknown>;
+  }
+  const lastSegment = segments[segments.length - 1]!;
+  if (DANGEROUS_KEYS.has(lastSegment)) return;
+  current[lastSegment] = value;
 }
 
 /** Coerce a string value to a number or boolean if applicable. */

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -6,6 +6,9 @@ import { formDataToObject } from './form-data';
 import type { FormSchema } from './validation';
 import { validate } from './validation';
 
+const FIELD_STATE_SIGNALS = new Set(['error', 'dirty', 'touched', 'value']);
+const FIELD_STATE_METHODS = new Set(['setValue', 'reset']);
+
 /**
  * An SDK method with endpoint metadata attached.
  * Generated SDK methods expose `.url` and `.method` for progressive enhancement.
@@ -41,8 +44,59 @@ export type ReservedFormNames =
 
 export type { FieldState };
 
-/** Mapped type providing FieldState for each field in TBody. */
+/** Mapped type providing FieldState for each field in TBody (flat — no nested access). */
 export type FieldAccessors<TBody> = { [K in keyof TBody]: FieldState<TBody[K]> };
+
+/** Built-in object types that should NOT recurse into NestedFieldAccessors. */
+type BuiltInObjects = Date | RegExp | File | Blob | Map<unknown, unknown> | Set<unknown>;
+
+/** FieldState signal/method property names that conflict with nested field names. */
+type FieldSignalReservedNames = 'error' | 'dirty' | 'touched' | 'value' | 'setValue' | 'reset';
+
+/** Check if any key of T collides with FieldState property names. */
+type HasReservedFieldName<T> = keyof T & FieldSignalReservedNames extends never ? false : true;
+
+/** Recursive field accessors for nested schemas. */
+export type NestedFieldAccessors<T> = {
+  [K in keyof T]: T[K] extends BuiltInObjects
+    ? FieldState<T[K]>
+    : T[K] extends Array<infer U>
+      ? FieldState<T[K]> & ArrayFieldAccessors<U>
+      : T[K] extends Record<string, unknown>
+        ? HasReservedFieldName<T[K]> extends true
+          ? {
+              __error: `Nested field name conflicts with FieldState property: ${keyof T[K] & FieldSignalReservedNames & string}`;
+            }
+          : FieldState<T[K]> & NestedFieldAccessors<T[K]>
+        : FieldState<T[K]>;
+};
+
+/** Array field accessors — numeric index access to element-level fields. */
+export type ArrayFieldAccessors<U> = {
+  [index: number]: U extends BuiltInObjects
+    ? FieldState<U>
+    : U extends Record<string, unknown>
+      ? FieldState<U> & NestedFieldAccessors<U>
+      : FieldState<U>;
+};
+
+/** Deep partial utility for initial values. */
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[K] extends Record<string, unknown>
+      ? DeepPartial<T[K]>
+      : T[K];
+};
+
+/** Union of all valid dot-paths through a nested type. */
+export type FieldPath<T, Prefix extends string = ''> =
+  | `${Prefix}${keyof T & string}`
+  | {
+      [K in keyof T & string]: T[K] extends Record<string, unknown>
+        ? FieldPath<T[K], `${Prefix}${K}.`>
+        : never;
+    }[keyof T & string];
 
 /** Mapped type providing typed field name strings for compile-time input validation. */
 export type FieldNames<TBody> = { readonly [K in keyof TBody & string]: K };
@@ -53,7 +107,7 @@ export interface FormBaseProperties<TBody> {
   method: string;
   onSubmit: (e: Event) => Promise<void>;
   reset: () => void;
-  setFieldError: (field: keyof TBody & string, message: string) => void;
+  setFieldError: (field: FieldPath<TBody>, message: string) => void;
   submit: (formData?: FormData) => Promise<void>;
   submitting: Signal<boolean>;
   dirty: ReadonlySignal<boolean>;
@@ -69,7 +123,7 @@ export interface FormBaseProperties<TBody> {
  * TResult is used by form() overloads for return type inference.
  */
 export type FormInstance<TBody, _TResult> = keyof TBody & ReservedFormNames extends never
-  ? FormBaseProperties<TBody> & FieldAccessors<TBody>
+  ? FormBaseProperties<TBody> & NestedFieldAccessors<TBody>
   : {
       __error: `Field name conflicts with reserved form property: ${keyof TBody & ReservedFormNames & string}`;
     };
@@ -78,8 +132,8 @@ export type FormInstance<TBody, _TResult> = keyof TBody & ReservedFormNames exte
 export interface FormOptions<TBody, TResult> {
   /** Explicit schema for client-side validation before submission. */
   schema?: FormSchema<TBody>;
-  /** Initial values for form fields. */
-  initial?: Partial<TBody> | (() => Partial<TBody>);
+  /** Initial values for form fields. Supports nested partial values. */
+  initial?: DeepPartial<TBody> | (() => DeepPartial<TBody>);
   /** Callback invoked after a successful submission. */
   onSuccess?: (result: TResult) => void;
   /** Callback invoked when validation or submission fails. */
@@ -110,6 +164,7 @@ export function form<TBody, TResult>(
   options?: FormOptions<TBody, TResult>,
 ): FormInstance<TBody, TResult> {
   const fieldCache = new Map<string, FieldState>();
+  const chainProxyCache = new Map<string, object>();
   const submitting = signal(false);
   // Generation counter — incremented when new fields are added to the cache.
   // Computed signals read this to re-evaluate when the field set changes.
@@ -131,12 +186,29 @@ export function form<TBody, TResult>(
     return true;
   });
 
+  function resolveNestedInitial(dotPath: string): unknown {
+    const initialObj =
+      typeof options?.initial === 'function' ? options.initial() : options?.initial;
+    if (!initialObj) return undefined;
+    const segments = dotPath.split('.');
+    let current: unknown = initialObj;
+    for (const segment of segments) {
+      if (current == null || typeof current !== 'object') return undefined;
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+  }
+
   function getOrCreateField(name: string): FieldState {
     let field = fieldCache.get(name);
     if (!field) {
-      const initialObj =
-        typeof options?.initial === 'function' ? options.initial() : options?.initial;
-      const initialValue = (initialObj as Record<string, unknown> | undefined)?.[name];
+      const initialValue = name.includes('.')
+        ? resolveNestedInitial(name)
+        : (() => {
+            const initialObj =
+              typeof options?.initial === 'function' ? options.initial() : options?.initial;
+            return (initialObj as Record<string, unknown> | undefined)?.[name];
+          })();
       field = createFieldState(name, initialValue);
       fieldCache.set(name, field);
       fieldGeneration.value++;
@@ -144,10 +216,34 @@ export function form<TBody, TResult>(
     return field;
   }
 
+  function getOrCreateChainProxy(dotPath: string): object {
+    let proxy = chainProxyCache.get(dotPath);
+    if (proxy) return proxy;
+
+    proxy = new Proxy(Object.create(null) as Record<string | symbol, unknown>, {
+      get(_target, prop) {
+        if (typeof prop === 'string') {
+          if (FIELD_STATE_SIGNALS.has(prop)) {
+            return getOrCreateField(dotPath)[prop as keyof FieldState];
+          }
+          if (FIELD_STATE_METHODS.has(prop)) {
+            return getOrCreateField(dotPath)[prop as keyof FieldState];
+          }
+          const childPath = `${dotPath}.${prop}`;
+          return getOrCreateChainProxy(childPath);
+        }
+        return undefined;
+      },
+    });
+
+    chainProxyCache.set(dotPath, proxy);
+    return proxy;
+  }
+
   const resolvedSchema = options?.schema ?? sdkMethod.meta?.bodySchema;
 
   async function submitPipeline(formData: FormData): Promise<void> {
-    const data = formDataToObject(formData);
+    const data = formDataToObject(formData, { nested: true });
 
     if (resolvedSchema) {
       const result = validate(resolvedSchema, data);
@@ -274,7 +370,7 @@ export function form<TBody, TResult>(
         if (knownProperties.has(prop)) {
           return target[prop];
         }
-        return getOrCreateField(prop);
+        return getOrCreateChainProxy(prop);
       }
       return Reflect.get(target, prop, receiver);
     },

--- a/packages/ui/src/form/public.ts
+++ b/packages/ui/src/form/public.ts
@@ -8,9 +8,14 @@
 export type { FieldState } from './field-state';
 export { createFieldState } from './field-state';
 export type {
+  ArrayFieldAccessors,
+  DeepPartial,
+  FieldAccessors,
   FieldNames,
+  FieldPath,
   FormInstance,
   FormOptions,
+  NestedFieldAccessors,
   SdkMethod,
   SdkMethodWithMeta,
 } from './form';

--- a/plans/nested-form-schemas.md
+++ b/plans/nested-form-schemas.md
@@ -1,0 +1,949 @@
+# Nested Object Schemas and Dynamic Field Access for form()
+
+**Issue:** #530
+**Status:** Draft (Rev 2 — addresses DX, Product, and Technical review feedback)
+**Parent:** form() API redesign (#527, PR #523)
+**Deferred from:** `plans/form-attrs-api-improvement.md` Section 7C
+
+---
+
+## 1. API Surface
+
+### 1A. Nested Object Schemas
+
+Given a nested schema:
+
+```ts
+import { s } from '@vertz/schema';
+
+const createUserSchema = s.object({
+  name: s.string().min(1),
+  address: s.object({
+    street: s.string().min(1),
+    city: s.string().min(1),
+    zip: s.string().length(5),
+  }),
+});
+
+type CreateUserBody = {
+  name: string;
+  address: {
+    street: string;
+    city: string;
+    zip: string;
+  };
+};
+```
+
+Usage in a component:
+
+```tsx
+const userForm = form(userApi.create, { schema: createUserSchema });
+
+return (
+  <form action={userForm.action} method={userForm.method} onSubmit={userForm.onSubmit}>
+    <input name="name" />
+    {userForm.name.error && <span>{userForm.name.error}</span>}
+
+    {/* Nested field access — 4-level chain */}
+    <input name="address.street" />
+    {userForm.address.street.error && <span>{userForm.address.street.error}</span>}
+
+    <input name="address.city" />
+    {userForm.address.city.error && <span>{userForm.address.city.error}</span>}
+
+    <input name="address.zip" />
+    {userForm.address.zip.error && <span>{userForm.address.zip.error}</span>}
+
+    <button type="submit" disabled={userForm.submitting}>Submit</button>
+  </form>
+);
+```
+
+**Key behaviors:**
+
+- `userForm.address.street` navigates to the `address.street` field via a chain proxy
+- `userForm.address.street.error` returns the error signal for field key `"address.street"`
+- `userForm.address.error` returns the error signal for the group-level field key `"address"` (useful for server-side group-level validation errors). **Important:** this is a simple FieldState for the `"address"` path, NOT a computed aggregate of child errors. If the schema validator reports a group-level error (e.g., `{ path: ['address'], message: 'Invalid address' }`), it appears here. Individual field errors (e.g., `address.street`) must be accessed at their own path. See "Group-Level vs. Leaf-Level Clarity" in Section 2.
+- Input `name` attributes use dot notation: `"address.street"`, `"address.city"`
+- `formDataToObject()` parses dot-path keys into nested objects when `nested: true` is passed: `{ address: { street: "...", city: "..." } }`. The form submit pipeline passes `nested: true` automatically.
+- Arbitrary nesting depth is supported: `form.a.b.c.d.error` works
+
+### 1B. Dynamic Field Access (Bracket Notation)
+
+```tsx
+function DynamicField({ fieldName }: { fieldName: string }) {
+  const taskForm = form(taskApi.create, { schema });
+
+  // Bracket notation — compiler transforms .error to .error.value
+  return (
+    <div>
+      {taskForm[fieldName].error && <span>{taskForm[fieldName].error}</span>}
+    </div>
+  );
+}
+```
+
+The compiler handles `ElementAccessExpression` as an intermediate chain step. When the leaf property is a `fieldSignalProperty`, `.value` is appended.
+
+### 1C. Field Arrays
+
+```tsx
+const orderSchema = s.object({
+  items: s.array(s.object({
+    product: s.string(),
+    quantity: s.number(),
+  })),
+});
+
+type OrderBody = {
+  items: Array<{ product: string; quantity: number }>;
+};
+
+const orderForm = form(orderApi.create, { schema: orderSchema });
+
+// Indexed access — numeric path segments
+<input name="items.0.product" />
+{orderForm.items[0].product.error && <span>{orderForm.items[0].product.error}</span>}
+
+<input name="items.1.product" />
+{orderForm.items[1].product.error && <span>{orderForm.items[1].product.error}</span>}
+```
+
+Array items use numeric indices in the dot-path: `"items.0.product"`. `formDataToObject()` recognizes numeric path segments and creates arrays.
+
+**Note:** This phase provides indexed access to array item fields. Dynamic add/remove helpers (e.g., `orderForm.items.push()`, `orderForm.items.remove(idx)`) and iteration (`orderForm.items.map(...)`) are deferred — see Non-Goals. Without those helpers, array field indexed access is primarily useful for forms with a known, fixed number of items (e.g., a 3-address form). The real user-facing payoff for dynamic arrays lands in the follow-up issue for array helpers.
+
+### 1D. Input Name Convention
+
+For nested fields, use dot-notation string literals for input `name` attributes:
+
+```tsx
+// Flat (existing — fields proxy still works for flat fields)
+<input name={userForm.fields.name} />  // "name"
+
+// Nested — use string literals with dot notation
+<input name="address.street" />
+<input name="address.city" />
+
+// Array — use template literals for dynamic indices
+<input name={`items.${i}.product`} />
+```
+
+The existing `fields` proxy continues to work for flat field names. Extending the `fields` proxy to nested schemas (returning chain proxies with `Symbol.toPrimitive` coercion) is deferred — the interaction between Proxy string coercion and JSX attribute assignment is fragile and not all JSX runtimes handle it consistently. String literals with dot notation are explicit, simple, and work everywhere.
+
+### 1E. Initial Values for Nested Fields
+
+```tsx
+const userForm = form(userApi.create, {
+  schema: createUserSchema,
+  initial: {
+    name: 'Alice',
+    address: { city: 'Springfield' },  // partial — only city, street/zip default to undefined
+  },
+});
+```
+
+The `initial` option type changes from `Partial<TBody>` to `DeepPartial<TBody>` (recursive partial). This allows providing partial initial values at any nesting depth — developers don't need to provide every nested field. When a nested field is accessed, the initial value is resolved by traversing the nested object using the dot-path segments.
+
+### 1F. `setFieldError` with Dot-Path Support
+
+```tsx
+// Flat (existing)
+userForm.setFieldError('name', 'Name is required');
+
+// Nested (new) — accepts dot-path strings
+userForm.setFieldError('address.street', 'Street is required');
+userForm.setFieldError('address', 'Invalid address');  // group-level error
+```
+
+The `setFieldError` signature changes from `(field: keyof TBody & string, message: string)` to `(field: FieldPath<TBody>, message: string)` where `FieldPath<TBody>` is a union of all valid dot-paths through the nested type (e.g., `"name" | "address" | "address.street" | "address.city" | "address.zip"`).
+
+---
+
+## 2. Manifesto Alignment
+
+### Principles Applied
+
+1. **If it builds, it works** — Recursive `FieldAccessors<T>` type ensures nested field paths are compile-time checked. Accessing `userForm.address.nonexistent.error` is a type error. Reserved field signal names (`error`, `dirty`, `touched`, `value`) are guarded at each nesting level.
+
+2. **One way to do things** — Nested fields use the same pattern as flat fields: `form.field.signal`. The nesting just adds more segments. No alternate API (`form.getField('address.street')`) — one access pattern for all depths.
+
+3. **AI agents are first-class users** — The nested pattern is predictable: `form.<path>.<signal>`. An LLM that understands flat form access immediately understands nested form access. Dot-path input names (`"address.street"`) follow the same convention.
+
+4. **Performance is not optional** — Chain proxies are lazy. No upfront field creation for every possible nested path. Fields are created on first access, same as flat fields.
+
+### Tradeoffs
+
+- **Explicit over implicit** — Dot-path input names make the nesting structure visible in HTML. No magic transformation of bracket notation in names.
+- **Convention over configuration** — Dot notation is the only path separator. No support for bracket notation in input names (`address[street]`) — one convention.
+
+### Group-Level vs. Leaf-Level Clarity
+
+A critical DX distinction: `userForm.address.error` and `userForm.address.street.error` refer to different fields.
+
+- `userForm.address.error` → FieldState for path `"address"` (group-level). Only populated if the validator explicitly reports an error at the `address` path, or if the developer calls `setFieldError('address', '...')`.
+- `userForm.address.street.error` → FieldState for path `"address.street"` (leaf-level). Populated by validation errors at `['address', 'street']`.
+
+`userForm.address.error` is NOT a computed aggregate of child errors. To check if any child field has an error, use the form-level `valid` signal (`userForm.valid`) or check each child individually.
+
+### What Was Rejected
+
+- **Nested `fields` proxy with `Symbol.toPrimitive` coercion** — Considered making `userForm.fields.address.street` return a chainable Proxy that coerces to `"address.street"` via `Symbol.toPrimitive`. Rejected because JSX attribute assignment behavior with Proxy objects varies across runtimes — some use property assignment (`el.name = value`), others use `setAttribute`. String coercion is not guaranteed. Developers use dot-notation string literals instead.
+- **Group-level computed aggregates** — Considered `userForm.address.dirty` returning a computed signal that aggregates all child field dirty states. Rejected for v1 — adds complexity with unclear use cases. Group-level `error`/`dirty`/`touched`/`value` create a simple FieldState for the group path, same as any other field.
+- **Bracket notation in input names** — Considered `address[street]` (Rails/PHP style). Rejected — dot notation is simpler, consistent with `@vertz/schema` error paths (`issue.path.join('.')`), and more JS-idiomatic.
+
+---
+
+## 3. Non-Goals
+
+- **Dynamic array helpers** — `form.items.push()`, `form.items.remove(idx)`, `form.items.length`, `form.items.map(...)`. These require array-aware proxies with mutation tracking. Deferred to a follow-up issue.
+- **Computed group aggregates** — `form.address.dirty` automatically computing from child fields. Deferred — simple FieldState per path is sufficient for v1.
+- **Nested `fields` proxy** — `fields.address.street` returning `"address.street"` via chain proxy with string coercion. Deferred due to fragile `Symbol.toPrimitive` interaction with JSX attribute assignment. Developers use dot-notation string literals for nested input names.
+- **Reactive initial values** — Already deferred in Section 7B of the parent design doc.
+- **File upload fields** — `formDataToObject()` already skips File entries. Nested file fields are out of scope.
+- **Deep validation error mapping** — The existing `validation.ts` already joins issue paths with `.` (`issue.path.join('.')`). No changes needed to the validation module.
+
+---
+
+## 4. Unknowns
+
+### Resolved
+
+1. **Can `formDataToObject()` reliably distinguish array indices from object keys?**
+   - Resolution: Numeric path segments are array indices. `"items.0.product"` → `{ items: [{ product: "..." }] }`. Non-numeric segments are object keys. This matches `@vertz/schema`'s path convention where array indices are numbers in the `issue.path` array.
+
+2. **Does the existing `validation.ts` need changes?**
+   - Resolution: No. It already does `issue.path.join('.')` to create field keys. Nested errors like `['address', 'street']` → `'address.street'` already work. The runtime stores fields with dot-path keys, so validation error mapping works unchanged.
+
+3. **Will N-level compiler chain support conflict with the existing 2-pass approach?**
+   - Resolution: The N-level approach replaces Pass 1 (3-level). It walks from any `PropertyAccessExpression` upward through the chain, checking if the root is a signal API var and the leaf is a `fieldSignalProperty`. Pass 2 (2-level signal API properties) remains unchanged. The skip-range mechanism still prevents double-transformation. **Critical constraint:** N-level field chains require **chain length >= 3** (at least one intermediate between root and leaf). Without this, `taskForm.dirty` (2-level) would be matched by both Pass 1 (as a field chain) and Pass 2 (as a signal property), with correctness depending on accidental range-skip mechanics.
+
+4. **Is `formDataToObject()` dot-path parsing a breaking change?**
+   - Resolution: Yes — a flat key like `"file.name"` would be parsed into `{ file: { name: "..." } }` instead of `{ "file.name": "..." }`. Mitigation: make nested parsing opt-in via `formDataToObject(fd, { nested: true })`. The form submit pipeline always passes `{ nested: true }`. External callers retain backward compatibility.
+
+5. **Will `NestedFieldAccessors<T>` hit TypeScript recursion limits?**
+   - Resolution: TypeScript supports ~50 levels of conditional type recursion. Typical form nesting is 2-4 levels, well within limits. **Critical:** Arrays and built-in objects (`Date`, `RegExp`, `File`, `Blob`) must be special-cased to prevent infinite recursion into prototype members. See Type Flow Map for `ArrayFieldAccessors` definition and built-in guards.
+
+6. **Does destructuring or aliasing break the compiler chain detection?**
+   - Resolution: Yes — this is a known and accepted limitation. `const addr = form.address; addr.street.error` won't transform because `addr` is not registered as a signal API var. This is consistent with how the compiler works today (single-pass, no cross-statement data flow analysis). Documented as a known limitation.
+
+### Open — None identified
+
+All unknowns were resolvable through code analysis. No POC needed.
+
+---
+
+## 5. POC Results
+
+No POC needed. The design is a natural extension of the existing form() architecture:
+- Proxy-based field access already works — extending to chain proxies is straightforward
+- `@vertz/schema` already produces nested error paths
+- `validation.ts` already joins paths with `.`
+- The compiler's chain detection is a generalization of existing 3-level logic
+
+---
+
+## 6. Type Flow Map
+
+### Concrete Type Definitions
+
+```ts
+/** Built-in object types that should NOT recurse into NestedFieldAccessors. */
+type BuiltInObjects = Date | RegExp | File | Blob | Map<unknown, unknown> | Set<unknown>;
+
+/** Recursive field accessors for nested schemas. */
+type NestedFieldAccessors<T> = {
+  [K in keyof T]: T[K] extends BuiltInObjects
+    ? FieldState<T[K]>                                          // Built-in → leaf
+    : T[K] extends Array<infer U>
+      ? FieldState<T[K]> & ArrayFieldAccessors<U>               // Array → indexed access
+      : T[K] extends Record<string, unknown>
+        ? HasReservedFieldName<T[K]> extends true
+          ? { __error: `Nested field name conflicts with FieldState property: ${ReservedFieldName<T[K]>}` }
+          : FieldState<T[K]> & NestedFieldAccessors<T[K]>       // Object → recurse
+        : FieldState<T[K]>                                      // Primitive → leaf
+};
+
+/** Array field accessors — numeric index access to element-level fields. */
+type ArrayFieldAccessors<U> = {
+  [index: number]: U extends BuiltInObjects
+    ? FieldState<U>
+    : U extends Record<string, unknown>
+      ? FieldState<U> & NestedFieldAccessors<U>
+      : FieldState<U>
+};
+
+/** Check if any key of T collides with FieldState signal property names. */
+type FieldSignalReservedNames = 'error' | 'dirty' | 'touched' | 'value' | 'setValue' | 'reset';
+type HasReservedFieldName<T> = keyof T & FieldSignalReservedNames extends never ? false : true;
+type ReservedFieldName<T> = keyof T & FieldSignalReservedNames & string;
+
+/** Deep partial utility for initial values. */
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[K] extends Record<string, unknown>
+      ? DeepPartial<T[K]>
+      : T[K]
+};
+
+/** Union of all valid dot-paths through a nested type. */
+type FieldPath<T, Prefix extends string = ''> =
+  | `${Prefix}${keyof T & string}`
+  | {
+      [K in keyof T & string]: T[K] extends Record<string, unknown>
+        ? FieldPath<T[K], `${Prefix}${K}.`>
+        : never
+    }[keyof T & string];
+```
+
+### Nested FieldAccessors Example
+
+```
+TBody = { name: string; address: { street: string; city: string } }
+
+FormInstance<TBody, TResult>
+  = FormBaseProperties<TBody> & NestedFieldAccessors<TBody>
+
+NestedFieldAccessors<TBody>
+  → .name: FieldState<string>
+      → .error: Signal<string | undefined>
+      → .dirty: Signal<boolean>
+      → .touched: Signal<boolean>
+      → .value: Signal<string>
+  → .address: FieldState<{ street: string; city: string }> & NestedFieldAccessors<{ street: string; city: string }>
+      → .error: Signal<string | undefined>       ← group-level error (NOT aggregated)
+      → .dirty: Signal<boolean>                   ← group-level dirty (NOT aggregated)
+      → .street: FieldState<string>
+          → .error: Signal<string | undefined>
+          → .value: Signal<string>
+      → .city: FieldState<string>
+          → .error: Signal<string | undefined>
+          → .value: Signal<string>
+```
+
+### Array FieldAccessors Example
+
+```
+TBody = { items: Array<{ product: string; quantity: number }> }
+
+NestedFieldAccessors<TBody>
+  → .items: FieldState<Array<...>> & ArrayFieldAccessors<{ product: string; quantity: number }>
+      → [0]: FieldState<{ product: string; quantity: number }> & NestedFieldAccessors<...>
+          → .product: FieldState<string>
+              → .error: Signal<string | undefined>
+          → .quantity: FieldState<number>
+              → .error: Signal<string | undefined>
+      → [1]: ...
+```
+
+### Reserved Name Guard (per nesting level)
+
+```
+type FieldSignalReservedNames = 'error' | 'dirty' | 'touched' | 'value' | 'setValue' | 'reset';
+
+// If a nested object has a field named 'error', 'dirty', 'touched', or 'value':
+TBody = { meta: { error: string; name: string } }
+
+NestedFieldAccessors<TBody>
+  → .meta: { __error: "Nested field name 'error' conflicts with FieldState property" }
+```
+
+This is a compile-time guard. The type produces an error object instead of valid accessors when a nested field name collides with FieldState signal property names.
+
+### Type Flow Paths Requiring Tests
+
+1. `TBody` with nested object → `NestedFieldAccessors` resolves nested `FieldState` types
+2. `TBody[K]` where K is a nested object → intermediate provides both FieldState AND deeper access
+3. `TBody[K]` where K is a primitive → terminal FieldState only
+4. `TBody` with field named `error`/`dirty`/`touched`/`value` inside a nested group → type error
+5. `TBody` with array field → indexed access returns element-level `NestedFieldAccessors`
+6. `TBody` with `Date` field → leaf FieldState (no recursion into Date prototype)
+7. `DeepPartial<TBody>` allows partial nested initial values
+8. `FieldPath<TBody>` produces union of all valid dot-paths
+9. `setFieldError` accepts `FieldPath<TBody>` strings
+
+---
+
+## 7. E2E Acceptance Test
+
+### Developer Walkthrough — Nested Object Schema
+
+```ts
+import { form, type FormInstance } from '@vertz/ui/form';
+import { s } from '@vertz/schema';
+
+// 1. Define a nested schema
+const userSchema = s.object({
+  name: s.string().min(1),
+  address: s.object({
+    street: s.string().min(1),
+    city: s.string().min(1),
+  }),
+});
+
+type UserBody = { name: string; address: { street: string; city: string } };
+
+const mockSdk = Object.assign(
+  (_body: UserBody) => Promise.resolve({ ok: true as const, data: { id: '1' } }),
+  { url: '/users', method: 'POST' as const },
+);
+
+const userForm = form(mockSdk, { schema: userSchema });
+
+// 2. Flat field access still works
+expect(userForm.name.error.value).toBeUndefined();
+userForm.name.error.value = 'Name is required';
+expect(userForm.name.error.value).toBe('Name is required');
+
+// 3. Nested field access works
+expect(userForm.address.street.error.value).toBeUndefined();
+userForm.address.street.error.value = 'Street is required';
+expect(userForm.address.street.error.value).toBe('Street is required');
+
+// 4. Nested fields are cached (same object identity)
+const streetField1 = userForm.address.street;
+const streetField2 = userForm.address.street;
+expect(streetField1).toBe(streetField2);
+
+// 5. Group-level field state works
+userForm.address.error.value = 'Invalid address';
+expect(userForm.address.error.value).toBe('Invalid address');
+
+// 6. Validation populates nested errors via dot-path keys
+const formData = new FormData();
+formData.set('name', '');
+formData.set('address.street', '');
+formData.set('address.city', '');
+await userForm.submit(formData);
+expect(userForm.name.error.value).toBeDefined();
+expect(userForm.address.street.error.value).toBeDefined();
+
+// 7. formDataToObject parses dot-paths into nested objects (opt-in)
+import { formDataToObject } from '@vertz/ui/form';
+const fd = new FormData();
+fd.set('name', 'Alice');
+fd.set('address.street', '123 Main');
+fd.set('address.city', 'Springfield');
+const obj = formDataToObject(fd, { nested: true });
+expect(obj).toEqual({ name: 'Alice', address: { street: '123 Main', city: 'Springfield' } });
+
+// 7b. formDataToObject without nested: true preserves flat keys (backward compat)
+const flatObj = formDataToObject(fd);
+expect(flatObj).toEqual({ name: 'Alice', 'address.street': '123 Main', 'address.city': 'Springfield' });
+
+// 8. setFieldError accepts dot-path strings
+userForm.setFieldError('address.street', 'Street is required');
+expect(userForm.address.street.error.value).toBe('Street is required');
+userForm.setFieldError('address', 'Invalid address');
+expect(userForm.address.error.value).toBe('Invalid address');
+
+// 9. DeepPartial initial values — can provide partial nested values
+const partialForm = form(mockSdk, {
+  schema: userSchema,
+  initial: { address: { city: 'Springfield' } },  // only city, no name/street
+});
+expect(partialForm.address.city.value.value).toBe('Springfield');
+expect(partialForm.address.street.value.value).toBeUndefined();
+
+// 10. Type safety — invalid nested paths are type errors
+// @ts-expect-error — 'nonexistent' is not a key of address
+userForm.address.nonexistent;
+```
+
+### Developer Walkthrough — Dynamic Field Access
+
+```ts
+// Bracket notation field access
+const fieldName = 'title';
+expect(taskForm[fieldName].error.value).toBeUndefined();
+taskForm[fieldName].error.value = 'Required';
+expect(taskForm[fieldName].error.value).toBe('Required');
+```
+
+### Developer Walkthrough — Array Fields
+
+```ts
+const orderSchema = s.object({
+  items: s.array(s.object({
+    product: s.string().min(1),
+    quantity: s.number(),
+  })),
+});
+
+type OrderBody = { items: Array<{ product: string; quantity: number }> };
+
+const orderForm = form(orderSdk, { schema: orderSchema });
+
+// Indexed array field access
+expect(orderForm.items[0].product.error.value).toBeUndefined();
+orderForm.items[0].product.error.value = 'Product required';
+expect(orderForm.items[0].product.error.value).toBe('Product required');
+
+// formDataToObject parses numeric indices as array elements
+const fd = new FormData();
+fd.set('items.0.product', 'Widget');
+fd.set('items.0.quantity', '5');
+fd.set('items.1.product', 'Gadget');
+fd.set('items.1.quantity', '3');
+const obj = formDataToObject(fd, { nested: true });
+expect(obj).toEqual({
+  items: [
+    { product: 'Widget', quantity: '5' },
+    { product: 'Gadget', quantity: '3' },
+  ],
+});
+```
+
+---
+
+## 8. Implementation Plan
+
+### Phase 1: formDataToObject Dot-Path Parsing
+
+**Goal:** `formDataToObject()` gains an opt-in `nested: true` option that parses dot-notation keys into nested objects, with numeric segments creating arrays. Without `nested: true`, behavior is unchanged (backward compatible).
+
+**Acceptance Criteria:**
+
+```typescript
+describe('Feature: formDataToObject dot-path parsing', () => {
+  describe('Given FormData with dot-separated keys and nested: true', () => {
+    describe('When formDataToObject() is called', () => {
+      it('Then parses "address.street" into { address: { street: value } }', () => {});
+      it('Then parses multiple nested keys into the same parent object', () => {});
+      it('Then handles deeply nested paths (3+ levels)', () => {});
+    });
+  });
+
+  describe('Given FormData with numeric path segments and nested: true', () => {
+    describe('When formDataToObject() is called', () => {
+      it('Then creates arrays for numeric indices: "items.0.name" → { items: [{ name: value }] }', () => {});
+      it('Then passes sparse indices through as-is (holes are undefined)', () => {});
+      it('Then handles mixed object and array nesting', () => {});
+    });
+  });
+
+  describe('Given FormData with flat keys (backward compatibility)', () => {
+    describe('When formDataToObject() is called without nested option', () => {
+      it('Then keys with dots are preserved as flat keys (no parsing)', () => {});
+      it('Then existing flat behavior is unchanged', () => {});
+      it('Then coercion still works independently of nested option', () => {});
+    });
+  });
+});
+```
+
+**Sparse array note:** Sparse indices (e.g., `items.0` and `items.5` with no items.1-4) create arrays with `undefined` holes. This is passed through as-is — schema validation catches invalid shapes. Compacting arrays is not done because it would silently reorder data.
+
+**Files changed:**
+- `packages/ui/src/form/form-data.ts` — add `nested` option to `FormDataOptions`, add `setNestedValue()` helper, update `formDataToObject()`
+- `packages/ui/src/form/__tests__/form-data.test.ts` — new test cases
+
+### Phase 2: Runtime Chain Proxy for Nested Field Access
+
+**Goal:** `form()` returns a proxy that supports N-level field access. `userForm.address.street` navigates to field `"address.street"`. Accessing a `fieldSignalProperty` (`error`, `dirty`, `touched`, `value`) on any chain proxy resolves to the FieldState for that dot-path. Chain proxies are cached for identity stability.
+
+**Acceptance Criteria:**
+
+```typescript
+describe('Feature: nested field access via chain proxy', () => {
+  describe('Given a form with a nested schema', () => {
+    describe('When accessing a nested field path', () => {
+      it('Then userForm.address.street returns a field accessor', () => {});
+      it('Then userForm.address.street.error is a signal', () => {});
+      it('Then userForm.address.street.error.value is undefined initially', () => {});
+      it('Then setting userForm.address.street.error.value updates the signal', () => {});
+    });
+
+    describe('When accessing the same nested path twice', () => {
+      it('Then returns the same chain proxy object (cached identity)', () => {});
+      it('Then the underlying FieldState is the same object', () => {});
+    });
+
+    describe('When accessing a group-level field state', () => {
+      it('Then userForm.address.error returns a signal for the "address" path', () => {});
+    });
+  });
+
+  describe('Given a form with flat fields', () => {
+    describe('When accessing flat fields', () => {
+      it('Then existing flat field access still works unchanged', () => {});
+      it('Then form-level signals (submitting, dirty, valid) still work', () => {});
+      it('Then form-level plain properties (action, method) still work', () => {});
+    });
+  });
+
+  describe('Given a form with nested initial values (DeepPartial)', () => {
+    describe('When a nested field is first accessed', () => {
+      it('Then the field value signal is initialized from the nested initial object', () => {});
+      it('Then missing nested initial values default to undefined', () => {});
+    });
+  });
+
+  describe('Given validation errors with dot-path keys', () => {
+    describe('When validation fails on nested fields', () => {
+      it('Then errors are set on the correct nested field states', () => {});
+    });
+  });
+
+  describe('Given setFieldError with dot-path strings', () => {
+    describe('When setting errors on nested fields', () => {
+      it('Then setFieldError("address.street", msg) sets the nested field error', () => {});
+      it('Then setFieldError("address", msg) sets the group-level error', () => {});
+    });
+  });
+});
+```
+
+**Files changed:**
+- `packages/ui/src/form/form.ts` — replace flat Proxy with chain proxy, add `chainProxyCache`, update `getOrCreateField()` to use dot-path keys, update initial value resolution to `resolveNestedInitial()`, update `setFieldError` to accept dot-paths, update submit pipeline to use `formDataToObject(fd, { nested: true })`, change `initial` type to `DeepPartial<TBody>`
+- `packages/ui/src/form/__tests__/form.test.ts` — new test cases for nested access
+
+### Phase 3: Compiler N-Level Chain Support
+
+**Goal:** The signal transformer and JSX analyzer support arbitrary-depth chains for form field signal access. `userForm.address.street.error` → `userForm.address.street.error.value` in compiled output. `ElementAccessExpression` is handled as an intermediate chain step.
+
+**Critical constraint:** N-level field chains require **chain length >= 3** (at least one intermediate between root and leaf). This prevents `taskForm.dirty` (2-level) from being matched as a field chain when `dirty` is both a `signalProperty` and a `fieldSignalProperty`. The 2-level case is handled by Pass 2.
+
+**Known limitations (consistent with existing compiler behavior):**
+- Destructuring breaks chains: `const { street } = form.address; street.error` — `street` is not a signal API var, no transform applied
+- Aliasing breaks chains: `const addr = form.address; addr.street.error` — `addr` is not registered, no transform
+
+**Acceptance Criteria:**
+
+```typescript
+describe('Feature: N-level form field chain transformation', () => {
+  describe('Given a form variable with fieldSignalProperties', () => {
+    describe('When the code has a 4-level chain (root.group.field.signal)', () => {
+      it('Then transforms userForm.address.street.error → .value', () => {});
+    });
+
+    describe('When the code has a 5-level chain (root.a.b.c.signal)', () => {
+      it('Then transforms deep chains → .value', () => {});
+    });
+
+    describe('When .value is already present', () => {
+      it('Then does not double-transform', () => {});
+    });
+
+    describe('When the leaf is NOT a fieldSignalProperty', () => {
+      it('Then does not transform', () => {});
+    });
+
+    describe('When an intermediate is a signalProperty or plainProperty', () => {
+      it('Then does not transform (not a field chain)', () => {});
+    });
+
+    describe('When the chain length is 2 (root.fieldSignalProp)', () => {
+      it('Then does not match N-level pass (handled by 2-level pass)', () => {});
+    });
+  });
+
+  describe('Given bracket notation (ElementAccessExpression)', () => {
+    describe('When the code has form[dynamicField].error', () => {
+      it('Then transforms → form[dynamicField].error.value', () => {});
+    });
+
+    describe('When bracket notation is in the middle of a chain', () => {
+      it('Then transforms form.items[0].name.error → .value', () => {});
+    });
+
+    describe('When multiple bracket notations form[a][b].error', () => {
+      it('Then transforms → form[a][b].error.value', () => {});
+    });
+  });
+
+  describe('Given existing 2-level and 3-level chains', () => {
+    describe('When the code has taskForm.submitting (2-level)', () => {
+      it('Then still transforms correctly via Pass 2', () => {});
+    });
+
+    describe('When the code has taskForm.title.error (3-level)', () => {
+      it('Then still transforms correctly via N-level pass', () => {});
+    });
+  });
+});
+
+describe('Feature: N-level JSX reactivity detection', () => {
+  describe('Given a 4-level chain in a JSX expression', () => {
+    it('Then marks the expression as reactive', () => {});
+  });
+
+  describe('Given bracket notation in a JSX expression', () => {
+    it('Then marks the expression as reactive', () => {});
+  });
+});
+```
+
+**Files changed:**
+- `packages/ui-compiler/src/transformers/signal-transformer.ts` — generalize Pass 1 to N-level, add `ElementAccessExpression` handling
+- `packages/ui-compiler/src/analyzers/jsx-analyzer.ts` — generalize 3-level detection to N-level, add `ElementAccessExpression`
+- `packages/ui-compiler/src/transformers/__tests__/signal-transformer.test.ts` — new test cases
+- `packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts` — new test cases (if exists)
+
+### Phase 4: Types and Integration Tests
+
+**Goal:** TypeScript types enforce correct nested field access. Invalid paths produce type errors. Integration test validates end-to-end developer experience with public imports only.
+
+**Acceptance Criteria:**
+
+```typescript
+describe('Feature: nested form type safety', () => {
+  describe('Given FormInstance with nested TBody', () => {
+    it('Then nested field access is typed: userForm.address.street is FieldState<string>', () => {});
+    it('Then invalid nested path is a type error', () => {});
+    it('Then field signal property on leaf is typed: .error is Signal<string | undefined>', () => {});
+  });
+
+  describe('Given a nested object with a reserved field name', () => {
+    it('Then type error is produced when nested field collides with FieldState property', () => {});
+  });
+
+  describe('Given FormInstance with array TBody field', () => {
+    it('Then indexed access is typed: form.items[0].product is FieldState<string>', () => {});
+  });
+
+  describe('Given FormInstance with Date field', () => {
+    it('Then Date field is a leaf FieldState (no recursion into Date methods)', () => {});
+  });
+
+  describe('Given DeepPartial initial values', () => {
+    it('Then partial nested initial values type-check correctly', () => {});
+  });
+
+  describe('Given setFieldError with FieldPath', () => {
+    it('Then dot-path strings are accepted: setFieldError("address.street", msg)', () => {});
+    // @ts-expect-error — invalid dot-path
+    it('Then invalid dot-paths are rejected', () => {});
+  });
+
+  describe('Given FieldPath utility type', () => {
+    it('Then produces union of all valid dot-paths', () => {});
+  });
+});
+
+describe('Feature: nested form integration walkthrough', () => {
+  it('Then form with nested schema validates and submits correctly', () => {});
+  it('Then validation errors populate nested field states', () => {});
+  it('Then formDataToObject produces nested objects for submission', () => {});
+  it('Then setFieldError works with dot-path strings', () => {});
+});
+```
+
+**Files changed:**
+- `packages/ui/src/form/form.ts` — update `FieldAccessors` type to recursive `NestedFieldAccessors`, add `DeepPartial`, `FieldPath`, `ArrayFieldAccessors`, `BuiltInObjects` guard types, update `FormBaseProperties.setFieldError` to accept `FieldPath<TBody>`, update `FormOptions.initial` to `DeepPartial<TBody>`
+- `packages/ui/src/form/__tests__/form.test-d.ts` — type-level tests (if exists, or create)
+- `packages/integration-tests/src/__tests__/form-walkthrough.test.ts` — extend with nested scenarios
+
+### Phase Dependencies
+
+```
+Phase 1 (formDataToObject) ← independent, no deps
+Phase 2 (chain proxy)      ← depends on Phase 1 (needs dot-path parsing for submit pipeline)
+Phase 3 (compiler)         ← independent of Phase 1/2 (compiler changes are orthogonal)
+Phase 4 (types + integration) ← depends on Phase 2 and Phase 3
+```
+
+Phases 1 and 3 can be done in parallel. Phase 2 depends on Phase 1. Phase 4 depends on 2 and 3.
+
+---
+
+## 9. Runtime Design Details
+
+### Chain Proxy Implementation
+
+The form Proxy is replaced with a two-level proxy system:
+
+1. **Root Proxy** — intercepts top-level property access on the form instance
+   - Known properties (`action`, `method`, `submitting`, etc.) → return directly
+   - Unknown string properties → return a `FieldChainProxy` for that path segment
+
+2. **FieldChainProxy** — a Proxy wrapping a dot-path string (e.g., `"address.street"`)
+   - If the accessed property is a `fieldSignalProperty` (`error`, `dirty`, `touched`, `value`) → resolve to `getOrCreateField(path).property`
+   - If the accessed property is a FieldState method (`setValue`, `reset`) → resolve to `getOrCreateField(path).method`
+   - Otherwise → return a cached `FieldChainProxy` extending the path
+
+**Chain proxies are cached** in a `chainProxyCache: Map<string, object>` keyed by the dot-path string. This ensures:
+- Referential identity: `userForm.address === userForm.address` (same Proxy object)
+- No GC churn from repeated intermediate access in render loops
+- Consistent with how `fieldCache` caches `FieldState` objects
+
+```ts
+const chainProxyCache = new Map<string, object>();
+
+function getOrCreateChainProxy(dotPath: string): object {
+  let proxy = chainProxyCache.get(dotPath);
+  if (proxy) return proxy;
+
+  proxy = new Proxy(Object.create(null), {
+    get(_target, prop) {
+      if (typeof prop === 'string') {
+        if (FIELD_STATE_SIGNALS.has(prop)) {
+          return getOrCreateField(dotPath)[prop];
+        }
+        if (FIELD_STATE_METHODS.has(prop)) {
+          return getOrCreateField(dotPath)[prop];
+        }
+        const childPath = `${dotPath}.${prop}`;
+        return getOrCreateChainProxy(childPath);
+      }
+      return undefined;
+    },
+  });
+
+  chainProxyCache.set(dotPath, proxy);
+  return proxy;
+}
+```
+
+### Initial Value Resolution for Nested Fields
+
+Currently `getOrCreateField()` reads initial values from a flat object:
+```ts
+const initialValue = initialObj?.[name];
+```
+
+For nested fields, the initial value is resolved by traversing the path:
+```ts
+function resolveNestedInitial(obj: Record<string, unknown> | undefined, dotPath: string): unknown {
+  if (!obj) return undefined;
+  const segments = dotPath.split('.');
+  let current: unknown = obj;
+  for (const segment of segments) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+```
+
+### formDataToObject Nested Parsing (opt-in)
+
+The `nested` option is added to `FormDataOptions`. When `true`, dot-separated keys are parsed into nested objects. When `false` (default), keys are preserved as flat strings (backward compatible).
+
+```ts
+export interface FormDataOptions {
+  coerce?: boolean;
+  nested?: boolean;  // NEW — opt-in nested dot-path parsing
+}
+
+function setNestedValue(obj: Record<string, unknown>, dotPath: string, value: unknown): void {
+  const segments = dotPath.split('.');
+  let current = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    const nextSegment = segments[i + 1];
+    const isNextArray = /^\d+$/.test(nextSegment);
+    if (!(segment in current)) {
+      current[segment] = isNextArray ? [] : {};
+    }
+    current = current[segment] as Record<string, unknown>;
+  }
+  current[segments[segments.length - 1]] = value;
+}
+```
+
+The form submit pipeline (`submitPipeline`) calls `formDataToObject(formData, { nested: true })` to produce nested objects for schema validation.
+
+### Event Delegation for Nested Input Names
+
+The existing `handleInputOrChange` and `handleFocusout` handlers use `target.name` to look up fields. For nested inputs, `target.name` is already the dot-path string (e.g., `"address.street"`), so `getOrCreateField(target.name)` works unchanged — the fieldCache stores fields with dot-path keys.
+
+---
+
+## 10. Compiler Design Details
+
+### N-Level Chain Detection Algorithm
+
+Replace the fixed 3-level Pass 1 with a general algorithm:
+
+1. For each `PropertyAccessExpression` node where the leaf property is a `fieldSignalProperty`:
+2. Walk up the chain collecting intermediate property accesses and element accesses
+3. Find the root: the first `Identifier` in the chain
+4. Check: root is a signal API var with `fieldSignalProperties`
+5. Check: **chain length >= 3** (at least one intermediate between root and leaf)
+6. Check: no intermediate `PropertyAccessExpression` name is a `signalProperty` or `plainProperty`
+7. If all checks pass → append `.value` to the leaf node, record the full chain range
+
+**Why chain length >= 3?** `dirty` appears in both `signalProperties` and `fieldSignalProperties`. Without the minimum length, `taskForm.dirty` (2-level) would match both Pass 1 (as a field chain for path `""` with leaf `dirty`) and Pass 2. The minimum length ensures 2-level chains are handled exclusively by Pass 2.
+
+```
+Chain: userForm.address.street.error
+       ^^^^^^^^                        root (Identifier, signal API var)
+                .address               intermediate (PropertyAccess, not signal/plain prop)
+                        .street        intermediate (PropertyAccess, not signal/plain prop)
+                               .error  leaf (fieldSignalProperty) → append .value
+```
+
+### ElementAccessExpression Handling
+
+An `ElementAccessExpression` (e.g., `form[x]`) can appear at any point in the chain. The algorithm treats it as an opaque intermediate step — it doesn't validate the bracket content, only checks:
+- The chain root is a signal API var
+- The leaf is a `fieldSignalProperty`
+
+```
+Chain: taskForm[fieldName].error
+       ^^^^^^^^                  root (Identifier, signal API var)
+               [fieldName]       intermediate (ElementAccess)
+                          .error leaf (fieldSignalProperty) → append .value
+
+Chain: orderForm.items[0].product.error
+       ^^^^^^^^^                        root
+                .items                  intermediate (PropertyAccess)
+                      [0]               intermediate (ElementAccess)
+                         .product       intermediate (PropertyAccess)
+                                 .error leaf → append .value
+```
+
+### Pass Structure
+
+The two-pass structure is preserved:
+- **Pass 1 (updated):** N-level field signal chains (replaces fixed 3-level)
+- **Pass 2 (unchanged):** 2-level signal API property chains
+
+Pass 1 records ranges of transformed chains. Pass 2 skips nodes inside those ranges, preventing double-transformation of intermediate property accesses.
+
+---
+
+## 11. Migration
+
+### Backward Compatibility
+
+Fully backward compatible:
+- Flat form fields continue to work identically
+- 3-level chains (`taskForm.title.error`) are a subset of N-level chains
+- `formDataToObject()` without `nested: true` produces the same output as before (flat keys preserved)
+- The `initial` type change from `Partial<TBody>` to `DeepPartial<TBody>` is widening — all existing code type-checks
+- The `setFieldError` type change from `keyof TBody & string` to `FieldPath<TBody>` includes all previous valid values
+
+### New Capability
+
+Developers opt in by:
+1. Using nested schemas with `form()`
+2. Using dot-notation string literals for nested input `name` attributes
+3. `formDataToObject(fd, { nested: true })` for external callers (form submit pipeline uses it automatically)
+
+---
+
+## 12. Review Log
+
+### Rev 1 → Rev 2 Changes
+
+Addressed feedback from three review agents (DX, Product/scope, Technical):
+
+| Finding | Source | Resolution |
+|---------|--------|------------|
+| Group-level vs. leaf-level `.error` ambiguity | DX #1 | Added "Group-Level vs. Leaf-Level Clarity" section in Manifesto Alignment. Documented that group-level FieldState is NOT aggregated. |
+| `Symbol.toPrimitive` unreliable for `fields` proxy in JSX | DX #2 | Deferred nested `fields` proxy entirely. Developers use dot-notation string literals. Added to Non-Goals. |
+| `FieldNames` type not updated for nesting | DX #4 | Deferred with nested `fields` proxy. |
+| `initial` needs `DeepPartial<TBody>` | DX #7 | Updated Section 1E and Phase 2/4 to use `DeepPartial<TBody>`. Added concrete type definition. |
+| `setFieldError` needs dot-path support | DX #8 | Added Section 1F. `setFieldError` accepts `FieldPath<TBody>`. Added type definition and test criteria. |
+| Field array indexed access limited standalone value | Product #1 | Added clarifying note in Section 1C. |
+| Sparse array behavior underspecified | Product #2, DX #6 | Documented in Phase 1 acceptance criteria. Sparse arrays pass through as-is. |
+| Chain proxy caching (identity bug) | Technical #1 | Added `chainProxyCache: Map<string, object>` to Section 9. Updated Phase 2 criteria. |
+| Array type special-casing in `NestedFieldAccessors` | Technical #2 | Added `ArrayFieldAccessors` concrete type definition in Section 6. |
+| Built-in object guard (Date, RegExp, etc.) | Technical #3 | Added `BuiltInObjects` type guard in Section 6. |
+| `formDataToObject` breaking change | Technical #4 | Made nested parsing opt-in (`nested: true`). Updated all sections and acceptance tests. |
+| N-level chain minimum length >= 3 | Technical #5 | Added as explicit constraint in Phase 3 and Section 10. Documented rationale for `dirty` overlap. |
+| Destructuring/aliasing limitations | Technical #6 | Added as Known Limitations in Phase 3. Documented in Unknowns section. |

--- a/reviews/nested-form-schemas/phase-all-implementation.md
+++ b/reviews/nested-form-schemas/phase-all-implementation.md
@@ -1,0 +1,338 @@
+# Nested Form Schemas — Full Implementation Review
+
+- **Author:** Implementation agent
+- **Reviewer:** Adversarial review agent (Claude Opus 4.6)
+- **Scope:** All 4 phases (form-data, chain proxy, compiler, types + integration)
+- **Date:** 2026-03-12
+
+## Changes
+
+- `packages/ui/src/form/form-data.ts` (modified) — `nested` option, `setNestedValue()` helper
+- `packages/ui/src/form/form.ts` (modified) — Chain proxy, nested types, updated FormInstance
+- `packages/ui/src/form/public.ts` (modified) — New type exports
+- `packages/ui/src/form/field-state.ts` (unchanged, reviewed for interaction)
+- `packages/ui/src/form/validation.ts` (unchanged, reviewed for interaction)
+- `packages/ui/src/form/__tests__/form-data.test.ts` (modified) — Nested parsing tests
+- `packages/ui/src/form/__tests__/form.test.ts` (modified) — Chain proxy and nested field tests
+- `packages/ui/src/form/__tests__/form.test-d.ts` (modified) — Type-level tests
+- `packages/ui-compiler/src/transformers/signal-transformer.ts` (modified) — N-level chains, ElementAccessExpression
+- `packages/ui-compiler/src/analyzers/jsx-analyzer.ts` (modified) — N-level reactivity detection
+- `packages/ui-compiler/src/transformers/__tests__/signal-transformer.test.ts` (modified) — N-level chain tests
+- `packages/ui-compiler/src/signal-api-registry.ts` (unchanged, reviewed for interaction)
+- `packages/integration-tests/src/__tests__/form-walkthrough.test.ts` (modified) — Nested integration tests
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (tests before/alongside implementation)
+- [ ] No type gaps or missing edge cases — **issues found**
+- [ ] No security issues — **issue found**
+- [x] Public API changes match design doc
+- [ ] Test coverage adequate for new behavior — **gaps found**
+- [x] Performance considerations (proxy chains, caching)
+- [x] Backward compatibility preserved
+
+---
+
+## Findings
+
+### BUG-1: Prototype Pollution in `setNestedValue` (Security — HIGH)
+
+**File:** `packages/ui/src/form/form-data.ts`, line 43-56
+
+`setNestedValue` takes a dot-separated path from FormData keys and uses each segment to create/traverse nested objects. There is no sanitization of dangerous property names. An attacker-controlled form submission (or malicious input) with keys like `__proto__.polluted` or `constructor.prototype.polluted` can pollute `Object.prototype`.
+
+```
+// Attacker crafts FormData with:
+//   key: "__proto__.isAdmin"  value: "true"
+//
+// setNestedValue(result, "__proto__.isAdmin", "true")
+//   segments = ["__proto__", "isAdmin"]
+//   current = result
+//   segment = "__proto__" → current["__proto__"] is Object.prototype (exists, so no new obj)
+//   current = Object.prototype
+//   current["isAdmin"] = "true"  ← prototype pollution!
+```
+
+**Fix:** Guard against `__proto__`, `constructor`, and `prototype` in path segments:
+
+```ts
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function setNestedValue(obj: Record<string, unknown>, dotPath: string, value: unknown): void {
+  const segments = dotPath.split('.');
+  for (const seg of segments) {
+    if (DANGEROUS_KEYS.has(seg)) return; // silently skip dangerous paths
+  }
+  // ... rest of implementation
+}
+```
+
+Similarly, `resolveNestedInitial` in `form.ts` (line 189-200) traverses user-provided initial objects using attacker-controllable dot-path strings. While the risk is lower (reading, not writing), accessing `__proto__` on an object returns `Object.prototype`, which could leak unexpected data. The same guard should be applied.
+
+---
+
+### BUG-2: `resolveNestedInitial` called on every field creation, factory function invoked multiple times
+
+**File:** `packages/ui/src/form/form.ts`, lines 189-217
+
+When `options.initial` is a function, `resolveNestedInitial` calls `options.initial()` every time a new nested field is created. Similarly, the flat path branch in `getOrCreateField` calls `options.initial()` for each flat field creation. If the factory function has side effects or returns different objects each time, field initial values can be inconsistent.
+
+```ts
+// resolveNestedInitial calls options.initial() on every invocation
+const initialObj =
+  typeof options?.initial === 'function' ? options.initial() : options?.initial;
+```
+
+If a developer provides `initial: () => fetchDefaultsFromStore()`, and fields are lazily created at different times, each field may get a different snapshot of the store.
+
+**Severity:** Medium. The design doc lists "Reactive initial values" as a non-goal, but calling a factory multiple times with potentially different results is a subtle correctness bug.
+
+**Fix:** Resolve the initial object once at form creation time (or lazily on first access, but cache it):
+
+```ts
+let resolvedInitial: DeepPartial<TBody> | undefined;
+function getInitialObj() {
+  if (resolvedInitial === undefined) {
+    resolvedInitial = typeof options?.initial === 'function'
+      ? options.initial()
+      : options?.initial ?? null; // use null as sentinel for "resolved but empty"
+  }
+  return resolvedInitial === null ? undefined : resolvedInitial;
+}
+```
+
+---
+
+### BUG-3: `FieldPath<T>` does not include array element paths
+
+**File:** `packages/ui/src/form/form.ts`, lines 93-99
+
+The `FieldPath` type recursion only enters `Record<string, unknown>` branches — it does not descend into arrays. For an `OrderBody = { items: Array<{ product: string }> }`, `FieldPath<OrderBody>` produces `"items"` only. It does NOT produce `"items.0.product"` or `"items.${number}.product"`.
+
+This means `setFieldError('items.0.product', 'Required')` is a **type error** at compile time, even though it works at runtime. This is a type gap.
+
+```ts
+// Current FieldPath:
+type FieldPath<T, Prefix extends string = ''> =
+  | `${Prefix}${keyof T & string}`
+  | {
+      [K in keyof T & string]: T[K] extends Record<string, unknown>
+        ? FieldPath<T[K], `${Prefix}${K}.`>
+        : never;
+    }[keyof T & string];
+
+// Array<{ product: string }> does NOT extend Record<string, unknown>
+// (it extends object, but the mapped type check fails)
+// So the recursion stops at "items"
+```
+
+**Fix:** Add an array branch to `FieldPath`:
+
+```ts
+type FieldPath<T, Prefix extends string = ''> =
+  | `${Prefix}${keyof T & string}`
+  | {
+      [K in keyof T & string]: T[K] extends Array<infer U>
+        ? U extends Record<string, unknown>
+          ? `${Prefix}${K}.${number}` | FieldPath<U, `${Prefix}${K}.${number}.`>
+          : never
+        : T[K] extends Record<string, unknown>
+          ? FieldPath<T[K], `${Prefix}${K}.`>
+          : never;
+    }[keyof T & string];
+```
+
+**Note:** There is also no type-level test in `form.test-d.ts` that validates `FieldPath` for array types. The type test for `setFieldError` on the `orderForm` is missing.
+
+---
+
+### BUG-4: `DeepPartial<T>` does not handle `BuiltInObjects`
+
+**File:** `packages/ui/src/form/form.ts`, lines 84-90
+
+`NestedFieldAccessors<T>` correctly guards against recursion into `BuiltInObjects` (Date, RegExp, File, Blob, Map, Set). However, `DeepPartial<T>` does not have the same guard. It checks `extends Array<infer U>` and `extends Record<string, unknown>`, but `Date`, `Map`, and `Set` all extend `Record<string, unknown>` via their index signatures.
+
+For a type like `{ createdAt: Date }`, `DeepPartial` will attempt to make Date's properties optional, producing a weird partial Date type instead of just `Date | undefined`.
+
+**Severity:** Low-Medium. In practice this may not cause visible issues because `DeepPartial<Date>` still accepts `Date` values. But it's inconsistent with the BuiltInObjects guard in NestedFieldAccessors.
+
+**Fix:** Add BuiltInObjects guard to DeepPartial:
+
+```ts
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends BuiltInObjects
+    ? T[K]
+    : T[K] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T[K] extends Record<string, unknown>
+        ? DeepPartial<T[K]>
+        : T[K];
+};
+```
+
+---
+
+### GAP-1: No JSX-level test coverage for N-level chain reactivity detection
+
+**File:** `packages/ui-compiler/src/analyzers/__tests__/jsx-analyzer.test.ts`
+
+The design doc (Phase 3 acceptance criteria) explicitly lists:
+
+> ```
+> describe('Feature: N-level JSX reactivity detection', () => {
+>   describe('Given a 4-level chain in a JSX expression', () => {
+>     it('Then marks the expression as reactive', () => {});
+>   });
+>   describe('Given bracket notation in a JSX expression', () => {
+>     it('Then marks the expression as reactive', () => {});
+>   });
+> });
+> ```
+
+These tests are completely missing. The `jsx-analyzer.test.ts` file has no tests for `fieldSignalProperties`, N-level chains, or `ElementAccessExpression`. The implementation in `jsx-analyzer.ts` has the logic (lines 92-167), but it is not tested.
+
+This is a TDD compliance violation. Untested code may contain latent bugs.
+
+---
+
+### GAP-2: No test for `taskForm.dirty` ambiguity (2-level vs field chain)
+
+`dirty` appears in both `signalProperties` and `fieldSignalProperties` in the signal API registry. The design doc explicitly calls this out as a "Critical constraint" (Section 4, Unknown 3, and Section 10). The correct behavior is:
+
+- `taskForm.dirty` (2-level) should be handled by Pass 2 as a signal property (form-level dirty)
+- `taskForm.title.dirty` (3-level) should be handled by Pass 1 as a field chain (per-field dirty)
+
+There is **no explicit test** for this ambiguity. The existing test "auto-unwraps new form-level signal property dirty" only tests the 2-level case. There is no test for the 3-level `taskForm.title.dirty` case specifically.
+
+While the N-level chain detection has the `chainLength < 3` guard (line 214 of signal-transformer.ts), the lack of a test for this specific edge case is concerning since it's called out as critical in the design doc.
+
+**Fix:** Add a test:
+
+```ts
+it('auto-unwraps 3-level field chain with dirty (taskForm.title.dirty)', () => {
+  const result = transform(
+    `function TaskForm() {\n  const taskForm = form({});\n  const d = taskForm.title.dirty;\n  return <div>{d}</div>;\n}`,
+    [formVar],
+  );
+  expect(result).toContain('taskForm.title.dirty.value');
+});
+```
+
+---
+
+### GAP-3: No test for `setFieldError` runtime accepting arbitrary strings
+
+**File:** `packages/ui/src/form/form.ts`, line 331
+
+At runtime, `setFieldError` accepts any string:
+
+```ts
+setFieldError: (field: string, message: string) => {
+  getOrCreateField(field).error.value = message;
+},
+```
+
+The runtime signature is `(field: string, message: string)` while the TypeScript type is `(field: FieldPath<TBody>, message: string)`. This is correct and expected (types constrain, runtime accepts). However, there is no test for what happens when `setFieldError` is called with a deeply nested dot-path at runtime (e.g., `'a.b.c.d'`). The test in `form.test.ts` only tests `'address.street'` (2 levels deep). This is a minor gap.
+
+---
+
+### GAP-4: `setNestedValue` does not handle pre-existing conflicting types
+
+**File:** `packages/ui/src/form/form-data.ts`, line 43-56
+
+If FormData contains both `address=foo` and `address.street=bar`, the code will:
+1. Set `result.address = 'foo'` (flat key)
+2. Then try `setNestedValue(result, 'address.street', 'bar')`, which does `current = result['address']` (the string `'foo'`), then tries to set a property on a string — which silently fails in non-strict mode or throws in strict mode.
+
+There is no test for this conflicting-key scenario. The behavior should be documented or guarded.
+
+**Severity:** Low. Unlikely in practice (malformed form submission), but the silent failure is concerning.
+
+---
+
+### GAP-5: `handleInputOrChange` for nested inputs — no runtime test with dot-path names
+
+**File:** `packages/ui/src/form/form.ts`, lines 301-306
+
+The design doc states (Section 9): "The existing `handleInputOrChange` and `handleFocusout` handlers use `target.name` to look up fields. For nested inputs, `target.name` is already the dot-path string (e.g., `"address.street"`), so `getOrCreateField(target.name)` works unchanged."
+
+There is no test for this. The `__bindElement` tests in `form.test.ts` only test flat field names (`'title'`). A test with `name="address.street"` dispatched through the form element's input/focusout event delegation would validate this claim.
+
+---
+
+### OBSERVATION-1: Chain proxy catches all Symbol access, returns undefined
+
+**File:** `packages/ui/src/form/form.ts`, lines 223-237
+
+The chain proxy's `get` trap returns `undefined` for non-string properties. This means:
+- `Symbol.toPrimitive` returns `undefined` (acceptable, no string coercion supported)
+- `Symbol.iterator` returns `undefined` (acceptable, no iteration)
+- `Symbol.toStringTag` returns `undefined`
+
+This is consistent with the design doc's rejection of `Symbol.toPrimitive` for the `fields` proxy. No issue, but worth noting: logging a chain proxy object (e.g., `console.log(form.address)`) will produce `[object Object]` with no useful introspection. DevTools may show an empty object. This could confuse developers during debugging.
+
+---
+
+### OBSERVATION-2: `fieldGeneration` signal for reactive dirty/valid
+
+The `fieldGeneration` signal pattern (line 171) is a clever solution for making `dirty` and `valid` computed signals react to new field additions. Reading `fieldGeneration.value` inside the computed callback creates a subscription, and incrementing it in `getOrCreateField` triggers re-evaluation.
+
+However, this means EVERY field access (even reading an existing field's error) does NOT trigger re-evaluation — only field creation does. The computed signals also iterate over `fieldCache.values()`, reading each field's `dirty`/`error` signal. This correctly subscribes to individual field changes.
+
+No issue. This is well-designed.
+
+---
+
+### OBSERVATION-3: Performance characteristics are sound
+
+- Chain proxies are cached in `chainProxyCache` (Map<string, object>) — no allocation on repeated access
+- FieldState objects are cached in `fieldCache` (Map<string, FieldState>) — lazy creation
+- N-level compiler detection walks up chains on each PropertyAccessExpression, but this is bounded by chain depth (typically 3-5) and runs at compile time, not runtime
+
+No performance concerns identified.
+
+---
+
+### OBSERVATION-4: `FieldPath` is not exported for external use
+
+`FieldPath` is exported in `public.ts` as a type-only export, which is correct. Developers can import it for custom helper functions that need to accept field paths. No issue.
+
+---
+
+### DESIGN ALIGNMENT: Matches design doc
+
+The implementation closely follows the design doc at `plans/nested-form-schemas.md`:
+
+- **Phase 1** (formDataToObject): Opt-in `nested` option, `setNestedValue`, backward compatible. Matches exactly.
+- **Phase 2** (chain proxy): `getOrCreateChainProxy`, `chainProxyCache`, `resolveNestedInitial`, `DeepPartial` initial values. Matches.
+- **Phase 3** (compiler): N-level chain detection with `chainLength >= 3`, ElementAccessExpression handling. Matches.
+- **Phase 4** (types): `NestedFieldAccessors`, `ArrayFieldAccessors`, `FieldPath`, `DeepPartial`, `BuiltInObjects` guard, reserved name guard. Matches.
+
+No design deviations detected.
+
+---
+
+## Summary
+
+| ID | Category | Severity | Description |
+|----|----------|----------|-------------|
+| BUG-1 | Security | HIGH | Prototype pollution in `setNestedValue` — no guard on `__proto__`/`constructor`/`prototype` |
+| BUG-2 | Correctness | Medium | `resolveNestedInitial` calls factory function on every field creation |
+| BUG-3 | Type gap | Medium | `FieldPath<T>` does not recurse into array element types |
+| BUG-4 | Type gap | Low-Medium | `DeepPartial<T>` does not guard against BuiltInObjects |
+| GAP-1 | Test coverage | Medium | No JSX analyzer tests for N-level chain reactivity |
+| GAP-2 | Test coverage | Medium | No test for `dirty` ambiguity (2-level signal vs 3-level field) |
+| GAP-3 | Test coverage | Low | No test for deeply nested dot-path runtime setFieldError |
+| GAP-4 | Edge case | Low | No test/guard for conflicting flat+nested FormData keys |
+| GAP-5 | Test coverage | Low | No runtime test for nested input name event delegation |
+
+## Verdict
+
+**Changes Requested**
+
+BUG-1 (prototype pollution) is a must-fix before merge. BUG-2 and BUG-3 should be fixed in this PR. GAP-1 and GAP-2 are TDD compliance issues that should be addressed. The remaining items can be addressed in follow-up if needed.
+
+## Resolution
+
+_Pending — awaiting fixes for findings above._


### PR DESCRIPTION
## Summary

- **Nested object schemas**: `form.address.street.error` navigates to FieldState for `"address.street"` via chain proxy with caching
- **Dynamic field access**: `form[dynamicField].error` works via ElementAccessExpression support in compiler
- **N-level compiler chains**: Arbitrary-depth PropertyAccessExpression detection replaces fixed 3-level, with prototype-pollution-safe `formDataToObject` nested parsing
- **Type safety**: `NestedFieldAccessors<T>`, `ArrayFieldAccessors<U>`, `DeepPartial<T>`, `FieldPath<T>`, `BuiltInObjects` guard, reserved field name collision detection

## Public API Changes

### New types exported from `@vertz/ui/form`
- `NestedFieldAccessors<T>` — recursive field accessors for nested schemas
- `ArrayFieldAccessors<U>` — numeric index access to array element fields
- `DeepPartial<T>` — recursive partial for nested initial values
- `FieldPath<T>` — union of all valid dot-paths for `setFieldError`

### Changed signatures
- `FormInstance<TBody, TResult>` now uses `NestedFieldAccessors<TBody>` (was `FieldAccessors<TBody>`)
- `FormOptions.initial` accepts `DeepPartial<TBody>` (was `Partial<TBody>`)
- `setFieldError` accepts `FieldPath<TBody>` (was `keyof TBody & string`)
- `formDataToObject` gains `nested?: boolean` option (backward compatible)

### Compiler changes
- Signal transformer: N-level chain detection with ElementAccessExpression support
- JSX analyzer: matching N-level reactivity detection
- Double-unwrap guard for chains ending with `.value` where sub-chain is already a field signal chain

## Test plan

- [x] 84 form unit tests (20 new: chain proxy, nested access, prototype pollution, formDataToObject)
- [x] 549 compiler tests (10 new: N-level chains, ElementAccessExpression, dirty ambiguity)
- [x] 39 integration tests (9 new: nested field access, validation, initial values)
- [x] 18 type-level tests (8 new: NestedFieldAccessors, ArrayFieldAccessors, DeepPartial, FieldPath, reserved names)
- [x] Full CI: 79/79 tasks passed (lint, typecheck, test, build)
- [x] Adversarial review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)