### PR TITLE
fix(server): SessionResolver type rejects app.auth.resolveSessionForSSR

### DIFF
--- a/.changeset/fix-session-resolver-types.md
+++ b/.changeset/fix-session-resolver-types.md
@@ -1,0 +1,11 @@
+---
+'@vertz/server': patch
+---
+
+fix(server): AuthInstance.resolveSessionForSSR now assignable to SessionResolver
+
+Updated the return type of `resolveSessionForSSR` on `AuthInstance` to use the
+correct `{ id: string; email: string; role: string }` user shape and `AccessSet | null`
+for `accessSet`, matching what the implementation already returns. Previously typed
+loosely as `Record<string, unknown>` / `unknown`, which caused a type error when
+passed to `createBunDevServer`'s `sessionResolver` option.

--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,7 @@
         "@vertz/theme-shadcn": "workspace:^",
         "@vertz/ui": "workspace:^",
         "@vertz/ui-auth": "workspace:^",
+        "@vertz/ui-server": "workspace:^",
         "bun-types": "^1.3.10",
         "happy-dom": "^20.7.0",
         "typescript": "^5.7.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -25,6 +25,7 @@
     "@vertz/theme-shadcn": "workspace:^",
     "@vertz/ui": "workspace:^",
     "@vertz/ui-auth": "workspace:^",
+    "@vertz/ui-server": "workspace:^",
     "vertz": "workspace:^",
     "@happy-dom/global-registrator": "^20.7.0",
     "bun-types": "^1.3.10",

--- a/packages/integration-tests/src/__tests__/session-resolver-compat.test-d.ts
+++ b/packages/integration-tests/src/__tests__/session-resolver-compat.test-d.ts
@@ -1,0 +1,36 @@
+/**
+ * Type-level test: AuthInstance.resolveSessionForSSR must be assignable to SessionResolver.
+ *
+ * Regression test for #1259: the loose types on AuthInstance.resolveSessionForSSR
+ * (Record<string, unknown> for user, unknown for accessSet) were not assignable to
+ * SessionResolver's SSRSessionInfo type.
+ */
+import { describe, it } from 'bun:test';
+import type { AuthInstance } from '@vertz/server';
+import type { SessionResolver } from '@vertz/ui-server';
+
+declare const auth: AuthInstance;
+
+describe('SessionResolver compatibility (#1259)', () => {
+  it('AuthInstance.resolveSessionForSSR is assignable to SessionResolver', () => {
+    const _resolver: SessionResolver = auth.resolveSessionForSSR;
+    void _resolver;
+  });
+
+  it('rejects a resolver returning wrong user shape', () => {
+    // @ts-expect-error — session.user missing required structure
+    const _resolver: SessionResolver = async (_req: Request) => ({
+      session: { user: 'not-an-object', expiresAt: 123 },
+    });
+    void _resolver;
+  });
+
+  it('rejects a resolver returning wrong accessSet type', () => {
+    // @ts-expect-error — accessSet must be AccessSet | null | undefined, not string
+    const _resolver: SessionResolver = async (_req: Request) => ({
+      session: { user: { id: '1', email: 'a@b.c', role: 'user' }, expiresAt: 123 },
+      accessSet: 'not-an-access-set',
+    });
+    void _resolver;
+  });
+});

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -12,6 +12,7 @@ import {
   type StringSchema,
   s,
 } from '@vertz/schema';
+import type { AccessSet } from './access-set';
 
 // ============================================================================
 // Session Types
@@ -566,9 +567,11 @@ export interface AuthInstance {
    * minimal session data + optional access set for client hydration.
    */
   resolveSessionForSSR: (request: Request) => Promise<{
-    session: { user: Record<string, unknown>; expiresAt: number };
-    /** AccessSet | null at runtime; typed as unknown to avoid cross-package dependency on @vertz/ui */
-    accessSet?: unknown;
+    session: {
+      user: { id: string; email: string; role: string; [key: string]: unknown };
+      expiresAt: number;
+    };
+    accessSet?: AccessSet | null;
   } | null>;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1259

- Updated `AuthInstance.resolveSessionForSSR` return type to use `{ id: string; email: string; role: string; [key: string]: unknown }` for user and `AccessSet | null` for `accessSet`, matching what the implementation already returns
- Previously typed loosely as `Record<string, unknown>` / `unknown`, causing a type error when passed to `createBunDevServer`'s `sessionResolver` option
- Added cross-package type regression test in `@vertz/integration-tests`

## Public API Changes

- `AuthInstance.resolveSessionForSSR` return type narrowed from `{ user: Record<string, unknown> }` to `{ user: { id: string; email: string; role: string; [key: string]: unknown } }` and `accessSet?: unknown` to `accessSet?: AccessSet | null`. This is a non-breaking narrowing — existing code that worked before still works.

## Test plan

- [x] Type-level regression test verifying `AuthInstance.resolveSessionForSSR` is assignable to `SessionResolver`
- [x] Negative type tests for wrong user shape and wrong accessSet type
- [x] `@vertz/server` typecheck clean
- [x] `@vertz/integration-tests` typecheck clean
- [x] `examples/linear` typecheck clean (the original error site)
- [x] All 1381 server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)