### PR TITLE
fix(ui-primitives,theme-shadcn): wire label class key through Select

### DIFF
--- a/.changeset/select-label-class.md
+++ b/.changeset/select-label-class.md
@@ -1,0 +1,6 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+---
+
+Wire `label` class key through Select: add `label` to `SelectClasses`, render a visible group label element in `SelectGroup`, and pass `label` styles in `createThemedSelect()`.

--- a/packages/theme-shadcn/src/components/primitives/select.ts
+++ b/packages/theme-shadcn/src/components/primitives/select.ts
@@ -64,6 +64,7 @@ export function createThemedSelect(styles: SelectStyleClasses): ThemedSelectComp
     item: styles.item,
     itemIndicator: styles.itemIndicator,
     group: styles.group,
+    label: styles.label,
     separator: styles.separator,
   });
 

--- a/packages/ui-primitives/src/composed/__tests__/with-styles.test-d.ts
+++ b/packages/ui-primitives/src/composed/__tests__/with-styles.test-d.ts
@@ -130,7 +130,8 @@ withStyles(ComposedSelect, {
   item: 'c',
   itemIndicator: 'd',
   group: 'e',
-  separator: 'f',
+  label: 'f',
+  separator: 'g',
 });
 
 // @ts-expect-error — missing required keys for Select

--- a/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
+++ b/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
@@ -332,6 +332,35 @@ describe('Composed Select', () => {
       const option = group!.querySelector('[role="option"]') as HTMLElement;
       expect(option).not.toBeNull();
     });
+
+    it('Then renders a visible label element inside the group', () => {
+      const root = ComposedSelect({
+        classes: { label: 'styled-label' },
+        children: () => {
+          const t = ComposedSelect.Trigger({ children: ['Pick'] });
+          const c = ComposedSelect.Content({
+            children: () => {
+              const g = ComposedSelect.Group({
+                label: 'Fruits',
+                children: () => {
+                  const i1 = ComposedSelect.Item({ value: 'apple', children: ['Apple'] });
+                  return [i1];
+                },
+              });
+              return [g];
+            },
+          });
+          return [t, c];
+        },
+      });
+      container.appendChild(root);
+
+      const group = root.querySelector('[role="group"]') as HTMLElement;
+      const labelEl = group!.querySelector('[data-part="group-label"]') as HTMLElement;
+      expect(labelEl).not.toBeNull();
+      expect(labelEl!.textContent).toBe('Fruits');
+      expect(labelEl!.className).toContain('styled-label');
+    });
   });
 
   describe('Given a Select with separator', () => {

--- a/packages/ui-primitives/src/select/select-composed.tsx
+++ b/packages/ui-primitives/src/select/select-composed.tsx
@@ -30,6 +30,7 @@ export interface SelectClasses {
   item?: string;
   itemIndicator?: string;
   group?: string;
+  label?: string;
   separator?: string;
 }
 
@@ -235,8 +236,13 @@ function SelectGroup({ label, children, className: cls, class: classProp }: Grou
   // Resolve children within context so nested Items register themselves
   const resolved = resolveChildren(children);
 
+  const labelClass = ctx.classes?.label;
+
   const el = (
     <div role="group" aria-label={label} class={groupClass || undefined}>
+      <div data-part="group-label" role="none" class={labelClass || undefined}>
+        {label}
+      </div>
       {...resolved}
     </div>
   ) as HTMLDivElement;


### PR DESCRIPTION
## Summary

- Add `label` to `SelectClasses` in `ui-primitives` so group labels can be styled
- Render a visible `<div data-part="group-label">` inside `SelectGroup` (mirrors `MenuLabel` in DropdownMenu)
- Wire `label` styles through `withStyles` in `createThemedSelect()` so the theme's label styles are no longer silently dropped
- Update type-level tests for `withStyles` to include the new `label` key

## Public API Changes

- `SelectClasses` gains an optional `label?: string` key (non-breaking addition)
- `SelectGroup` now renders a visible label element with `data-part="group-label"` inside the group container

## Test plan

- [x] New test: `SelectGroup` renders a visible label element with correct text and class
- [x] All existing 558 ui-primitives tests pass
- [x] Type-level test updated for `withStyles` positive case
- [x] Typecheck passes for both `ui-primitives` and `theme-shadcn`

Fixes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)