### PR TITLE
fix(examples): increase waitFor timeout in task-list test for CI

### DIFF
--- a/examples/task-manager/src/tests/task-list.test.ts
+++ b/examples/task-manager/src/tests/task-list.test.ts
@@ -49,11 +49,14 @@ describe('TaskListPage', () => {
     const { page, router } = renderTaskListPage();
     const { queryByText, unmount } = renderTest(page);
 
-    // Wait for the mock tasks to load and render
-    await waitFor(() => {
-      expect(queryByText('Set up CI/CD pipeline')).not.toBeNull();
-      expect(queryByText('Implement user authentication')).not.toBeNull();
-    });
+    // Wait for the mock tasks to load and render (mock delay is 1s, CI needs margin)
+    await waitFor(
+      () => {
+        expect(queryByText('Set up CI/CD pipeline')).not.toBeNull();
+        expect(queryByText('Implement user authentication')).not.toBeNull();
+      },
+      { timeout: 3000 },
+    );
 
     unmount();
     router.dispose();


### PR DESCRIPTION
## Summary

- Increases `waitFor` timeout in `task-list.test.ts` from default 1000ms to 3000ms
- The mock `fetchTasks()` has a 1s delay, leaving zero margin for rendering on slower CI runners — causing the "renders task cards after loading" test to flake

## Public API Changes

None.

## Test plan

- [x] All task-manager tests pass locally (27/27)
- [x] Quality gates pass (79/79 turbo tasks)
- [ ] CI workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)