### PR TITLE
fix(ui-server): eliminate flaky timer leak in SSR lazy component test

### DIFF
--- a/packages/ui-server/src/__tests__/ssr-render.test.ts
+++ b/packages/ui-server/src/__tests__/ssr-render.test.ts
@@ -469,23 +469,10 @@ describe('SSR lazy route resolution', () => {
   });
 
   it('timed-out lazy components fall back to empty container', async () => {
-    let timerId: ReturnType<typeof setTimeout>;
     const routes = defineRoutes({
       '/slow': {
-        component: () =>
-          new Promise<{ default: () => Node }>((resolve) => {
-            timerId = setTimeout(
-              () =>
-                resolve({
-                  default: () => {
-                    const el = document.createElement('div');
-                    el.textContent = 'Slow Content';
-                    return el;
-                  },
-                }),
-              10000,
-            );
-          }),
+        // A component that never resolves — simulates a very slow lazy load
+        component: () => new Promise<{ default: () => Node }>(() => {}),
       },
     });
 
@@ -505,8 +492,6 @@ describe('SSR lazy route resolution', () => {
     // Should still produce valid HTML, just without the lazy content
     expect(result.html).toBeDefined();
     expect(result.html).not.toContain('Slow Content');
-    // Clean up leaked timer to prevent "document is not defined" between test files
-    clearTimeout(timerId!);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace `setTimeout(10000ms)` with a never-resolving Promise in the SSR lazy component timeout test
- Eliminates a flaky CI failure where the timer fired between test files, calling `document.createElement` after the SSR document shim was torn down
- This caused cascading `ReferenceError: document is not defined` and `Cannot call describe() after test run completed` errors in `sourcemap-offset.test.ts`

## Public API Changes

None — test-only change.

## Test plan

- [x] All 670 `@vertz/ui-server` tests pass locally
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-push quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)