### PR TITLE
fix(component-catalog): checkbox demo casing and JSX pattern

### DIFF
--- a/examples/component-catalog/src/demos/checkbox.tsx
+++ b/examples/component-catalog/src/demos/checkbox.tsx
@@ -1,7 +1,7 @@
 import { demoStyles } from '../styles/catalog';
 import { themeComponents } from '../styles/theme';
 
-const { checkbox } = themeComponents.primitives;
+const { Checkbox } = themeComponents.primitives;
 
 export function CheckboxDemo() {
   return (
@@ -10,7 +10,7 @@ export function CheckboxDemo() {
         <div className={demoStyles.sectionTitle}>Default</div>
         <div className={demoStyles.row}>
           <label style="display: flex; align-items: center; gap: 8px; color: var(--color-foreground)">
-            {checkbox({}).root}
+            <Checkbox />
             Accept terms and conditions
           </label>
         </div>
@@ -19,7 +19,7 @@ export function CheckboxDemo() {
         <div className={demoStyles.sectionTitle}>Checked by default</div>
         <div className={demoStyles.row}>
           <label style="display: flex; align-items: center; gap: 8px; color: var(--color-foreground)">
-            {checkbox({ defaultChecked: true }).root}
+            <Checkbox defaultChecked />
             Email notifications
           </label>
         </div>
@@ -28,7 +28,7 @@ export function CheckboxDemo() {
         <div className={demoStyles.sectionTitle}>Disabled</div>
         <div className={demoStyles.row}>
           <label style="display: flex; align-items: center; gap: 8px; color: var(--color-muted-foreground); opacity: 0.5">
-            {checkbox({ disabled: true }).root}
+            <Checkbox disabled />
             Disabled option
           </label>
         </div>


### PR DESCRIPTION
## Summary
- Fixed `checkbox` (lowercase) → `Checkbox` (correct PascalCase) destructuring from `themeComponents.primitives`
- Replaced old factory pattern (`checkbox({}).root`) with JSX (`<Checkbox />`)
- Demo now shows default, checked-by-default, and disabled states correctly

Fixes #1401

## Public API Changes
None — example code only.

## Test plan
- [ ] Component catalog loads without runtime errors
- [ ] Checkbox demo renders all three states (default, checked, disabled)
- [ ] SSR works correctly (no errors on page load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)