### PR TITLE
fix(ui): clear SSR children before appending lazy route components (#1347)

### DIFF
--- a/.changeset/fix-hydration-lazy-route-duplicates.md
+++ b/.changeset/fix-hydration-lazy-route-duplicates.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui': patch
+---
+
+Fix duplicate route components during production hydration with lazy (code-split) routes. RouterView and Outlet now clear SSR children before appending the resolved lazy component. Also fix disposal scope leak for async route components in RouterView.

--- a/packages/ui/src/router/__tests__/outlet.test.ts
+++ b/packages/ui/src/router/__tests__/outlet.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { onMount } from '../../component/lifecycle';
+import { endHydration, startHydration } from '../../hydrate/hydration-context';
 import { signal } from '../../runtime/signal';
 import type { Router } from '../navigate';
 import { Outlet, OutletContext } from '../outlet';
@@ -94,5 +95,47 @@ describe('Outlet', () => {
     // Changing the external signal should NOT re-trigger Outlet's domEffect
     externalSignal.value = 'updated';
     expect(renderCount).toBe(1);
+  });
+
+  test('hydration with lazy child does not produce duplicate elements (#1347)', async () => {
+    // Simulate SSR-rendered DOM:
+    // <div> (Outlet container)
+    //   <div data-testid="child">SSR Child</div>
+    // </div>
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div data-testid="child">SSR Child</div></div>';
+
+    const outletContainer = root.firstChild as HTMLElement;
+    expect(outletContainer.children.length).toBe(1);
+
+    startHydration(root);
+
+    const childComponent = signal<(() => Node | Promise<{ default: () => Node }>) | undefined>(() =>
+      Promise.resolve({
+        default: () => {
+          const el = document.createElement('div');
+          el.setAttribute('data-testid', 'child');
+          el.textContent = 'CSR Child';
+          return el;
+        },
+      }),
+    );
+
+    let outlet: HTMLElement;
+    OutletContext.Provider({ childComponent, router: mockRouter }, () => {
+      outlet = Outlet();
+    });
+
+    endHydration();
+
+    // Before promise resolves, SSR content should still be present
+    expect(outlet!.children.length).toBe(1);
+
+    // After promise resolves, the lazy component replaces SSR content
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Must have exactly 1 child — NOT 2 (the bug was SSR + CSR both present)
+    expect(outlet!.children.length).toBe(1);
+    expect(outlet!.textContent).toBe('CSR Child');
   });
 });

--- a/packages/ui/src/router/__tests__/router-view.test.ts
+++ b/packages/ui/src/router/__tests__/router-view.test.ts
@@ -1017,4 +1017,50 @@ describe('RouterView', () => {
     expect(pageCleanedUp).toBe(true);
     router.dispose();
   });
+
+  test('hydration with lazy route does not produce duplicate elements (#1347)', async () => {
+    // Simulate SSR-rendered DOM:
+    // <div> (RouterView container)
+    //   <div data-testid="page">SSR Content</div> (route component)
+    // </div>
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div data-testid="page">SSR Content</div></div>';
+
+    const routerViewContainer = root.firstChild as HTMLElement;
+    expect(routerViewContainer.children.length).toBe(1);
+
+    startHydration(root);
+
+    const routes = defineRoutes({
+      '/': {
+        component: () =>
+          Promise.resolve({
+            default: () => {
+              const el = document.createElement('div');
+              el.setAttribute('data-testid', 'page');
+              el.textContent = 'CSR Content';
+              return el;
+            },
+          }),
+      },
+    });
+    const router = createRouter(routes, '/');
+    let view: HTMLElement;
+    RouterContext.Provider(router, () => {
+      view = RouterView({ router });
+    });
+
+    endHydration();
+
+    // Before promise resolves, SSR content should still be present
+    expect(view!.children.length).toBe(1);
+
+    // After promise resolves, the lazy component replaces SSR content
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Must have exactly 1 child — NOT 2 (the bug was SSR + CSR both present)
+    expect(view!.children.length).toBe(1);
+    expect(view!.textContent).toBe('CSR Content');
+    router.dispose();
+  });
 });

--- a/packages/ui/src/router/outlet.ts
+++ b/packages/ui/src/router/outlet.ts
@@ -78,6 +78,14 @@ export function Outlet(): HTMLElement {
           result.then((mod) => {
             // Guard against stale resolution from rapid navigation.
             if (gen !== renderGen) return;
+            // Clear any existing content before appending the lazy-loaded
+            // component. During hydration the container still holds SSR
+            // children (the initial render skips clearing). Without this,
+            // the resolved component is appended alongside the SSR content,
+            // producing duplicate route elements.
+            while (container.firstChild) {
+              container.removeChild(container.firstChild);
+            }
             // Re-enter a disposal scope so the async component's
             // cleanups are captured and run on the next swap.
             childCleanups = pushScope();

--- a/packages/ui/src/router/router-view.ts
+++ b/packages/ui/src/router/router-view.ts
@@ -117,16 +117,34 @@ export function RouterView({ router, fallback }: RouterViewProps): HTMLElement {
         const levels = buildLevels(newMatched);
         const rootFactory = buildInsideOutFactory(newMatched, levels, 0, router);
 
+        let asyncRoute = false;
         RouterContext.Provider(router, () => {
           const result = rootFactory();
 
           if (result instanceof Promise) {
+            asyncRoute = true;
+            // Pop the scope from pushScope() above — nothing useful was
+            // captured since the component returned a Promise instead of
+            // rendering synchronously.
+            popScope();
             result.then((mod) => {
               if (gen !== renderGen) return;
+              // Clear any existing content before appending the lazy-loaded
+              // component. During hydration the container still holds SSR
+              // children (the initial render skips clearing). Without this,
+              // the resolved component is appended alongside the SSR content,
+              // producing duplicate route elements.
+              while (container.firstChild) {
+                container.removeChild(container.firstChild);
+              }
+              // Re-enter a disposal scope so the async component's
+              // cleanups are captured and run on the next navigation.
+              pageCleanups = pushScope();
               RouterContext.Provider(router, () => {
                 const node = (mod as { default: () => Node }).default();
                 container.appendChild(node);
               });
+              popScope();
             });
           } else {
             __append(container, result);
@@ -134,7 +152,9 @@ export function RouterView({ router, fallback }: RouterViewProps): HTMLElement {
         });
 
         prevLevels = levels;
-        popScope();
+        if (!asyncRoute) {
+          popScope();
+        }
       };
 
       doRender();


### PR DESCRIPTION
## Summary

- **RouterView** and **Outlet** now clear the container before appending resolved lazy (code-split) route components during hydration, preventing duplicate DOM elements
- **RouterView** async disposal scope leak fixed — lazy page components now render inside a proper disposal scope so their `onMount` cleanups are captured and run on navigation
- Added regression tests for both RouterView and Outlet hydration with lazy routes

## Root Cause

During production builds, Bun code-splits route components into dynamic `import()` calls. During hydration:
1. `isFirstHydrationRender` flag causes the initial container clear to be skipped (SSR children are already in the DOM)
2. The route factory returns a `Promise` (lazy import)
3. When the Promise resolves, `container.appendChild(node)` appends the CSR component **alongside** the SSR children — producing duplicates

## Public API Changes

None — internal fix only.

## Test plan

- [x] RED state verified: test fails without the fix (`Expected: 1, Received: 2`)
- [x] GREEN state: all 2083 `@vertz/ui` tests pass
- [x] New test: `hydration with lazy route does not produce duplicate elements (#1347)` in `router-view.test.ts`
- [x] New test: `hydration with lazy child does not produce duplicate elements (#1347)` in `outlet.test.ts`
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-push hooks pass (full turborepo CI)

Fixes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)