### PR TITLE
fix(ui-primitives): resolve composed primitives content children inside Provider

### DIFF
--- a/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
+++ b/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
@@ -258,10 +258,13 @@ function ComposedAlertDialogRoot({
     _contentClaimed: false,
   };
 
-  // Phase 1: resolve children to collect registrations
+  // Phase 1: resolve children to collect registrations, then resolve content
+  // children while still inside the Provider so sub-components can access context
   let resolvedNodes: Node[] = [];
+  let contentNodes: Node[] = [];
   AlertDialogContext.Provider(ctxValue, () => {
     resolvedNodes = resolveChildren(children);
+    contentNodes = resolveChildren(reg.contentChildren);
   });
 
   // Phase 2: reactive state — compiler transforms `let` to signal
@@ -313,8 +316,6 @@ function ComposedAlertDialogRoot({
     _tryOnCleanup(() => triggerEl.removeEventListener('click', handleClick));
   }
 
-  // Resolve content children
-  const contentNodes = resolveChildren(reg.contentChildren);
   const combined = [classes?.content, reg.contentCls].filter(Boolean).join(' ');
 
   // Create content panel first so we can wire the delegation handler

--- a/packages/ui-primitives/src/dialog/dialog-composed.tsx
+++ b/packages/ui-primitives/src/dialog/dialog-composed.tsx
@@ -204,10 +204,13 @@ function ComposedDialogRoot({ children, classes, onOpenChange, closeIcon }: Comp
     _contentClaimed: false,
   };
 
-  // Phase 1: resolve children to collect registrations
+  // Phase 1: resolve children to collect registrations, then resolve content
+  // children while still inside the Provider so sub-components can access context
   let resolvedNodes: Node[] = [];
+  let contentNodes: Node[] = [];
   DialogContext.Provider(ctxValue, () => {
     resolvedNodes = resolveChildren(children);
+    contentNodes = resolveChildren(reg.contentChildren);
   });
 
   // Phase 2: reactive state — compiler transforms `let` to signal
@@ -269,8 +272,6 @@ function ComposedDialogRoot({ children, classes, onOpenChange, closeIcon }: Comp
     _tryOnCleanup(() => closeIcon.removeEventListener('click', handleCloseIconClick));
   }
 
-  // Resolve content children
-  const contentNodes = resolveChildren(reg.contentChildren);
   const combined = [classes?.content, reg.contentCls].filter(Boolean).join(' ');
 
   // Create content panel first so we can wire the close-delegation handler

--- a/packages/ui-primitives/src/popover/popover-composed.tsx
+++ b/packages/ui-primitives/src/popover/popover-composed.tsx
@@ -148,8 +148,10 @@ function ComposedPopoverRoot({
 
   // Phase 1: resolve children to collect registrations
   let resolvedNodes: Node[] = [];
+  let contentNodes: Node[] = [];
   PopoverContext.Provider(ctxValue, () => {
     resolvedNodes = resolveChildren(children);
+    contentNodes = resolveChildren(reg.contentChildren);
   });
 
   // Phase 2: reactive state — compiler transforms `let` to signal
@@ -213,8 +215,6 @@ function ComposedPopoverRoot({
     _tryOnCleanup(() => triggerEl.removeEventListener('click', handleClick));
   }
 
-  // Resolve content children
-  const contentNodes = resolveChildren(reg.contentChildren);
   const combined = [classes?.content, reg.contentCls].filter(Boolean).join(' ');
 
   return (

--- a/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
+++ b/packages/ui-primitives/src/tooltip/tooltip-composed.tsx
@@ -142,14 +142,16 @@ function ComposedTooltipRoot({
     _contentClaimed: false,
   };
 
-  // Phase 1: resolve children to collect registrations
+  // Phase 1: resolve children to collect registrations, then resolve content
+  // children while still inside the Provider so sub-components can access context
   let resolvedNodes: Node[] = [];
+  let contentNodes: Node[] = [];
   TooltipContext.Provider(ctxValue, () => {
     resolvedNodes = resolveChildren(children);
+    contentNodes = resolveChildren(reg.contentChildren);
   });
 
   // Phase 2: build tooltip content element
-  const contentNodes = resolveChildren(reg.contentChildren);
   const combined = [classes?.content, reg.contentCls].filter(Boolean).join(' ');
 
   const tooltipEl = (


### PR DESCRIPTION
## Summary

- Fix context access error in AlertDialog, Dialog, Popover, Tooltip when using JSX children
- Move content child resolution inside Provider scope
- Verified with create-vertz-app walkthrough — all 4 composed primitives now work with JSX

## Test plan

- [x] All 605 ui-primitives tests pass
- [x] AlertDialog children (Title, Description) render without "must be used inside" error
- [x] create-vertz-app walkthrough: form, delete confirmation, SSR all work

The bug was that `resolveChildren(reg.contentChildren)` happened **outside** the Provider scope, so sub-component thunks (from JSX) couldn't access context when they evaluated. Now resolved inside the Provider callback.