### PR TITLE
fix(ci): remove stale changeset and fix flaky task-list test

### DIFF
--- a/.changeset/inline-small-css.md
+++ b/.changeset/inline-small-css.md
@@ -1,5 +1,0 @@
----
-'@vertz/landing': patch
----
-
-Inline small CSS into HTML `<style>` tags instead of `<link>` tags in production build to eliminate render-blocking requests


### PR DESCRIPTION
## Summary

- Removes `.changeset/inline-small-css.md` which referenced `@vertz/landing` — a package that doesn't exist in the monorepo. This caused the Release workflow to fail: `changeset version` couldn't apply it to any package, producing zero changes, so the version PR branch was identical to `main` and GitHub rejected the PR creation with "No commits between main and changeset-release/main"
- Increases `waitFor` timeout in `task-list.test.ts` from default 1000ms to 3000ms. The mock `fetchTasks()` has a 1s delay, leaving zero margin for rendering on slower CI runners — causing the test to flake

## Public API Changes

None.

## Test plan

- [x] All task-manager tests pass locally (27/27)
- [x] Quality gates pass (79/79 turbo tasks)
- [ ] Release workflow passes on main after merge
- [ ] CI workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)