### PR TITLE
feat(linear): inline status/priority mutations with optimistic updates

### DIFF
--- a/examples/linear/src/components/edit-issue-dialog.tsx
+++ b/examples/linear/src/components/edit-issue-dialog.tsx
@@ -1,0 +1,155 @@
+import type { DialogHandle } from '@vertz/ui';
+import { css } from '@vertz/ui';
+import { api } from '../api/client';
+import { editIssueSchema } from '../lib/edit-issue-schema';
+import { PRIORITIES, STATUSES } from '../lib/issue-config';
+import type { Issue } from '../lib/types';
+import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
+import { Button } from './button';
+
+const styles = css({
+  formError: ['text:sm', 'text:destructive', 'mb:4'],
+});
+
+interface EditIssueDialogProps {
+  issue: Issue;
+  dialog: DialogHandle<boolean>;
+}
+
+export function EditIssueDialog({ issue, dialog }: EditIssueDialogProps) {
+  let submitting = false;
+  let formError = '';
+  let titleError = '';
+
+  const handleSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    formError = '';
+    titleError = '';
+
+    const formData = new FormData(e.target as HTMLFormElement);
+    const data = Object.fromEntries(formData.entries());
+
+    const result = editIssueSchema.parse(data);
+    if (!result.ok) {
+      const err = result.error as Error & { fieldErrors?: Record<string, string> };
+      if (err.fieldErrors?.title) {
+        titleError = err.fieldErrors.title;
+      }
+      formError = err.message;
+      return;
+    }
+
+    submitting = true;
+    const res = await api.issues.update(issue.id, result.data);
+    submitting = false;
+
+    if (!res.ok) {
+      formError = 'Failed to save changes';
+      return;
+    }
+
+    dialog.close(true);
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: dialog overlay backdrop
+    <div
+      className={dialogStyles.overlay}
+      data-state="open"
+      role="presentation"
+      onClick={(e: MouseEvent) => {
+        if (e.target === e.currentTarget) dialog.close(false);
+      }}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === 'Escape') dialog.close(false);
+      }}
+    >
+      <div
+        className={dialogStyles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Edit Issue"
+        data-state="open"
+      >
+        <h3 className={dialogStyles.title}>Edit Issue</h3>
+        <form onSubmit={handleSubmit}>
+          {formError && <div className={styles.formError}>{formError}</div>}
+
+          <div className={formStyles.field}>
+            <label className={labelStyles.base} htmlFor="edit-issue-title">
+              Title
+            </label>
+            <input
+              className={inputStyles.base}
+              id="edit-issue-title"
+              name="title"
+              value={issue.title}
+              placeholder="Issue title"
+            />
+            {titleError && <span className={formStyles.error}>{titleError}</span>}
+          </div>
+
+          <div className={formStyles.field}>
+            <label className={labelStyles.base} htmlFor="edit-issue-description">
+              Description
+            </label>
+            <textarea
+              className={inputStyles.base}
+              id="edit-issue-description"
+              name="description"
+              placeholder="Optional description"
+              style="min-height: 5rem; resize: vertical"
+            >
+              {issue.description ?? ''}
+            </textarea>
+          </div>
+
+          <div className={formStyles.field}>
+            <label className={labelStyles.base} htmlFor="edit-issue-status">
+              Status
+            </label>
+            <select
+              className={formStyles.select}
+              id="edit-issue-status"
+              name="status"
+              value={issue.status}
+            >
+              {STATUSES.map((s) => (
+                <option value={s.value} key={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={formStyles.field}>
+            <label className={labelStyles.base} htmlFor="edit-issue-priority">
+              Priority
+            </label>
+            <select
+              className={formStyles.select}
+              id="edit-issue-priority"
+              name="priority"
+              value={issue.priority}
+            >
+              {PRIORITIES.map((p) => (
+                <option value={p.value} key={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <footer className={dialogStyles.footer}>
+            <Button intent="outline" size="sm" onClick={() => dialog.close(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" intent="primary" size="sm" disabled={submitting}>
+              {submitting ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/examples/linear/src/components/issue-card.tsx
+++ b/examples/linear/src/components/issue-card.tsx
@@ -1,6 +1,6 @@
 import { css } from '@vertz/ui';
-import { PRIORITY_CONFIG } from '../lib/issue-config';
-import type { Issue } from '../lib/types';
+import { PRIORITIES, PRIORITY_CONFIG, STATUSES } from '../lib/issue-config';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 
 const styles = css({
   card: [
@@ -16,31 +16,88 @@ const styles = css({
   identifier: ['text:xs', 'text:muted-foreground', 'mb:1'],
   title: ['text:sm', 'text:foreground', 'font:medium'],
   meta: ['flex', 'items:center', 'gap:2', 'mt:2'],
+  inlineSelect: [
+    'text:xs',
+    'bg:transparent',
+    'border:0',
+    'cursor:pointer',
+    'text:muted-foreground',
+    'outline:none',
+    'p:0',
+  ],
   priority: ['text:xs', 'font:medium'],
 });
 
 interface IssueCardProps {
   issue: Issue;
   projectKey?: string;
+  onStatusChange?: (issueId: string, status: IssueStatus) => void;
+  onPriorityChange?: (issueId: string, priority: IssuePriority) => void;
 }
 
-export function IssueCard({ issue, projectKey }: IssueCardProps) {
+export function IssueCard({ issue, projectKey, onStatusChange, onPriorityChange }: IssueCardProps) {
   const identifier = projectKey ? `${projectKey}-${issue.number}` : `#${issue.number}`;
+
+  const stopPropagation = (e: Event) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   return (
     <div className={styles.card}>
       <div className={styles.identifier}>{identifier}</div>
       <div className={styles.title}>{issue.title}</div>
-      {issue.priority !== 'none' && PRIORITY_CONFIG[issue.priority] && (
-        <div className={styles.meta}>
-          <span
-            className={styles.priority}
-            style={`color: ${PRIORITY_CONFIG[issue.priority].color}`}
+      <div className={styles.meta}>
+        {onStatusChange ? (
+          <select
+            className={styles.inlineSelect}
+            value={issue.status}
+            onClick={stopPropagation}
+            onChange={(e: Event) => {
+              e.stopPropagation();
+              onStatusChange(issue.id, (e.target as HTMLSelectElement).value as IssueStatus);
+            }}
           >
-            {PRIORITY_CONFIG[issue.priority].label}
-          </span>
-        </div>
-      )}
+            {STATUSES.map((s) => (
+              <option value={s.value} key={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        {onPriorityChange ? (
+          <select
+            className={styles.inlineSelect}
+            value={issue.priority}
+            onClick={stopPropagation}
+            onChange={(e: Event) => {
+              e.stopPropagation();
+              onPriorityChange(issue.id, (e.target as HTMLSelectElement).value as IssuePriority);
+            }}
+            style={
+              issue.priority !== 'none' && PRIORITY_CONFIG[issue.priority]
+                ? `color: ${PRIORITY_CONFIG[issue.priority].color}`
+                : ''
+            }
+          >
+            {PRIORITIES.map((p) => (
+              <option value={p.value} key={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        ) : (
+          issue.priority !== 'none' &&
+          PRIORITY_CONFIG[issue.priority] && (
+            <span
+              className={styles.priority}
+              style={`color: ${PRIORITY_CONFIG[issue.priority].color}`}
+            >
+              {PRIORITY_CONFIG[issue.priority].label}
+            </span>
+          )
+        )}
+      </div>
     </div>
   );
 }

--- a/examples/linear/src/components/issue-row.tsx
+++ b/examples/linear/src/components/issue-row.tsx
@@ -1,6 +1,12 @@
 import { css } from '@vertz/ui';
-import { PRIORITY_CONFIG, STATUS_COLORS, STATUS_LABELS } from '../lib/issue-config';
-import type { Issue } from '../lib/types';
+import {
+  PRIORITIES,
+  PRIORITY_CONFIG,
+  STATUS_COLORS,
+  STATUS_LABELS,
+  STATUSES,
+} from '../lib/issue-config';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 
 const styles = css({
   row: [
@@ -17,6 +23,16 @@ const styles = css({
   ],
   identifier: ['text:xs', 'text:muted-foreground', 'w:20', 'shrink-0'],
   title: ['text:sm', 'text:foreground', 'flex-1', 'overflow-hidden', 'whitespace-nowrap'],
+  inlineSelect: [
+    'text:xs',
+    'bg:transparent',
+    'border:0',
+    'cursor:pointer',
+    'text:muted-foreground',
+    'outline:none',
+    'shrink-0',
+    'p:0',
+  ],
   status: ['text:xs', 'px:2', 'py:0.5', 'rounded:full', 'shrink-0'],
   priority: ['text:xs', 'shrink-0', 'font:medium'],
 });
@@ -24,22 +40,74 @@ const styles = css({
 interface IssueRowProps {
   issue: Issue;
   projectKey?: string;
+  onStatusChange?: (issueId: string, status: IssueStatus) => void;
+  onPriorityChange?: (issueId: string, priority: IssuePriority) => void;
 }
 
-export function IssueRow({ issue, projectKey }: IssueRowProps) {
+export function IssueRow({ issue, projectKey, onStatusChange, onPriorityChange }: IssueRowProps) {
   const identifier = projectKey ? `${projectKey}-${issue.number}` : `#${issue.number}`;
+
+  const stopPropagation = (e: Event) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   return (
     <div className={styles.row}>
       <span className={styles.identifier}>{identifier}</span>
       <span className={styles.title}>{issue.title}</span>
-      <span className={`${styles.status} ${STATUS_COLORS[issue.status] ?? ''}`}>
-        {STATUS_LABELS[issue.status] ?? issue.status}
-      </span>
-      {issue.priority !== 'none' && PRIORITY_CONFIG[issue.priority] && (
-        <span className={styles.priority} style={`color: ${PRIORITY_CONFIG[issue.priority].color}`}>
-          {PRIORITY_CONFIG[issue.priority].label}
+      {onStatusChange ? (
+        <select
+          className={styles.inlineSelect}
+          value={issue.status}
+          onClick={stopPropagation}
+          onChange={(e: Event) => {
+            e.stopPropagation();
+            onStatusChange(issue.id, (e.target as HTMLSelectElement).value as IssueStatus);
+          }}
+        >
+          {STATUSES.map((s) => (
+            <option value={s.value} key={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <span className={`${styles.status} ${STATUS_COLORS[issue.status] ?? ''}`}>
+          {STATUS_LABELS[issue.status] ?? issue.status}
         </span>
+      )}
+      {onPriorityChange ? (
+        <select
+          className={styles.inlineSelect}
+          value={issue.priority}
+          onClick={stopPropagation}
+          onChange={(e: Event) => {
+            e.stopPropagation();
+            onPriorityChange(issue.id, (e.target as HTMLSelectElement).value as IssuePriority);
+          }}
+          style={
+            issue.priority !== 'none' && PRIORITY_CONFIG[issue.priority]
+              ? `color: ${PRIORITY_CONFIG[issue.priority].color}`
+              : ''
+          }
+        >
+          {PRIORITIES.map((p) => (
+            <option value={p.value} key={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        issue.priority !== 'none' &&
+        PRIORITY_CONFIG[issue.priority] && (
+          <span
+            className={styles.priority}
+            style={`color: ${PRIORITY_CONFIG[issue.priority].color}`}
+          >
+            {PRIORITY_CONFIG[issue.priority].label}
+          </span>
+        )
       )}
     </div>
   );

--- a/examples/linear/src/components/status-column.tsx
+++ b/examples/linear/src/components/status-column.tsx
@@ -1,5 +1,5 @@
 import { css, Link } from '@vertz/ui';
-import type { Issue } from '../lib/types';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 import { IssueCard } from './issue-card';
 
 const styles = css({
@@ -16,9 +16,18 @@ interface StatusColumnProps {
   issues: Issue[];
   projectKey?: string;
   projectId: string;
+  onStatusChange?: (issueId: string, status: IssueStatus) => void;
+  onPriorityChange?: (issueId: string, priority: IssuePriority) => void;
 }
 
-export function StatusColumn({ label, issues, projectKey, projectId }: StatusColumnProps) {
+export function StatusColumn({
+  label,
+  issues,
+  projectKey,
+  projectId,
+  onStatusChange,
+  onPriorityChange,
+}: StatusColumnProps) {
   return (
     <div className={styles.column}>
       <div className={styles.columnHeader}>
@@ -29,7 +38,12 @@ export function StatusColumn({ label, issues, projectKey, projectId }: StatusCol
         {issues.length === 0 && <div className={styles.empty}>No issues</div>}
         {issues.map((issue) => (
           <Link href={`/projects/${projectId}/issues/${issue.id}`} key={issue.id}>
-            <IssueCard issue={issue} projectKey={projectKey} />
+            <IssueCard
+              issue={issue}
+              projectKey={projectKey}
+              onStatusChange={onStatusChange}
+              onPriorityChange={onPriorityChange}
+            />
           </Link>
         ))}
       </div>

--- a/examples/linear/src/lib/edit-issue-schema.test.ts
+++ b/examples/linear/src/lib/edit-issue-schema.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test';
+import { editIssueSchema } from './edit-issue-schema';
+
+describe('editIssueSchema', () => {
+  describe('Given valid issue data', () => {
+    it('returns ok with parsed data for a complete update', () => {
+      const result = editIssueSchema.parse({
+        title: 'Updated title',
+        description: 'Updated description',
+        status: 'in_progress',
+        priority: 'high',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.title).toBe('Updated title');
+        expect(result.data.description).toBe('Updated description');
+        expect(result.data.status).toBe('in_progress');
+        expect(result.data.priority).toBe('high');
+      }
+    });
+
+    it('trims whitespace from title and description', () => {
+      const result = editIssueSchema.parse({
+        title: '  Trimmed title  ',
+        description: '  Trimmed desc  ',
+        status: 'todo',
+        priority: 'none',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.title).toBe('Trimmed title');
+        expect(result.data.description).toBe('Trimmed desc');
+      }
+    });
+
+    it('allows empty description', () => {
+      const result = editIssueSchema.parse({
+        title: 'Title',
+        description: '',
+        status: 'backlog',
+        priority: 'none',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.description).toBeUndefined();
+      }
+    });
+  });
+
+  describe('Given invalid issue data', () => {
+    it('returns error when title is empty', () => {
+      const result = editIssueSchema.parse({
+        title: '',
+        status: 'todo',
+        priority: 'none',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const err = result.error as Error & { fieldErrors: Record<string, string> };
+        expect(err.fieldErrors.title).toBe('Title is required');
+      }
+    });
+
+    it('returns error when title is missing', () => {
+      const result = editIssueSchema.parse({
+        status: 'todo',
+        priority: 'none',
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns error for invalid status', () => {
+      const result = editIssueSchema.parse({
+        title: 'Title',
+        status: 'invalid_status',
+        priority: 'none',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const err = result.error as Error & { fieldErrors: Record<string, string> };
+        expect(err.fieldErrors.status).toBe('Invalid status');
+      }
+    });
+
+    it('returns error for invalid priority', () => {
+      const result = editIssueSchema.parse({
+        title: 'Title',
+        status: 'todo',
+        priority: 'invalid_priority',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const err = result.error as Error & { fieldErrors: Record<string, string> };
+        expect(err.fieldErrors.priority).toBe('Invalid priority');
+      }
+    });
+
+    it('returns error for non-object data', () => {
+      const result = editIssueSchema.parse(null);
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/examples/linear/src/lib/edit-issue-schema.ts
+++ b/examples/linear/src/lib/edit-issue-schema.ts
@@ -1,0 +1,54 @@
+import type { FormSchema } from '@vertz/ui';
+import type { IssuePriority, IssueStatus } from './types';
+
+const VALID_STATUSES: IssueStatus[] = ['backlog', 'todo', 'in_progress', 'done', 'cancelled'];
+const VALID_PRIORITIES: IssuePriority[] = ['urgent', 'high', 'medium', 'low', 'none'];
+
+export interface EditIssueInput {
+  title: string;
+  description?: string;
+  status: string;
+  priority: string;
+}
+
+export const editIssueSchema: FormSchema<EditIssueInput> = {
+  parse(data: unknown) {
+    if (typeof data !== 'object' || data === null) {
+      return { ok: false as const, error: new Error('Invalid form data') };
+    }
+    const obj = data as Record<string, unknown>;
+    const errors: Record<string, string> = {};
+
+    if (!obj.title || typeof obj.title !== 'string' || obj.title.trim().length === 0) {
+      errors.title = 'Title is required';
+    }
+
+    const status = (obj.status as string) || 'backlog';
+    if (!VALID_STATUSES.includes(status as IssueStatus)) {
+      errors.status = 'Invalid status';
+    }
+
+    const priority = (obj.priority as string) || 'none';
+    if (!VALID_PRIORITIES.includes(priority as IssuePriority)) {
+      errors.priority = 'Invalid priority';
+    }
+
+    if (Object.keys(errors).length > 0) {
+      const err = new Error('Validation failed');
+      (err as Error & { fieldErrors: Record<string, string> }).fieldErrors = errors;
+      return { ok: false as const, error: err };
+    }
+
+    const description = obj.description ? String(obj.description).trim() : undefined;
+
+    return {
+      ok: true as const,
+      data: {
+        title: (obj.title as string).trim(),
+        description: description || undefined,
+        status,
+        priority,
+      },
+    };
+  },
+};

--- a/examples/linear/src/lib/issue-config.ts
+++ b/examples/linear/src/lib/issue-config.ts
@@ -24,6 +24,14 @@ export const STATUS_COLORS: Record<IssueStatus, string> = {
   cancelled: 'bg:muted text:muted-foreground',
 };
 
+export const PRIORITIES: { value: IssuePriority; label: string }[] = [
+  { value: 'none', label: 'None' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
 export const PRIORITY_CONFIG: Record<IssuePriority, { label: string; color: string }> = {
   urgent: { label: 'Urgent', color: '#ef4444' },
   high: { label: 'High', color: '#f97316' },

--- a/examples/linear/src/pages/issue-detail-page.tsx
+++ b/examples/linear/src/pages/issue-detail-page.tsx
@@ -1,9 +1,11 @@
-import { css, query, useParams } from '@vertz/ui';
+import { css, query, useDialogStack, useParams } from '@vertz/ui';
 import { api } from '../api/client';
+import { Button } from '../components/button';
 import { CommentSection } from '../components/comment-section';
+import { EditIssueDialog } from '../components/edit-issue-dialog';
 import { PrioritySelect } from '../components/priority-select';
 import { StatusSelect } from '../components/status-select';
-import type { IssuePriority, IssueStatus } from '../lib/types';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 
 const styles = css({
   container: ['p:6'],
@@ -12,7 +14,8 @@ const styles = css({
   layout: ['flex', 'gap:8'],
   main: ['flex-1'],
   identifier: ['text:sm', 'text:muted-foreground', 'mb:2'],
-  title: ['font:xl', 'font:bold', 'text:foreground', 'mb:4'],
+  titleRow: ['flex', 'items:center', 'gap:3', 'mb:4'],
+  title: ['font:xl', 'font:bold', 'text:foreground'],
   description: ['text:sm', 'text:foreground', 'leading:relaxed'],
   noDescription: ['text:sm', 'text:muted-foreground', 'italic'],
   sidebar: [
@@ -36,6 +39,7 @@ export function IssueDetailPage() {
   const project = query(api.projects.get(projectId));
   const comments = query(api.comments.list({ issueId }));
   const users = query(api.users.list());
+  const stack = useDialogStack();
 
   let updateError = '';
 
@@ -71,6 +75,18 @@ export function IssueDetailPage() {
     issue.refetch();
   };
 
+  const handleEdit = async () => {
+    if (!issue.data) return;
+    try {
+      const updated = await stack.open(EditIssueDialog, {
+        issue: issue.data as Issue,
+      });
+      if (updated) issue.refetch();
+    } catch {
+      // Dialog dismissed — no action needed
+    }
+  };
+
   return (
     <div className={styles.container}>
       {issue.loading && <div className={styles.loading}>Loading issue...</div>}
@@ -85,7 +101,12 @@ export function IssueDetailPage() {
             <div className={styles.identifier}>
               {`${project.data?.key ?? '...'}-${issue.data.number}`}
             </div>
-            <h2 className={styles.title}>{issue.data.title}</h2>
+            <div className={styles.titleRow}>
+              <h2 className={styles.title}>{issue.data.title}</h2>
+              <Button intent="outline" size="sm" onClick={handleEdit}>
+                Edit
+              </Button>
+            </div>
             {issue.data.description ? (
               <p className={styles.description}>{issue.data.description}</p>
             ) : (

--- a/examples/linear/src/pages/issue-list-page.tsx
+++ b/examples/linear/src/pages/issue-list-page.tsx
@@ -5,7 +5,7 @@ import { CreateIssueDialog } from '../components/create-issue-dialog';
 import { IssueRow } from '../components/issue-row';
 import { StatusFilter } from '../components/status-filter';
 import { ViewToggle } from '../components/view-toggle';
-import type { Issue } from '../lib/types';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 import { emptyStateStyles } from '../styles/components';
 
 const styles = css({
@@ -29,6 +29,21 @@ export function IssueListPage() {
     statusFilter === 'all'
       ? issues.data?.items
       : issues.data?.items.filter((i) => i.status === statusFilter);
+
+  const handleStatusChange = async (issueId: string, status: IssueStatus) => {
+    const res = await api.issues.update(issueId, { status });
+    if (!res.ok) {
+      console.error('Failed to update status');
+    }
+    // MutationEventBus auto-triggers query revalidation
+  };
+
+  const handlePriorityChange = async (issueId: string, priority: IssuePriority) => {
+    const res = await api.issues.update(issueId, { priority });
+    if (!res.ok) {
+      console.error('Failed to update priority');
+    }
+  };
 
   const handleNewIssue = async () => {
     try {
@@ -82,7 +97,12 @@ export function IssueListPage() {
         <div className={styles.list}>
           {filtered.map((issue) => (
             <Link href={`/projects/${projectId}/issues/${issue.id}`} key={issue.id}>
-              <IssueRow issue={issue as Issue} projectKey={project.data?.key} />
+              <IssueRow
+                issue={issue as Issue}
+                projectKey={project.data?.key}
+                onStatusChange={handleStatusChange}
+                onPriorityChange={handlePriorityChange}
+              />
             </Link>
           ))}
         </div>

--- a/examples/linear/src/pages/project-board-page.tsx
+++ b/examples/linear/src/pages/project-board-page.tsx
@@ -5,7 +5,7 @@ import { CreateIssueDialog } from '../components/create-issue-dialog';
 import { StatusColumn } from '../components/status-column';
 import { ViewToggle } from '../components/view-toggle';
 import { STATUSES } from '../lib/issue-config';
-import type { Issue, IssueStatus } from '../lib/types';
+import type { Issue, IssuePriority, IssueStatus } from '../lib/types';
 
 const styles = css({
   container: ['p:6'],
@@ -22,14 +22,59 @@ export function ProjectBoardPage() {
   const project = query(api.projects.get(projectId));
   const stack = useDialogStack();
 
-  // Group issues by status — declarative single-expression for compiler reactivity.
+  // Optimistic overrides for immediate column movement on status change.
+  // Reassigning the whole object triggers reactivity via compiler signal transform.
+  let optimisticStatuses: Record<string, IssueStatus> = {};
+  let optimisticPriorities: Record<string, IssuePriority> = {};
+
+  // Group issues by status — uses optimistic overrides for immediate column movement.
   // collectDeps() walks into the .map() callback body and finds issues.data,
-  // so the compiler correctly classifies `columns` as computed.
+  // optimisticStatuses, and optimisticPriorities, so the compiler correctly
+  // classifies `columns` as computed.
   const columns: { status: IssueStatus; label: string; items: Issue[] }[] = STATUSES.map((s) => ({
     status: s.value,
     label: s.label,
-    items: (issues.data?.items.filter((i) => i.status === s.value) ?? []) as Issue[],
+    items: (issues.data?.items
+      .filter((i) => (optimisticStatuses[i.id] ?? i.status) === s.value)
+      .map((i) => ({
+        ...i,
+        status: (optimisticStatuses[i.id] ?? i.status) as Issue['status'],
+        priority: (optimisticPriorities[i.id] ?? i.priority) as Issue['priority'],
+      })) ?? []) as Issue[],
   }));
+
+  const handleStatusChange = async (issueId: string, status: IssueStatus) => {
+    // Apply optimistic override — card moves to new column immediately
+    optimisticStatuses = { ...optimisticStatuses, [issueId]: status };
+
+    const res = await api.issues.update(issueId, { status });
+
+    // Clear optimistic override — let query data take over
+    const next = { ...optimisticStatuses };
+    delete next[issueId];
+    optimisticStatuses = next;
+
+    if (!res.ok) {
+      // Query data still has old value, so card reverts to original column
+      return;
+    }
+
+    // MutationEventBus auto-triggers revalidation for entity-backed queries
+  };
+
+  const handlePriorityChange = async (issueId: string, priority: IssuePriority) => {
+    optimisticPriorities = { ...optimisticPriorities, [issueId]: priority };
+
+    const res = await api.issues.update(issueId, { priority });
+
+    const next = { ...optimisticPriorities };
+    delete next[issueId];
+    optimisticPriorities = next;
+
+    if (!res.ok) {
+      return;
+    }
+  };
 
   const handleNewIssue = async () => {
     try {
@@ -64,6 +109,8 @@ export function ProjectBoardPage() {
               issues={col.items}
               projectKey={project.data?.key}
               projectId={projectId}
+              onStatusChange={handleStatusChange}
+              onPriorityChange={handlePriorityChange}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Add inline status and priority `<select>` dropdowns to `IssueCard` (board view) and `IssueRow` (list view) for changing issue status/priority without navigating away
- Implement optimistic state management in `ProjectBoardPage` — status changes move cards to new columns immediately before server confirmation
- Wire `MutationEventBus` query revalidation via `api.issues.update()` for automatic data refresh
- Add `EditIssueDialog` with form validation for editing issues from the detail page
- Extract shared `PRIORITIES` config to `issue-config.ts` to reduce duplication
- Server rejection automatically rolls back optimistic overrides

## Public API Changes

None — all changes are in the `@vertz-examples/linear` example app (private, not published).

## Changed Files

| File | Change |
|------|--------|
| `issue-card.tsx` | Add `onStatusChange`/`onPriorityChange` callbacks, inline selects with `stopPropagation` |
| `issue-row.tsx` | Same inline select pattern for list view |
| `status-column.tsx` | Pass mutation callbacks through to `IssueCard` |
| `project-board-page.tsx` | Optimistic `let` state for status/priority overrides, mutation handlers |
| `issue-list-page.tsx` | Wire mutation handlers to `IssueRow` |
| `issue-detail-page.tsx` | Add Edit button with `EditIssueDialog` via `useDialogStack` |
| `edit-issue-dialog.tsx` | New dialog with manual form handling and validation |
| `edit-issue-schema.ts` | Validation schema for edit form |
| `edit-issue-schema.test.ts` | Tests for validation schema |
| `issue-config.ts` | Add shared `PRIORITIES` export |

## Test plan

- [x] `editIssueSchema` unit tests pass (8 tests)
- [x] All linear example tests pass (23 tests)
- [x] TypeCheck clean (no new errors)
- [x] Biome lint clean
- [x] Pre-push quality gates pass (82/82)

Fixes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)