### PR TITLE
fix(cli): add vertz meta-package to esbuild external list

### DIFF
--- a/.changeset/api-build-vertz-external.md
+++ b/.changeset/api-build-vertz-external.md
@@ -1,0 +1,5 @@
+---
+'@vertz/cli': patch
+---
+
+Add `vertz` meta-package to esbuild external list in production build orchestrator

--- a/packages/cli/src/production-build/__tests__/orchestrator.test.ts
+++ b/packages/cli/src/production-build/__tests__/orchestrator.test.ts
@@ -310,6 +310,24 @@ describe('BuildOrchestrator', () => {
     });
   });
 
+  describe('esbuild externals', () => {
+    it('should externalize vertz meta-package imports', async () => {
+      const esbuild = await import('esbuild');
+      const mockBuild = esbuild.build as Mock;
+
+      orchestrator = new BuildOrchestrator({
+        ...defaultConfig,
+        typecheck: false,
+      });
+
+      await orchestrator.build();
+
+      expect(mockBuild).toHaveBeenCalled();
+      const buildOptions = mockBuild.mock.calls[0][0];
+      expect(buildOptions.external).toContain('vertz');
+    });
+  });
+
   describe('build duration', () => {
     it('should record build duration', async () => {
       orchestrator = new BuildOrchestrator({

--- a/packages/cli/src/production-build/orchestrator.ts
+++ b/packages/cli/src/production-build/orchestrator.ts
@@ -235,7 +235,7 @@ export class BuildOrchestrator {
         target: this.getEsbuildTarget(),
         minify: this.config.minify,
         sourcemap: this.config.sourcemap,
-        external: ['@vertz/*', '@anthropic-ai/sdk'],
+        external: ['@vertz/*', 'vertz', '@anthropic-ai/sdk'],
         logLevel: 'info',
         metafile: true, // Enable metafile for analysis
       });


### PR DESCRIPTION
## Summary

- Add `vertz` to the `external` list in the production build orchestrator's esbuild config
- Scaffolded apps import from `vertz/server`, `vertz/db`, `vertz/schema` (the meta-package), but esbuild's `@vertz/*` glob doesn't match bare `vertz/*` imports — causing them to be bundled instead of externalized
- Add test verifying `vertz` is included in the external list

## Public API Changes

None — internal build config fix only.

Fixes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)