### PR TITLE
fix(ui-primitives,theme-shadcn): sheet overlay pointer-events none when closed

### DIFF
--- a/.changeset/sheet-overlay-pointer-events.md
+++ b/.changeset/sheet-overlay-pointer-events.md
@@ -1,0 +1,6 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+---
+
+Sheet overlay no longer blocks pointer events when closed. Added `pointer-events: none` to the overlay's closed state in both the theme CSS and the composed component's inline style.

--- a/packages/theme-shadcn/src/__tests__/sheet.test.ts
+++ b/packages/theme-shadcn/src/__tests__/sheet.test.ts
@@ -45,6 +45,10 @@ describe('sheet styles', () => {
     expect(sheet.css).toContain('vz-slide-out-to-left');
     expect(sheet.css).toContain('vz-slide-out-to-right');
   });
+
+  it('overlay CSS includes pointer-events:none when data-state is closed', () => {
+    expect(sheet.css).toContain('pointer-events');
+  });
 });
 
 describe('themed Sheet', () => {

--- a/packages/theme-shadcn/src/styles/sheet.ts
+++ b/packages/theme-shadcn/src/styles/sheet.ts
@@ -53,7 +53,10 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
         '&[data-state="open"]': [animationDecl('vz-fade-in 100ms ease-out forwards')],
       },
       {
-        '&[data-state="closed"]': [animationDecl('vz-fade-out 100ms ease-out forwards')],
+        '&[data-state="closed"]': [
+          animationDecl('vz-fade-out 100ms ease-out forwards'),
+          { 'pointer-events': 'none' },
+        ],
       },
     ],
     sheetPanelLeft: [

--- a/packages/ui-primitives/src/sheet/__tests__/sheet-composed.test.ts
+++ b/packages/ui-primitives/src/sheet/__tests__/sheet-composed.test.ts
@@ -201,6 +201,48 @@ describe('Composed Sheet', () => {
     });
   });
 
+  describe('Given a Sheet with closed overlay', () => {
+    describe('When the sheet is initially rendered (closed)', () => {
+      it('Then the overlay has pointer-events none so it does not block clicks', () => {
+        const btn = document.createElement('button');
+
+        const root = ComposedSheet({
+          children: () => {
+            const t = ComposedSheet.Trigger({ children: [btn] });
+            const c = ComposedSheet.Content({ children: ['Body'] });
+            return [t, c];
+          },
+        });
+        container.appendChild(root);
+
+        const overlay = root.querySelector('[data-sheet-overlay]') as HTMLElement;
+        expect(overlay.style.pointerEvents).toBe('none');
+      });
+    });
+
+    describe('When the sheet is opened then closed', () => {
+      it('Then the overlay pointer-events revert to none', () => {
+        const btn = document.createElement('button');
+
+        const root = ComposedSheet({
+          children: () => {
+            const t = ComposedSheet.Trigger({ children: [btn] });
+            const c = ComposedSheet.Content({ children: ['Body'] });
+            return [t, c];
+          },
+        });
+        container.appendChild(root);
+
+        btn.click();
+        const overlay = root.querySelector('[data-sheet-overlay]') as HTMLElement;
+        expect(overlay.style.pointerEvents).not.toBe('none');
+
+        overlay.click();
+        expect(overlay.style.pointerEvents).toBe('none');
+      });
+    });
+  });
+
   describe('Given a Sheet rendered inside a disposal scope', () => {
     describe('When the disposal scope cleanups are run', () => {
       it('Then removeEventListener is called for the trigger click handler', () => {

--- a/packages/ui-primitives/src/sheet/sheet-composed.tsx
+++ b/packages/ui-primitives/src/sheet/sheet-composed.tsx
@@ -311,7 +311,7 @@ function ComposedSheetRoot({
         data-sheet-overlay=""
         aria-hidden={isOpen ? 'false' : 'true'}
         data-state={isOpen ? 'open' : 'closed'}
-        style={isOpen ? '' : 'display: none'}
+        style={isOpen ? '' : 'display: none; pointer-events: none'}
         class={classes?.overlay || undefined}
         onClick={() => close()}
       />


### PR DESCRIPTION
## Summary

- Sheet overlay (`data-sheet-overlay`, `position: fixed; inset: 0; z-index: 50`) blocked pointer events even when the sheet was closed
- The CSS fade-out animation left the overlay at `opacity: 0` with `animation-fill-mode: forwards` — visually hidden but still capturing all clicks
- Added `pointer-events: none` to the overlay's `data-state="closed"` CSS rule in `@vertz/theme-shadcn`
- Added `pointer-events: none` to the composed component's inline style as defense-in-depth in `@vertz/ui-primitives`

Fixes #1407

## Public API Changes

None — this is a CSS/styling fix only. No API surface changes.

## Test plan

- [x] Theme CSS test: overlay CSS includes `pointer-events` rule for closed state
- [x] Composed component test: overlay has `pointer-events: none` when initially rendered (closed)
- [x] Composed component test: overlay `pointer-events` reverts to `none` after open → close cycle
- [x] All 607 ui-primitives tests pass
- [x] All 450 theme-shadcn tests pass
- [x] Typecheck clean for both packages
- [x] Lint clean for changed files
- [x] Pre-push quality gates pass (82/82 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)