### PR TITLE
fix(ui-primitives): accordion trigger buttons invisible during hydration

### DIFF
--- a/packages/ui-primitives/src/accordion/__tests__/accordion-hydration.test.ts
+++ b/packages/ui-primitives/src/accordion/__tests__/accordion-hydration.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Hydration test for ComposedAccordion.
+ *
+ * Reproduces #1406: during hydration, buildContentEl's __element("div") claims
+ * the SSR accordion root div, setting display:none on it and hiding all
+ * trigger buttons.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { mount, resetInjectedStyles } from '@vertz/ui';
+import { ComposedAccordion } from '../accordion-composed';
+
+/**
+ * Renders a component in CSR mode (no hydration) and returns its HTML string.
+ * Used to generate realistic SSR HTML for hydration tests.
+ */
+function csrHTML(factory: () => HTMLElement): string {
+  const temp = document.createElement('div');
+  const el = factory();
+  temp.appendChild(el);
+  return temp.innerHTML;
+}
+
+function createAccordion(onValueChange?: (v: string[]) => void) {
+  return ComposedAccordion({
+    onValueChange,
+    children: () => {
+      const i1 = ComposedAccordion.Item({
+        value: 'item1',
+        children: () => {
+          const t = ComposedAccordion.Trigger({ children: ['Trigger 1'] });
+          const c = ComposedAccordion.Content({ children: ['Content 1'] });
+          return [t, c];
+        },
+      });
+      const i2 = ComposedAccordion.Item({
+        value: 'item2',
+        children: () => {
+          const t = ComposedAccordion.Trigger({ children: ['Trigger 2'] });
+          const c = ComposedAccordion.Content({ children: ['Content 2'] });
+          return [t, c];
+        },
+      });
+      return [i1, i2];
+    },
+  });
+}
+
+describe('ComposedAccordion — hydration (#1406)', () => {
+  let root: HTMLDivElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    root.id = 'app';
+    document.body.appendChild(root);
+    resetInjectedStyles();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(root);
+    resetInjectedStyles();
+  });
+
+  describe('Given SSR HTML from an Accordion', () => {
+    describe('When hydrated via mount()', () => {
+      it('Then trigger buttons are visible (root not corrupted with display:none)', () => {
+        const ssrHtml = csrHTML(() => createAccordion());
+        root.innerHTML = ssrHtml;
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+        mount(() => createAccordion());
+
+        // The accordion root should NOT have display:none —
+        // this was the bug: buildContentEl claimed the SSR root as a content
+        // element during hydration, setting display:none on it
+        const accordionRoot = root.querySelector('[data-orientation="vertical"]');
+        expect(accordionRoot).not.toBeNull();
+        expect((accordionRoot as HTMLElement).style.display).not.toBe('none');
+
+        // Trigger buttons should exist and be accessible
+        const triggers = root.querySelectorAll('button[aria-expanded]');
+        expect(triggers.length).toBe(2);
+
+        // The accordion root should NOT have role="region" (that's for content elements)
+        expect(accordionRoot?.getAttribute('role')).not.toBe('region');
+
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+      });
+
+      it('Then clicking a trigger expands content after hydration', () => {
+        const ssrHtml = csrHTML(() => createAccordion());
+        root.innerHTML = ssrHtml;
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+        let lastValue: string[] | undefined;
+        mount(() =>
+          createAccordion((v) => {
+            lastValue = v;
+          }),
+        );
+
+        // Click second trigger to expand it
+        const triggers = root.querySelectorAll('button[aria-expanded]');
+        expect(triggers.length).toBe(2);
+        (triggers[1] as HTMLElement).click();
+        expect(lastValue).toContain('item2');
+
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('Given SSR HTML from an Accordion with a pre-opened item', () => {
+    describe('When hydrated via mount()', () => {
+      it('Then the pre-opened content is visible and closed content is hidden', () => {
+        const ssrHtml = csrHTML(() =>
+          ComposedAccordion({
+            defaultValue: ['item1'],
+            children: () => {
+              const i1 = ComposedAccordion.Item({
+                value: 'item1',
+                children: () => {
+                  const t = ComposedAccordion.Trigger({ children: ['Trigger 1'] });
+                  const c = ComposedAccordion.Content({ children: ['Content 1'] });
+                  return [t, c];
+                },
+              });
+              const i2 = ComposedAccordion.Item({
+                value: 'item2',
+                children: () => {
+                  const t = ComposedAccordion.Trigger({ children: ['Trigger 2'] });
+                  const c = ComposedAccordion.Content({ children: ['Content 2'] });
+                  return [t, c];
+                },
+              });
+              return [i1, i2];
+            },
+          }),
+        );
+        root.innerHTML = ssrHtml;
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+        mount(() =>
+          ComposedAccordion({
+            defaultValue: ['item1'],
+            children: () => {
+              const i1 = ComposedAccordion.Item({
+                value: 'item1',
+                children: () => {
+                  const t = ComposedAccordion.Trigger({ children: ['Trigger 1'] });
+                  const c = ComposedAccordion.Content({ children: ['Content 1'] });
+                  return [t, c];
+                },
+              });
+              const i2 = ComposedAccordion.Item({
+                value: 'item2',
+                children: () => {
+                  const t = ComposedAccordion.Trigger({ children: ['Trigger 2'] });
+                  const c = ComposedAccordion.Content({ children: ['Content 2'] });
+                  return [t, c];
+                },
+              });
+              return [i1, i2];
+            },
+          }),
+        );
+
+        // First trigger should be expanded
+        const triggers = root.querySelectorAll('button[aria-expanded]');
+        expect(triggers.length).toBe(2);
+        expect((triggers[0] as HTMLElement).getAttribute('aria-expanded')).toBe('true');
+        expect((triggers[1] as HTMLElement).getAttribute('aria-expanded')).toBe('false');
+
+        // First content should be visible, second hidden
+        const contents = root.querySelectorAll('[role="region"]');
+        expect(contents.length).toBe(2);
+        expect((contents[0] as HTMLElement).style.display).not.toBe('none');
+        expect((contents[1] as HTMLElement).style.display).toBe('none');
+
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+      });
+    });
+  });
+});

--- a/packages/ui-primitives/src/accordion/accordion-composed.tsx
+++ b/packages/ui-primitives/src/accordion/accordion-composed.tsx
@@ -6,7 +6,6 @@
 
 import type { ChildValue } from '@vertz/ui';
 import { createContext, resolveChildren, useContext } from '@vertz/ui';
-import { _tryOnCleanup } from '@vertz/ui/internals';
 import { setDataState, setExpanded, setHidden, setHiddenAnimated } from '../utils/aria';
 import { uniqueId } from '../utils/id';
 import { handleListNavigation, isKey, Keys } from '../utils/keyboard';
@@ -207,67 +206,62 @@ function AccordionContent({ children, className: cls, class: classProp }: SlotPr
 }
 
 // ---------------------------------------------------------------------------
-// Element builders — standalone functions outside the Root component body so
-// the Vertz compiler does not classify their return values as computed().
+// Element builder — standalone function outside the Root component body so
+// the Vertz compiler does not classify its return values as computed().
+//
+// Uses nested JSX so that elements are created in DOM order:
+//   item div → button (trigger) → div (content)
+// This is critical for hydration (#1406): the hydration cursor claims
+// elements in sibling order, so the creation order must match the SSR
+// DOM structure. Previously, separate builders created trigger/content
+// BEFORE the item wrapper, causing buildContentEl's __element("div") to
+// claim the SSR accordion root div and corrupt it with display:none.
 // ---------------------------------------------------------------------------
 
-function buildTriggerEl(
+function buildItem(
   item: ItemRegistration,
   classes: AccordionClasses | undefined,
   isOpen: boolean,
-): HTMLButtonElement {
+  onTriggerClick: () => void,
+): { itemEl: HTMLDivElement; triggerEl: HTMLButtonElement; contentEl: HTMLDivElement } {
   const triggerClass = [classes?.trigger, item.triggerClass].filter(Boolean).join(' ');
-  const resolved = resolveChildren(item.triggerChildren);
-  return (
-    <button
-      type="button"
-      id={item.triggerId}
-      aria-controls={item.contentId}
-      data-value={item.value}
-      aria-expanded={isOpen ? 'true' : 'false'}
-      data-state={isOpen ? 'open' : 'closed'}
-      class={triggerClass || undefined}
-    >
-      {...resolved}
-    </button>
-  ) as HTMLButtonElement;
-}
-
-function buildContentEl(
-  item: ItemRegistration,
-  classes: AccordionClasses | undefined,
-  isOpen: boolean,
-): HTMLDivElement {
   const contentClass = [classes?.content, item.contentClass].filter(Boolean).join(' ');
-  const resolved = resolveChildren(item.contentChildren);
-  return (
-    <div
-      role="region"
-      id={item.contentId}
-      aria-labelledby={item.triggerId}
-      aria-hidden={isOpen ? 'false' : 'true'}
-      data-state={isOpen ? 'open' : 'closed'}
-      style={isOpen ? '' : 'display: none'}
-      class={contentClass || undefined}
-    >
-      {...resolved}
-    </div>
-  ) as HTMLDivElement;
-}
-
-function buildItemEl(
-  item: ItemRegistration,
-  classes: AccordionClasses | undefined,
-  triggerEl: HTMLButtonElement,
-  contentEl: HTMLDivElement,
-): HTMLDivElement {
   const itemClass = classes?.item || undefined;
-  return (
+  const resolvedTrigger = resolveChildren(item.triggerChildren);
+  const resolvedContent = resolveChildren(item.contentChildren);
+
+  const itemEl = (
     <div data-value={item.value} class={itemClass}>
-      {triggerEl}
-      {contentEl}
+      <button
+        type="button"
+        id={item.triggerId}
+        aria-controls={item.contentId}
+        data-value={item.value}
+        aria-expanded={isOpen ? 'true' : 'false'}
+        data-state={isOpen ? 'open' : 'closed'}
+        class={triggerClass || undefined}
+        onClick={onTriggerClick}
+      >
+        {...resolvedTrigger}
+      </button>
+      <div
+        role="region"
+        id={item.contentId}
+        aria-labelledby={item.triggerId}
+        aria-hidden={isOpen ? 'false' : 'true'}
+        data-state={isOpen ? 'open' : 'closed'}
+        style={isOpen ? '' : 'display: none'}
+        class={contentClass || undefined}
+      >
+        {...resolvedContent}
+      </div>
     </div>
   ) as HTMLDivElement;
+
+  const triggerEl = itemEl.querySelector(`#${item.triggerId}`) as HTMLButtonElement;
+  const contentEl = itemEl.querySelector(`#${item.contentId}`) as HTMLDivElement;
+
+  return { itemEl, triggerEl, contentEl };
 }
 
 // ---------------------------------------------------------------------------
@@ -315,22 +309,14 @@ function ComposedAccordionRoot({
     resolveChildren(children);
   });
 
-  // Phase 2: build trigger, content, and item elements.
-  // Use plain arrays with a loop — the compiler only transforms top-level
-  // `const` assignments; variables inside loop bodies are not analyzed.
+  // Phase 2: build items inside the root JSX return.
+  // Items are built inside the root element via .map() so that during
+  // hydration, the cursor is correctly positioned inside the root and
+  // claims elements in DOM order (root → item → trigger → content).
+  // See #1406: previously, items were built before the root, causing
+  // buildContentEl's __element("div") to claim the SSR root div.
   const triggerEls: HTMLButtonElement[] = [];
   const contentEls: HTMLDivElement[] = [];
-  const itemEls: HTMLDivElement[] = [];
-
-  for (const item of reg.items) {
-    const isOpen = defaultValue.includes(item.value);
-    const triggerEl = buildTriggerEl(item, classes, isOpen);
-    const contentEl = buildContentEl(item, classes, isOpen);
-    const itemEl = buildItemEl(item, classes, triggerEl, contentEl);
-    triggerEls.push(triggerEl);
-    contentEls.push(contentEl);
-    itemEls.push(itemEl);
-  }
 
   // let for reactive state — compiler transforms to signal
   let openValues: string[] = [...defaultValue];
@@ -384,27 +370,6 @@ function ComposedAccordionRoot({
     }
   }
 
-  // Wire click handlers on each trigger (explicit for cleanup)
-  for (let i = 0; i < triggerEls.length; i++) {
-    const triggerEl = triggerEls[i]!;
-    const itemValue = reg.items[i]!.value;
-    const handleClick = () => toggleItem(itemValue);
-    triggerEl.addEventListener('click', handleClick);
-    _tryOnCleanup(() => triggerEl.removeEventListener('click', handleClick));
-  }
-
-  // Initialize open heights for initially-open items
-  for (let i = 0; i < reg.items.length; i++) {
-    const item = reg.items[i]!;
-    if (defaultValue.includes(item.value)) {
-      const contentEl = contentEls[i]!;
-      requestAnimationFrame(() => {
-        const height = contentEl.scrollHeight;
-        contentEl.style.setProperty('--accordion-content-height', `${height}px`);
-      });
-    }
-  }
-
   const handleKeydown = (event: KeyboardEvent) => {
     if (isKey(event, Keys.ArrowUp, Keys.ArrowDown, Keys.Home, Keys.End)) {
       handleListNavigation(event, triggerEls, { orientation: 'vertical' });
@@ -413,7 +378,25 @@ function ComposedAccordionRoot({
 
   return (
     <div data-orientation="vertical" onKeydown={handleKeydown}>
-      {...itemEls}
+      {reg.items.map((item) => {
+        const isOpen = defaultValue.includes(item.value);
+        const { itemEl, triggerEl, contentEl } = buildItem(item, classes, isOpen, () =>
+          toggleItem(item.value),
+        );
+        triggerEls.push(triggerEl);
+        contentEls.push(contentEl);
+
+        if (isOpen) {
+          requestAnimationFrame(() => {
+            contentEl.style.setProperty(
+              '--accordion-content-height',
+              `${contentEl.scrollHeight}px`,
+            );
+          });
+        }
+
+        return itemEl;
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fix accordion trigger buttons being invisible after hydration (#1406)
- Root cause: hydration cursor claimed the SSR accordion root `<div>` as a content element, corrupting it with `role="region"` and `display: none`
- Fix: restructure element creation order to match SSR DOM structure — merge three separate builders into a single `buildItem` with nested JSX (item div → button → content div), built inside root JSX via `.map()` so the hydration cursor is correctly positioned

## Public API Changes

None — internal restructuring only. No changes to `ComposedAccordion` props or sub-component API.

## Test plan

- [x] New hydration test: root not corrupted with `display: none` after hydration
- [x] New hydration test: trigger buttons visible and accessible after hydration
- [x] New hydration test: click interaction works after hydration
- [x] New hydration test: pre-opened items preserve expanded/collapsed state after hydration
- [x] Existing 8 accordion-composed tests pass (CSR mode)
- [x] All 610 ui-primitives tests pass
- [x] Typecheck clean
- [x] Lint clean

Fixes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)