### PR TITLE
chore(component-catalog): change dev port to 8000

### DIFF
--- a/examples/component-catalog/package.json
+++ b/examples/component-catalog/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun node_modules/@vertz/cli/dist/vertz.js dev",
+    "dev": "bun node_modules/@vertz/cli/dist/vertz.js dev --port 8000",
     "build": "bun node_modules/@vertz/cli/dist/vertz.js build",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Change component catalog dev server port from 3000 to 8000 to avoid conflicts with other local services

## Public API Changes
None — example package only.

## Test plan
- [x] `bun run dev` starts on port 8000
- [x] Catalog loads at http://localhost:8000


🤖 Generated with [Claude Code](https://claude.com/claude-code)