### PR TITLE
fix(landing): update scaffold command to use @latest for cache busting

### DIFF
--- a/sites/landing-nextjs-vercel/src/components/get-started.tsx
+++ b/sites/landing-nextjs-vercel/src/components/get-started.tsx
@@ -10,10 +10,7 @@ export function GetStarted() {
     >
       <div className="max-w-4xl mx-auto grid grid-cols-2 gap-12 items-center">
         <div>
-          <h2
-            className="text-4xl mb-6"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
+          <h2 className="text-4xl mb-6" style={{ fontFamily: 'var(--font-display)' }}>
             Get started in 30 seconds.
           </h2>
           <p className="text-lg mb-4 text-gray-400">
@@ -29,18 +26,14 @@ export function GetStarted() {
             boxShadow: '0 20px 25px -5px rgb(0 0 0 / 0.1)',
           }}
         >
-          <div className="mb-2 text-gray-500">$ bun create vertz my-app</div>
+          <div className="mb-2 text-gray-500">$ bun create vertz@latest my-app</div>
           <div className="mb-2 text-gray-500">$ cd my-app</div>
           <div className="text-gray-500">$ bun dev</div>
           <div className="mt-4" style={{ color: '#4ade80' }}>
             {'\u2713'} SQLite database ready
           </div>
-          <div style={{ color: '#4ade80' }}>
-            {'\u2713'} API server on http://localhost:3000/api
-          </div>
-          <div style={{ color: '#4ade80' }}>
-            {'\u2713'} UI on http://localhost:3000
-          </div>
+          <div style={{ color: '#4ade80' }}>{'\u2713'} API server on http://localhost:3000/api</div>
+          <div style={{ color: '#4ade80' }}>{'\u2713'} UI on http://localhost:3000</div>
         </div>
       </div>
     </section>

--- a/sites/landing-nextjs-vercel/src/components/hero.tsx
+++ b/sites/landing-nextjs-vercel/src/components/hero.tsx
@@ -8,8 +8,14 @@ export function Hero() {
       {/* Badge */}
       <div className="flex items-center gap-2 mb-8">
         <span className="relative flex h-2.5 w-2.5">
-          <span className="absolute inline-flex h-full w-full rounded-full opacity-40" style={{ background: '#60a5fa' }} />
-          <span className="relative inline-flex rounded-full h-2.5 w-2.5" style={{ background: '#3b82f6' }} />
+          <span
+            className="absolute inline-flex h-full w-full rounded-full opacity-40"
+            style={{ background: '#60a5fa' }}
+          />
+          <span
+            className="relative inline-flex rounded-full h-2.5 w-2.5"
+            style={{ background: '#3b82f6' }}
+          />
         </span>
         <span className="text-xs tracking-widest uppercase text-gray-500 font-[family-name:var(--font-mono)]">
           Public Beta
@@ -53,7 +59,7 @@ function CopyButton() {
   const [copied, setCopied] = useState(false);
 
   function handleClick() {
-    navigator.clipboard.writeText('bun create vertz my-app');
+    navigator.clipboard.writeText('bun create vertz@latest my-app');
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -70,7 +76,7 @@ function CopyButton() {
         transition: 'all 0.15s',
       }}
     >
-      <span className="text-gray-500">$</span> bun create vertz my-app
+      <span className="text-gray-500">$</span> bun create vertz@latest my-app
       <span className="text-xs text-gray-500">{copied ? 'Copied!' : '(click to copy)'}</span>
     </button>
   );

--- a/sites/landing-nextjs/src/components/get-started.tsx
+++ b/sites/landing-nextjs/src/components/get-started.tsx
@@ -10,10 +10,7 @@ export function GetStarted() {
     >
       <div className="max-w-4xl mx-auto grid grid-cols-2 gap-12 items-center">
         <div>
-          <h2
-            className="text-4xl mb-6"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
+          <h2 className="text-4xl mb-6" style={{ fontFamily: 'var(--font-display)' }}>
             Get started in 30 seconds.
           </h2>
           <p className="text-lg mb-4 text-gray-400">
@@ -29,18 +26,14 @@ export function GetStarted() {
             boxShadow: '0 20px 25px -5px rgb(0 0 0 / 0.1)',
           }}
         >
-          <div className="mb-2 text-gray-500">$ bun create vertz my-app</div>
+          <div className="mb-2 text-gray-500">$ bun create vertz@latest my-app</div>
           <div className="mb-2 text-gray-500">$ cd my-app</div>
           <div className="text-gray-500">$ bun dev</div>
           <div className="mt-4" style={{ color: '#4ade80' }}>
             {'\u2713'} SQLite database ready
           </div>
-          <div style={{ color: '#4ade80' }}>
-            {'\u2713'} API server on http://localhost:3000/api
-          </div>
-          <div style={{ color: '#4ade80' }}>
-            {'\u2713'} UI on http://localhost:3000
-          </div>
+          <div style={{ color: '#4ade80' }}>{'\u2713'} API server on http://localhost:3000/api</div>
+          <div style={{ color: '#4ade80' }}>{'\u2713'} UI on http://localhost:3000</div>
         </div>
       </div>
     </section>

--- a/sites/landing-nextjs/src/components/hero.tsx
+++ b/sites/landing-nextjs/src/components/hero.tsx
@@ -8,8 +8,14 @@ export function Hero() {
       {/* Badge */}
       <div className="flex items-center gap-2 mb-8">
         <span className="relative flex h-2.5 w-2.5">
-          <span className="absolute inline-flex h-full w-full rounded-full opacity-40" style={{ background: '#60a5fa' }} />
-          <span className="relative inline-flex rounded-full h-2.5 w-2.5" style={{ background: '#3b82f6' }} />
+          <span
+            className="absolute inline-flex h-full w-full rounded-full opacity-40"
+            style={{ background: '#60a5fa' }}
+          />
+          <span
+            className="relative inline-flex rounded-full h-2.5 w-2.5"
+            style={{ background: '#3b82f6' }}
+          />
         </span>
         <span className="text-xs tracking-widest uppercase text-gray-500 font-[family-name:var(--font-mono)]">
           Public Beta
@@ -53,7 +59,7 @@ function CopyButton() {
   const [copied, setCopied] = useState(false);
 
   function handleClick() {
-    navigator.clipboard.writeText('bun create vertz my-app');
+    navigator.clipboard.writeText('bun create vertz@latest my-app');
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -70,7 +76,7 @@ function CopyButton() {
         transition: 'all 0.15s',
       }}
     >
-      <span className="text-gray-500">$</span> bun create vertz my-app
+      <span className="text-gray-500">$</span> bun create vertz@latest my-app
       <span className="text-xs text-gray-500">{copied ? 'Copied!' : '(click to copy)'}</span>
     </button>
   );

--- a/sites/landing/src/components/copy-button.tsx
+++ b/sites/landing/src/components/copy-button.tsx
@@ -49,7 +49,7 @@ export default function CopyButton() {
   let copied = false;
 
   function handleClick() {
-    navigator.clipboard.writeText('bun create vertz my-app');
+    navigator.clipboard.writeText('bun create vertz@latest my-app');
     copied = true;
     setTimeout(() => {
       copied = false;
@@ -66,7 +66,7 @@ export default function CopyButton() {
       <span class={s.mobileBadge} style={copied ? 'opacity: 1' : 'opacity: 0'}>
         Copied!
       </span>
-      <span class={s.dollarSign}>$</span> bun create vertz my-app
+      <span class={s.dollarSign}>$</span> bun create vertz@latest my-app
       <span class={s.copyPrefix}>
         <span style="grid-area: 1/1; visibility: hidden; pointer-events: none">
           (click to copy)

--- a/sites/landing/src/components/get-started.tsx
+++ b/sites/landing/src/components/get-started.tsx
@@ -46,7 +46,7 @@ export function GetStarted() {
           class={s.terminal}
           style="border-color: #1e1e22; font-family: var(--font-mono); box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1)"
         >
-          <div class={`${s.terminalLine} ${s.terminalCmd}`}>$ bun create vertz my-app</div>
+          <div class={`${s.terminalLine} ${s.terminalCmd}`}>$ bun create vertz@latest my-app</div>
           <div class={`${s.terminalLine} ${s.terminalCmd}`}>$ cd my-app</div>
           <div class={s.terminalCmd}>$ bun dev</div>
           <div class={s.successLine} style="color: #4ade80">


### PR DESCRIPTION
## Summary

- Updates all `bun create vertz my-app` references to `bun create vertz@latest my-app` across all three landing sites
- Ensures users copying the command from landing pages won't hit the stale `bunx` cache issue (#1298)

## Files Changed

- `sites/landing/src/components/copy-button.tsx` — display + clipboard copy
- `sites/landing/src/components/get-started.tsx` — terminal display
- `sites/landing-nextjs/src/components/hero.tsx` — display + clipboard copy
- `sites/landing-nextjs/src/components/get-started.tsx` — terminal display
- `sites/landing-nextjs-vercel/src/components/hero.tsx` — display + clipboard copy
- `sites/landing-nextjs-vercel/src/components/get-started.tsx` — terminal display

## Public API Changes

None.

## Test plan

- [ ] Verify all 6 files show `bun create vertz@latest my-app`
- [ ] Verify clipboard copy text matches displayed text
- [ ] No remaining `bun create vertz my-app` (without `@latest`) in sites/

Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)