### PR TITLE
fix(task-manager): stabilize flaky settings E2E test

### DIFF
--- a/examples/task-manager/e2e/settings.spec.ts
+++ b/examples/task-manager/e2e/settings.spec.ts
@@ -49,14 +49,20 @@ test.describe('Settings', () => {
     await page.goto('/settings');
     await expect(page.getByTestId('settings-page')).toBeVisible();
 
+    // Wait for JS chunks to load and hydration to complete — the <select>
+    // is SSR-rendered (visible immediately), but the onChange handler is
+    // only attached after hydration. Without this, selectOption can fire
+    // before the handler exists and flashSaved() never runs.
+    await page.waitForLoadState('networkidle');
+
     const select = page.getByTestId('default-priority-select');
-    await expect(select).toBeVisible({ timeout: 10000 });
+    await expect(select).toBeVisible();
 
     // Change priority to "high"
     await select.selectOption('high');
     await expect(select).toHaveValue('high');
 
-    // Saved message should appear (may take a moment for the save + re-render)
-    await expect(page.getByTestId('saved-message')).toBeVisible({ timeout: 10000 });
+    // Saved message should appear
+    await expect(page.getByTestId('saved-message')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Fix flaky `default priority select works` E2E test in the task-manager example
- Root cause: SSR renders the `<select>` immediately (visible), but the `onChange` handler only attaches after hydration. Playwright's `selectOption()` could fire before hydration completed, so `flashSaved()` never ran and the saved-message never appeared.
- Fix: add `page.waitForLoadState('networkidle')` after navigation to ensure all JS chunks are loaded and hydration is complete before interacting with the select

## Test plan

- [x] Ran the settings E2E test 5 times with `--repeat-each=5` — 25/25 passed, zero flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)