### PR TITLE
fix(compiler): .map() on reactive arrays always transforms to __list() (#1249)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "examples/component-catalog": {
       "name": "@vertz-examples/component-catalog",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -120,7 +120,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -143,7 +143,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -171,7 +171,7 @@
     },
     "packages/cli-runtime": {
       "name": "@vertz/cli-runtime",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -183,7 +183,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -201,7 +201,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -213,7 +213,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -226,7 +226,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -239,7 +239,7 @@
     },
     "packages/create-vertz": {
       "name": "create-vertz",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "bin": {
         "create-vertz": "./bin/create-vertz.ts",
       },
@@ -249,7 +249,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -263,7 +263,7 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
@@ -295,7 +295,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "devDependencies": {
         "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
@@ -304,7 +304,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -316,7 +316,7 @@
     },
     "packages/icons": {
       "name": "@vertz/icons",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
         "bunup": "^0.16.31",
@@ -370,7 +370,7 @@
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -382,7 +382,7 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -400,7 +400,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/server": "workspace:^",
@@ -414,7 +414,7 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/ui": "workspace:^",
         "@vertz/ui-primitives": "workspace:^",
@@ -428,7 +428,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -440,7 +440,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -454,7 +454,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -471,7 +471,7 @@
     },
     "packages/ui-compiler": {
       "name": "@vertz/ui-compiler",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@vertz/ui": "workspace:^",
@@ -488,7 +488,7 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
         "@vertz/ui": "workspace:^",
@@ -503,7 +503,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@capsizecss/unpack": "^4.0.0",
@@ -526,7 +526,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@vertz/cloudflare": "workspace:^",
         "@vertz/db": "workspace:^",

--- a/packages/ui-compiler/src/transformers/__tests__/list-transformer.test.ts
+++ b/packages/ui-compiler/src/transformers/__tests__/list-transformer.test.ts
@@ -53,8 +53,8 @@ function App() {
     });
   });
 
-  describe('static .map() - no transform', () => {
-    it('does NOT transform static array .map() to __list()', () => {
+  describe('static .map() — always uses __list()', () => {
+    it('transforms static array .map() to __list() (runtime handles static arrays gracefully)', () => {
       const result = compile(
         `
 function App() {
@@ -64,8 +64,10 @@ function App() {
         `.trim(),
       );
 
-      // Static arrays should not use __list
-      expect(result.code).not.toContain('__list(');
+      // __list() handles static arrays gracefully — domEffect runs once, never re-fires.
+      // Always transforming .map() ensures callback parameters from APIs like queryMatch()
+      // (reactive proxies at runtime but opaque to the compiler) get proper list reconciliation.
+      expect(result.code).toContain('__list(');
     });
   });
 
@@ -84,6 +86,40 @@ function App() {
       expect(result.code).toContain('UserCard(');
       // Key function should use user.id
       expect(result.code).toContain('user.id');
+    });
+  });
+
+  describe('.map() on callback parameters (queryMatch pattern)', () => {
+    it('transforms .map() on callback parameter inside function call to __list()', () => {
+      const result = compile(
+        `
+import { query, queryMatch } from '@vertz/ui';
+function App() {
+  const q = query(() => fetch('/api'));
+  return <div>{queryMatch(q, {
+    loading: () => <span>Loading</span>,
+    error: (e) => <span>Error</span>,
+    data: (response) => <ul>{response.items.map(item => <li key={item.id}>{item.name}</li>)}</ul>,
+  })}</div>;
+}
+        `.trim(),
+      );
+
+      expect(result.code).toContain('__list(');
+      expect(result.code).toContain('item.id');
+    });
+
+    it('transforms .map() on const array variable to __list()', () => {
+      const result = compile(
+        `
+function App() {
+  const navItems = [{ label: "Home" }, { label: "About" }];
+  return <nav>{navItems.map(item => <a key={item.label}>{item.label}</a>)}</nav>;
+}
+        `.trim(),
+      );
+
+      expect(result.code).toContain('__list(');
     });
   });
 

--- a/packages/ui-compiler/src/transformers/jsx-transformer.ts
+++ b/packages/ui-compiler/src/transformers/jsx-transformer.ts
@@ -392,8 +392,12 @@ function transformChild(
       }
     }
 
-    // List patterns: keep gated by reactive flag (static arrays don't need reconciliation)
-    if (exprInfo?.reactive) {
+    // List patterns: always transform .map() to __list() regardless of reactivity.
+    // __list() handles static arrays gracefully (domEffect runs once, never re-fires).
+    // Gating by reactivity misses callback parameters from APIs like queryMatch(),
+    // where the parameter is a reactive proxy at runtime but opaque to the compiler.
+    // This matches __conditional(), which is also ungated.
+    {
       const listCode = tryTransformList(exprNode, reactiveNames, jsxMap, parentVar, source);
       if (listCode) {
         return listCode;

--- a/packages/ui/src/query/__tests__/query-match.test.ts
+++ b/packages/ui/src/query/__tests__/query-match.test.ts
@@ -397,6 +397,68 @@ describe('queryMatch()', () => {
     wrapper.dispose();
   });
 
+  test('__list inside data handler updates when data changes via proxy (issue #1249)', () => {
+    // Reproduces the exact bug scenario: .map() on the data proxy parameter
+    // should update the DOM when query data changes. The compiler now generates
+    // __list() for ALL .map() calls in JSX, so `response.items.map(...)` becomes
+    // `__list(el, () => response.items, ...)` where `response` is the reactive proxy.
+    const qr = fakeQueryResult<{ items: { id: string; title: string }[] }>({
+      loading: false,
+      data: { items: [{ id: '1', title: 'First' }] },
+    });
+
+    const container = document.createElement('div');
+
+    const wrapper = queryMatch(qr, {
+      loading: () => document.createElement('div'),
+      error: () => document.createElement('div'),
+      data: (response) => {
+        const el = document.createElement('ul');
+        // Simulates compiler output: __list(el, () => response.items, ...)
+        // `response` is the reactive proxy — response.items reads from dataSignal.value
+        __list(
+          el,
+          () => response.items,
+          (item) => item.id,
+          (item) => {
+            const li = document.createElement('li');
+            domEffect(() => {
+              li.textContent = item.title;
+            });
+            return li;
+          },
+        );
+        return el;
+      },
+    });
+    container.appendChild(wrapper);
+
+    const listEl = wrapper.children[0] as HTMLElement;
+    expect(listEl.children.length).toBe(1);
+    expect(listEl.children[0]?.textContent).toBe('First');
+
+    // Simulate cache invalidation + refetch: data changes
+    qr._data.value = {
+      items: [
+        { id: '1', title: 'First (updated)' },
+        { id: '2', title: 'Second' },
+      ],
+    };
+
+    // __list should reactively update: existing key '1' updates, new key '2' appears
+    expect(listEl.children.length).toBe(2);
+    expect(listEl.children[0]?.textContent).toBe('First (updated)');
+    expect(listEl.children[1]?.textContent).toBe('Second');
+
+    // Remove an item
+    qr._data.value = { items: [{ id: '2', title: 'Second' }] };
+
+    expect(listEl.children.length).toBe(1);
+    expect(listEl.children[0]?.textContent).toBe('Second');
+
+    wrapper.dispose();
+  });
+
   test('__list updates reactive bindings when item changes at same index key', () => {
     // Reproduces the compiler-generated scenario: .map() without explicit key
     // generates index-based keyFn. __list wraps each item in a reactive proxy,


### PR DESCRIPTION
## Summary

- Fix compiler gating that prevented `.map()` on callback parameters (like `queryMatch` data handler) from transforming to reactive `__list()`
- Remove reactive gate on `.map()` → `__list()` transformation, matching existing behavior for `__conditional`
- __list() runtime handles static arrays gracefully (domEffect runs once, never re-fires)

## Test plan

- [x] 582 compiler tests pass
- [x] 2078 UI runtime tests pass (including new integration test for #1249)
- [x] Task-manager E2E: 40 passed, 5 skipped
- [x] Benchmarks E2E: 46 passed (1 pre-existing failure unrelated to this change)
- [x] Typecheck clean
- [x] Lint clean