### PR TITLE
fix(component-catalog): add Select.Trigger and use placeholder in select demo

### DIFF
--- a/examples/component-catalog/src/demos/select.tsx
+++ b/examples/component-catalog/src/demos/select.tsx
@@ -9,7 +9,8 @@ export function SelectDemo() {
       <div className={demoStyles.section}>
         <div className={demoStyles.sectionTitle}>Basic select</div>
         <div>
-          <Select defaultValue="Select a fruit...">
+          <Select placeholder="Select a fruit...">
+            <Select.Trigger />
             <Select.Content>
               <Select.Item value="apple">Apple</Select.Item>
               <Select.Item value="banana">Banana</Select.Item>
@@ -22,7 +23,8 @@ export function SelectDemo() {
       <div className={demoStyles.section}>
         <div className={demoStyles.sectionTitle}>With groups</div>
         <div>
-          <Select defaultValue="Select a food...">
+          <Select placeholder="Select a food...">
+            <Select.Trigger />
             <Select.Content>
               <Select.Group label="Fruits">
                 <Select.Item value="apple">Apple</Select.Item>


### PR DESCRIPTION
## Summary

- Added missing `<Select.Trigger />` to both Select demo variants (basic and with groups)
- Changed `defaultValue="Select a fruit/food..."` to `placeholder="Select a fruit/food..."` — the text is prompt text, not a pre-selected value

Fixes #1403

## Public API Changes

None — this is a demo fix only.

## Test plan

- [x] Existing `select-composed.test.ts` tests pass (16/16)
- [x] Component catalog typecheck passes
- [x] Biome lint clean
- [ ] Manual: Select demo renders a styled trigger button with placeholder text
- [ ] Manual: Clicking the trigger opens a dropdown with styled options
- [ ] Manual: Selecting an option updates the trigger text
- [ ] Manual: "With groups" variant shows group labels and separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)