### PR TITLE
fix(ui-server): add dataset property to SSR DOM shim

### DIFF
--- a/.changeset/dataset-ssr-shim.md
+++ b/.changeset/dataset-ssr-shim.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-server': patch
+---
+
+Add `dataset` property to SSR DOM shim elements, fixing crashes when components access `el.dataset.*` during SSR

--- a/packages/ui-server/src/dom-shim/__tests__/dom-shim.test.ts
+++ b/packages/ui-server/src/dom-shim/__tests__/dom-shim.test.ts
@@ -667,6 +667,96 @@ describe('DOM Shim', () => {
     });
   });
 
+  describe('dataset property', () => {
+    beforeEach(() => {
+      installDomShim();
+    });
+
+    it('should set data-* attribute when assigning dataset property', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'alertdialog-trigger';
+      expect(el.getAttribute('data-slot')).toBe('alertdialog-trigger');
+    });
+
+    it('should read from data-* attribute via dataset property', () => {
+      const el = new SSRElement('div');
+      el.setAttribute('data-slot', 'trigger');
+      expect(el.dataset.slot).toBe('trigger');
+    });
+
+    it('should convert camelCase to kebab-case for attribute name', () => {
+      const el = new SSRElement('div');
+      el.dataset.testValue = 'hello';
+      expect(el.getAttribute('data-test-value')).toBe('hello');
+    });
+
+    it('should convert kebab-case attribute to camelCase for reading', () => {
+      const el = new SSRElement('div');
+      el.setAttribute('data-test-value', 'hello');
+      expect(el.dataset.testValue).toBe('hello');
+    });
+
+    it('should return undefined for unset dataset properties', () => {
+      const el = new SSRElement('div');
+      expect(el.dataset.missing).toBeUndefined();
+    });
+
+    it('should reflect dataset in toVNode output', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'trigger';
+      const vnode = el.toVNode();
+      expect(vnode.attrs['data-slot']).toBe('trigger');
+    });
+
+    it('should support Object.keys() enumeration', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'trigger';
+      el.dataset.testValue = 'hello';
+      const keys = Object.keys(el.dataset);
+      expect(keys).toContain('slot');
+      expect(keys).toContain('testValue');
+      expect(keys).toHaveLength(2);
+    });
+
+    it('should support "in" operator', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'trigger';
+      expect('slot' in el.dataset).toBe(true);
+      expect('missing' in el.dataset).toBe(false);
+    });
+
+    it('should support spread operator', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'trigger';
+      el.dataset.testValue = 'hello';
+      const copy = { ...el.dataset };
+      expect(copy).toEqual({ slot: 'trigger', testValue: 'hello' });
+    });
+
+    it('should coerce numeric values to string', () => {
+      const el = new SSRElement('div');
+      // biome-ignore lint/suspicious/noExplicitAny: testing numeric coercion
+      (el.dataset as any).count = 42;
+      expect(el.getAttribute('data-count')).toBe('42');
+    });
+
+    it('should overwrite existing dataset value', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'a';
+      el.dataset.slot = 'b';
+      expect(el.dataset.slot).toBe('b');
+      expect(el.getAttribute('data-slot')).toBe('b');
+    });
+
+    it('should delete data-* attribute when using delete operator', () => {
+      const el = new SSRElement('div');
+      el.dataset.slot = 'trigger';
+      expect(el.getAttribute('data-slot')).toBe('trigger');
+      delete el.dataset.slot;
+      expect(el.getAttribute('data-slot')).toBeNull();
+    });
+  });
+
   describe('style property', () => {
     beforeEach(() => {
       installDomShim();

--- a/packages/ui-server/src/dom-shim/ssr-element.ts
+++ b/packages/ui-server/src/dom-shim/ssr-element.ts
@@ -5,6 +5,66 @@ import { SSRNode } from './ssr-node';
 import { SSRTextNode } from './ssr-text-node';
 
 /**
+ * Convert camelCase to kebab-case: "testValue" → "test-value"
+ */
+function camelToKebab(str: string): string {
+  return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+/**
+ * Convert kebab-case to camelCase: "test-value" → "testValue"
+ */
+function kebabToCamel(str: string): string {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Proxy-based DOMStringMap shim for el.dataset
+ */
+function createDatasetProxy(element: SSRElement): DOMStringMap {
+  return new Proxy({} as DOMStringMap, {
+    set(_target, prop, value) {
+      if (typeof prop === 'string') {
+        element.setAttribute(`data-${camelToKebab(prop)}`, String(value));
+      }
+      return true;
+    },
+    get(_target, prop) {
+      if (typeof prop === 'string') {
+        return element.getAttribute(`data-${camelToKebab(prop)}`) ?? undefined;
+      }
+      return undefined;
+    },
+    has(_target, prop) {
+      if (typeof prop === 'string') {
+        return element.getAttribute(`data-${camelToKebab(prop)}`) !== null;
+      }
+      return false;
+    },
+    deleteProperty(_target, prop) {
+      if (typeof prop === 'string') {
+        element.removeAttribute(`data-${camelToKebab(prop)}`);
+      }
+      return true;
+    },
+    ownKeys() {
+      return Object.keys(element.attrs)
+        .filter((k) => k.startsWith('data-'))
+        .map((k) => kebabToCamel(k.slice(5)));
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (typeof prop === 'string') {
+        const val = element.getAttribute(`data-${camelToKebab(prop)}`);
+        if (val !== null) {
+          return { configurable: true, enumerable: true, value: val };
+        }
+      }
+      return undefined;
+    },
+  });
+}
+
+/**
  * Proxy-based CSSStyleDeclaration shim
  */
 // biome-ignore lint/suspicious/noExplicitAny: SSR DOM shim requires dynamic typing
@@ -49,11 +109,13 @@ export class SSRElement extends SSRNode {
   _innerHTML: string | null = null;
   // biome-ignore lint/suspicious/noExplicitAny: SSR DOM shim requires dynamic typing
   style: { display: string; [key: string]: any };
+  dataset: DOMStringMap;
 
   constructor(tag: string) {
     super();
     this.tag = tag;
     this.style = createStyleProxy(this);
+    this.dataset = createDatasetProxy(this);
   }
 
   setAttribute(name: string, value: string): void {


### PR DESCRIPTION
## Summary

- Add `dataset` (DOMStringMap) proxy to SSR DOM shim elements, fixing crashes when components access `el.dataset.*` during SSR
- Implements full Proxy with `get`, `set`, `has`, `deleteProperty`, `ownKeys`, and `getOwnPropertyDescriptor` traps
- Supports camelCase ↔ kebab-case mapping (e.g., `el.dataset.testValue` ↔ `data-test-value`)
- `Object.keys(el.dataset)` and spread `{...el.dataset}` work correctly (required by `scanSlots` in `@vertz/ui-primitives`)

Closes #1309

## Public API Changes

None — this is an internal SSR shim fix. No public API changes.

## Test plan

- [x] `el.dataset.foo = 'bar'` sets `data-foo` attribute
- [x] `el.dataset.foo` reads from `data-foo` attribute
- [x] camelCase to kebab-case conversion (`testValue` → `data-test-value`)
- [x] `Object.keys(el.dataset)` returns camelCase keys
- [x] `'prop' in el.dataset` works
- [x] `{...el.dataset}` spread works
- [x] `delete el.dataset.foo` removes `data-foo`
- [x] Numeric values coerced to string
- [x] Undefined for unset properties
- [x] VNode serialization includes data-* attributes
- [x] All 767 ui-server tests pass

**Note:** 5 pre-existing `Access Set — Client Integration` test failures exist on main — not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)