### PR TITLE
fix(ui-primitives): low-level Radio.Item disabled support + keyboard nav skip (#1379)

### DIFF
--- a/.changeset/radio-disabled-nav.md
+++ b/.changeset/radio-disabled-nav.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Add disabled item support to low-level Radio.Item and skip disabled items in handleListNavigation keyboard navigation

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -93,7 +93,7 @@ export type { ProgressElements, ProgressOptions, ProgressState } from './progres
 export { Progress } from './progress/progress';
 export type { ComposedProgressProps, ProgressClasses } from './progress/progress-composed';
 export { ComposedProgress } from './progress/progress-composed';
-export type { RadioElements, RadioOptions, RadioState } from './radio/radio';
+export type { RadioElements, RadioItemOptions, RadioOptions, RadioState } from './radio/radio';
 export { Radio } from './radio/radio';
 export type { ComposedRadioGroupProps, RadioGroupClasses } from './radio/radio-composed';
 export { ComposedRadioGroup } from './radio/radio-composed';

--- a/packages/ui-primitives/src/radio/__tests__/radio.test.ts
+++ b/packages/ui-primitives/src/radio/__tests__/radio.test.ts
@@ -87,6 +87,106 @@ describe('Radio', () => {
     expect(item2.getAttribute('data-state')).toBe('unchecked');
   });
 
+  describe('disabled items', () => {
+    it('sets aria-disabled="true" when disabled option is passed', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item = Item('opt1', 'Option 1', { disabled: true });
+
+      expect(item.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('sets data-disabled attribute when disabled', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item = Item('opt1', 'Option 1', { disabled: true });
+
+      expect(item.getAttribute('data-disabled')).toBe('');
+    });
+
+    it('does not select disabled item on click', () => {
+      const onValueChange = vi.fn();
+      const { root, state, Item } = Radio.Root({ onValueChange });
+      container.appendChild(root);
+      Item('opt1', 'Option 1', { disabled: true });
+      Item('opt2', 'Option 2');
+
+      // Click the disabled item
+      root
+        .querySelector('[data-value="opt1"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(state.value.peek()).toBe('');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('skips disabled items when navigating with ArrowDown', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item1 = Item('opt1', 'Option 1');
+      Item('opt2', 'Option 2', { disabled: true });
+      const item3 = Item('opt3', 'Option 3');
+
+      container.appendChild(root);
+      item1.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(document.activeElement).toBe(item3);
+    });
+
+    it('skips disabled items when navigating with ArrowUp', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item1 = Item('opt1', 'Option 1');
+      Item('opt2', 'Option 2', { disabled: true });
+      const item3 = Item('opt3', 'Option 3');
+
+      item3.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+      expect(document.activeElement).toBe(item1);
+    });
+
+    it('skips disabled items when looping forward', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item1 = Item('opt1', 'Option 1');
+      const item2 = Item('opt2', 'Option 2');
+      Item('opt3', 'Option 3', { disabled: true });
+
+      item2.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(document.activeElement).toBe(item1);
+    });
+
+    it('skips disabled items with Home key', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      Item('opt1', 'Option 1', { disabled: true });
+      const item2 = Item('opt2', 'Option 2');
+      const item3 = Item('opt3', 'Option 3');
+
+      item3.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+
+      expect(document.activeElement).toBe(item2);
+    });
+
+    it('skips disabled items with End key', () => {
+      const { root, Item } = Radio.Root();
+      container.appendChild(root);
+      const item1 = Item('opt1', 'Option 1');
+      Item('opt2', 'Option 2');
+      Item('opt3', 'Option 3', { disabled: true });
+
+      item1.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+
+      expect(document.activeElement).toBe(root.querySelector('[data-value="opt2"]'));
+    });
+  });
+
   describe('Given a Radio group with items', () => {
     describe('When destroy() is called', () => {
       it('Then removes click event listeners from items', () => {

--- a/packages/ui-primitives/src/radio/radio.tsx
+++ b/packages/ui-primitives/src/radio/radio.tsx
@@ -5,7 +5,7 @@
 
 import type { Signal } from '@vertz/ui';
 import { signal } from '@vertz/ui';
-import { setChecked, setDataState } from '../utils/aria';
+import { setChecked, setDataState, setDisabled } from '../utils/aria';
 import type { ElementAttrs } from '../utils/attrs';
 import { applyAttrs } from '../utils/attrs';
 import { setRovingTabindex } from '../utils/focus';
@@ -48,13 +48,18 @@ function RadioGroup(
   ) as HTMLElement;
 }
 
+export interface RadioItemOptions {
+  disabled?: boolean;
+}
+
 function RadioItem(
   value: string,
   label: string | undefined,
   isActive: boolean,
+  disabled: boolean,
   selectItem: (value: string) => void,
 ): HTMLElement {
-  return (
+  const el = (
     <div
       role="radio"
       id={uniqueId('radio')}
@@ -62,17 +67,24 @@ function RadioItem(
       aria-checked={isActive ? 'true' : 'false'}
       data-state={isActive ? 'checked' : 'unchecked'}
       onClick={() => {
-        selectItem(value);
+        if (!disabled) selectItem(value);
       }}
     >
       {label ?? value}
     </div>
   ) as HTMLElement;
+
+  if (disabled) {
+    setDisabled(el, true);
+    el.setAttribute('data-disabled', '');
+  }
+
+  return el;
 }
 
 function RadioRoot(options: RadioOptions = {}): RadioElements & {
   state: RadioState;
-  Item: (value: string, label?: string) => HTMLElement;
+  Item: (value: string, label?: string, itemOptions?: RadioItemOptions) => HTMLElement;
   destroy: () => void;
 } {
   const { defaultValue = '', onValueChange, ...attrs } = options;
@@ -96,12 +108,13 @@ function RadioRoot(options: RadioOptions = {}): RadioElements & {
   const root = RadioGroup(items, itemValues, selectItem);
   const cleanups: (() => void)[] = [];
 
-  function Item(value: string, label?: string): HTMLElement {
+  function Item(value: string, label?: string, itemOptions?: RadioItemOptions): HTMLElement {
     const isActive = value === state.value.peek();
+    const disabled = itemOptions?.disabled ?? false;
 
-    const item = RadioItem(value, label, isActive, selectItem);
+    const item = RadioItem(value, label, isActive, disabled, selectItem);
     const handleClick = () => {
-      item.focus();
+      if (!disabled) item.focus();
     };
     item.addEventListener('click', handleClick);
     cleanups.push(() => item.removeEventListener('click', handleClick));
@@ -129,7 +142,7 @@ function RadioRoot(options: RadioOptions = {}): RadioElements & {
 export const Radio: {
   Root: (options?: RadioOptions) => RadioElements & {
     state: RadioState;
-    Item: (value: string, label?: string) => HTMLElement;
+    Item: (value: string, label?: string, itemOptions?: RadioItemOptions) => HTMLElement;
     destroy: () => void;
   };
 } = {

--- a/packages/ui-primitives/src/utils/keyboard.ts
+++ b/packages/ui-primitives/src/utils/keyboard.ts
@@ -50,24 +50,16 @@ export function handleListNavigation(
 
   if (isKey(event, prevKey)) {
     event.preventDefault();
-    if (currentIndex <= 0) {
-      nextIndex = loop ? items.length - 1 : 0;
-    } else {
-      nextIndex = currentIndex - 1;
-    }
+    nextIndex = findEnabled(items, currentIndex, -1, loop);
   } else if (isKey(event, nextKey)) {
     event.preventDefault();
-    if (currentIndex >= items.length - 1) {
-      nextIndex = loop ? 0 : items.length - 1;
-    } else {
-      nextIndex = currentIndex + 1;
-    }
+    nextIndex = findEnabled(items, currentIndex, 1, loop);
   } else if (isKey(event, Keys.Home)) {
     event.preventDefault();
-    nextIndex = 0;
+    nextIndex = findEnabledFrom(items, 0, 1);
   } else if (isKey(event, Keys.End)) {
     event.preventDefault();
-    nextIndex = items.length - 1;
+    nextIndex = findEnabledFrom(items, items.length - 1, -1);
   }
 
   const target = items[nextIndex];
@@ -77,6 +69,43 @@ export function handleListNavigation(
   }
 
   return null;
+}
+
+function isDisabled(el: HTMLElement): boolean {
+  return el.getAttribute('aria-disabled') === 'true';
+}
+
+function findEnabled(
+  items: HTMLElement[],
+  current: number,
+  direction: 1 | -1,
+  loop: boolean,
+): number {
+  const len = items.length;
+  let candidate = current;
+  for (let i = 0; i < len; i++) {
+    candidate += direction;
+    if (loop) {
+      candidate = ((candidate % len) + len) % len;
+    } else if (candidate < 0 || candidate >= len) {
+      return -1;
+    }
+    const el = items[candidate];
+    if (el && !isDisabled(el)) return candidate;
+  }
+  return -1;
+}
+
+function findEnabledFrom(items: HTMLElement[], start: number, direction: 1 | -1): number {
+  const len = items.length;
+  let candidate = start;
+  for (let i = 0; i < len; i++) {
+    if (candidate < 0 || candidate >= len) return -1;
+    const el = items[candidate];
+    if (el && !isDisabled(el)) return candidate;
+    candidate += direction;
+  }
+  return -1;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `Radio.Item()` now accepts an optional `{ disabled: true }` third parameter
- Disabled items get `aria-disabled="true"` and `data-disabled` attributes
- Disabled items cannot be selected via click
- `handleListNavigation()` in `utils/keyboard.ts` now skips items with `aria-disabled="true"` for all navigation keys (ArrowUp/Down, Home/End, loop wrapping)
- Export `RadioItemOptions` type from package index

## Public API Changes

- **Addition:** `Radio.Item(value, label?, { disabled?: boolean })` — new optional third parameter
- **Addition:** `RadioItemOptions` type exported from `@vertz/ui-primitives`
- **Behavioral:** `handleListNavigation()` now skips `aria-disabled="true"` items — backward compatible since items without `aria-disabled` are unaffected

## Test plan

- [x] Disabled item sets `aria-disabled="true"` and `data-disabled`
- [x] Disabled item ignores click (value unchanged, callback not called)
- [x] ArrowDown skips disabled items
- [x] ArrowUp skips disabled items
- [x] Loop wrapping skips disabled items
- [x] Home key skips disabled first item
- [x] End key skips disabled last item
- [x] All existing Radio tests still pass (16/16)
- [x] Full ui-primitives suite passes (605/605)
- [x] Typecheck clean
- [x] Biome lint clean

Fixes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)