### PR TITLE
chore(ui-primitives): strip bare chunk imports from barrel for clean tree-shaking

### DIFF
--- a/.changeset/strip-bare-chunk-imports.md
+++ b/.changeset/strip-bare-chunk-imports.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Strip redundant bare chunk imports from barrel output and revert sideEffects to false for optimal tree-shaking

--- a/packages/ui-primitives/bunup.config.ts
+++ b/packages/ui-primitives/bunup.config.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createVertzLibraryPlugin } from '@vertz/ui-compiler';
+import type { BunupPlugin } from 'bunup';
 import { defineConfig } from 'bunup';
 
 // Auto-discover component entries: each src/<component>/<component>.ts(x) file.
@@ -11,9 +12,35 @@ const componentEntries = readdirSync('src', { withFileTypes: true })
     return existsSync(tsx) ? [tsx] : [ts];
   });
 
+/**
+ * Strips bare `import"../shared/chunk-*.js"` statements from entry-point files.
+ *
+ * bunup's multi-entry code splitting emits bare imports in the barrel for shared
+ * utility chunks whose exports aren't directly re-exported. These are unnecessary —
+ * every component chunk already imports its needed utilities via named imports.
+ * The bare imports prevent tree-shaking when `sideEffects: false` is set.
+ */
+function stripBareChunkImports(): BunupPlugin {
+  return {
+    name: 'strip-bare-chunk-imports',
+    hooks: {
+      onBuildDone: ({ files }) => {
+        for (const file of files) {
+          if (file.kind !== 'entry-point' || !file.fullPath.endsWith('.js')) continue;
+          const content = readFileSync(file.fullPath, 'utf8');
+          const cleaned = content.replace(/^import\s*"[^"]*chunk-[^"]*\.js";\n?/gm, '');
+          if (cleaned !== content) {
+            writeFileSync(file.fullPath, cleaned);
+          }
+        }
+      },
+    },
+  };
+}
+
 export default defineConfig({
   entry: ['src/index.ts', 'src/utils.ts', ...componentEntries],
   dts: true,
-  plugins: [createVertzLibraryPlugin()],
+  plugins: [createVertzLibraryPlugin(), stripBareChunkImports()],
   external: ['@vertz/ui', '@vertz/ui/internals'],
 });

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -48,7 +48,5 @@
   "engines": {
     "node": ">=22"
   },
-  "sideEffects": [
-    "./dist/shared/*.js"
-  ]
+  "sideEffects": false
 }


### PR DESCRIPTION
## Summary

- Add a bunup `onBuildDone` plugin (`stripBareChunkImports`) that removes redundant bare `import"../shared/chunk-*.js"` statements from entry-point files after build
- Revert `sideEffects` from `["./dist/shared/*.js"]` back to `false` for optimal tree-shaking with zero esbuild warnings

## Public API Changes

- `sideEffects` in `package.json` changed from `["./dist/shared/*.js"]` to `false` — consumers get better tree-shaking

## Why

bunup's multi-entry code splitting emits bare side-effect-only imports in the barrel for shared utility chunks. These are unnecessary — every component chunk already imports its needed utilities via named imports. The bare imports caused esbuild `ignored-bare-import` warnings when `sideEffects: false` was set, which PR #1175 worked around by marking shared chunks as having side effects. This PR eliminates the root cause instead.

## Test plan

- [x] `ignored-bare-import` warning regression test passes (zero warnings)
- [x] Single-import bundle ratio unchanged at 56.9% (pre-existing, not affected by this change)
- [x] All 605 ui-primitives unit tests pass
- [x] Full quality gates pass (lint + typecheck + test + build)

Fixes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)