### PR TITLE
feat(create-vertz-app): replace confirm() with AlertDialog and add hover state

### DIFF
--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -328,10 +328,13 @@ describe('templates', () => {
       expect(result).toContain('api.tasks.update');
     });
 
-    it('uses confirm dialog for delete', () => {
+    it('uses AlertDialog for delete confirmation', () => {
       const result = homePageTemplate();
       expect(result).toContain('api.tasks.delete');
-      expect(result).toContain('confirm(');
+      expect(result).toContain('AlertDialog');
+      expect(result).toContain('AlertDialog.Trigger');
+      expect(result).toContain('AlertDialog.Action');
+      expect(result).not.toContain('confirm(');
     });
 
     it('shows remaining task count', () => {
@@ -339,6 +342,11 @@ describe('templates', () => {
       expect(result).toContain('remaining');
       expect(result).toContain('.filter');
       expect(result).toContain('!t.completed');
+    });
+
+    it('has hover state on task items', () => {
+      const result = homePageTemplate();
+      expect(result).toContain('hover:bg:accent');
     });
 
     it('uses ListTransition for animated list', () => {

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -846,6 +846,7 @@ import { api } from '../client';
 import { themeComponents } from '../styles/theme';
 
 const { Button } = themeComponents;
+const { AlertDialog } = themeComponents.primitives;
 
 // Global CSS for list item enter/exit animations
 void globalCss({
@@ -886,6 +887,8 @@ const styles = css({
     'border:1',
     'border:border',
     'bg:card',
+    'hover:bg:accent',
+    'transition:colors',
   ],
   checkbox: ['w:4', 'h:4', 'cursor:pointer', 'rounded:sm'],
   label: ['flex-1', 'text:sm', 'text:foreground'],
@@ -908,9 +911,7 @@ function TaskItem({ id, title, completed }: TaskItemProps) {
   };
 
   const handleDelete = async () => {
-    if (confirm(\`Delete "\${title}"?\`)) {
-      await api.tasks.delete(id);
-    }
+    await api.tasks.delete(id);
   };
 
   return (
@@ -924,7 +925,21 @@ function TaskItem({ id, title, completed }: TaskItemProps) {
       <span className={completed ? styles.labelDone : styles.label}>
         {title}
       </span>
-      <Button intent="ghost" size="sm" onClick={handleDelete}>Delete</Button>
+      <AlertDialog onAction={handleDelete}>
+        <AlertDialog.Trigger>
+          <Button intent="ghost" size="sm">Delete</Button>
+        </AlertDialog.Trigger>
+        <AlertDialog.Content>
+          <AlertDialog.Title>Delete task?</AlertDialog.Title>
+          <AlertDialog.Description>
+            This action cannot be undone.
+          </AlertDialog.Description>
+          <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action>Delete</AlertDialog.Action>
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #1299

The scaffold template's delete confirmation used browser `confirm()` instead of showcasing the Vertz AlertDialog component. This PR:

- **Replaces `confirm()` with composable `<AlertDialog>`** — uses `AlertDialog.Trigger`, `AlertDialog.Content`, `AlertDialog.Title`, `AlertDialog.Description`, `AlertDialog.Footer`, `AlertDialog.Cancel`, and `AlertDialog.Action` sub-components to demonstrate the framework's dialog stack
- **Adds hover state to task items** — `hover:bg:accent` with `transition:colors` for smooth visual feedback
- **Updates tests** to verify AlertDialog usage and hover state

## Public API Changes

None — template string output only. No runtime API changes.

## Test plan

- [x] All 76 template tests pass (including updated AlertDialog and new hover tests)
- [x] Lint clean (`bunx biome check` — no errors)
- [x] Pre-push quality gates pass (turbo lint, build, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)