### PR TITLE
refactor(ui): add canSignals() to remove double-cast (#1255)

### DIFF
--- a/.changeset/can-signals-refactor.md
+++ b/.changeset/can-signals-refactor.md
@@ -1,0 +1,11 @@
+---
+'@vertz/ui': patch
+'@vertz/ui-auth': patch
+---
+
+refactor(ui): add canSignals() to avoid double-cast in ProtectedRoute
+
+Extracted signal-creation logic from can() into shared createAccessCheckRaw() helper.
+Added canSignals() that returns raw ReadonlySignal properties for framework code
+that runs without compiler transforms. Updated createEntitlementGuard to use
+canSignals() — eliminates the `as unknown as ReadonlySignal<boolean>` double-cast.

--- a/packages/ui-auth/src/entitlement-check.ts
+++ b/packages/ui-auth/src/entitlement-check.ts
@@ -1,6 +1,5 @@
-import type { ReadonlySignal } from '@vertz/ui';
-import type { AccessCheck, Entitlement } from '@vertz/ui/auth';
-import { can } from '@vertz/ui/auth';
+import type { Entitlement, RawAccessCheck } from '@vertz/ui/auth';
+import { canSignals } from '@vertz/ui/auth';
 
 /**
  * Create entitlement checks for the given entitlements and return a function
@@ -8,15 +7,15 @@ import { can } from '@vertz/ui/auth';
  * `.value` properties, so it must be called inside a reactive scope (computed,
  * domEffect, __child, __conditional) to establish tracking.
  *
- * `can()` is called eagerly (must happen while context scope is active),
+ * `canSignals()` is called eagerly (must happen while context scope is active),
  * and the returned function reads `.allowed.value` lazily.
  */
 export function createEntitlementGuard(requires: Entitlement[] | undefined): () => boolean {
   if (!requires || requires.length === 0) {
     return () => true;
   }
-  // Call can() eagerly while context scope is available
-  const checks: AccessCheck[] = requires.map((e) => can(e));
-  // Return a function that reads .allowed.value reactively
-  return () => checks.every((c) => (c.allowed as unknown as ReadonlySignal<boolean>).value);
+  // Call canSignals() eagerly while context scope is available
+  const checks: RawAccessCheck[] = requires.map((e) => canSignals(e));
+  // Return a function that reads .allowed.value reactively — no double-cast needed
+  return () => checks.every((c) => c.allowed.value);
 }

--- a/packages/ui/src/auth/__tests__/access-context.test-d.ts
+++ b/packages/ui/src/auth/__tests__/access-context.test-d.ts
@@ -5,7 +5,8 @@
  * shape and rejects invalid usage. Checked by `tsc --noEmit`.
  */
 
-import { can } from '../access-context';
+import type { ReadonlySignal } from '../../runtime/signal-types';
+import { can, canSignals, type RawAccessCheck } from '../access-context';
 import type { AccessCheck, DenialMeta, DenialReason } from '../access-set-types';
 
 // ─── Positive: can('x') returns AccessCheck with correct properties ──────
@@ -41,3 +42,36 @@ can();
 
 // @ts-expect-error - AccessCheck does not have a 'nonexistent' property
 check.nonexistent;
+
+// ─── canSignals() returns RawAccessCheck with ReadonlySignal properties ──
+
+declare const raw: RawAccessCheck;
+
+// allowed is ReadonlySignal<boolean>
+const _rawAllowed: ReadonlySignal<boolean> = raw.allowed;
+void _rawAllowed;
+
+// loading is ReadonlySignal<boolean>
+const _rawLoading: ReadonlySignal<boolean> = raw.loading;
+void _rawLoading;
+
+// reasons is ReadonlySignal<DenialReason[]>
+const _rawReasons: ReadonlySignal<DenialReason[]> = raw.reasons;
+void _rawReasons;
+
+// reason is ReadonlySignal<DenialReason | undefined>
+const _rawReason: ReadonlySignal<DenialReason | undefined> = raw.reason;
+void _rawReason;
+
+// meta is ReadonlySignal<DenialMeta | undefined>
+const _rawMeta: ReadonlySignal<DenialMeta | undefined> = raw.meta;
+void _rawMeta;
+
+// ─── Negative: canSignals() properties are NOT plain values ─────────────
+
+// @ts-expect-error - canSignals().allowed is ReadonlySignal<boolean>, not boolean
+const _badAllowed: boolean = raw.allowed;
+void _badAllowed;
+
+// @ts-expect-error - canSignals() requires at least one argument
+canSignals();

--- a/packages/ui/src/auth/__tests__/access-context.test.ts
+++ b/packages/ui/src/auth/__tests__/access-context.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, spyOn } from 'bun:test';
 import { createContext, useContext } from '../../component/context';
 import { signal } from '../../runtime/signal';
-import { AccessContext, type AccessContextValue, can, useAccessContext } from '../access-context';
+import {
+  AccessContext,
+  type AccessContextValue,
+  can,
+  canSignals,
+  useAccessContext,
+} from '../access-context';
 import type { AccessCheckData, AccessSet } from '../access-set-types';
 
 function makeAccessSet(
@@ -226,6 +232,101 @@ describe('can()', () => {
     expect(result!.allowed.value).toBe(false);
 
     // Update the access set
+    accessSet.value = makeAccessSet({
+      'project:edit': { allowed: true, reasons: [] },
+    });
+
+    expect(result!.allowed.value).toBe(true);
+  });
+});
+
+describe('canSignals()', () => {
+  it('returns RawAccessCheck with all ReadonlySignal properties', () => {
+    const accessSet = signal<AccessSet | null>(
+      makeAccessSet({
+        'project:view': {
+          allowed: true,
+          reasons: [],
+          reason: undefined,
+          meta: { limit: { max: 10, consumed: 3, remaining: 7 } },
+        },
+      }),
+    );
+    const loading = signal(false);
+
+    let result: ReturnType<typeof canSignals>;
+    withProvider({ accessSet, loading }, () => {
+      result = canSignals('project:view');
+    });
+
+    // All properties are ReadonlySignal — access .value directly
+    expect(result!.allowed.value).toBe(true);
+    expect(result!.loading.value).toBe(false);
+    expect(result!.reasons.value).toEqual([]);
+    expect(result!.reason.value).toBeUndefined();
+    expect(result!.meta.value?.limit?.remaining).toBe(7);
+  });
+
+  it('returns fail-secure fallback when no provider', () => {
+    const result = canSignals('project:view');
+
+    expect(result.allowed.value).toBe(false);
+    expect(result.reasons.value).toContain('not_authenticated');
+    expect(result.reason.value).toBe('not_authenticated');
+    expect(result.meta.value).toBeUndefined();
+    expect(result.loading.value).toBe(false);
+  });
+
+  it('warns in dev when no provider', () => {
+    const consoleSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    canSignals('project:view');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'canSignals() called without AccessContext.Provider — all checks denied',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('uses entity.__access when present', () => {
+    const accessSet = signal<AccessSet | null>(
+      makeAccessSet({
+        'project:edit': { allowed: false, reasons: ['role_required'] },
+      }),
+    );
+    const loading = signal(false);
+
+    const entity = {
+      __access: {
+        'project:edit': { allowed: true, reasons: [] as string[] },
+      },
+    };
+
+    let result: ReturnType<typeof canSignals>;
+    withProvider({ accessSet, loading }, () => {
+      result = canSignals('project:edit', entity as { __access: Record<string, AccessCheckData> });
+    });
+
+    // Entity-level check says allowed, even though global says denied
+    expect(result!.allowed.value).toBe(true);
+  });
+
+  it('returns same reactive behavior as can()', () => {
+    const accessSet = signal<AccessSet | null>(
+      makeAccessSet({
+        'project:edit': { allowed: false, reasons: ['role_required'] },
+      }),
+    );
+    const loading = signal(false);
+
+    let result: ReturnType<typeof canSignals>;
+    withProvider({ accessSet, loading }, () => {
+      result = canSignals('project:edit');
+    });
+
+    expect(result!.allowed.value).toBe(false);
+
+    // Update reactively
     accessSet.value = makeAccessSet({
       'project:edit': { allowed: true, reasons: [] },
     });

--- a/packages/ui/src/auth/access-context.ts
+++ b/packages/ui/src/auth/access-context.ts
@@ -9,7 +9,13 @@
 import { type Context, createContext, type UnwrapSignals, useContext } from '../component/context';
 import { computed } from '../runtime/signal';
 import type { ReadonlySignal, Signal } from '../runtime/signal-types';
-import type { AccessCheck, AccessCheckData, AccessSet, DenialReason } from './access-set-types';
+import type {
+  AccessCheck,
+  AccessCheckData,
+  AccessSet,
+  DenialMeta,
+  DenialReason,
+} from './access-set-types';
 
 // ============================================================================
 // Context
@@ -55,53 +61,41 @@ export type Entitlement = keyof EntitlementRegistry extends never
   : Extract<keyof EntitlementRegistry, string>;
 
 // ============================================================================
-// can()
+// can() + canSignals()
 // ============================================================================
 
 /**
- * Signal-backed fallback for when no provider is present — fail-secure.
- * Uses computed() for consistency with the provider path, so the return shape
- * is always signal-backed regardless of provider presence.
+ * @internal Signal-backed version of AccessCheck — actual runtime type of can() return.
+ * Use with canSignals() when framework code needs reactive signal access without compiler transforms.
  */
-function createFallbackDenied(): AccessCheck {
-  return {
-    allowed: computed(() => false),
-    reasons: computed(() => ['not_authenticated'] as DenialReason[]),
-    reason: computed(() => 'not_authenticated' as DenialReason),
-    meta: computed(() => undefined),
-    loading: computed(() => false),
-    // signal-api pattern: compiler auto-unwraps .value (same as query()/form())
-  } as unknown as AccessCheck;
+export interface RawAccessCheck {
+  readonly allowed: ReadonlySignal<boolean>;
+  readonly reasons: ReadonlySignal<DenialReason[]>;
+  readonly reason: ReadonlySignal<DenialReason | undefined>;
+  readonly meta: ReadonlySignal<DenialMeta | undefined>;
+  readonly loading: ReadonlySignal<boolean>;
 }
 
 const __DEV__ = typeof process !== 'undefined' && process.env.NODE_ENV !== 'production';
 
 /**
- * Check if the current user has a specific entitlement.
- *
- * Must be called in the component body (like query()/form()).
- * Returns an AccessCheck with ReadonlySignal properties that the
- * compiler auto-unwraps via signal-api registration.
- *
- * **UI-advisory only.** Server always re-validates before mutations.
- * `can()` controls UI visibility, not authorization.
- *
- * @param entitlement - The entitlement to check
- * @param entity - Optional entity with pre-computed `__access` metadata
+ * Internal helper: creates signal-backed access check properties.
+ * When ctx is null (no provider), returns fail-secure fallback.
+ * useContext() is called by can()/canSignals(), not here.
  */
-export function can(
+function createAccessCheckRaw(
+  ctx: UnwrapSignals<AccessContextValue> | null | undefined,
   entitlement: Entitlement,
   entity?: { __access?: Record<string, AccessCheckData> },
-): AccessCheck {
-  // Use useContext directly (not useAccessContext) because can() needs
-  // graceful fallback to FALLBACK_DENIED when no provider is present.
-  const ctx = useContext(AccessContext);
-
+): RawAccessCheck {
   if (!ctx) {
-    if (__DEV__) {
-      console.warn('can() called without AccessContext.Provider — all checks denied');
-    }
-    return createFallbackDenied();
+    return {
+      allowed: computed(() => false),
+      reasons: computed(() => ['not_authenticated'] as DenialReason[]),
+      reason: computed(() => 'not_authenticated' as DenialReason),
+      meta: computed(() => undefined),
+      loading: computed(() => false),
+    };
   }
 
   // Create computed signals that derive from the context's access set.
@@ -125,6 +119,55 @@ export function can(
       if (!set) return ctx.loading as boolean;
       return false;
     }),
-    // signal-api pattern: compiler auto-unwraps .value (same as query()/form())
-  } as unknown as AccessCheck;
+  };
+}
+
+/**
+ * Check if the current user has a specific entitlement.
+ *
+ * Must be called in the component body (like query()/form()).
+ * Returns an AccessCheck with ReadonlySignal properties that the
+ * compiler auto-unwraps via signal-api registration.
+ *
+ * **UI-advisory only.** Server always re-validates before mutations.
+ * `can()` controls UI visibility, not authorization.
+ *
+ * @param entitlement - The entitlement to check
+ * @param entity - Optional entity with pre-computed `__access` metadata
+ */
+export function can(
+  entitlement: Entitlement,
+  entity?: { __access?: Record<string, AccessCheckData> },
+): AccessCheck {
+  const ctx = useContext(AccessContext);
+
+  if (!ctx && __DEV__) {
+    console.warn('can() called without AccessContext.Provider — all checks denied');
+  }
+
+  // signal-api pattern: compiler auto-unwraps .value (same as query()/form())
+  return createAccessCheckRaw(ctx, entitlement, entity) as unknown as AccessCheck;
+}
+
+/**
+ * @internal Framework use only.
+ * Same as can() but returns raw ReadonlySignal properties.
+ * Use when framework code needs reactive signal access without compiler transforms.
+ *
+ * Must NOT be added to the signal-api-registry — the compiler must not auto-unwrap these.
+ *
+ * @param entitlement - The entitlement to check
+ * @param entity - Optional entity with pre-computed `__access` metadata
+ */
+export function canSignals(
+  entitlement: Entitlement,
+  entity?: { __access?: Record<string, AccessCheckData> },
+): RawAccessCheck {
+  const ctx = useContext(AccessContext);
+
+  if (!ctx && __DEV__) {
+    console.warn('canSignals() called without AccessContext.Provider — all checks denied');
+  }
+
+  return createAccessCheckRaw(ctx, entitlement, entity);
 }

--- a/packages/ui/src/auth/public.ts
+++ b/packages/ui/src/auth/public.ts
@@ -8,8 +8,13 @@
  */
 
 // --- Access control (existing) ---
-export type { AccessContextValue, Entitlement, EntitlementRegistry } from './access-context';
-export { AccessContext, can, useAccessContext } from './access-context';
+export type {
+  AccessContextValue,
+  Entitlement,
+  EntitlementRegistry,
+  RawAccessCheck,
+} from './access-context';
+export { AccessContext, can, canSignals, useAccessContext } from './access-context';
 export type {
   AccessEventClient,
   AccessEventClientOptions,

--- a/plans/1255-can-signals-refactor.md
+++ b/plans/1255-can-signals-refactor.md
@@ -1,0 +1,108 @@
+# refactor(ui): remove double-cast for can().allowed — #1255
+
+## Problem
+
+`createEntitlementGuard()` in `@vertz/ui-auth` uses a double-cast to access the raw signal behind `can()`:
+
+```ts
+(c.allowed as unknown as ReadonlySignal<boolean>).value
+```
+
+This violates the `no-double-cast` Biome rule and is fragile. The signal-api pattern intentionally hides signals behind plain types for user code (compiler auto-unwraps), but framework code (no compiler) needs raw signal access.
+
+## API Surface
+
+### New type: `RawAccessCheck`
+
+```ts
+/** @internal Signal-backed version of AccessCheck — actual runtime type of can() return. */
+export interface RawAccessCheck {
+  readonly allowed: ReadonlySignal<boolean>;
+  readonly reasons: ReadonlySignal<DenialReason[]>;
+  readonly reason: ReadonlySignal<DenialReason | undefined>;
+  readonly meta: ReadonlySignal<DenialMeta | undefined>;
+  readonly loading: ReadonlySignal<boolean>;
+}
+```
+
+### New function: `canSignals()`
+
+```ts
+/**
+ * @internal Framework use only.
+ * Same as can() but returns raw ReadonlySignal properties.
+ * Use when framework code needs reactive signal access without compiler transforms.
+ */
+export function canSignals(
+  entitlement: Entitlement,
+  entity?: { __access?: Record<string, AccessCheckData> },
+): RawAccessCheck;
+```
+
+### Usage in `createEntitlementGuard`
+
+```ts
+// BEFORE
+const checks: AccessCheck[] = requires.map((e) => can(e));
+return () => checks.every((c) => (c.allowed as unknown as ReadonlySignal<boolean>).value);
+
+// AFTER
+const checks: RawAccessCheck[] = requires.map((e) => canSignals(e));
+return () => checks.every((c) => c.allowed.value);
+```
+
+## Implementation
+
+1. Add `RawAccessCheck` interface to `access-context.ts` (co-located with `canSignals()`, keeps `access-set-types.ts` free of runtime type imports)
+2. Extract shared signal-creation logic from `can()` into `createAccessCheckRaw(ctx, entitlement, entity)` helper
+   - **`ctx` is passed as a parameter** — `useContext()` is called by `can()`/`canSignals()`, not the helper
+   - **Handles null ctx** (no-provider fallback): when `ctx` is `null`, returns the fail-secure fallback signals (current `createFallbackDenied()` logic merged into this helper)
+3. `can()` calls `useContext()` + passes ctx to helper + casts result to `AccessCheck` (existing behavior)
+4. New `canSignals()` calls `useContext()` + passes ctx to helper + returns `RawAccessCheck` directly (zero casts)
+5. Update `createEntitlementGuard` to use `canSignals()` instead of `can()`
+6. Export `canSignals` and `RawAccessCheck` from `@vertz/ui/auth`
+
+**Important:** `canSignals()` must **NOT** be added to the compiler's signal-api-registry. It returns raw `ReadonlySignal` properties — if registered, the compiler would auto-insert `.value`, causing double-unwrap bugs.
+
+## Manifesto Alignment
+
+- **Signals are an implementation detail**: `can()` stays unchanged for users. `canSignals()` is `@internal`.
+- **No magic**: Framework code gets clean typed access instead of brittle double-casts.
+
+## Non-Goals
+
+- Changing `can()` public API
+- Generalizing this pattern for all signal-apis (query, form) — only `can()` needs it today
+- Removing the `as unknown as AccessCheck` cast in `can()` — that cast is correct and intentional
+- Adding `canSignals()` to the signal-api-registry — it returns raw signals, compiler must NOT auto-unwrap
+
+## Unknowns
+
+None identified.
+
+## Type Flow Map
+
+```
+canSignals(entitlement)
+  → createAccessCheckRaw(ctx, entitlement)
+    → { allowed: ReadonlySignal<boolean>, ... }  (RawAccessCheck)
+      → createEntitlementGuard reads .allowed.value  (boolean)
+```
+
+No dead generics — `RawAccessCheck` maps 1:1 to `AccessCheck` property types wrapped in `ReadonlySignal`.
+
+## E2E Acceptance Test
+
+```ts
+// createEntitlementGuard returns a reactive function using canSignals()
+describe('Given canSignals() returns raw signal properties', () => {
+  describe('When createEntitlementGuard reads .allowed.value', () => {
+    it('Then returns boolean without double-casting', () => {
+      // Existing tests cover behavior — this refactor changes types, not behavior
+    });
+  });
+});
+
+// @ts-expect-error: canSignals() returns ReadonlySignal, not plain boolean
+const bad: boolean = canSignals('test').allowed; // Type error — it's ReadonlySignal<boolean>
+```


### PR DESCRIPTION
## Summary

- Extracted signal-creation logic from `can()` into shared `createAccessCheckRaw()` helper
- Added `canSignals()` that returns `RawAccessCheck` with typed `ReadonlySignal` properties — for framework code that runs without compiler transforms
- Updated `createEntitlementGuard` in `@vertz/ui-auth` to use `canSignals()` instead of `can()` + double-cast
- Eliminates the `(c.allowed as unknown as ReadonlySignal<boolean>).value` pattern completely

## Public API Changes

- **New (internal):** `canSignals(entitlement, entity?)` — `@internal`, same as `can()` but returns raw signals
- **New (internal):** `RawAccessCheck` type — signal-backed version of `AccessCheck`
- **Unchanged:** `can()` — no changes to public API

## Test plan

- [x] `canSignals()` returns RawAccessCheck with all ReadonlySignal properties
- [x] `canSignals()` returns fail-secure fallback when no provider
- [x] `canSignals()` warns in dev when no provider
- [x] `canSignals()` uses entity.__access when present
- [x] `canSignals()` reactive updates work correctly
- [x] Type-level tests: RawAccessCheck properties are ReadonlySignal<T>, not plain T
- [x] Type-level tests: negative test confirms `boolean` assignment fails
- [x] ProtectedRoute tests pass with updated entitlement-check
- [x] Full CI (82 tasks) passes

Fixes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)