### PR TITLE
fix(linear): replace raw SQL schema bootstrap with autoMigrate()

### DIFF
--- a/examples/linear/src/api/db.ts
+++ b/examples/linear/src/api/db.ts
@@ -1,107 +1,18 @@
 /**
  * Database setup for the Linear clone.
  *
- * Uses Bun's built-in SQLite wrapped as a D1-compatible binding so we can
- * use createDb() with dialect: 'sqlite'. This gives us a full DatabaseClient
- * which auto-wires auth stores when passed to createServer().
+ * Uses createDb() with path-based SQLite and autoMigrate to create/update
+ * tables from the schema model definitions. No hand-written DDL.
  */
 
-import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { Database } from 'bun:sqlite';
 import { createDb } from '@vertz/db';
+import { isOk } from '@vertz/schema';
 import { authModels } from '@vertz/server';
 import { commentsModel, issuesModel, projectsModel, usersModel } from './schema';
 import { seedDatabase } from './seed';
 
-// ---------------------------------------------------------------------------
-// D1-compatible wrapper for bun:sqlite
-// ---------------------------------------------------------------------------
-
-function createBunD1(dbPath: string) {
-  const sqlite = new Database(dbPath);
-  sqlite.exec('PRAGMA journal_mode=WAL');
-  sqlite.exec('PRAGMA foreign_keys=ON');
-
-  // Auto-create app tables (dev only — production uses migrations)
-  // NOTE: If upgrading from a pre-tenant DB, delete data/linear.db and restart.
-  sqlite.exec(`CREATE TABLE IF NOT EXISTS users (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    name TEXT NOT NULL,
-    email TEXT NOT NULL UNIQUE,
-    avatar_url TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  sqlite.exec(`CREATE TABLE IF NOT EXISTS projects (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    name TEXT NOT NULL,
-    key TEXT NOT NULL UNIQUE,
-    description TEXT,
-    created_by TEXT NOT NULL DEFAULT '',
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  sqlite.exec(`CREATE TABLE IF NOT EXISTS issues (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    project_id TEXT NOT NULL REFERENCES projects(id),
-    number INTEGER NOT NULL,
-    title TEXT NOT NULL,
-    description TEXT,
-    status TEXT NOT NULL DEFAULT 'backlog',
-    priority TEXT NOT NULL DEFAULT 'none',
-    assignee_id TEXT REFERENCES users(id),
-    created_by TEXT NOT NULL DEFAULT '',
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(project_id, number)
-  )`);
-
-  sqlite.exec(`CREATE TABLE IF NOT EXISTS comments (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
-    body TEXT NOT NULL,
-    author_id TEXT NOT NULL REFERENCES users(id),
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  seedDatabase(sqlite);
-
-  return {
-    prepare(sql: string) {
-      const stmt = sqlite.prepare(sql);
-      return {
-        bind(...values: unknown[]) {
-          return {
-            all: async () => ({
-              results: stmt.all(...(values as SQLQueryBindings[])) as unknown[],
-            }),
-            run: async () => {
-              const info = stmt.run(...(values as SQLQueryBindings[]));
-              return { meta: { changes: info.changes } };
-            },
-          };
-        },
-        all: async () => ({ results: stmt.all() as unknown[] }),
-        run: async () => {
-          const info = stmt.run();
-          return { meta: { changes: info.changes } };
-        },
-      };
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Database instance
-// ---------------------------------------------------------------------------
-
-const d1 = createBunD1('./data/linear.db');
+const DB_PATH = './data/linear.db';
 
 export const db = createDb({
   models: {
@@ -112,6 +23,15 @@ export const db = createDb({
     comments: commentsModel,
   },
   dialect: 'sqlite',
-  // biome-ignore lint/suspicious/noExplicitAny: bun:sqlite D1 wrapper
-  d1: d1 as any,
+  path: DB_PATH,
+  migrations: { autoApply: true },
 });
+
+// First query triggers autoMigrate (creates tables from model definitions).
+// Then seed if the database is empty.
+const result = await db.projects.count();
+if (isOk(result) && result.data === 0) {
+  const sqlite = new Database(DB_PATH);
+  seedDatabase(sqlite);
+  sqlite.close();
+}

--- a/examples/linear/src/api/seed.test.ts
+++ b/examples/linear/src/api/seed.test.ts
@@ -1,71 +1,45 @@
 import { Database } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { SEED_TENANT_ID } from './schema';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDb } from '@vertz/db';
+import { commentsModel, issuesModel, projectsModel, SEED_TENANT_ID, usersModel } from './schema';
 import { seedDatabase } from './seed';
-
-function createTestDb(): Database {
-  const db = new Database(':memory:');
-  db.exec('PRAGMA foreign_keys=ON');
-
-  db.exec(`CREATE TABLE IF NOT EXISTS users (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    name TEXT NOT NULL,
-    email TEXT NOT NULL UNIQUE,
-    avatar_url TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  db.exec(`CREATE TABLE IF NOT EXISTS projects (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    name TEXT NOT NULL,
-    key TEXT NOT NULL UNIQUE,
-    description TEXT,
-    created_by TEXT NOT NULL DEFAULT '',
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  db.exec(`CREATE TABLE IF NOT EXISTS issues (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    project_id TEXT NOT NULL REFERENCES projects(id),
-    number INTEGER NOT NULL,
-    title TEXT NOT NULL,
-    description TEXT,
-    status TEXT NOT NULL DEFAULT 'backlog',
-    priority TEXT NOT NULL DEFAULT 'none',
-    assignee_id TEXT REFERENCES users(id),
-    created_by TEXT NOT NULL DEFAULT '',
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(project_id, number)
-  )`);
-
-  db.exec(`CREATE TABLE IF NOT EXISTS comments (
-    id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL DEFAULT '',
-    issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
-    body TEXT NOT NULL,
-    author_id TEXT NOT NULL REFERENCES users(id),
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  return db;
-}
 
 describe('seedDatabase', () => {
   let db: Database;
+  let tmpDir: string;
 
-  beforeEach(() => {
-    db = createTestDb();
+  beforeEach(async () => {
+    // Create tables via autoMigrate (same path as production db.ts)
+    tmpDir = mkdtempSync(join(tmpdir(), 'seed-test-'));
+    const dbPath = join(tmpDir, 'test.db');
+
+    const client = createDb({
+      models: {
+        users: usersModel,
+        projects: projectsModel,
+        issues: issuesModel,
+        comments: commentsModel,
+      },
+      dialect: 'sqlite',
+      path: dbPath,
+      migrations: { autoApply: true },
+    });
+
+    // Trigger lazy migration to create tables
+    await client.projects.count();
+    await client.close();
+
+    // Open raw bun:sqlite for seeding and verification
+    db = new Database(dbPath);
+    db.exec('PRAGMA foreign_keys=ON');
   });
 
   afterEach(() => {
     db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   describe('Given a fresh database', () => {


### PR DESCRIPTION
## Summary

- Replace hand-written `CREATE TABLE` statements in `db.ts` with `createDb()` using `path`-based SQLite and `migrations: { autoApply: true }`
- Replace duplicated DDL in `seed.test.ts` with the same `createDb()` + autoMigrate approach
- Remove the entire D1-compatible wrapper (`createBunD1`) that was only needed for the raw SQL approach

Schema is now defined in **one place only**: the model definitions in `schema.ts`.

Fixes #1425

## Public API Changes

None — this is an internal change to an example app.

## Test plan

- [x] All 10 seed tests pass with autoMigrate-created tables
- [x] Typecheck passes for the linear example
- [x] Full monorepo quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)