### PR TITLE
chore(db): remove dead code in auto-migrate and sql-generator

### DIFF
--- a/packages/db/src/migration/auto-migrate.ts
+++ b/packages/db/src/migration/auto-migrate.ts
@@ -77,15 +77,6 @@ export async function autoMigrate(options: AutoMigrateOptions): Promise<void> {
     const diff = computeDiff({ version: 1, tables: {}, enums: {} }, currentSchema);
 
     if (diff.changes.length > 0) {
-      // Log any destructive changes even on first run (unlikely but possible)
-      for (const change of diff.changes) {
-        if (isDestructiveChange(change)) {
-          console.warn(
-            `[auto-migrate] Warning: Destructive change detected on first run: ${change.type}`,
-          );
-        }
-      }
-
       const sql = generateMigrationSql(
         diff.changes,
         {

--- a/packages/db/src/migration/sql-generator.ts
+++ b/packages/db/src/migration/sql-generator.ts
@@ -39,18 +39,17 @@ function isEnumType(col: ColumnSnapshot, enums?: Record<string, string[]>): bool
 
 /**
  * Get enum values for a column type.
+ * Callers must guard with `isEnumType()` first — this always finds a match
+ * when the column type is a known enum.
  */
-function getEnumValues(
-  col: ColumnSnapshot,
-  enums?: Record<string, string[]>,
-): string[] | undefined {
-  if (!enums) return undefined;
+function getEnumValues(col: ColumnSnapshot, enums: Record<string, string[]>): string[] {
   for (const [enumName, values] of Object.entries(enums)) {
     if (col.type.toLowerCase() === enumName.toLowerCase() || col.type === enumName) {
       return values;
     }
   }
-  return undefined;
+  // Unreachable when callers guard with isEnumType()
+  return [];
 }
 
 /**
@@ -69,11 +68,11 @@ function columnDef(
   let sqlType: string;
   let checkConstraint: string | undefined;
 
-  if (isEnum && dialect.name === 'sqlite') {
+  if (isEnum && enums && dialect.name === 'sqlite') {
     // SQLite: use TEXT with CHECK constraint for enums
     sqlType = dialect.mapColumnType('text');
     const enumValues = getEnumValues(col, enums);
-    if (enumValues && enumValues.length > 0) {
+    if (enumValues.length > 0) {
       const escapedValues = enumValues.map((v) => `'${escapeSqlString(v)}'`).join(', ');
       checkConstraint = `CHECK("${snakeName}" IN (${escapedValues}))`;
     }
@@ -189,7 +188,7 @@ export function generateMigrationSql(
           for (const [, col] of Object.entries(table.columns)) {
             if (isEnumType(col, enums)) {
               const enumValues = getEnumValues(col, enums);
-              if (enumValues && enumValues.length > 0) {
+              if (enumValues.length > 0) {
                 // Check if we already emitted this enum type
                 const enumSnakeName = camelToSnake(col.type);
                 const alreadyEmitted = statements.some((s) =>


### PR DESCRIPTION
## Summary

- Remove unreachable destructive-change warning loop in `auto-migrate.ts` first-run path (empty→current diff can never produce `table_removed`/`column_removed`)
- Tighten `getEnumValues` in `sql-generator.ts` — all callers already guard with `isEnumType()`, so the `return undefined` fallback was dead code
- Follow-up cleanup from the coverage PR (#1288)

## Test plan

- `bun test packages/db/` — all 1220 tests pass
- `bunx tsc --noEmit` — typecheck clean