### PR TITLE
fix(catalog): register Vertz compiler plugin for client-side bundler

### DIFF
--- a/examples/component-catalog/bun-plugin-shim.ts
+++ b/examples/component-catalog/bun-plugin-shim.ts
@@ -1,0 +1,12 @@
+/**
+ * Thin shim that wraps @vertz/ui-server/bun-plugin for bunfig.toml consumption.
+ *
+ * bunfig.toml `[serve.static] plugins` requires a default export of type BunPlugin.
+ * The @vertz/ui-server/bun-plugin package exports a factory function (createVertzBunPlugin)
+ * as a named export — this shim bridges the two.
+ */
+import { createVertzBunPlugin } from '@vertz/ui-server/bun-plugin';
+
+const { plugin } = createVertzBunPlugin();
+
+export default plugin;

--- a/examples/component-catalog/bunfig.toml
+++ b/examples/component-catalog/bunfig.toml
@@ -1,0 +1,2 @@
+[serve.static]
+plugins = ["./bun-plugin-shim.ts"]


### PR DESCRIPTION
## Summary

- Add `bunfig.toml` and `bun-plugin-shim.ts` to the component catalog so Bun's client-side dev bundler uses the Vertz compiler plugin
- Without this, JSX is processed by Bun's native transform (`jsxDEV`) which evaluates children eagerly, breaking `Provider` context — `Link` components crash with "must be used within RouterContext.Provider"
- Same pattern already used by the task-manager example

## Test plan

- [x] Catalog renders correctly on SSR and after hydration (no blank page)
- [x] No console errors ("Link must be used within RouterContext.Provider" is gone)
- [x] Sidebar navigation works (client-side routing via context-based Link)
- [x] Verified bundle contains `__element` (Vertz compiler) instead of `jsxDEV` (native Bun)