### PR TITLE
fix(scaffold): use form() API and fix compiler vertz/ui recognition

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "examples/component-catalog": {
       "name": "@vertz-examples/component-catalog",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -121,7 +121,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -144,7 +144,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -172,7 +172,7 @@
     },
     "packages/cli-runtime": {
       "name": "@vertz/cli-runtime",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -184,7 +184,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -202,7 +202,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -214,7 +214,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -227,7 +227,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -240,7 +240,7 @@
     },
     "packages/create-vertz": {
       "name": "create-vertz",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "bin": {
         "create-vertz": "./bin/create-vertz.ts",
       },
@@ -250,7 +250,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -264,7 +264,7 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
@@ -296,7 +296,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "devDependencies": {
         "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
@@ -305,7 +305,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -317,7 +317,7 @@
     },
     "packages/icons": {
       "name": "@vertz/icons",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
         "bunup": "^0.16.31",
@@ -373,7 +373,7 @@
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -385,7 +385,7 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -403,7 +403,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/server": "workspace:^",
@@ -417,7 +417,7 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/ui": "workspace:^",
         "@vertz/ui-primitives": "workspace:^",
@@ -431,7 +431,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -443,7 +443,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -457,7 +457,7 @@
     },
     "packages/ui-auth": {
       "name": "@vertz/ui-auth",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -471,7 +471,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -488,7 +488,7 @@
     },
     "packages/ui-compiler": {
       "name": "@vertz/ui-compiler",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@vertz/ui": "workspace:^",
@@ -505,7 +505,7 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
         "@vertz/ui": "workspace:^",
@@ -520,7 +520,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@capsizecss/unpack": "^4.0.0",
@@ -544,7 +544,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@vertz/cloudflare": "workspace:^",
         "@vertz/db": "workspace:^",

--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -272,6 +272,41 @@ describe('templates', () => {
     it('exports HomePage component', () => {
       expect(homePageTemplate()).toContain('export function HomePage()');
     });
+
+    it('uses form() API for task creation instead of manual submit', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('form(api.tasks.create');
+      expect(result).toContain('resetOnSuccess: true');
+      expect(result).not.toContain('handleSubmit');
+      expect(result).not.toContain('refetch');
+    });
+
+    it('imports form from vertz/ui', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('form,');
+    });
+
+    it('uses form fields for input name binding', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('taskForm.fields.title');
+    });
+
+    it('uses form action/method/onSubmit on the form element', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('taskForm.action');
+      expect(result).toContain('taskForm.method');
+      expect(result).toContain('taskForm.onSubmit');
+    });
+
+    it('shows per-field validation errors', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('taskForm.title.error');
+    });
+
+    it('disables submit button during submission', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('taskForm.submitting');
+    });
   });
 
   describe('claudeMdTemplate', () => {

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -776,6 +776,7 @@ export function homePageTemplate(): string {
   ListTransition,
   css,
   fadeOut,
+  form,
   globalCss,
   query,
   queryMatch,
@@ -797,9 +798,10 @@ void globalCss({
 const pageStyles = css({
   container: ['py:2', 'w:full'],
   heading: ['font:xl', 'font:bold', 'text:foreground', 'mb:4'],
-  form: ['flex', 'gap:2', 'mb:6'],
+  form: ['flex', 'gap:2', 'items:start', 'mb:6'],
+  inputWrap: ['flex-1'],
   input: [
-    'flex-1',
+    'w:full',
     'px:3',
     'py:2',
     'rounded:md',
@@ -808,12 +810,13 @@ const pageStyles = css({
     'bg:background',
     'text:foreground',
   ],
+  fieldError: ['text:destructive', 'font:xs', 'mt:1'],
   button: [
     'px:4',
     'py:2',
     'rounded:md',
-    'bg:primary.600',
-    'text:white',
+    'bg:primary',
+    'text:primary-foreground',
     'font:medium',
     'cursor:pointer',
   ],
@@ -837,31 +840,36 @@ const pageStyles = css({
 export function HomePage() {
   const tasksQuery = query(api.tasks.list());
 
-  const handleSubmit = async (e: SubmitEvent) => {
-    e.preventDefault();
-    const form = e.target as HTMLFormElement;
-    const data = new FormData(form);
-    const title = data.get('title') as string;
-    if (!title.trim()) return;
-
-    await api.tasks.create({ title });
-    form.reset();
-    tasksQuery.refetch();
-  };
+  const taskForm = form(api.tasks.create, {
+    resetOnSuccess: true,
+  });
 
   return (
     <div class={pageStyles.container} data-testid="home-page">
       <h1 class={pageStyles.heading}>Tasks</h1>
 
-      <form class={pageStyles.form} onSubmit={handleSubmit}>
-        <input
-          name="title"
-          class={pageStyles.input}
-          placeholder="What needs to be done?"
-          required
-        />
-        <button type="submit" class={pageStyles.button}>
-          Add
+      <form
+        class={pageStyles.form}
+        action={taskForm.action}
+        method={taskForm.method}
+        onSubmit={taskForm.onSubmit}
+      >
+        <div class={pageStyles.inputWrap}>
+          <input
+            name={taskForm.fields.title}
+            class={pageStyles.input}
+            placeholder="What needs to be done?"
+          />
+          <span class={pageStyles.fieldError}>
+            {taskForm.title.error}
+          </span>
+        </div>
+        <button
+          type="submit"
+          class={pageStyles.button}
+          disabled={taskForm.submitting}
+        >
+          {taskForm.submitting.value ? 'Adding...' : 'Add'}
         </button>
       </form>
 

--- a/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
@@ -423,10 +423,13 @@ function buildImportAliasMap(
 
   for (const importDecl of sourceFile.getImportDeclarations()) {
     const moduleSpecifier = importDecl.getModuleSpecifierValue();
-    // Auto-load framework manifest for @vertz/ui and subpaths (@vertz/ui/*) when not explicitly provided
+    // Auto-load framework manifest for @vertz/ui (and vertz/ui meta-package) when not explicitly provided
     const manifest =
       manifests?.[moduleSpecifier] ??
-      (moduleSpecifier === '@vertz/ui' || moduleSpecifier.startsWith('@vertz/ui/')
+      (moduleSpecifier === '@vertz/ui' ||
+      moduleSpecifier.startsWith('@vertz/ui/') ||
+      moduleSpecifier === 'vertz/ui' ||
+      moduleSpecifier.startsWith('vertz/ui/')
         ? loadFrameworkManifest()
         : undefined);
 

--- a/packages/ui-server/src/bun-plugin/plugin.ts
+++ b/packages/ui-server/src/bun-plugin/plugin.ts
@@ -129,7 +129,7 @@ export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunP
   ) as import('@vertz/ui-compiler').ReactivityManifest;
   const manifestResult = generateAllManifests({
     srcDir,
-    packageManifests: { '@vertz/ui': frameworkManifestJson },
+    packageManifests: { '@vertz/ui': frameworkManifestJson, 'vertz/ui': frameworkManifestJson },
   });
 
   // Mutable manifest map — HMR updates can modify it


### PR DESCRIPTION
## Summary

- **Scaffold template**: Replace manual `handleSubmit` + `api.tasks.create()` + `tasksQuery.refetch()` with `form(api.tasks.create, { resetOnSuccess: true })` — the recommended pattern with automatic optimistic updates
- **Compiler**: Recognize `vertz/ui` imports (the meta-package) in addition to `@vertz/ui` for signal API unwrapping. Without this, `form()`, `query()` etc. imported from `vertz/ui` are not treated as signal-returning APIs, causing `[object Object]` in SSR output
- **Button styling**: Fix `bg:primary.600` (undefined CSS variable) → `bg:primary` which exists in the shadcn base theme

## Public API Changes

None — these are internal fixes to the scaffold template and compiler import resolution.

## Test plan

- [x] 686 tests pass across `create-vertz-app` and `ui-compiler` packages
- [x] Full turbo CI pipeline passes (79/79 tasks)
- [x] Manual E2E: scaffolded app inside monorepo, dev server starts, form renders with visible button, adding tasks updates the list immediately via optimistic updates
- [ ] After release: `bunx @vertz/create-vertz-app` produces a working app out of the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)