### PR TITLE
docs: add SSG / generateParams documentation

### DIFF
--- a/packages/docs/api-reference/ui/router.mdx
+++ b/packages/docs/api-reference/ui/router.mdx
@@ -48,6 +48,8 @@ function defineRoutes<const T extends Record<string, RouteConfigLike>>(
 | `params` | `ParamSchema` | Parse and validate route params (`:id` → `number`) |
 | `searchParams` | `SearchParamSchema` | Parse and validate search/query params |
 | `children` | `RouteDefinitionMap` | Nested routes (rendered via `Outlet`) |
+| `prerender` | `boolean` | Pre-render this route at build time (`true` = SSG, `false` = skip) |
+| `generateParams` | `() => Record<string, string>[] \| Promise<Record<string, string>[]>` | Generate param combinations for pre-rendering dynamic routes |
 
 ---
 

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -101,7 +101,7 @@
           },
           {
             "group": "Deployment",
-            "pages": ["guides/deploy/static-sites", "guides/deploy/og-images"]
+            "pages": ["guides/deploy/static-sites", "guides/deploy/ssg", "guides/deploy/og-images"]
           }
         ],
         "tab": "Guides"

--- a/packages/docs/guides/deploy/ssg.mdx
+++ b/packages/docs/guides/deploy/ssg.mdx
@@ -1,0 +1,214 @@
+---
+title: Static Site Generation (SSG)
+description: "Pre-render routes at build time with generateParams and prerender"
+---
+
+Vertz can pre-render routes to static HTML at build time. Static pages load instantly — no server-side rendering per request, no JavaScript needed for content-only pages.
+
+## How it works
+
+When you run `vertz build`, the build pipeline:
+
+1. Builds client and server bundles
+2. Discovers all routes from your app
+3. Collects pre-renderable paths (static routes + `generateParams` expansions)
+4. Renders each path to a complete HTML file
+5. Writes them to `dist/client/<path>/index.html`
+
+Pages with interactive components (hydration markers) keep their client JS. Purely static pages have all `<script>` tags stripped — zero JavaScript shipped.
+
+## Mark routes for pre-rendering
+
+Add `prerender: true` to any static route:
+
+```tsx
+import { defineRoutes } from 'vertz/ui';
+
+const routes = defineRoutes({
+  '/': {
+    component: () => HomePage(),
+    prerender: true,
+  },
+  '/about': {
+    component: () => AboutPage(),
+    prerender: true,
+  },
+  '/dashboard': {
+    component: () => Dashboard(),
+    prerender: false, // requires runtime data — skip
+  },
+});
+```
+
+Routes without `prerender` are not pre-rendered. Routes with `prerender: false` are explicitly skipped.
+
+## Dynamic routes with `generateParams`
+
+For routes with `:param` segments, provide a `generateParams` function that returns all param combinations to pre-render:
+
+```tsx
+const routes = defineRoutes({
+  '/blog/:slug': {
+    component: () => BlogPost(),
+    loader: async (ctx) => fetchPost(ctx.params.slug),
+    generateParams: async () => [
+      { slug: 'intro-to-vertz' },
+      { slug: 'reactive-signals' },
+      { slug: 'type-safe-routing' },
+    ],
+  },
+});
+```
+
+At build time, this expands to three pages:
+- `dist/client/blog/intro-to-vertz/index.html`
+- `dist/client/blog/reactive-signals/index.html`
+- `dist/client/blog/type-safe-routing/index.html`
+
+A route with `generateParams` is implicitly pre-rendered — you don't need `prerender: true`.
+
+### Fetching params from a data source
+
+`generateParams` can be async. Fetch slugs from a database, CMS, or API:
+
+```tsx
+const routes = defineRoutes({
+  '/blog/:slug': {
+    component: () => BlogPost(),
+    loader: async (ctx) => fetchPost(ctx.params.slug),
+    generateParams: async () => {
+      const posts = await db.select().from(postsTable);
+      return posts.map((post) => ({ slug: post.slug }));
+    },
+  },
+});
+```
+
+### Multiple params
+
+For routes with multiple dynamic segments, return objects with all param keys:
+
+```tsx
+const routes = defineRoutes({
+  '/docs/:section/:page': {
+    component: () => DocsPage(),
+    generateParams: async () => [
+      { section: 'guides', page: 'quickstart' },
+      { section: 'guides', page: 'routing' },
+      { section: 'api', page: 'router' },
+    ],
+  },
+});
+```
+
+If a param key is missing from a returned object, the build fails with a clear error message telling you which key was missing.
+
+## Export routes from your app
+
+For `vertz build` to discover `generateParams`, export your routes from `app.tsx`:
+
+```tsx
+// src/app.tsx
+import { getInjectedCSS } from 'vertz/ui';
+import { routes } from './router';
+
+export { getInjectedCSS };
+export { routes };
+
+export function App() {
+  // ...
+}
+```
+
+The build pipeline imports the server bundle and reads the `routes` export to collect pre-render paths.
+
+## Nested routes
+
+Parent and child routes are independent for pre-rendering. A parent with `prerender: false` does not prevent its children from being pre-rendered:
+
+```tsx
+const routes = defineRoutes({
+  '/admin': {
+    component: () => AdminLayout(),
+    prerender: false, // layout needs auth — skip
+    children: {
+      '/help': {
+        component: () => AdminHelpPage(),
+        prerender: true, // but help page is static
+      },
+    },
+  },
+});
+```
+
+## Build output
+
+After `vertz build`, pre-rendered pages are in `dist/client/`:
+
+```
+dist/client/
+├── index.html                      # / (if prerender: true)
+├── about/
+│   └── index.html                  # /about
+├── blog/
+│   ├── intro-to-vertz/
+│   │   └── index.html              # /blog/intro-to-vertz
+│   └── reactive-signals/
+│       └── index.html              # /blog/reactive-signals
+├── assets/
+│   ├── entry-client-[hash].js      # Client bundle
+│   └── vertz.css                   # Extracted CSS
+└── _shell.html                     # HTML template (for SSR fallback)
+```
+
+The build console shows what was pre-rendered:
+
+```
+📄 Pre-rendering routes...
+  Discovered 5 route(s): /, /about, /blog/:slug, /dashboard, /admin/help
+  Pre-rendering 4 route(s) (2 static, 2 from generateParams)...
+  ✓ / → dist/client/index.html
+  ✓ /about → dist/client/about/index.html
+  ✓ /blog/intro-to-vertz → dist/client/blog/intro-to-vertz/index.html
+  ✓ /blog/reactive-signals → dist/client/blog/reactive-signals/index.html
+```
+
+## When to use SSG vs SSR
+
+| | SSG (`prerender: true`) | SSR (default) |
+|---|---|---|
+| **Rendered** | Once, at build time | Every request |
+| **Data** | Build-time only | Per-request (fresh) |
+| **Performance** | Instant — served from CDN | Server render + data fetch |
+| **Use case** | Blog posts, docs, landing pages | Dashboards, auth-gated pages |
+
+You can mix both in the same app. Pre-render your marketing pages and blog, while keeping your dashboard as SSR.
+
+## Troubleshooting
+
+### "Pre-render failed for /path"
+
+The route's component or loader threw during build-time rendering. Common causes:
+- The loader depends on runtime-only data (auth, cookies, request headers)
+- A component accesses `window` or `document` unconditionally
+
+Fix: Add `prerender: false` to the route, or guard browser-only code:
+
+```tsx
+if (typeof window !== 'undefined') {
+  // browser-only code
+}
+```
+
+### "generateParams returned params missing key"
+
+The objects returned by `generateParams` don't include all `:param` segments in the route pattern. Check that every dynamic segment has a matching key in each returned object.
+
+<CardGroup cols={2}>
+  <Card title="Static Sites" icon="globe" href="/guides/deploy/static-sites">
+    Deploy a static Vertz site to Cloudflare Workers
+  </Card>
+  <Card title="SSR" icon="server" href="/guides/ui/ssr">
+    Server-side rendering for dynamic apps
+  </Card>
+</CardGroup>

--- a/packages/docs/guides/deploy/static-sites.mdx
+++ b/packages/docs/guides/deploy/static-sites.mdx
@@ -317,6 +317,9 @@ The dev server's SSR output includes HMR scripts, WebSocket overlays, and Bun de
 | **Command** | `bun run build` | `vertz build` |
 
 <CardGroup cols={2}>
+  <Card title="SSG with generateParams" icon="bolt" href="/guides/deploy/ssg">
+    Pre-render dynamic routes at build time
+  </Card>
   <Card title="OG Images" icon="image" href="/guides/deploy/og-images">
     Generate Open Graph images for social sharing
   </Card>

--- a/packages/docs/guides/ui/routing.mdx
+++ b/packages/docs/guides/ui/routing.mdx
@@ -229,6 +229,33 @@ export function AdminLayout() {
 }
 ```
 
+## Pre-rendering (SSG)
+
+Routes can be pre-rendered to static HTML at build time. Add `prerender: true` for static routes, or `generateParams` for dynamic routes:
+
+```tsx
+defineRoutes({
+  '/about': {
+    component: () => AboutPage(),
+    prerender: true,
+  },
+  '/blog/:slug': {
+    component: () => BlogPost(),
+    loader: async (ctx) => fetchPost(ctx.params.slug),
+    generateParams: async () => {
+      const posts = await db.select().from(postsTable);
+      return posts.map((post) => ({ slug: post.slug }));
+    },
+  },
+  '/dashboard': {
+    component: () => Dashboard(),
+    prerender: false, // requires runtime data
+  },
+});
+```
+
+When you run `vertz build`, routes with `prerender: true` or `generateParams` are rendered to `dist/client/<path>/index.html`. See the [SSG guide](/guides/deploy/ssg) for details.
+
 ## Lazy-loaded routes
 
 Return a dynamic import from `component` for code splitting:


### PR DESCRIPTION
## Summary

- New docs page `guides/deploy/ssg.mdx` covering static site generation with `generateParams` and `prerender`
- Updated `guides/ui/routing.mdx` with a "Pre-rendering (SSG)" section
- Updated `api-reference/ui/router.mdx` RouteConfig table with `prerender` and `generateParams` fields
- Updated `guides/deploy/static-sites.mdx` with cross-reference to the new SSG guide
- Registered new page in `docs.json` navigation

## What's documented

- `prerender: true` for static routes
- `generateParams` API with examples (static paths, dynamic from DB/API, multiple params)
- Nested route pre-rendering behavior (parent opt-out doesn't affect children)
- `vertz build` integration and output structure
- SSG vs SSR comparison table
- Troubleshooting section
- End-to-end blog post example with `generateParams` fetching slugs

Fixes #1398

## Public API Changes

None — documentation only.

## Test plan

- [ ] Verify new page renders correctly in Mintlify
- [ ] Verify cross-links between SSG, static sites, SSR, and routing pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)