### PR TITLE
fix(ui-primitives): add Home/End key support to ComposedRadioGroup

### DIFF
--- a/.changeset/radio-home-end-keys.md
+++ b/.changeset/radio-home-end-keys.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+ComposedRadioGroup now supports Home/End keys to jump to the first/last enabled item, skipping disabled items.

--- a/packages/ui-primitives/src/radio/__tests__/radio-composed.test.ts
+++ b/packages/ui-primitives/src/radio/__tests__/radio-composed.test.ts
@@ -228,6 +228,45 @@ describe('Composed RadioGroup', () => {
     });
   });
 
+  describe('Given a RadioGroup with enabled and disabled items', () => {
+    function createGroup() {
+      const root = ComposedRadioGroup({
+        defaultValue: 'b',
+        children: () => {
+          ComposedRadioGroup.Item({ value: 'a', disabled: true, children: ['Alpha'] });
+          ComposedRadioGroup.Item({ value: 'b', children: ['Beta'] });
+          ComposedRadioGroup.Item({ value: 'c', disabled: true, children: ['Charlie'] });
+          ComposedRadioGroup.Item({ value: 'd', children: ['Delta'] });
+          return [];
+        },
+      });
+      container.appendChild(root);
+      return root;
+    }
+
+    describe('When Home is pressed', () => {
+      it('Then focuses the first enabled item, skipping disabled ones', () => {
+        const root = createGroup();
+        const items = root.querySelectorAll('[role="radio"]');
+        (items[3] as HTMLElement).focus();
+
+        root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+        expect(document.activeElement).toBe(items[1]);
+      });
+    });
+
+    describe('When End is pressed', () => {
+      it('Then focuses the last enabled item, skipping disabled ones', () => {
+        const root = createGroup();
+        const items = root.querySelectorAll('[role="radio"]');
+        (items[1] as HTMLElement).focus();
+
+        root.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+        expect(document.activeElement).toBe(items[3]);
+      });
+    });
+  });
+
   describe('Given a RadioGroup where all items are disabled', () => {
     describe('When ArrowDown is pressed', () => {
       it('Then focus stays on the current item', () => {
@@ -245,6 +284,44 @@ describe('Composed RadioGroup', () => {
         (items[0] as HTMLElement).focus();
 
         root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+        expect(document.activeElement).toBe(items[0]);
+      });
+    });
+
+    describe('When Home is pressed', () => {
+      it('Then focus stays on the current item', () => {
+        const root = ComposedRadioGroup({
+          defaultValue: 'a',
+          children: () => {
+            ComposedRadioGroup.Item({ value: 'a', disabled: true, children: ['Alpha'] });
+            ComposedRadioGroup.Item({ value: 'b', disabled: true, children: ['Beta'] });
+            return [];
+          },
+        });
+        container.appendChild(root);
+        const items = root.querySelectorAll('[role="radio"]');
+        (items[0] as HTMLElement).focus();
+
+        root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+        expect(document.activeElement).toBe(items[0]);
+      });
+    });
+
+    describe('When End is pressed', () => {
+      it('Then focus stays on the current item', () => {
+        const root = ComposedRadioGroup({
+          defaultValue: 'a',
+          children: () => {
+            ComposedRadioGroup.Item({ value: 'a', disabled: true, children: ['Alpha'] });
+            ComposedRadioGroup.Item({ value: 'b', disabled: true, children: ['Beta'] });
+            return [];
+          },
+        });
+        container.appendChild(root);
+        const items = root.querySelectorAll('[role="radio"]');
+        (items[0] as HTMLElement).focus();
+
+        root.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
         expect(document.activeElement).toBe(items[0]);
       });
     });

--- a/packages/ui-primitives/src/radio/radio-composed.tsx
+++ b/packages/ui-primitives/src/radio/radio-composed.tsx
@@ -158,25 +158,35 @@ function ComposedRadioGroupRoot({
         const currentIdx = itemRefs.findIndex((r) => r.current === document.activeElement);
         if (currentIdx < 0) return;
 
-        let direction = 0;
+        const len = itemRefs.length;
+        let nextIdx = -1;
+
         if (isKey(event, Keys.ArrowDown, Keys.ArrowRight)) {
           event.preventDefault();
-          direction = 1;
+          nextIdx = (currentIdx + 1) % len;
         } else if (isKey(event, Keys.ArrowUp, Keys.ArrowLeft)) {
           event.preventDefault();
-          direction = -1;
+          nextIdx = (currentIdx - 1 + len) % len;
+        } else if (isKey(event, Keys.Home)) {
+          event.preventDefault();
+          nextIdx = 0;
+        } else if (isKey(event, Keys.End)) {
+          event.preventDefault();
+          nextIdx = len - 1;
         }
 
-        if (direction !== 0) {
-          const len = itemRefs.length;
-          let nextIdx = (currentIdx + direction + len) % len;
-          // Skip disabled items, stop if we loop back to the current item
-          while (nextIdx !== currentIdx && registrations[nextIdx]?.disabled) {
-            nextIdx = (nextIdx + direction + len) % len;
-          }
-          if (nextIdx !== currentIdx) {
-            selectItem(itemValues[nextIdx] ?? '', nextIdx);
-          }
+        if (nextIdx < 0) return;
+
+        // Skip disabled items: scan forward for Home/ArrowDown/Right, backward for End/ArrowUp/Left
+        const direction = isKey(event, Keys.End, Keys.ArrowUp, Keys.ArrowLeft) ? -1 : 1;
+        const startIdx = nextIdx;
+        while (registrations[nextIdx]?.disabled) {
+          nextIdx = (nextIdx + direction + len) % len;
+          if (nextIdx === startIdx) return; // all disabled
+        }
+
+        if (nextIdx !== currentIdx) {
+          selectItem(itemValues[nextIdx] ?? '', nextIdx);
         }
       }}
     >


### PR DESCRIPTION
## Summary

- Add Home/End key support to `ComposedRadioGroup` keyboard handler per WAI-ARIA radio group pattern
- Both keys skip disabled items (Home scans forward, End scans backward)
- Refactored arrow key disabled-skipping to share the same scan logic

Fixes #1380

## Public API Changes

None — internal keyboard behavior only.

## Test plan

- [x] Home key focuses first enabled item, skipping disabled ones
- [x] End key focuses last enabled item, skipping disabled ones
- [x] When all items are disabled, Home/End keeps focus on current item
- [x] All existing tests continue to pass (561 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)