### PR TITLE
fix(create-vertz-app): require non-empty title in tasks schema template

### DIFF
--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -198,6 +198,11 @@ describe('templates', () => {
       expect(result).toContain("d.table('tasks'");
       expect(result).toContain('d.model(tasksTable)');
     });
+
+    it('requires non-empty title with min(1)', () => {
+      const result = schemaTemplate();
+      expect(result).toContain('d.text().min(1)');
+    });
   });
 
   describe('dbTemplate', () => {

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -680,7 +680,7 @@ export function schemaTemplate(): string {
 
 export const tasksTable = d.table('tasks', {
   id: d.uuid().primary(),
-  title: d.text(),
+  title: d.text().min(1),
   completed: d.boolean().default(false),
   createdAt: d.timestamp().default('now').readOnly(),
   updatedAt: d.timestamp().autoUpdate().readOnly(),


### PR DESCRIPTION
## Summary

- Change `d.text()` to `d.text().min(1)` for the `title` field in the generated `schema.ts` template
- Add test verifying the min-length constraint is present in the generated output

Fixes #1410

## Public API Changes

None — this only affects the scaffolded template output from `create-vertz-app`.

## Test plan

- [x] New test: `schemaTemplate > requires non-empty title with min(1)`
- [x] All existing template tests pass
- [x] Pre-push quality gates pass (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)