### PR TITLE
feat(linear): retrofit tenant scoping on all entities

### DIFF
--- a/examples/linear/TENANT_RETROFIT_DX.md
+++ b/examples/linear/TENANT_RETROFIT_DX.md
@@ -1,0 +1,49 @@
+# Tenant Scoping Retrofit — DX Report
+
+Documenting the experience of adding multi-tenancy to the Linear clone after the app was already built.
+
+## What Was Changed
+
+- **4 tables** gained a `tenantId` column (users, projects, issues, comments)
+- **Seed data** updated to include a default tenant ID
+- **Server config** gained a `tenant.verifyMembership` callback
+- **`onUserCreated` hook** explicitly sets tenantId for new signups
+- **E2E tests** now call `/api/auth/switch-tenant` after signup
+
+## What Was Easy
+
+1. **Schema changes** — Adding `tenantId: d.text()` to each table definition was trivial. The schema builder made it a one-line addition per table.
+
+2. **Auto-scoping just works** — Zero changes to entity access rules. The framework detected `tenantId` columns and automatically added tenant filtering to all CRUD operations. No manual `rules.where({ tenantId: ... })` needed.
+
+3. **Entity files untouched** — `users.entity.ts`, `projects.entity.ts`, `issues.entity.ts`, and `comments.entity.ts` required zero modifications. The framework handled everything.
+
+4. **Seed data** — Straightforward: export a constant `SEED_TENANT_ID`, add `tenant_id` to each INSERT statement.
+
+5. **Before hooks preserved** — The existing `before.create` hooks (auto-increment issue numbers, auto-set `createdBy`/`authorId`) continued working without changes. The framework's tenant auto-set runs at a different layer (crud-pipeline) and doesn't interfere.
+
+## What Was Painful
+
+1. **Raw SQL table definitions** — Because the Linear clone uses raw `CREATE TABLE` SQL in `db.ts` (dev-only auto-migration), every table needed a manual `tenant_id TEXT NOT NULL DEFAULT ''` addition. A proper migration system would have made this a single migration file. Having the schema defined in two places (d.table and CREATE TABLE) is error-prone.
+
+2. **Chicken-and-egg at signup** — When `onUserCreated` fires, the user's session has no `tenantId` yet (they just signed up). The framework's auto-set (`input.tenantId = ctx.tenantId`) is skipped when `ctx.tenantId` is null. So `onUserCreated` must explicitly pass `tenantId` in the create data. This is a footgun — if you forget, the user is created with `tenantId: ''` and becomes invisible to tenant-scoped queries.
+
+3. **E2E test two-step auth** — After signup, a separate `POST /api/auth/switch-tenant` call is needed before the user can see any tenant-scoped data. This makes the test setup more complex. A `defaultTenantId` option in the auth config (auto-switch on first login) would simplify this.
+
+4. **No DB migration story** — The `CREATE TABLE IF NOT EXISTS` pattern means existing databases won't get the new columns. Users must delete their `data/linear.db` and restart. A real app needs `ALTER TABLE ... ADD COLUMN`.
+
+## What the Framework Could Improve
+
+1. **`defaultTenantId` or `onSignup.tenantId`** — Allow setting an initial tenantId during signup so the first session already includes it. This would eliminate the two-step auth flow and the footgun in `onUserCreated`.
+
+2. **Warn on missing tenantId in create** — When a tenant-scoped entity's create is called with no `tenantId` in context AND no `tenantId` in the input data, log a warning or throw. Currently it silently inserts with whatever default the DB has (empty string), creating orphaned records.
+
+3. **Schema-driven DDL** — If the framework could generate `CREATE TABLE` SQL from `d.table()` definitions, the schema would be defined once. This would make retrofits like adding `tenantId` a single-line change instead of editing two files.
+
+4. **Migration support** — `ALTER TABLE ADD COLUMN` generation from schema diffs would make retrofitting production databases feasible.
+
+## Verdict
+
+Adding tenant scoping after the fact was **surprisingly easy** at the application layer. The framework's auto-detection of `tenantId` columns and automatic WHERE filtering meant zero changes to entity definitions or access rules. The pain points were all around infrastructure (raw SQL, migrations) and the signup flow (chicken-and-egg with session tenantId). For a production app, the signup flow would need a proper tenant creation/invitation system anyway, so the `onUserCreated` explicitness is acceptable — but a `defaultTenantId` shortcut for simple single-tenant-per-user apps would significantly reduce friction.
+
+**Total LOC changed: ~30 lines of actual logic** (excluding SQL boilerplate and test updates).

--- a/examples/linear/e2e/linear.spec.ts
+++ b/examples/linear/e2e/linear.spec.ts
@@ -1,25 +1,10 @@
 import { expect, test } from '@playwright/test';
 
-/**
- * Signs up (or signs in) a test user and returns cookies for authenticated
- * requests. Uses email/password auth enabled alongside OAuth for dev/testing.
- */
-async function authenticate(baseURL: string) {
-  const email = `e2e-${Date.now()}@test.local`;
-  const password = 'TestPassword123!';
+/** The default seed tenant — must match SEED_TENANT_ID in schema.ts. */
+const SEED_TENANT_ID = 'tenant-acme';
 
-  const res = await fetch(`${baseURL}/api/auth/signup`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-VTZ-Request': '1' },
-    body: JSON.stringify({ email, password }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Auth signup failed: ${res.status} ${body}`);
-  }
-
-  // Extract Set-Cookie headers — the server sets session cookies
+/** Extract Set-Cookie headers into Playwright-compatible cookie objects. */
+function extractCookies(res: Response, baseURL: string) {
   const cookies: { name: string; value: string; domain: string; path: string }[] = [];
   const url = new URL(baseURL);
 
@@ -37,6 +22,49 @@ async function authenticate(baseURL: string) {
   }
 
   return cookies;
+}
+
+/**
+ * Signs up a test user, then switches to the seed tenant so all entity
+ * operations are tenant-scoped. Returns cookies with tenantId in the JWT.
+ */
+async function authenticate(baseURL: string) {
+  const email = `e2e-${Date.now()}@test.local`;
+  const password = 'TestPassword123!';
+
+  // 1. Sign up — session has no tenantId yet
+  const signupRes = await fetch(`${baseURL}/api/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-VTZ-Request': '1' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!signupRes.ok) {
+    const body = await signupRes.text();
+    throw new Error(`Auth signup failed: ${signupRes.status} ${body}`);
+  }
+
+  const signupCookies = extractCookies(signupRes, baseURL);
+
+  // 2. Switch to seed tenant — session now includes tenantId in JWT
+  const cookieHeader = signupCookies.map((c) => `${c.name}=${c.value}`).join('; ');
+  const switchRes = await fetch(`${baseURL}/api/auth/switch-tenant`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-VTZ-Request': '1',
+      Cookie: cookieHeader,
+    },
+    body: JSON.stringify({ tenantId: SEED_TENANT_ID }),
+  });
+
+  if (!switchRes.ok) {
+    const body = await switchRes.text();
+    throw new Error(`Switch tenant failed: ${switchRes.status} ${body}`);
+  }
+
+  // Use cookies from switch-tenant (they contain the updated JWT with tenantId)
+  return extractCookies(switchRes, baseURL);
 }
 
 test.describe('Linear Clone', () => {

--- a/examples/linear/src/api/db.ts
+++ b/examples/linear/src/api/db.ts
@@ -22,8 +22,10 @@ function createBunD1(dbPath: string) {
   sqlite.exec('PRAGMA foreign_keys=ON');
 
   // Auto-create app tables (dev only — production uses migrations)
+  // NOTE: If upgrading from a pre-tenant DB, delete data/linear.db and restart.
   sqlite.exec(`CREATE TABLE IF NOT EXISTS users (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     name TEXT NOT NULL,
     email TEXT NOT NULL UNIQUE,
     avatar_url TEXT,
@@ -33,6 +35,7 @@ function createBunD1(dbPath: string) {
 
   sqlite.exec(`CREATE TABLE IF NOT EXISTS projects (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     name TEXT NOT NULL,
     key TEXT NOT NULL UNIQUE,
     description TEXT,
@@ -43,6 +46,7 @@ function createBunD1(dbPath: string) {
 
   sqlite.exec(`CREATE TABLE IF NOT EXISTS issues (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     project_id TEXT NOT NULL REFERENCES projects(id),
     number INTEGER NOT NULL,
     title TEXT NOT NULL,
@@ -58,6 +62,7 @@ function createBunD1(dbPath: string) {
 
   sqlite.exec(`CREATE TABLE IF NOT EXISTS comments (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
     body TEXT NOT NULL,
     author_id TEXT NOT NULL REFERENCES users(id),

--- a/examples/linear/src/api/schema.ts
+++ b/examples/linear/src/api/schema.ts
@@ -1,11 +1,16 @@
 import { d } from '@vertz/db';
 
+// Default tenant ID — all seed data and new signups belong to this tenant.
+// In a real app you'd have a tenants table and a membership flow.
+export const SEED_TENANT_ID = 'tenant-acme';
+
 // ---------------------------------------------------------------------------
 // Users — developer-owned table, populated via onUserCreated callback
 // ---------------------------------------------------------------------------
 
 export const usersTable = d.table('users', {
   id: d.text().primary(),
+  tenantId: d.text().default(''),
   name: d.text(),
   email: d.text().unique(),
   avatarUrl: d.text().nullable(),
@@ -21,6 +26,7 @@ export const usersModel = d.model(usersTable);
 
 export const projectsTable = d.table('projects', {
   id: d.uuid().primary({ generate: 'uuid' }),
+  tenantId: d.text().default(''),
   name: d.text(),
   key: d.text().unique(),
   description: d.text().nullable(),
@@ -37,6 +43,7 @@ export const projectsModel = d.model(projectsTable);
 
 export const issuesTable = d.table('issues', {
   id: d.uuid().primary({ generate: 'uuid' }),
+  tenantId: d.text().default(''),
   projectId: d.uuid(),
   number: d.integer().default(0),
   title: d.text(),
@@ -57,6 +64,7 @@ export const issuesModel = d.model(issuesTable);
 
 export const commentsTable = d.table('comments', {
   id: d.uuid().primary({ generate: 'uuid' }),
+  tenantId: d.text().default(''),
   issueId: d.uuid(),
   body: d.text(),
   authorId: d.text().default(''),

--- a/examples/linear/src/api/seed.test.ts
+++ b/examples/linear/src/api/seed.test.ts
@@ -1,5 +1,6 @@
 import { Database } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { SEED_TENANT_ID } from './schema';
 import { seedDatabase } from './seed';
 
 function createTestDb(): Database {
@@ -8,6 +9,7 @@ function createTestDb(): Database {
 
   db.exec(`CREATE TABLE IF NOT EXISTS users (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     name TEXT NOT NULL,
     email TEXT NOT NULL UNIQUE,
     avatar_url TEXT,
@@ -17,6 +19,7 @@ function createTestDb(): Database {
 
   db.exec(`CREATE TABLE IF NOT EXISTS projects (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     name TEXT NOT NULL,
     key TEXT NOT NULL UNIQUE,
     description TEXT,
@@ -27,6 +30,7 @@ function createTestDb(): Database {
 
   db.exec(`CREATE TABLE IF NOT EXISTS issues (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     project_id TEXT NOT NULL REFERENCES projects(id),
     number INTEGER NOT NULL,
     title TEXT NOT NULL,
@@ -42,6 +46,7 @@ function createTestDb(): Database {
 
   db.exec(`CREATE TABLE IF NOT EXISTS comments (
     id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT '',
     issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
     body TEXT NOT NULL,
     author_id TEXT NOT NULL REFERENCES users(id),
@@ -132,6 +137,17 @@ describe('seedDatabase', () => {
         // All timestamps should be different (staggered)
         const unique = new Set(timestamps.map((t) => t.created_at));
         expect(unique.size).toBe(10);
+      });
+
+      it('Then all seed records have the seed tenant ID', () => {
+        seedDatabase(db);
+
+        for (const table of ['users', 'projects', 'issues', 'comments']) {
+          const rows = db
+            .query(`SELECT tenant_id FROM ${table} WHERE tenant_id != ?`)
+            .all(SEED_TENANT_ID) as { tenant_id: string }[];
+          expect(rows).toHaveLength(0);
+        }
       });
     });
   });

--- a/examples/linear/src/api/seed.ts
+++ b/examples/linear/src/api/seed.ts
@@ -8,6 +8,9 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import { SEED_TENANT_ID } from './schema';
+
+const T = SEED_TENANT_ID;
 
 export function seedDatabase(sqlite: Database) {
   const projectCount = sqlite.query('SELECT COUNT(*) as count FROM projects').get() as {
@@ -19,45 +22,45 @@ export function seedDatabase(sqlite: Database) {
   // Seed users are inserted directly for development.
   // In production, users are created via OAuth.
   // Seed IDs use 'seed-' prefix to distinguish from OAuth-created users.
-  sqlite.exec(`INSERT INTO users (id, name, email, avatar_url) VALUES
-    ('seed-alice', 'Alice Chen', 'alice@example.com', NULL),
-    ('seed-bob', 'Bob Martinez', 'bob@example.com', NULL)
+  sqlite.exec(`INSERT INTO users (id, tenant_id, name, email, avatar_url) VALUES
+    ('seed-alice', '${T}', 'Alice Chen', 'alice@example.com', NULL),
+    ('seed-bob', '${T}', 'Bob Martinez', 'bob@example.com', NULL)
   `);
 
   // --- Projects ---
-  sqlite.exec(`INSERT INTO projects (id, name, key, description, created_by, created_at) VALUES
-    ('proj-eng', 'Engineering', 'ENG', 'Core platform development', 'seed-alice', '2026-02-15 09:00:00'),
-    ('proj-des', 'Design', 'DES', 'Design system and UI work', 'seed-alice', '2026-02-16 10:30:00'),
-    ('proj-doc', 'Documentation', 'DOC', 'Docs, guides, and tutorials', 'seed-bob', '2026-02-18 14:00:00')
+  sqlite.exec(`INSERT INTO projects (id, tenant_id, name, key, description, created_by, created_at) VALUES
+    ('proj-eng', '${T}', 'Engineering', 'ENG', 'Core platform development', 'seed-alice', '2026-02-15 09:00:00'),
+    ('proj-des', '${T}', 'Design', 'DES', 'Design system and UI work', 'seed-alice', '2026-02-16 10:30:00'),
+    ('proj-doc', '${T}', 'Documentation', 'DOC', 'Docs, guides, and tutorials', 'seed-bob', '2026-02-18 14:00:00')
   `);
 
   // --- Issues ---
-  sqlite.exec(`INSERT INTO issues (id, project_id, number, title, description, status, priority, assignee_id, created_by, created_at) VALUES
-    ('iss-1', 'proj-eng', 1, 'Set up CI pipeline', 'Configure GitHub Actions for build, test, and deploy.', 'done', 'high', 'seed-bob', 'seed-alice', '2026-02-20 09:15:00'),
-    ('iss-2', 'proj-eng', 2, 'Add database migrations', 'Implement migration system for schema changes.', 'in_progress', 'high', 'seed-alice', 'seed-alice', '2026-02-21 11:00:00'),
-    ('iss-3', 'proj-eng', 3, 'API rate limiting', 'Add rate limiting middleware to protect endpoints.', 'todo', 'medium', NULL, 'seed-bob', '2026-02-22 14:30:00'),
-    ('iss-4', 'proj-eng', 4, 'Fix memory leak in query cache', 'Query cache grows unbounded under sustained load.', 'backlog', 'urgent', 'seed-alice', 'seed-bob', '2026-02-24 10:00:00'),
-    ('iss-5', 'proj-eng', 5, 'Upgrade TypeScript to 5.5', NULL, 'backlog', 'low', NULL, 'seed-alice', '2026-02-25 16:00:00'),
-    ('iss-6', 'proj-eng', 6, 'Add error boundary components', 'Wrap route-level components in error boundaries.', 'todo', 'medium', 'seed-bob', 'seed-alice', '2026-02-26 09:30:00'),
-    ('iss-7', 'proj-des', 1, 'Create color token system', 'Define semantic color tokens for light and dark themes.', 'in_progress', 'high', 'seed-alice', 'seed-alice', '2026-02-20 10:00:00'),
-    ('iss-8', 'proj-des', 2, 'Design empty states', 'Create illustrations and copy for empty list/board views.', 'todo', 'medium', NULL, 'seed-bob', '2026-02-23 13:00:00'),
-    ('iss-9', 'proj-des', 3, 'Audit accessibility', 'WCAG 2.1 AA audit on all interactive components.', 'backlog', 'high', NULL, 'seed-alice', '2026-02-27 11:30:00'),
-    ('iss-10', 'proj-doc', 1, 'Write getting started guide', 'Step-by-step guide from install to first entity.', 'in_progress', 'high', 'seed-bob', 'seed-bob', '2026-02-19 09:00:00'),
-    ('iss-11', 'proj-doc', 2, 'Document entity API', 'Reference docs for entity(), access rules, hooks.', 'todo', 'medium', 'seed-alice', 'seed-bob', '2026-02-22 10:00:00'),
-    ('iss-12', 'proj-doc', 3, 'Add code examples', NULL, 'backlog', 'low', NULL, 'seed-alice', '2026-02-28 15:00:00')
+  sqlite.exec(`INSERT INTO issues (id, tenant_id, project_id, number, title, description, status, priority, assignee_id, created_by, created_at) VALUES
+    ('iss-1', '${T}', 'proj-eng', 1, 'Set up CI pipeline', 'Configure GitHub Actions for build, test, and deploy.', 'done', 'high', 'seed-bob', 'seed-alice', '2026-02-20 09:15:00'),
+    ('iss-2', '${T}', 'proj-eng', 2, 'Add database migrations', 'Implement migration system for schema changes.', 'in_progress', 'high', 'seed-alice', 'seed-alice', '2026-02-21 11:00:00'),
+    ('iss-3', '${T}', 'proj-eng', 3, 'API rate limiting', 'Add rate limiting middleware to protect endpoints.', 'todo', 'medium', NULL, 'seed-bob', '2026-02-22 14:30:00'),
+    ('iss-4', '${T}', 'proj-eng', 4, 'Fix memory leak in query cache', 'Query cache grows unbounded under sustained load.', 'backlog', 'urgent', 'seed-alice', 'seed-bob', '2026-02-24 10:00:00'),
+    ('iss-5', '${T}', 'proj-eng', 5, 'Upgrade TypeScript to 5.5', NULL, 'backlog', 'low', NULL, 'seed-alice', '2026-02-25 16:00:00'),
+    ('iss-6', '${T}', 'proj-eng', 6, 'Add error boundary components', 'Wrap route-level components in error boundaries.', 'todo', 'medium', 'seed-bob', 'seed-alice', '2026-02-26 09:30:00'),
+    ('iss-7', '${T}', 'proj-des', 1, 'Create color token system', 'Define semantic color tokens for light and dark themes.', 'in_progress', 'high', 'seed-alice', 'seed-alice', '2026-02-20 10:00:00'),
+    ('iss-8', '${T}', 'proj-des', 2, 'Design empty states', 'Create illustrations and copy for empty list/board views.', 'todo', 'medium', NULL, 'seed-bob', '2026-02-23 13:00:00'),
+    ('iss-9', '${T}', 'proj-des', 3, 'Audit accessibility', 'WCAG 2.1 AA audit on all interactive components.', 'backlog', 'high', NULL, 'seed-alice', '2026-02-27 11:30:00'),
+    ('iss-10', '${T}', 'proj-doc', 1, 'Write getting started guide', 'Step-by-step guide from install to first entity.', 'in_progress', 'high', 'seed-bob', 'seed-bob', '2026-02-19 09:00:00'),
+    ('iss-11', '${T}', 'proj-doc', 2, 'Document entity API', 'Reference docs for entity(), access rules, hooks.', 'todo', 'medium', 'seed-alice', 'seed-bob', '2026-02-22 10:00:00'),
+    ('iss-12', '${T}', 'proj-doc', 3, 'Add code examples', NULL, 'backlog', 'low', NULL, 'seed-alice', '2026-02-28 15:00:00')
   `);
 
   // --- Comments ---
-  sqlite.exec(`INSERT INTO comments (id, issue_id, body, author_id, created_at) VALUES
-    ('com-1', 'iss-1', 'CI is green on all branches. Merging the config PR now.', 'seed-bob', '2026-02-21 10:30:00'),
-    ('com-2', 'iss-1', 'Confirmed — builds pass. Moving to done.', 'seed-alice', '2026-02-21 14:15:00'),
-    ('com-3', 'iss-2', 'Started with drizzle-kit but hit issues with D1. Switching to manual SQL migrations.', 'seed-alice', '2026-02-22 09:00:00'),
-    ('com-4', 'iss-4', 'Reproduced with 10k sequential queries. The WeakRef cleanup isn''t firing.', 'seed-bob', '2026-02-25 11:00:00'),
-    ('com-5', 'iss-4', 'Root cause: the finalizer only runs on GC, which is lazy. Need explicit eviction.', 'seed-alice', '2026-02-25 15:30:00'),
-    ('com-6', 'iss-7', 'First pass at tokens is up. Using oklch for perceptual uniformity.', 'seed-alice', '2026-02-22 16:00:00'),
-    ('com-7', 'iss-10', 'Draft is ready for review. Covers install, first entity, and dev server.', 'seed-bob', '2026-02-24 09:45:00'),
-    ('com-8', 'iss-3', 'Should we use a token bucket or sliding window? Token bucket is simpler.', 'seed-bob', '2026-02-23 10:00:00'),
-    ('com-9', 'iss-6', 'The framework should provide ErrorBoundary as a primitive. Opened a separate issue.', 'seed-alice', '2026-02-27 14:00:00'),
-    ('com-10', 'iss-2', 'Migration system working. Need to add rollback support before closing.', 'seed-alice', '2026-03-01 11:30:00')
+  sqlite.exec(`INSERT INTO comments (id, tenant_id, issue_id, body, author_id, created_at) VALUES
+    ('com-1', '${T}', 'iss-1', 'CI is green on all branches. Merging the config PR now.', 'seed-bob', '2026-02-21 10:30:00'),
+    ('com-2', '${T}', 'iss-1', 'Confirmed — builds pass. Moving to done.', 'seed-alice', '2026-02-21 14:15:00'),
+    ('com-3', '${T}', 'iss-2', 'Started with drizzle-kit but hit issues with D1. Switching to manual SQL migrations.', 'seed-alice', '2026-02-22 09:00:00'),
+    ('com-4', '${T}', 'iss-4', 'Reproduced with 10k sequential queries. The WeakRef cleanup isn''t firing.', 'seed-bob', '2026-02-25 11:00:00'),
+    ('com-5', '${T}', 'iss-4', 'Root cause: the finalizer only runs on GC, which is lazy. Need explicit eviction.', 'seed-alice', '2026-02-25 15:30:00'),
+    ('com-6', '${T}', 'iss-7', 'First pass at tokens is up. Using oklch for perceptual uniformity.', 'seed-alice', '2026-02-22 16:00:00'),
+    ('com-7', '${T}', 'iss-10', 'Draft is ready for review. Covers install, first entity, and dev server.', 'seed-bob', '2026-02-24 09:45:00'),
+    ('com-8', '${T}', 'iss-3', 'Should we use a token bucket or sliding window? Token bucket is simpler.', 'seed-bob', '2026-02-23 10:00:00'),
+    ('com-9', '${T}', 'iss-6', 'The framework should provide ErrorBoundary as a primitive. Opened a separate issue.', 'seed-alice', '2026-02-27 14:00:00'),
+    ('com-10', '${T}', 'iss-2', 'Migration system working. Need to add rollback support before closing.', 'seed-alice', '2026-03-01 11:30:00')
   `);
 }

--- a/examples/linear/src/api/server.ts
+++ b/examples/linear/src/api/server.ts
@@ -12,6 +12,7 @@ import { comments } from './entities/comments.entity';
 import { issues } from './entities/issues.entity';
 import { projects } from './entities/projects.entity';
 import { users } from './entities/users.entity';
+import { SEED_TENANT_ID } from './schema';
 
 const APP_URL = process.env.APP_URL ?? 'http://localhost:3001';
 
@@ -35,13 +36,24 @@ export const app = createServer({
     oauthSuccessRedirect: '/projects',
     oauthErrorRedirect: '/login',
 
+    // Tenant switching — enables POST /api/auth/switch-tenant.
+    // In a real app verifyMembership would check a tenant_members table.
+    // Here we auto-assign every user to the default seed tenant.
+    tenant: {
+      verifyMembership: async (_userId, tenantId) => {
+        return tenantId === SEED_TENANT_ID;
+      },
+    },
+
     // Bridge auth → entity: populate the developer's users table from GitHub profile.
     // Also handles email/password signups (for dev/E2E testing).
+    // tenantId is set explicitly because the session has no tenant yet at signup time.
     onUserCreated: async (payload, ctx) => {
       if (payload.provider) {
         const profile = payload.profile as Record<string, unknown>;
         await ctx.entities.users.create({
           id: payload.user.id,
+          tenantId: SEED_TENANT_ID,
           email: payload.user.email,
           name: (profile.name as string) ?? (profile.login as string),
           avatarUrl: profile.avatar_url as string,
@@ -49,6 +61,7 @@ export const app = createServer({
       } else {
         await ctx.entities.users.create({
           id: payload.user.id,
+          tenantId: SEED_TENANT_ID,
           email: payload.user.email,
           name: payload.user.email.split('@')[0],
           avatarUrl: null,


### PR DESCRIPTION
## Summary

Retrofits multi-tenancy onto the Linear clone example app by adding `tenantId` to all 4 entity tables. This is intentionally the **last** feature added to the Linear clone to evaluate the developer experience of adding tenancy after the fact.

- Add `tenantId` column to users, projects, issues, and comments tables
- Update seed data with a consistent `SEED_TENANT_ID` (`tenant-acme`)
- Enable `tenant.verifyMembership` in server auth config
- Set tenantId explicitly in `onUserCreated` (session has no tenant at signup time)
- Update E2E auth flow: signup → switch-tenant → use tenant-scoped session
- Add test verifying all seed records have correct tenantId
- Document the full retrofit DX experience in `TENANT_RETROFIT_DX.md`

**Key finding:** Framework auto-scoping required **zero changes** to entity definitions or access rules — adding the `tenantId` column was sufficient for the framework to auto-detect and apply tenant filtering.

## Public API Changes

None — this only modifies the Linear clone example app. No framework packages changed.

## DX Retrofit Findings

**Easy:** Schema column addition, auto-scoping detection, entity files untouched, before hooks preserved.

**Painful:** Raw SQL duplication (schema defined in 2 places), chicken-and-egg at signup (no tenantId in session yet), two-step E2E auth flow, no migration story.

**Framework improvements suggested:** `defaultTenantId` config, warning on missing tenantId in create, schema-driven DDL generation, migration support.

Full writeup: `examples/linear/TENANT_RETROFIT_DX.md`

## Test plan

- [x] All 24 linear clone unit tests pass (including new tenant verification test)
- [x] Typecheck passes
- [x] Lint passes
- [x] Pre-push quality gates pass (82/82 tasks)
- [ ] E2E tests pass with tenant-scoped auth flow (requires running dev server)

Fixes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)