### PR TITLE
fix(ui-compiler,ui-primitives): object/array literals no longer wrapped in computed() (#1387)

### DIFF
--- a/.changeset/object-literal-computed-fix.md
+++ b/.changeset/object-literal-computed-fix.md
@@ -1,0 +1,10 @@
+---
+'@vertz/ui-compiler': patch
+'@vertz/ui-primitives': patch
+---
+
+fix(ui-compiler): object/array literals no longer incorrectly wrapped in computed()
+
+The ReactivityAnalyzer now skips object and array literal initializers during
+computed classification, matching the existing behavior for function definitions.
+This removes the need for `build*Ctx()` helper workarounds in composed primitives.

--- a/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
+++ b/packages/ui-compiler/src/analyzers/__tests__/reactivity-analyzer.test.ts
@@ -717,4 +717,75 @@ describe('ReactivityAnalyzer', () => {
     // Derived from signal property → computed
     expect(findVar(result?.variables, 'isAllowed')?.kind).toBe('computed');
   });
+
+  // ─── Object/array literal classification (#1387) ──────────────
+
+  it('classifies object literal referencing a reactive source as static', () => {
+    const [result] = analyze(`
+      function Comp({ classes }) {
+        const ctx = { classes, name: 'test', register: () => {} };
+        return <div>{ctx.name}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'ctx')?.kind).toBe('static');
+  });
+
+  it('classifies object literal referencing a signal as static', () => {
+    const [result] = analyze(`
+      function Comp() {
+        let count = 0;
+        const handlers = { increment: () => { count++; }, get: () => count };
+        return <div onClick={handlers.increment}>{count}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'handlers')?.kind).toBe('static');
+  });
+
+  it('classifies array literal referencing a reactive source as static', () => {
+    const [result] = analyze(`
+      function Comp({ items }) {
+        const list = [items, 'extra'];
+        return <div>{list}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'list')?.kind).toBe('static');
+  });
+
+  it('classifies object literal referencing a signal via function call as static', () => {
+    const [result] = analyze(`
+      function buildCtx(classes, register) {
+        return { classes, register, _claimed: false };
+      }
+      function Comp({ classes }) {
+        const ctx = buildCtx(classes, (el) => {});
+        return <div>{ctx._claimed}</div>;
+      }
+    `);
+    // The call expression result still becomes computed (function call, not literal),
+    // but the object literal inside buildCtx is static
+    expect(findVar(result?.variables, 'ctx')?.kind).toBe('computed');
+  });
+
+  it('classifies object literal with nested reactive references as static', () => {
+    const [result] = analyze(`
+      import { useContext } from '@vertz/ui';
+      function Comp() {
+        const theme = useContext(ThemeCtx);
+        const config = { theme, extra: 42 };
+        return <div>{config.extra}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'config')?.kind).toBe('static');
+  });
+
+  it('classifies array literal with signal elements as static', () => {
+    const [result] = analyze(`
+      function Comp() {
+        let count = 0;
+        const arr = [count, count * 2];
+        return <div>{arr}</div>;
+      }
+    `);
+    expect(findVar(result?.variables, 'arr')?.kind).toBe('static');
+  });
 });

--- a/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
+++ b/packages/ui-compiler/src/analyzers/reactivity-analyzer.ts
@@ -49,6 +49,7 @@ export class ReactivityAnalyzer {
         deps: string[];
         propertyAccesses: Map<string, Set<string>>;
         isFunctionDef: boolean;
+        isStructuralLiteral: boolean;
       }
     >();
     const signalApiVars = new Map<string, SignalApiConfig>(); // Track variables assigned from signal APIs
@@ -122,6 +123,7 @@ export class ReactivityAnalyzer {
                     deps: [],
                     propertyAccesses: new Map(),
                     isFunctionDef: false,
+                    isStructuralLiteral: false,
                   });
                 }
               }
@@ -146,6 +148,7 @@ export class ReactivityAnalyzer {
                 deps,
                 propertyAccesses: propAccesses,
                 isFunctionDef: false,
+                isStructuralLiteral: false,
               };
               consts.set(bindingName, entry);
               destructuredFromMap.set(bindingName, syntheticName);
@@ -159,6 +162,7 @@ export class ReactivityAnalyzer {
                 deps,
                 propertyAccesses,
                 isFunctionDef: false,
+                isStructuralLiteral: false,
               };
               if (isLet) {
                 lets.set(bindingName, entry);
@@ -178,6 +182,11 @@ export class ReactivityAnalyzer {
         const isFunctionDef =
           unwrappedInit?.isKind(SyntaxKind.ArrowFunction) === true ||
           unwrappedInit?.isKind(SyntaxKind.FunctionExpression) === true;
+        // Object/array literals are one-time structural constructions — they should
+        // never be wrapped in computed(). Like function defs, they are stable references.
+        const isStructuralLiteral =
+          unwrappedInit?.isKind(SyntaxKind.ObjectLiteralExpression) === true ||
+          unwrappedInit?.isKind(SyntaxKind.ArrayLiteralExpression) === true;
         const { refs: deps, propertyAccesses } = init
           ? collectDeps(init)
           : { refs: [] as string[], propertyAccesses: new Map<string, Set<string>>() };
@@ -187,6 +196,7 @@ export class ReactivityAnalyzer {
           deps,
           propertyAccesses,
           isFunctionDef,
+          isStructuralLiteral,
         };
 
         // Check if this is assigned from a signal API call or reactive source API call.
@@ -275,7 +285,7 @@ export class ReactivityAnalyzer {
       for (const [name, info] of consts) {
         if (computeds.has(name)) continue;
         if (signalApiVars.has(name)) continue;
-        if (info.isFunctionDef) continue;
+        if (info.isFunctionDef || info.isStructuralLiteral) continue;
         const dependsOnReactive = info.deps.some((dep) => {
           if (signals.has(dep) || computeds.has(dep) || reactiveSourceVars.has(dep)) return true;
           const apiConfig = signalApiVars.get(dep);

--- a/packages/ui-primitives/src/accordion/accordion-composed.tsx
+++ b/packages/ui-primitives/src/accordion/accordion-composed.tsx
@@ -137,24 +137,26 @@ function AccordionItem({ value, children }: ItemProps) {
     contentClass: undefined,
   };
 
-  const itemCtx = buildAccordionItemCtx(
+  const itemCtx: AccordionItemContextValue = {
     value,
     triggerId,
     contentId,
-    ctx.classes,
-    (triggerChildren, triggerClass) => {
+    classes: ctx.classes,
+    _registerTrigger: (triggerChildren, triggerClass) => {
       if (itemReg.triggerChildren === undefined) {
         itemReg.triggerChildren = triggerChildren;
         itemReg.triggerClass = triggerClass;
       }
     },
-    (contentChildren, contentClass) => {
+    _registerContent: (contentChildren, contentClass) => {
       if (itemReg.contentChildren === undefined) {
         itemReg.contentChildren = contentChildren;
         itemReg.contentClass = contentClass;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Resolve children (Trigger, Content) to collect their registrations
   AccordionItemContext.Provider(itemCtx, () => {
@@ -282,39 +284,6 @@ export interface ComposedAccordionProps {
 
 export type AccordionClassKey = keyof AccordionClasses;
 
-// Helper to build context value — avoids compiler wrapping object literal in computed().
-function buildAccordionCtx(
-  classes: AccordionClasses | undefined,
-  registerItem: (reg: ItemRegistration) => void,
-): AccordionContextValue {
-  return {
-    classes,
-    _registerItem: registerItem,
-    _itemsClaimed: new Set(),
-  };
-}
-
-// Helper to build item context value — avoids compiler wrapping object literal in computed().
-function buildAccordionItemCtx(
-  value: string,
-  triggerId: string,
-  contentId: string,
-  classes: AccordionClasses | undefined,
-  registerTrigger: (children: ChildValue, cls?: string) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): AccordionItemContextValue {
-  return {
-    value,
-    triggerId,
-    contentId,
-    classes,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
 function ComposedAccordionRoot({
   children,
   classes,
@@ -330,12 +299,16 @@ function ComposedAccordionRoot({
     itemMap: Map<string, ItemRegistration>;
   } = { items: [], itemMap: new Map() };
 
-  const ctxValue = buildAccordionCtx(classes, (itemReg) => {
-    if (!reg.itemMap.has(itemReg.value)) {
-      reg.items.push(itemReg);
-      reg.itemMap.set(itemReg.value, itemReg);
-    }
-  });
+  const ctxValue: AccordionContextValue = {
+    classes,
+    _registerItem: (itemReg) => {
+      if (!reg.itemMap.has(itemReg.value)) {
+        reg.items.push(itemReg);
+        reg.itemMap.set(itemReg.value, itemReg);
+      }
+    },
+    _itemsClaimed: new Set(),
+  };
 
   // Phase 1: resolve children to collect item registrations
   AccordionContext.Provider(ctxValue, () => {

--- a/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
+++ b/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
@@ -223,28 +223,6 @@ export interface ComposedAlertDialogProps {
 
 export type AlertDialogClassKey = keyof AlertDialogClasses;
 
-// Helper to build the context value — avoids compiler wrapping an object
-// literal in computed(), which breaks the block-vs-object-literal ambiguity.
-function buildAlertDialogCtx(
-  titleId: string,
-  descriptionId: string,
-  classes: AlertDialogClasses | undefined,
-  onAction: (() => void) | undefined,
-  registerTrigger: (el: HTMLElement) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): AlertDialogContextValue {
-  return {
-    titleId,
-    descriptionId,
-    classes,
-    onAction,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
 function ComposedAlertDialogRoot({
   children,
   classes,
@@ -262,21 +240,23 @@ function ComposedAlertDialogRoot({
     contentCls: string | undefined;
   } = { triggerEl: null, contentChildren: undefined, contentCls: undefined };
 
-  const ctxValue = buildAlertDialogCtx(
+  const ctxValue: AlertDialogContextValue = {
     titleId,
     descriptionId,
     classes,
     onAction,
-    (el) => {
+    _registerTrigger: (el) => {
       reg.triggerEl = el;
     },
-    (contentChildren, cls) => {
+    _registerContent: (contentChildren, cls) => {
       if (reg.contentChildren === undefined) {
         reg.contentChildren = contentChildren;
         reg.contentCls = cls;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];

--- a/packages/ui-primitives/src/dialog/dialog-composed.tsx
+++ b/packages/ui-primitives/src/dialog/dialog-composed.tsx
@@ -175,26 +175,6 @@ export interface ComposedDialogProps {
 
 export type DialogClassKey = keyof DialogClasses;
 
-// Helper to build the context value — avoids compiler wrapping an object
-// literal in computed(), which breaks the block-vs-object-literal ambiguity.
-function buildDialogCtx(
-  titleId: string,
-  descriptionId: string,
-  classes: DialogClasses | undefined,
-  registerTrigger: (el: HTMLElement) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): DialogContextValue {
-  return {
-    titleId,
-    descriptionId,
-    classes,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
 function ComposedDialogRoot({ children, classes, onOpenChange, closeIcon }: ComposedDialogProps) {
   const ids = linkedIds('dialog');
   const titleId = `${ids.contentId}-title`;
@@ -207,20 +187,22 @@ function ComposedDialogRoot({ children, classes, onOpenChange, closeIcon }: Comp
     contentCls: string | undefined;
   } = { triggerEl: null, contentChildren: undefined, contentCls: undefined };
 
-  const ctxValue = buildDialogCtx(
+  const ctxValue: DialogContextValue = {
     titleId,
     descriptionId,
     classes,
-    (el) => {
+    _registerTrigger: (el) => {
       reg.triggerEl = el;
     },
-    (contentChildren, cls) => {
+    _registerContent: (contentChildren, cls) => {
       if (reg.contentChildren === undefined) {
         reg.contentChildren = contentChildren;
         reg.contentCls = cls;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];

--- a/packages/ui-primitives/src/dropdown-menu/dropdown-menu-composed.tsx
+++ b/packages/ui-primitives/src/dropdown-menu/dropdown-menu-composed.tsx
@@ -212,39 +212,6 @@ function MenuSeparator({ className: cls, class: classProp }: SlotProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Context value builder — outside component body to avoid computed() wrapping
-// ---------------------------------------------------------------------------
-
-function buildCtxValue(
-  reg: {
-    userTrigger: HTMLElement | null;
-    contentChildren: Node[];
-    items: HTMLDivElement[];
-  },
-  classes: DropdownMenuClasses | undefined,
-  onSelect: ((value: string) => void) | undefined,
-): DropdownMenuContextValue {
-  return {
-    classes,
-    onSelect,
-    _registerTrigger: (el: HTMLElement) => {
-      reg.userTrigger = el;
-    },
-    _registerContent: (children: Node[]) => {
-      for (let i = 0; i < children.length; i++) {
-        const child = children[i];
-        if (child) reg.contentChildren.push(child);
-      }
-    },
-    _registerItem: (el: HTMLDivElement) => {
-      reg.items.push(el);
-    },
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Root composed component
 // ---------------------------------------------------------------------------
 
@@ -294,8 +261,23 @@ function ComposedDropdownMenuRoot({
     resolvedNodes: [],
   };
 
-  // Build context value via helper to avoid compiler computed() wrapping
-  const ctxValue = buildCtxValue(reg, classes, onSelect);
+  const ctxValue: DropdownMenuContextValue = {
+    classes,
+    onSelect,
+    _registerTrigger: (el: HTMLElement) => {
+      reg.userTrigger = el;
+    },
+    _registerContent: (children: Node[]) => {
+      children.forEach((child) => {
+        reg.contentChildren.push(child);
+      });
+    },
+    _registerItem: (el: HTMLDivElement) => {
+      reg.items.push(el);
+    },
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   DropdownMenuContext.Provider(ctxValue, () => {
@@ -321,9 +303,9 @@ function ComposedDropdownMenuRoot({
   // --- State management functions ---
 
   function updateActiveItem(index: number): void {
-    for (let i = 0; i < reg.items.length; i++) {
-      reg.items[i]?.setAttribute('tabindex', i === index ? '0' : '-1');
-    }
+    reg.items.forEach((item, i) => {
+      item.setAttribute('tabindex', i === index ? '0' : '-1');
+    });
   }
 
   function handleClickOutside(event: MouseEvent): void {

--- a/packages/ui-primitives/src/popover/popover-composed.tsx
+++ b/packages/ui-primitives/src/popover/popover-composed.tsx
@@ -109,20 +109,6 @@ export interface ComposedPopoverProps {
 
 export type PopoverClassKey = keyof PopoverClasses;
 
-// Helper to build the context value — avoids compiler wrapping an object
-// literal in computed(), which breaks the block-vs-object-literal ambiguity.
-function buildPopoverCtx(
-  registerTrigger: (el: HTMLElement) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): PopoverContextValue {
-  return {
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
 function ComposedPopoverRoot({
   children,
   classes,
@@ -146,17 +132,19 @@ function ComposedPopoverRoot({
     dismissCleanup: null,
   };
 
-  const ctxValue = buildPopoverCtx(
-    (el) => {
+  const ctxValue: PopoverContextValue = {
+    _registerTrigger: (el) => {
       reg.triggerEl = el;
     },
-    (contentChildren, cls) => {
+    _registerContent: (contentChildren, cls) => {
       if (reg.contentChildren === undefined) {
         reg.contentChildren = contentChildren;
         reg.contentCls = cls;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];

--- a/packages/ui-primitives/src/radio/radio-composed.tsx
+++ b/packages/ui-primitives/src/radio/radio-composed.tsx
@@ -117,9 +117,6 @@ function ComposedRadioGroupRoot({
   }
 
   // Build items — inline signal refs so the compiler emits reactive __attr() calls.
-  // Using intermediate `const isActive = value === selectedValue` would be cleaner,
-  // but the compiler doesn't track derived consts as reactive inside .map() callbacks
-  // yet (see #1342). Once that's fixed, this can be simplified.
   const itemNodes = registrations.map((reg, i) => {
     const { value, disabled: isDisabled, labelText } = reg;
 

--- a/packages/ui-primitives/src/select/select-composed.tsx
+++ b/packages/ui-primitives/src/select/select-composed.tsx
@@ -1,13 +1,6 @@
 /**
  * Composed Select — high-level composable component with fully declarative JSX.
  * Sub-components self-wire via context. No factory dependency.
- *
- * Compiler constraints applied:
- * - `const reg` object for registration (not `let` — avoids signal transforms)
- * - `buildSelectCtx()` helper outside component for context value construction
- * - `buildItemEl()` outside component body to avoid computed() on JSX returns
- * - `for` loops instead of `.map()` at top level
- * - Content panel as separate JSX variable for event delegation cleanup
  */
 
 import type { ChildValue } from '@vertz/ui';
@@ -105,73 +98,6 @@ interface GroupProps extends SlotProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: create reg object outside component body
-// (avoids compiler wrapping object literal in computed())
-// ---------------------------------------------------------------------------
-
-function createSelectReg(defaultValue: string): SelectReg {
-  return {
-    items: [],
-    contentChildren: [],
-    contentClass: undefined,
-    floatingCleanup: null,
-    dismissCleanup: null,
-    selectedValue: defaultValue,
-    isOpen: false,
-    activeIndex: -1,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: build context value outside component body
-// (avoids compiler wrapping object literal in computed())
-// ---------------------------------------------------------------------------
-
-function buildSelectCtx(
-  classes: SelectClasses | undefined,
-  registerItem: (el: HTMLDivElement, value: string) => void,
-  registerContent: (contentChildren: Node[], cls?: string) => void,
-): SelectContextValue {
-  return {
-    classes,
-    _registerItem: registerItem,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: build item element outside component body
-// (avoids compiler classifying JSX return as computed())
-// ---------------------------------------------------------------------------
-
-function buildItemEl(
-  value: string,
-  isSelected: boolean,
-  label: string,
-  itemClass: string,
-  indicatorClass: string | undefined,
-): HTMLDivElement {
-  const el = (
-    <div
-      role="option"
-      data-value={value}
-      tabindex="-1"
-      aria-selected={isSelected ? 'true' : 'false'}
-      data-state={isSelected ? 'active' : 'inactive'}
-    >
-      {label}
-      <span data-part="indicator" style="display: none" class={indicatorClass || undefined} />
-    </div>
-  ) as HTMLDivElement;
-
-  if (itemClass) el.className = itemClass;
-
-  return el;
-}
-
-// ---------------------------------------------------------------------------
 // Sub-components — self-wiring via context
 // ---------------------------------------------------------------------------
 
@@ -212,16 +138,21 @@ function SelectItem({ value, children, className: cls, class: classProp }: ItemP
     .trim();
 
   const itemClass = [ctx.classes?.item, effectiveCls].filter(Boolean).join(' ');
+  const displayLabel = label || value;
 
-  // Build element using standalone helper to avoid computed() wrapping
   // Click handler wired by Root after items are collected
-  const el = buildItemEl(
-    value,
-    false, // selection state set by Root after all items are registered
-    label || value,
-    itemClass,
-    ctx.classes?.itemIndicator,
-  );
+  const el = (
+    <div role="option" data-value={value} tabindex="-1" aria-selected="false" data-state="inactive">
+      {displayLabel}
+      <span
+        data-part="indicator"
+        style="display: none"
+        class={ctx.classes?.itemIndicator || undefined}
+      />
+    </div>
+  ) as HTMLDivElement;
+
+  if (itemClass) el.className = itemClass;
 
   ctx._registerItem(el, value);
 
@@ -284,32 +215,35 @@ function ComposedSelectRoot({
   const ids = linkedIds('select');
 
   // Plain reg object — NOT `let` variables (compiler would transform to signals)
-  // Created via helper function to avoid compiler wrapping object literal in computed()
-  const reg = createSelectReg(defaultValue);
+  const reg: SelectReg = {
+    items: [],
+    contentChildren: [],
+    contentClass: undefined,
+    floatingCleanup: null,
+    dismissCleanup: null,
+    selectedValue: defaultValue,
+    isOpen: false,
+    activeIndex: -1,
+  };
 
   // --- Helper functions that close over reg ---
 
   function updateActiveItem(index: number): void {
-    for (let i = 0; i < reg.items.length; i++) {
-      const item = reg.items[i];
-      if (item) {
-        item.el.setAttribute('tabindex', i === index ? '0' : '-1');
-      }
-    }
+    reg.items.forEach((item, i) => {
+      item.el.setAttribute('tabindex', i === index ? '0' : '-1');
+    });
   }
 
   function selectItem(value: string): void {
     reg.selectedValue = value;
-    for (let i = 0; i < reg.items.length; i++) {
-      const item = reg.items[i];
-      if (!item) continue;
+    reg.items.forEach((item) => {
       const isActive = item.value === value;
       item.el.setAttribute('aria-selected', isActive ? 'true' : 'false');
       item.el.setAttribute('data-state', isActive ? 'active' : 'inactive');
       if (isActive) {
         triggerText.textContent = item.el.textContent ?? value;
       }
-    }
+    });
     onValueChange?.(value);
     close();
   }
@@ -337,13 +271,7 @@ function ComposedSelectRoot({
     }
 
     // Focus selected item or content
-    let selectedIdx = -1;
-    for (let i = 0; i < reg.items.length; i++) {
-      if (reg.items[i]?.value === reg.selectedValue) {
-        selectedIdx = i;
-        break;
-      }
-    }
+    const selectedIdx = reg.items.findIndex((item) => item.value === reg.selectedValue);
     if (selectedIdx >= 0) {
       reg.activeIndex = selectedIdx;
       updateActiveItem(selectedIdx);
@@ -371,16 +299,18 @@ function ComposedSelectRoot({
 
   // --- Build context and resolve children (Phase 1) ---
 
-  const ctxValue = buildSelectCtx(
+  const ctxValue: SelectContextValue = {
     classes,
-    (el: HTMLDivElement, value: string) => {
+    _registerItem: (el: HTMLDivElement, value: string) => {
       reg.items.push({ el, value });
     },
-    (contentChildren: Node[], cls?: string) => {
+    _registerContent: (contentChildren: Node[], cls?: string) => {
       reg.contentChildren = contentChildren;
       reg.contentClass = cls;
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   SelectContext.Provider(ctxValue, () => {
     resolveChildren(children);
@@ -388,27 +318,22 @@ function ComposedSelectRoot({
 
   // --- Wire item click handlers now that selectItem is defined ---
 
-  for (let i = 0; i < reg.items.length; i++) {
-    const item = reg.items[i];
-    if (!item) continue;
-    const itemValue = item.value;
+  reg.items.forEach((item) => {
     const handleItemClick = () => {
-      selectItem(itemValue);
+      selectItem(item.value);
     };
     item.el.addEventListener('click', handleItemClick);
     _tryOnCleanup(() => item.el.removeEventListener('click', handleItemClick));
-  }
+  });
 
   // --- Set initial selection state on items ---
 
   if (defaultValue) {
-    for (let i = 0; i < reg.items.length; i++) {
-      const item = reg.items[i];
-      if (!item) continue;
+    reg.items.forEach((item) => {
       const isSelected = item.value === defaultValue;
       item.el.setAttribute('aria-selected', isSelected ? 'true' : 'false');
       item.el.setAttribute('data-state', isSelected ? 'active' : 'inactive');
-    }
+    });
   }
 
   // --- Build trigger ---
@@ -419,12 +344,9 @@ function ComposedSelectRoot({
 
   // Set trigger text to selected item's label if defaultValue matches
   if (defaultValue) {
-    for (let i = 0; i < reg.items.length; i++) {
-      const item = reg.items[i];
-      if (item && item.value === defaultValue) {
-        triggerText.textContent = item.el.textContent ?? defaultValue;
-        break;
-      }
+    const match = reg.items.find((item) => item.value === defaultValue);
+    if (match) {
+      triggerText.textContent = match.el.textContent ?? defaultValue;
     }
   }
 
@@ -512,20 +434,14 @@ function ComposedSelectRoot({
       }
     }
 
-    const itemEls: HTMLElement[] = [];
-    for (let i = 0; i < reg.items.length; i++) {
-      const item = reg.items[i];
-      if (item) itemEls.push(item.el);
-    }
+    const itemEls = reg.items.map((item) => item.el);
 
     const result = handleListNavigation(event, itemEls, { orientation: 'vertical' });
     if (result) {
-      for (let i = 0; i < reg.items.length; i++) {
-        if (reg.items[i]?.el === result) {
-          reg.activeIndex = i;
-          updateActiveItem(i);
-          break;
-        }
+      const idx = reg.items.findIndex((item) => item.el === result);
+      if (idx >= 0) {
+        reg.activeIndex = idx;
+        updateActiveItem(idx);
       }
       return;
     }
@@ -533,14 +449,13 @@ function ComposedSelectRoot({
     // Type-ahead: single-char search
     if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
       const char = event.key.toLowerCase();
-      for (let i = 0; i < reg.items.length; i++) {
-        const item = reg.items[i];
-        if (item?.el.textContent?.toLowerCase().startsWith(char)) {
-          reg.activeIndex = i;
-          updateActiveItem(i);
-          item.el.focus();
-          break;
-        }
+      const idx = reg.items.findIndex((item) =>
+        item.el.textContent?.toLowerCase().startsWith(char),
+      );
+      if (idx >= 0) {
+        reg.activeIndex = idx;
+        updateActiveItem(idx);
+        reg.items[idx]!.el.focus();
       }
     }
   };

--- a/packages/ui-primitives/src/sheet/sheet-composed.tsx
+++ b/packages/ui-primitives/src/sheet/sheet-composed.tsx
@@ -156,27 +156,12 @@ export interface ComposedSheetProps {
 
 export type SheetClassKey = keyof SheetClasses;
 
-// Helper to build the context value — avoids compiler wrapping an object
-// literal in computed(), which breaks the block-vs-object-literal ambiguity.
-function buildSheetCtx(
-  titleId: string,
-  descriptionId: string,
-  classes: SheetClasses | undefined,
-  registerTrigger: (el: HTMLElement) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): SheetContextValue {
-  return {
-    titleId,
-    descriptionId,
-    classes,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
-function ComposedSheetRoot({ children, classes, side = 'right', onOpenChange }: ComposedSheetProps) {
+function ComposedSheetRoot({
+  children,
+  classes,
+  side = 'right',
+  onOpenChange,
+}: ComposedSheetProps) {
   const ids = linkedIds('sheet');
   const titleId = `${ids.contentId}-title`;
   const descriptionId = `${ids.contentId}-description`;
@@ -189,14 +174,14 @@ function ComposedSheetRoot({ children, classes, side = 'right', onOpenChange }: 
     contentRegistered: boolean;
   } = { triggerEl: null, contentNodes: [], contentCls: undefined, contentRegistered: false };
 
-  const ctxValue = buildSheetCtx(
+  const ctxValue: SheetContextValue = {
     titleId,
     descriptionId,
     classes,
-    (el) => {
+    _registerTrigger: (el) => {
       reg.triggerEl = el;
     },
-    (contentChildren, cls) => {
+    _registerContent: (contentChildren, cls) => {
       if (!reg.contentRegistered) {
         reg.contentRegistered = true;
         // Resolve content children immediately while still inside the Provider scope
@@ -205,7 +190,9 @@ function ComposedSheetRoot({ children, classes, side = 'right', onOpenChange }: 
         reg.contentCls = cls;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];

--- a/packages/ui-primitives/src/tabs/tabs-composed.tsx
+++ b/packages/ui-primitives/src/tabs/tabs-composed.tsx
@@ -198,21 +198,6 @@ export interface ComposedTabsProps {
 
 export type TabsClassKey = keyof TabsClasses;
 
-// Helper to build context value — avoids compiler wrapping object literal in computed().
-function buildTabsCtx(
-  classes: TabsClasses | undefined,
-  registerTrigger: (value: string, children: ChildValue, cls?: string) => void,
-  registerContent: (value: string, children: ChildValue, cls?: string) => void,
-): TabsContextValue {
-  return {
-    classes,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggersClaimed: new Set(),
-    _contentsClaimed: new Set(),
-  };
-}
-
 function ComposedTabsRoot({
   children,
   classes,
@@ -226,9 +211,9 @@ function ComposedTabsRoot({
     tabMap: Map<string, TabRegistration>;
   } = { tabs: [], tabMap: new Map() };
 
-  const ctxValue = buildTabsCtx(
+  const ctxValue: TabsContextValue = {
     classes,
-    (value, triggerChildren, triggerClass) => {
+    _registerTrigger: (value, triggerChildren, triggerClass) => {
       if (!reg.tabMap.has(value)) {
         const baseId = uniqueId('tab');
         const entry: TabRegistration = {
@@ -244,14 +229,16 @@ function ComposedTabsRoot({
         reg.tabMap.set(value, entry);
       }
     },
-    (value, panelChildren, panelClass) => {
+    _registerContent: (value, panelChildren, panelClass) => {
       const entry = reg.tabMap.get(value);
       if (entry && entry.panelChildren === undefined) {
         entry.panelChildren = panelChildren;
         entry.panelClass = panelClass;
       }
     },
-  );
+    _triggersClaimed: new Set(),
+    _contentsClaimed: new Set(),
+  };
 
   // Phase 1: resolve children to collect registrations
   TabsContext.Provider(ctxValue, () => {

--- a/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
+++ b/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
@@ -110,24 +110,6 @@ export interface ComposedTooltipProps {
 
 export type TooltipClassKey = keyof TooltipClasses;
 
-// Helper to build the context value — avoids compiler wrapping an object
-// literal in computed(), which breaks the block-vs-object-literal ambiguity.
-function buildTooltipCtx(
-  contentId: string,
-  classes: TooltipClasses | undefined,
-  registerTrigger: (el: HTMLElement) => void,
-  registerContent: (children: ChildValue, cls?: string) => void,
-): TooltipContextValue {
-  return {
-    contentId,
-    classes,
-    _registerTrigger: registerTrigger,
-    _registerContent: registerContent,
-    _triggerClaimed: false,
-    _contentClaimed: false,
-  };
-}
-
 function ComposedTooltipRoot({
   children,
   classes,
@@ -144,19 +126,21 @@ function ComposedTooltipRoot({
     floatingCleanup: (() => void) | null;
   } = { triggerEl: null, contentChildren: undefined, contentCls: undefined, floatingCleanup: null };
 
-  const ctxValue = buildTooltipCtx(
+  const ctxValue: TooltipContextValue = {
     contentId,
     classes,
-    (el) => {
+    _registerTrigger: (el) => {
       reg.triggerEl = el;
     },
-    (contentChildren, cls) => {
+    _registerContent: (contentChildren, cls) => {
       if (reg.contentChildren === undefined) {
         reg.contentChildren = contentChildren;
         reg.contentCls = cls;
       }
     },
-  );
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];


### PR DESCRIPTION
## Summary

- **Compiler fix**: `ReactivityAnalyzer` now skips `const` object/array literal initializers during computed classification, matching the existing skip for function definitions. Object literals referencing reactive sources (props, signals, computeds) stay as plain `const` instead of being incorrectly wrapped in `computed()`.
- **Primitive cleanup**: Removed all `build*Ctx()` helper workarounds from 9 composed primitives, inlining context object literals directly into component bodies.
- **Code quality**: Replaced `for` loops with `.map()`/`.forEach()`/`.findIndex()` in select-composed and dropdown-menu-composed. Removed stale comment from radio-composed.

Net result: **-134 lines** across the primitives package with no behavioral changes.

## Public API Changes

None — all changes are internal to the compiler analyzer and primitive component implementations.

## Test plan

- [x] 6 new analyzer tests covering object/array literals with reactive refs
- [x] Existing test `still classifies value expression reading signal as computed` confirms no regression
- [x] 651/651 ui-compiler tests pass
- [x] 394/394 ui-primitives tests pass
- [x] 446/446 theme-shadcn tests pass
- [x] Full typecheck clean
- [x] Biome lint clean

Fixes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)