### PR TITLE
fix(cli): read version from package.json and show in create output

### DIFF
--- a/.changeset/cli-dynamic-version.md
+++ b/.changeset/cli-dynamic-version.md
@@ -1,0 +1,5 @@
+---
+'@vertz/cli': patch
+---
+
+Read CLI version from package.json instead of hardcoded value; show version in `vertz create` output

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -12,9 +12,12 @@ describe('createCLI', () => {
     expect(program.name()).toBe('vertz');
   });
 
-  it('sets a version', () => {
+  it('reads version from package.json (not hardcoded)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const pkg = JSON.parse(readFileSync(resolve(import.meta.dir, '../../package.json'), 'utf-8'));
     const program = createCLI();
-    expect(program.version()).toBe('0.1.0');
+    expect(program.version()).toBe(pkg.version);
   });
 
   it('registers check command', () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { CodegenConfig, CodegenIR } from '@vertz/codegen';
 import { Command } from 'commander';
 import { createJiti } from 'jiti';
@@ -18,20 +20,22 @@ import { generateAction } from './commands/generate';
 import { loadDbContext } from './commands/load-db-context';
 import { startAction } from './commands/start';
 
+const pkg = JSON.parse(readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf-8'));
+
 export function createCLI(): Command {
   const program = new Command();
 
   program
     .name('vertz')
     .description('Vertz CLI — build, check, and serve your Vertz app')
-    .version('0.1.0');
+    .version(pkg.version);
 
   // Create command - scaffold a new Vertz project
   program
     .command('create <name>')
     .description('Scaffold a new Vertz project')
     .action(async (name: string) => {
-      const result = await createAction({ projectName: name });
+      const result = await createAction({ projectName: name, version: pkg.version });
       if (!result.ok) {
         console.error(result.error.message);
         process.exit(1);

--- a/packages/cli/src/commands/__tests__/create.test.ts
+++ b/packages/cli/src/commands/__tests__/create.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'bun:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { createAction } from '../create';
@@ -18,12 +18,36 @@ describe('createAction', () => {
     }
   });
 
+  it('includes the package version in the creating message', async () => {
+    const originalCwd = process.cwd();
+    process.chdir(testDir);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}) as Mock<
+      (...args: unknown[]) => unknown
+    >;
+
+    const pkg = JSON.parse(
+      await fs.readFile(path.resolve(import.meta.dir, '../../../package.json'), 'utf-8'),
+    );
+
+    await createAction({ projectName: 'version-test-app', version: pkg.version });
+
+    const creatingMsg = logSpy.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('Creating Vertz app:'),
+    );
+    expect(creatingMsg).toBeDefined();
+    expect(creatingMsg?.[0]).toContain(`(v${pkg.version})`);
+
+    logSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
+
   it('creates a new full-stack Vertz project', async () => {
     const originalCwd = process.cwd();
 
     process.chdir(testDir);
 
-    const result = await createAction({ projectName: 'my-test-app' });
+    const result = await createAction({ projectName: 'my-test-app', version: '0.0.0' });
 
     expect(result.ok).toBe(true);
 
@@ -55,7 +79,7 @@ describe('createAction', () => {
     const originalCwd = process.cwd();
     process.chdir(testDir);
 
-    const result = await createAction({});
+    const result = await createAction({ version: '0.0.0' });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -69,7 +93,7 @@ describe('createAction', () => {
     const originalCwd = process.cwd();
     process.chdir(testDir);
 
-    const result = await createAction({ projectName: 'Invalid_Project_Name!' });
+    const result = await createAction({ projectName: 'Invalid_Project_Name!', version: '0.0.0' });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -85,7 +109,7 @@ describe('createAction', () => {
 
     await fs.mkdir(path.join(testDir, 'existing-app'));
 
-    const result = await createAction({ projectName: 'existing-app' });
+    const result = await createAction({ projectName: 'existing-app', version: '0.0.0' });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,10 +3,11 @@ import { err, ok, type Result } from '@vertz/errors';
 
 export interface CreateOptions {
   projectName?: string;
+  version: string;
 }
 
 export async function createAction(options: CreateOptions): Promise<Result<void, Error>> {
-  const { projectName } = options;
+  const { projectName, version } = options;
 
   // Validate project name
   if (!projectName) {
@@ -22,7 +23,7 @@ export async function createAction(options: CreateOptions): Promise<Result<void,
   try {
     const resolved = await resolveOptions({ projectName });
 
-    console.log(`Creating Vertz app: ${resolved.projectName}`);
+    console.log(`Creating Vertz app: ${resolved.projectName} (v${version})`);
 
     const targetDir = process.cwd();
     await scaffold(targetDir, resolved);


### PR DESCRIPTION
## Summary

Fixes #1305

- `vertz --version` now shows the correct version from `package.json` instead of hardcoded `0.1.0`
- `vertz create <name>` output now includes the version: `Creating Vertz app: my-app (v0.2.20)`
- Version is passed as a parameter from `cli.ts` to `createAction` to avoid bundling path issues

## Public API Changes

- `CreateOptions` interface now requires a `version: string` field (internal API, not user-facing)

## Test plan

- [x] `cli.test.ts` verifies version matches `package.json` dynamically
- [x] `create.test.ts` verifies the "Creating" message includes `(v<version>)`
- [x] All 433 CLI tests pass
- [x] Typecheck clean
- [x] Biome lint clean
- [x] Pre-push quality gates (82/82 cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)