### PR TITLE
feat(ui-primitives): extract composed primitives from theme-shadcn

### DIFF
--- a/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
+++ b/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
@@ -228,13 +228,12 @@ function ComposedAlertDialogRoot({
     }
   });
 
-  return (
-    <div style="display: contents">
-      {userTrigger}
-      {alertDialog.overlay}
-      {alertDialog.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  if (userTrigger) wrapper.appendChild(userTrigger);
+  wrapper.appendChild(alertDialog.overlay);
+  wrapper.appendChild(alertDialog.content);
+  return wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-primitives/src/dialog/dialog-composed.tsx
+++ b/packages/ui-primitives/src/dialog/dialog-composed.tsx
@@ -202,13 +202,12 @@ function ComposedDialogRoot({ children, classes, onOpenChange, closeIcon }: Comp
     dialog.content.appendChild(closeIcon);
   }
 
-  return (
-    <div style="display: contents">
-      {userTrigger}
-      {dialog.overlay}
-      {dialog.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  if (userTrigger) wrapper.appendChild(userTrigger);
+  wrapper.appendChild(dialog.overlay);
+  wrapper.appendChild(dialog.content);
+  return wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-primitives/src/dropdown-menu/dropdown-menu-composed.tsx
+++ b/packages/ui-primitives/src/dropdown-menu/dropdown-menu-composed.tsx
@@ -153,12 +153,11 @@ function ComposedDropdownMenuRoot({ children, classes, onSelect }: ComposedDropd
     });
   }
 
-  return (
-    <div style="display: contents">
-      {userTrigger}
-      {menu.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  if (userTrigger) wrapper.appendChild(userTrigger);
+  wrapper.appendChild(menu.content);
+  return wrapper;
 }
 
 function processMenuSlots(

--- a/packages/ui-primitives/src/popover/popover-composed.tsx
+++ b/packages/ui-primitives/src/popover/popover-composed.tsx
@@ -108,12 +108,11 @@ function ComposedPopoverRoot({ children, classes, onOpenChange }: ComposedPopove
     }
   }
 
-  return (
-    <div style="display: contents">
-      {userTrigger}
-      {popover.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  if (userTrigger) wrapper.appendChild(userTrigger);
+  wrapper.appendChild(popover.content);
+  return wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-primitives/src/select/select-composed.tsx
+++ b/packages/ui-primitives/src/select/select-composed.tsx
@@ -143,12 +143,11 @@ function ComposedSelectRoot({
     processContentSlots(contentChildren, select, classes);
   }
 
-  return (
-    <div style="display: contents">
-      {select.trigger}
-      {select.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  wrapper.appendChild(select.trigger);
+  wrapper.appendChild(select.content);
+  return wrapper;
 }
 
 function processContentSlots(

--- a/packages/ui-primitives/src/sheet/sheet-composed.tsx
+++ b/packages/ui-primitives/src/sheet/sheet-composed.tsx
@@ -170,13 +170,12 @@ function ComposedSheetRoot({ children, classes, side, onOpenChange }: ComposedSh
     if (target) sheet.hide();
   });
 
-  return (
-    <div style="display: contents">
-      {userTrigger}
-      {sheet.overlay}
-      {sheet.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  if (userTrigger) wrapper.appendChild(userTrigger);
+  wrapper.appendChild(sheet.overlay);
+  wrapper.appendChild(sheet.content);
+  return wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
+++ b/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
@@ -90,12 +90,11 @@ function ComposedTooltipRoot({ children, classes, delay }: ComposedTooltipProps)
     }
   }
 
-  return (
-    <div style="display: contents">
-      {tooltip.trigger}
-      {tooltip.content}
-    </div>
-  ) as HTMLElement;
+  const wrapper = document.createElement('div');
+  wrapper.style.display = 'contents';
+  wrapper.appendChild(tooltip.trigger);
+  wrapper.appendChild(tooltip.content);
+  return wrapper;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extracts behavioral component logic from `@vertz/theme-shadcn` into `@vertz/ui-primitives` as "composed primitives". The theme package becomes purely about styling via the `withStyles()` utility, enabling theme switching without duplicating behavioral code.

### Phase 1: Dialog & AlertDialog
- `ComposedDialog` and `ComposedAlertDialog` — slot scanning, trigger wiring, ARIA sync, overlay/close handling
- `withStyles()` utility — pre-binds `classes` prop, preserves sub-component properties via `StyledPrimitive<C>` type
- Theme migration: dialog and alert-dialog now delegate all behavior to composed primitives

### Phase 2: Tabs, Accordion, Select
- `ComposedTabs` — list/trigger/content slot scanning, tab creation, class distribution
- `ComposedAccordion` — nested item/trigger/content slot scanning, accordion item creation
- `ComposedSelect` — recursive group processing, trigger/content wiring
- Theme migration: all three components now use `withStyles()`; tabs support default/line variants

### Phase 3: Popover, Tooltip, Sheet, DropdownMenu
- `ComposedPopover` — slot scanning, trigger wiring, ARIA sync via `onOpenChange`
- `ComposedTooltip` — trigger/content slot scanning, class distribution
- `ComposedSheet` — context-based class distribution for Title/Description/Close, event delegation for close buttons, side prop
- `ComposedDropdownMenu` — ARIA sync via `onOpenChange` (added to `MenuOptions`), recursive group processing
- Theme migration: all four components delegate behavior to composed primitives

## Public API Changes

### Additions (`@vertz/ui-primitives`)
- `ComposedDialog`, `ComposedAlertDialog`, `ComposedTabs`, `ComposedAccordion`, `ComposedSelect`, `ComposedPopover`, `ComposedTooltip`, `ComposedSheet`, `ComposedDropdownMenu` — high-level composable components
- `withStyles()` — utility for pre-binding CSS classes to composed primitives
- `StyledPrimitive<C>` — type for styled composed components
- `MenuOptions.onOpenChange` — new callback on `Menu.Root`

### Breaking (`@vertz/theme-shadcn`)
- Theme components now return wrapper `<div style="display:contents">` instead of user trigger element directly (affects Popover, DropdownMenu, Sheet, Tooltip)
- `DropdownMenuRootProps` no longer extends `MenuOptions` — positioning is handled by the composed primitive
- Sub-components (Title, Description, Close) now read theme classes from context — must be created inside the root component's children thunk

## Test Plan

- [x] 476 ui-primitives tests passing (all composed primitive tests)
- [x] 75 theme-shadcn tests passing (themed-primitives + sheet)
- [x] TypeScript strict mode — both packages pass typecheck
- [x] Biome lint — clean (warnings are pre-existing non-null assertions in other test sections)
- [x] Adversarial review — blocker (MutationObserver leak) fixed, should-fix items addressed
- [x] Pre-push quality gates (turbo: lint, typecheck, test, build) — all 82 tasks pass

## Design Doc
- `plans/composed-primitives.md` — approved by 3 reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)