### PR TITLE
fix(linear): use JSX syntax instead of function calls

### DIFF
--- a/examples/linear/src/components/auth-guard.tsx
+++ b/examples/linear/src/components/auth-guard.tsx
@@ -68,7 +68,9 @@ export function WorkspaceShell() {
           </button>
         </div>
       </aside>
-      <main class={sidebarStyles.main}>{Outlet()}</main>
+      <main class={sidebarStyles.main}>
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/examples/linear/src/router.tsx
+++ b/examples/linear/src/router.tsx
@@ -25,21 +25,22 @@ function IndexRedirect() {
 
 export const routes = defineRoutes({
   '/login': {
-    component: () => LoginPage(),
+    component: () => <LoginPage />,
   },
   '/': {
-    component: () =>
-      ProtectedRoute({
-        loginPath: '/login',
-        fallback: () => <div>Loading...</div>,
-        children: () => <WorkspaceShell />,
-      }),
+    component: () => (
+      <ProtectedRoute
+        loginPath="/login"
+        fallback={() => <div>Loading...</div>}
+        children={() => <WorkspaceShell />}
+      />
+    ),
     children: {
       '/': {
-        component: () => IndexRedirect(),
+        component: () => <IndexRedirect />,
       },
       '/projects': {
-        component: () => ProjectsPage(),
+        component: () => <ProjectsPage />,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Replace `{Outlet()}` with `<Outlet />` in `auth-guard.tsx`
- Replace `ProtectedRoute({...})` with `<ProtectedRoute ... />` in `router.tsx`
- Replace all `Component()` calls with `<Component />` JSX in route definitions

Follows the "always use JSX" convention from `.claude/rules/ui-components.md`.

## Public API Changes

None — example app only.

## Test plan

- [x] `bunx biome check` passes
- [x] `tsc --noEmit` passes (only pre-existing #1259 SessionResolver error remains)
- [x] Full turbo quality gates pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)