### PR TITLE
fix(ui): sync child inside lazy parent hydration re-entry loses nodes on mismatch

### DIFF
--- a/.changeset/fix-sync-hydration-mismatch.md
+++ b/.changeset/fix-sync-hydration-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui': patch
+---
+
+fix(ui): add mismatch fallback to sync path during hydration re-entry in Outlet and RouterView

--- a/packages/ui/src/router/__tests__/outlet.test.ts
+++ b/packages/ui/src/router/__tests__/outlet.test.ts
@@ -141,4 +141,88 @@ describe('Outlet', () => {
     // The SSR node should be preserved (same DOM reference, not recreated)
     expect(outlet!.firstChild).toBe(ssrChildNode);
   });
+
+  test('sync child with mismatched tag during hydration re-entry appears in DOM (#1368)', () => {
+    // Simulate SSR-rendered DOM:
+    // <div> (outlet container)
+    //   <div data-testid="child">SSR Child</div>
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div data-testid="child">SSR Child</div></div>';
+
+    startHydration(root);
+
+    // Sync child creates a <span> — mismatches SSR's <div>
+    const childComponent = signal<(() => Node) | undefined>(() => {
+      const el = __element('span');
+      el.textContent = 'Client Child';
+      return el;
+    });
+
+    let outlet: HTMLElement;
+    OutletContext.Provider({ childComponent, router: mockRouter }, () => {
+      outlet = Outlet();
+    });
+
+    endHydration();
+
+    // The <span> should be in the DOM despite the mismatch
+    expect(outlet!.children.length).toBe(1);
+    expect(outlet!.firstChild!.nodeName).toBe('SPAN');
+    expect(outlet!.textContent).toBe('Client Child');
+  });
+
+  test('sync child using document.createElement during hydration re-entry is appended (#1368)', () => {
+    // Non-compiled component uses document.createElement instead of __element
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div>SSR Content</div></div>';
+
+    startHydration(root);
+
+    const childComponent = signal<(() => Node) | undefined>(() => {
+      // Non-compiled component — doesn't use __element at all
+      const el = document.createElement('p');
+      el.textContent = 'Non-compiled';
+      return el;
+    });
+
+    let outlet: HTMLElement;
+    OutletContext.Provider({ childComponent, router: mockRouter }, () => {
+      outlet = Outlet();
+    });
+
+    endHydration();
+
+    expect(outlet!.children.length).toBe(1);
+    expect(outlet!.firstChild!.nodeName).toBe('P');
+    expect(outlet!.textContent).toBe('Non-compiled');
+  });
+
+  test('sync child that claims SSR node during hydration is not double-appended (#1368)', () => {
+    // When the tag matches, the SSR node is claimed — no duplicate append
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div data-testid="child">SSR Child</div></div>';
+
+    const outletContainer = root.firstChild as HTMLElement;
+    const ssrChildNode = outletContainer.firstChild as HTMLElement;
+
+    startHydration(root);
+
+    const childComponent = signal<(() => Node) | undefined>(() => {
+      // Sync child claims the SSR <div> — tags match
+      const el = __element('div');
+      el.setAttribute('data-testid', 'child');
+      return el;
+    });
+
+    let outlet: HTMLElement;
+    OutletContext.Provider({ childComponent, router: mockRouter }, () => {
+      outlet = Outlet();
+    });
+
+    endHydration();
+
+    // The claimed SSR node should still be the only child (no duplication)
+    expect(outlet!.children.length).toBe(1);
+    expect(outlet!.firstChild).toBe(ssrChildNode);
+  });
 });

--- a/packages/ui/src/router/__tests__/router-view.test.ts
+++ b/packages/ui/src/router/__tests__/router-view.test.ts
@@ -1289,4 +1289,35 @@ describe('RouterView', () => {
     expect(view!.textContent).toBe('Other Page');
     router.dispose();
   });
+
+  test('sync route with mismatched tag during hydration appears in DOM (#1368)', () => {
+    // SSR rendered a <div>, but the sync route creates a <span>
+    const root = document.createElement('div');
+    root.innerHTML = '<div><div data-testid="ssr">SSR</div></div>';
+
+    startHydration(root);
+
+    const routes = defineRoutes({
+      '/': {
+        component: () => {
+          const el = __element('span');
+          el.textContent = 'CSR Mismatch';
+          return el;
+        },
+      },
+    });
+    const router = createRouter(routes, '/');
+    let view: HTMLElement;
+    RouterContext.Provider(router, () => {
+      view = RouterView({ router });
+    });
+
+    endHydration();
+
+    // The <span> should be in the DOM despite the mismatch
+    expect(view!.children.length).toBe(1);
+    expect(view!.firstChild!.nodeName).toBe('SPAN');
+    expect(view!.textContent).toBe('CSR Mismatch');
+    router.dispose();
+  });
 });

--- a/packages/ui/src/router/outlet.ts
+++ b/packages/ui/src/router/outlet.ts
@@ -122,6 +122,16 @@ export function Outlet(): HTMLElement {
           });
         } else {
           __append(container, result);
+          // Safety fallback: if hydration suppressed __append and the node
+          // wasn't claimed from SSR (mismatch), fall back to CSR append.
+          // Guard on getIsHydrating() — outside hydration __append works
+          // normally and contains() may not exist (SSR shim).
+          if (getIsHydrating() && !container.contains(result)) {
+            while (container.firstChild) {
+              container.removeChild(container.firstChild);
+            }
+            container.appendChild(result);
+          }
           popScope();
         }
       } else {

--- a/packages/ui/src/router/router-view.ts
+++ b/packages/ui/src/router/router-view.ts
@@ -173,6 +173,16 @@ export function RouterView({ router, fallback }: RouterViewProps): HTMLElement {
             });
           } else {
             __append(container, result);
+            // Safety fallback: if hydration suppressed __append and the node
+            // wasn't claimed from SSR (mismatch), fall back to CSR append.
+            // Guard on getIsHydrating() — outside hydration __append works
+            // normally and contains() may not exist (SSR shim).
+            if (getIsHydrating() && !container.contains(result)) {
+              while (container.firstChild) {
+                container.removeChild(container.firstChild);
+              }
+              container.appendChild(result);
+            }
           }
         });
 


### PR DESCRIPTION
## Summary

- Add `container.contains(result)` mismatch fallback to the **sync path** in both `Outlet` and `RouterView`, matching the existing pattern used by the async path
- Guard the fallback with `getIsHydrating()` to avoid calling `contains()` on the SSR DOM shim (which doesn't implement it)

## What was happening

When a lazy parent route resolves and re-enters hydration (`startHydration(container)`), any **sync child** rendered inside that scope has `__append()` suppressed (because `getIsHydrating()` returns `true`). If the child's root element doesn't match the SSR node (tag mismatch or `document.createElement` instead of `__element`), the new node is never appended to the DOM — content silently disappears.

The async path already had a safety fallback (`if (!container.contains(node)) { ... appendChild ... }`), but the sync path at `outlet.ts:124` and `router-view.ts:175` did not.

## Public API Changes

None — internal hydration behavior fix only.

## Test plan

- [x] Outlet: sync child with mismatched tag during hydration → node appears in DOM
- [x] Outlet: sync child using `document.createElement` during hydration → node is appended
- [x] Outlet: sync child that claims SSR node → no double-append (regression guard)
- [x] RouterView: sync route with mismatched tag during hydration → node appears in DOM
- [x] SSR tests: `ui-server` SSR render tests still pass (no `contains()` crash on shim)

Fixes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)