### PR TITLE
feat(cloudflare): add beforeRender middleware hook to createHandler()

### DIFF
--- a/.changeset/cloudflare-before-render-hook.md
+++ b/.changeset/cloudflare-before-render-hook.md
@@ -1,0 +1,5 @@
+---
+'@vertz/cloudflare': patch
+---
+
+Add `beforeRender` middleware hook to `createHandler()` config. The hook runs before SSR rendering on non-API routes and can return a `Response` to short-circuit (e.g., redirect to `/login`). Returns `undefined`/`void` to proceed normally.

--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -93,6 +93,19 @@ export interface CloudflareHandlerConfig {
    * with TTL-based revalidation. Only applies to SSR routes (not API).
    */
   cache?: CacheConfig;
+
+  /**
+   * Middleware hook called before SSR rendering on non-API routes.
+   *
+   * Return a `Response` to short-circuit (e.g., redirect to `/login`).
+   * Return `undefined`/`void` to proceed with normal SSR rendering.
+   *
+   * Receives the incoming `Request` and the Worker `env` bindings.
+   */
+  beforeRender?: (
+    request: Request,
+    env: unknown,
+  ) => Response | undefined | Promise<Response | undefined> | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +264,7 @@ function createFullStackHandler(config: CloudflareHandlerConfig): CloudflareWork
     securityHeaders,
     imageOptimizer: imageOptimizerHandler,
     cache: cacheConfig,
+    beforeRender,
   } = config;
   const cacheTtl = cacheConfig?.ttl ?? 3600;
   const swr = cacheConfig?.staleWhileRevalidate !== false;
@@ -367,6 +381,14 @@ function createFullStackHandler(config: CloudflareHandlerConfig): CloudflareWork
         } catch (error) {
           console.error('Unhandled error in worker:', error);
           return applyHeaders(new Response('Internal Server Error', { status: 500 }), nonce);
+        }
+      }
+
+      // beforeRender middleware — runs before SSR on non-API routes
+      if (beforeRender) {
+        const earlyResponse = await beforeRender(request, env);
+        if (earlyResponse) {
+          return applyHeaders(earlyResponse, nonce);
         }
       }
 

--- a/packages/cloudflare/tests/handler.test.ts
+++ b/packages/cloudflare/tests/handler.test.ts
@@ -822,3 +822,181 @@ describe('createHandler (image optimizer integration)', () => {
     expect(apiHandler).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// beforeRender middleware hook
+// ---------------------------------------------------------------------------
+
+describe('createHandler (beforeRender hook)', () => {
+  const mockEnv = { DB: {} };
+  const mockCtx = {} as ExecutionContext;
+
+  it('short-circuits SSR when beforeRender returns a Response', async () => {
+    const ssrHandler = mock().mockResolvedValue(
+      new Response('<html>SSR</html>', {
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { Location: '/login' },
+    });
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      ssr: ssrHandler,
+      beforeRender: async () => redirectResponse,
+    });
+
+    const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/login');
+    expect(ssrHandler).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with SSR when beforeRender returns undefined', async () => {
+    const ssrHandler = mock().mockResolvedValue(
+      new Response('<html>SSR</html>', {
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      ssr: ssrHandler,
+      beforeRender: async () => undefined,
+    });
+
+    const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+    expect(ssrHandler).toHaveBeenCalled();
+    expect(await response.text()).toBe('<html>SSR</html>');
+  });
+
+  it('proceeds normally when no beforeRender hook is provided (backward compat)', async () => {
+    const ssrHandler = mock().mockResolvedValue(
+      new Response('<html>SSR</html>', {
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      ssr: ssrHandler,
+    });
+
+    const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+    expect(ssrHandler).toHaveBeenCalled();
+    expect(await response.text()).toBe('<html>SSR</html>');
+  });
+
+  it('passes request and env to the beforeRender hook', async () => {
+    const beforeRender = mock().mockResolvedValue(undefined);
+    const env = { DB: {}, AUTH_SECRET: 'secret' };
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      ssr: () => Promise.resolve(new Response('<html></html>')),
+      beforeRender,
+    });
+
+    const request = new Request('https://example.com/dashboard');
+    await worker.fetch(request, env, mockCtx);
+
+    expect(beforeRender).toHaveBeenCalledWith(request, env);
+  });
+
+  it('short-circuits even when no SSR handler is configured (non-SSR routes)', async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { Location: '/login' },
+    });
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      beforeRender: async () => redirectResponse,
+    });
+
+    const response = await worker.fetch(
+      new Request('https://example.com/dashboard'),
+      mockEnv,
+      mockCtx,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/login');
+  });
+
+  it('applies security headers to the beforeRender response', async () => {
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      securityHeaders: true,
+      beforeRender: async () => new Response('Redirecting', { status: 302 }),
+    });
+
+    const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+
+  it('does not run beforeRender for API routes', async () => {
+    const apiHandler = mock().mockResolvedValue(new Response('{"ok":true}'));
+    const beforeRender = mock().mockResolvedValue(
+      new Response(null, { status: 302, headers: { Location: '/login' } }),
+    );
+
+    const worker = createHandler({
+      app: () => mockApp(apiHandler),
+      basePath: '/api',
+      beforeRender,
+    });
+
+    const response = await worker.fetch(
+      new Request('https://example.com/api/todos'),
+      mockEnv,
+      mockCtx,
+    );
+
+    expect(apiHandler).toHaveBeenCalled();
+    expect(beforeRender).not.toHaveBeenCalled();
+    expect(await response.text()).toBe('{"ok":true}');
+  });
+
+  it('does not run beforeRender for image optimizer routes', async () => {
+    const beforeRender = mock().mockResolvedValue(
+      new Response(null, { status: 302, headers: { Location: '/login' } }),
+    );
+    const optimizerHandler = mock().mockResolvedValue(
+      new Response('optimized-image', {
+        headers: { 'Content-Type': 'image/webp' },
+      }),
+    );
+
+    const worker = createHandler({
+      app: () => mockApp(),
+      basePath: '/api',
+      imageOptimizer: optimizerHandler,
+      beforeRender,
+    });
+
+    const response = await worker.fetch(
+      new Request('https://example.com/_vertz/image?url=https%3A%2F%2Fcdn.example.com%2Fx.jpg'),
+      mockEnv,
+      mockCtx,
+    );
+
+    expect(optimizerHandler).toHaveBeenCalled();
+    expect(beforeRender).not.toHaveBeenCalled();
+    expect(response.headers.get('Content-Type')).toBe('image/webp');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `beforeRender` hook to `CloudflareHandlerConfig` for running middleware before SSR rendering on non-API routes
- Hook receives `Request` and `env`, returns `Response` to short-circuit or `undefined`/`void` to proceed
- Primary use case: auth guard at the Worker level (validate `vtz_session` cookie, redirect to `/login`)

Fixes #817

## Public API Changes

### Additions
- `CloudflareHandlerConfig.beforeRender` — optional async middleware hook

```typescript
createHandler({
  app: (env) => createServer({ ... }),
  basePath: '/api',
  ssr: { module: appModule },
  beforeRender: async (request, env) => {
    const session = getCookie(request, 'vtz_session');
    if (!session && !isPublicRoute(request.url)) {
      return Response.redirect('/login', 302);
    }
  },
});
```

### Behavior
- Runs after image optimizer and API routing, before SSR/404
- Security headers applied to hook responses when `securityHeaders: true`
- No-op when not provided (fully backward compatible)

## Test plan

- [x] Hook returning Response short-circuits SSR (redirect case)
- [x] Hook returning undefined proceeds with SSR normally
- [x] No hook provided — backward compatible, SSR works as before
- [x] Hook receives correct Request and env arguments
- [x] Works with non-SSR routes (404 fallback)
- [x] Security headers applied to hook responses
- [x] API routes bypass beforeRender entirely
- [x] Image optimizer routes bypass beforeRender entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)