### PR TITLE
feat(ui): Link component accepts class prop (#1290)

### DIFF
--- a/examples/component-catalog/src/app.tsx
+++ b/examples/component-catalog/src/app.tsx
@@ -43,7 +43,7 @@ function Sidebar() {
       <div class={navStyles.subtitle}>{componentRegistry.length} themed components</div>
       <div class={scrollStyles.thin} style="flex: 1; min-height: 0; overflow-y: auto;">
         <div style="display: flex; flex-direction: column; gap: 2px;">
-          <Link href="/" className={navStyles.navItem} activeClass={navStyles.navItemActive}>
+          <Link href="/" class={navStyles.navItem} activeClass={navStyles.navItemActive}>
             Overview
           </Link>
           {categoryOrder.flatMap((cat) => {
@@ -55,7 +55,7 @@ function Sidebar() {
                 {entries.map((entry) => (
                   <Link
                     href={`/${entry.slug}`}
-                    className={navStyles.navItem}
+                    class={navStyles.navItem}
                     activeClass={navStyles.navItemActive}
                   >
                     {entry.name}

--- a/examples/linear/src/components/auth-guard.tsx
+++ b/examples/linear/src/components/auth-guard.tsx
@@ -58,13 +58,13 @@ export function WorkspaceShell() {
       <aside class={sidebarStyles.sidebar} data-testid="sidebar">
         <div class={sidebarStyles.brand}>Linear Clone</div>
         <nav class={sidebarStyles.nav}>
-          <Link href="/projects" className={sidebarStyles.navItem}>
+          <Link href="/projects" class={sidebarStyles.navItem}>
             Projects
           </Link>
           {projects.data?.items.map((project) => (
             <Link
               href={`/projects/${project.id}`}
-              className={sidebarStyles.projectLink}
+              class={sidebarStyles.projectLink}
               key={project.id}
             >
               {`${project.key} — ${project.name}`}

--- a/examples/linear/src/components/project-layout.tsx
+++ b/examples/linear/src/components/project-layout.tsx
@@ -15,7 +15,7 @@ export function ProjectLayout() {
   return (
     <div>
       <header class={styles.header}>
-        <Link href="/projects" className={styles.breadcrumb}>
+        <Link href="/projects" class={styles.breadcrumb}>
           Projects
         </Link>
         <span class={styles.separator}>/</span>

--- a/examples/linear/src/components/view-toggle.tsx
+++ b/examples/linear/src/components/view-toggle.tsx
@@ -32,14 +32,10 @@ interface ViewToggleProps {
 export function ViewToggle({ projectId }: ViewToggleProps) {
   return (
     <div class={styles.container}>
-      <Link href={`/projects/${projectId}`} className={styles.tab} activeClass={styles.activeTab}>
+      <Link href={`/projects/${projectId}`} class={styles.tab} activeClass={styles.activeTab}>
         List
       </Link>
-      <Link
-        href={`/projects/${projectId}/board`}
-        className={styles.tab}
-        activeClass={styles.activeTab}
-      >
+      <Link href={`/projects/${projectId}/board`} class={styles.tab} activeClass={styles.activeTab}>
         Board
       </Link>
     </div>

--- a/packages/ui/src/router/__tests__/link.test.ts
+++ b/packages/ui/src/router/__tests__/link.test.ts
@@ -63,6 +63,27 @@ describe('Link component', () => {
     expect(el.classList.contains('nav-link')).toBe(true);
   });
 
+  test('applies class prop to the anchor', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    const el = Link({ children: 'Home', class: 'nav-link', href: '/' });
+
+    expect(el.classList.contains('nav-link')).toBe(true);
+  });
+
+  test('class prop takes precedence over className', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    const el = Link({ children: 'Home', class: 'primary', className: 'secondary', href: '/' });
+
+    expect(el.classList.contains('primary')).toBe(true);
+    expect(el.classList.contains('secondary')).toBe(false);
+  });
+
   test('does not navigate on ctrl+click (allows new tab)', () => {
     const currentPath = signal('/');
     const navigate = vi.fn();
@@ -349,6 +370,19 @@ describe('Link (context-based)', () => {
       Link({ children: 'Home', className: 'nav-link', href: '/' }),
     );
     expect(el.classList.contains('nav-link')).toBe(true);
+  });
+
+  test('applies class prop to the anchor', () => {
+    const el = renderInRouter('/', () => Link({ children: 'Home', class: 'nav-link', href: '/' }));
+    expect(el.classList.contains('nav-link')).toBe(true);
+  });
+
+  test('class prop takes precedence over className', () => {
+    const el = renderInRouter('/', () =>
+      Link({ children: 'Home', class: 'primary', className: 'secondary', href: '/' }),
+    );
+    expect(el.classList.contains('primary')).toBe(true);
+    expect(el.classList.contains('secondary')).toBe(false);
   });
 
   test('accepts thunked children', () => {

--- a/packages/ui/src/router/link.ts
+++ b/packages/ui/src/router/link.ts
@@ -49,7 +49,12 @@ export interface LinkProps<T extends Record<string, RouteConfigLike> = RouteDefi
   children: string | Node | (() => string | Node);
   /** Class applied when the link's href matches the current path. */
   activeClass?: string;
-  /** Static class name for the anchor element. */
+  /** Static class for the anchor element. */
+  class?: string;
+  /**
+   * Static class name for the anchor element.
+   * @deprecated Use `class` instead. Will be removed in v1.
+   */
   className?: string;
   /** Prefetch strategy. 'hover' triggers server pre-fetch on mouseenter/focus. */
   prefetch?: 'hover';
@@ -77,6 +82,7 @@ export function createLink(
     href,
     children,
     activeClass,
+    class: classProp,
     className,
     prefetch,
   }: LinkProps): HTMLAnchorElement {
@@ -94,9 +100,10 @@ export function createLink(
     };
 
     // Build static props for the anchor element
+    const effectiveClass = classProp ?? className;
     const props: Record<string, string> = { href: safeHref };
-    if (className) {
-      props.class = className;
+    if (effectiveClass) {
+      props.class = effectiveClass;
     }
 
     const el = __element('a', props) as HTMLAnchorElement;
@@ -147,7 +154,13 @@ export function createLink(
  * Reads the router from `RouterContext` automatically — no manual wiring needed.
  * Just use `<Link href="/about">About</Link>` inside a router-provided tree.
  */
-export function Link({ href, children, activeClass, className }: LinkProps): HTMLAnchorElement {
+export function Link({
+  href,
+  children,
+  activeClass,
+  class: classProp,
+  className,
+}: LinkProps): HTMLAnchorElement {
   const router = useContext(RouterContext);
   if (!router) {
     throw new Error('Link must be used within a RouterContext.Provider (via createRouter)');
@@ -164,9 +177,10 @@ export function Link({ href, children, activeClass, className }: LinkProps): HTM
     router.navigate({ to: safeHref });
   };
 
+  const effectiveClass = classProp ?? className;
   const props: Record<string, string> = { href: safeHref };
-  if (className) {
-    props.class = className;
+  if (effectiveClass) {
+    props.class = effectiveClass;
   }
 
   const el = __element('a', props) as HTMLAnchorElement;

--- a/plans/link-class-prop.md
+++ b/plans/link-class-prop.md
@@ -1,0 +1,117 @@
+# Link `class` Prop Alignment
+
+**Issue:** [#1290](https://github.com/vertz-dev/vertz/issues/1290)
+**Status:** Draft
+
+## Problem
+
+The `Link` component in `@vertz/ui` uses `className` for its static CSS class prop. Every other element in Vertz JSX uses `class` (the native HTML attribute). This inconsistency forces developers to remember which convention applies to which element.
+
+## API Surface
+
+### Before
+
+```tsx
+<Link href="/about" className={styles.link}>About</Link>
+```
+
+### After
+
+```tsx
+// Primary — consistent with all other elements
+<Link href="/about" class={styles.link}>About</Link>
+
+// Deprecated alias — existing code continues to work
+<Link href="/about" className={styles.link}>About</Link>
+```
+
+### Type definition
+
+```ts
+export interface LinkProps<T extends Record<string, RouteConfigLike> = RouteDefinitionMap> {
+  href: RoutePaths<T>;
+  children: string | Node | (() => string | Node);
+  activeClass?: string;
+  /** Static class for the anchor element. */
+  class?: string;
+  /**
+   * @deprecated Use `class` instead. Will be removed in v1.
+   */
+  className?: string;
+  prefetch?: 'hover';
+}
+```
+
+When both `class` and `className` are provided, `class` wins.
+
+## Manifesto Alignment
+
+- **Principle: No magic, no surprise** — `class` is the attribute name used everywhere else in Vertz JSX. Using `className` only on `Link` is the surprise.
+- **Principle: Framework honesty** — Vertz doesn't pretend to be React. It uses `class` not `className`.
+
+## Non-Goals
+
+- Removing `className` entirely (breaking change, deferred to v1)
+- Adding runtime deprecation warnings (too noisy for a prop rename)
+- Changing any other component's prop naming
+
+## Unknowns
+
+None identified.
+
+## Type Flow Map
+
+No generics introduced. The existing `T` generic on `LinkProps` is unchanged.
+
+## E2E Acceptance Test
+
+```ts
+describe('Feature: Link class prop', () => {
+  describe('Given a Link with class prop', () => {
+    describe('When rendered', () => {
+      it('Then applies the class to the anchor element', () => {
+        const el = Link({ children: 'Home', class: 'nav-link', href: '/' });
+        expect(el.classList.contains('nav-link')).toBe(true);
+      });
+    });
+  });
+
+  describe('Given a Link with className prop (deprecated)', () => {
+    describe('When rendered', () => {
+      it('Then still applies the class to the anchor element', () => {
+        const el = Link({ children: 'Home', className: 'nav-link', href: '/' });
+        expect(el.classList.contains('nav-link')).toBe(true);
+      });
+    });
+  });
+
+  describe('Given a Link with both class and className', () => {
+    describe('When rendered', () => {
+      it('Then class takes precedence', () => {
+        const el = Link({ children: 'Home', class: 'primary', className: 'secondary', href: '/' });
+        expect(el.classList.contains('primary')).toBe(true);
+        expect(el.classList.contains('secondary')).toBe(false);
+      });
+    });
+  });
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Add `class` prop and update tests (single phase)
+
+1. **TDD: Add tests for `class` prop** on both `createLink` and context-based `Link`
+   - `class` prop applies to anchor
+   - `className` still works (backward compat)
+   - `class` takes precedence over `className`
+2. **Update `LinkProps`** — add `class?: string`, add `@deprecated` to `className`
+3. **Update `createLink()` and `Link()`** — resolve `class ?? className`
+4. **Update examples** — change all `<Link className=...>` to `<Link class=...>`
+5. **Quality gates** — test, typecheck, lint
+
+**Acceptance criteria:**
+- All existing Link tests pass unchanged
+- New tests for `class` prop pass
+- All examples use `class` instead of `className`
+- `className` still works but is typed as `@deprecated`


### PR DESCRIPTION
## Summary

- Add `class` as the primary prop name for the `Link` component, consistent with all other Vertz JSX elements
- Keep `className` as a `@deprecated` alias for backward compatibility
- `class` takes precedence when both props are provided
- Updated all example usages to use `class` instead of `className`

Closes #1290

## Public API Changes

### `LinkProps` (additions)
- `class?: string` — new primary prop for static CSS class
- `className` marked `@deprecated` — will be removed in v1

### Breaking changes
None. `className` continues to work.

## Test plan

- [x] `class` prop applies to anchor (`createLink` + context-based `Link`)
- [x] `className` backward compat (existing tests unchanged)
- [x] `class` takes precedence over `className` when both provided
- [x] All 2035 existing tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)