### PR TITLE
feat(testing): add createAuthClient for E2E test auth setup

### DIFF
--- a/.changeset/auth-testing-client.md
+++ b/.changeset/auth-testing-client.md
@@ -1,0 +1,5 @@
+---
+'@vertz/testing': patch
+---
+
+Add `createAuthClient()` for programmatic auth in E2E tests. Wraps auth HTTP endpoints (signup, signIn, switchTenant) and returns cookies in Playwright-compatible format, eliminating raw fetch boilerplate in test setup.

--- a/examples/linear/e2e/linear.spec.ts
+++ b/examples/linear/e2e/linear.spec.ts
@@ -1,76 +1,24 @@
 import { expect, test } from '@playwright/test';
+import { createAuthClient } from '@vertz/testing';
 
 /** The default seed tenant — must match SEED_TENANT_ID in schema.ts. */
 const SEED_TENANT_ID = 'tenant-acme';
 
-/** Extract Set-Cookie headers into Playwright-compatible cookie objects. */
-function extractCookies(res: Response, baseURL: string) {
-  const cookies: { name: string; value: string; domain: string; path: string }[] = [];
-  const url = new URL(baseURL);
-
-  for (const header of res.headers.getSetCookie()) {
-    const [nameValue] = header.split(';');
-    const eqIdx = nameValue.indexOf('=');
-    if (eqIdx > 0) {
-      cookies.push({
-        name: nameValue.slice(0, eqIdx),
-        value: nameValue.slice(eqIdx + 1),
-        domain: url.hostname,
-        path: '/',
-      });
-    }
-  }
-
-  return cookies;
-}
-
-/**
- * Signs up a test user, then switches to the seed tenant so all entity
- * operations are tenant-scoped. Returns cookies with tenantId in the JWT.
- */
-async function authenticate(baseURL: string) {
-  const email = `e2e-${Date.now()}@test.local`;
-  const password = 'TestPassword123!';
-
-  // 1. Sign up — session has no tenantId yet
-  const signupRes = await fetch(`${baseURL}/api/auth/signup`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-VTZ-Request': '1' },
-    body: JSON.stringify({ email, password }),
-  });
-
-  if (!signupRes.ok) {
-    const body = await signupRes.text();
-    throw new Error(`Auth signup failed: ${signupRes.status} ${body}`);
-  }
-
-  const signupCookies = extractCookies(signupRes, baseURL);
-
-  // 2. Switch to seed tenant — session now includes tenantId in JWT
-  const cookieHeader = signupCookies.map((c) => `${c.name}=${c.value}`).join('; ');
-  const switchRes = await fetch(`${baseURL}/api/auth/switch-tenant`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-VTZ-Request': '1',
-      Cookie: cookieHeader,
-    },
-    body: JSON.stringify({ tenantId: SEED_TENANT_ID }),
-  });
-
-  if (!switchRes.ok) {
-    const body = await switchRes.text();
-    throw new Error(`Switch tenant failed: ${switchRes.status} ${body}`);
-  }
-
-  // Use cookies from switch-tenant (they contain the updated JWT with tenantId)
-  return extractCookies(switchRes, baseURL);
-}
-
 test.describe('Linear Clone', () => {
   test.beforeEach(async ({ context, baseURL }) => {
     const url = baseURL ?? 'http://localhost:3001';
-    const cookies = await authenticate(url);
+    const client = createAuthClient({ baseURL: url });
+
+    const { cookies: signupCookies } = await client.signup({
+      email: `e2e-${Date.now()}@test.local`,
+      password: 'TestPassword123!',
+    });
+
+    const { cookies } = await client.switchTenant({
+      tenantId: SEED_TENANT_ID,
+      cookies: signupCookies,
+    });
+
     await context.addCookies(cookies);
   });
 

--- a/packages/testing/src/__tests__/auth-client.test.ts
+++ b/packages/testing/src/__tests__/auth-client.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { createAuth } from '@vertz/server';
+import type { Server } from 'bun';
+import type { AuthClient } from '../auth-client';
+import { createAuthClient } from '../auth-client';
+
+// ---------------------------------------------------------------------------
+// Test server setup — minimal auth instance with tenant switching
+// ---------------------------------------------------------------------------
+
+let server: Server;
+let baseURL: string;
+let client: AuthClient;
+
+const TEST_TENANT_ID = 'tenant-test';
+
+const auth = createAuth({
+  session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
+  jwtSecret: 'auth-client-test-secret-at-least-32-chars!!',
+  isProduction: false,
+  tenant: {
+    verifyMembership: async (_userId: string, tenantId: string) => {
+      // Allow the test tenant, deny everything else
+      return tenantId === TEST_TENANT_ID;
+    },
+  },
+});
+
+beforeAll(async () => {
+  server = Bun.serve({
+    port: 0, // random available port
+    fetch: (req) => auth.handler(req),
+  });
+  baseURL = `http://localhost:${server.port}`;
+  client = createAuthClient({ baseURL });
+});
+
+afterAll(() => {
+  server?.stop(true);
+  auth.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthClient', () => {
+  it('returns an object with signup, signIn, and switchTenant methods', () => {
+    const c = createAuthClient({ baseURL: 'http://localhost:3000' });
+
+    expect(c.signup).toBeFunction();
+    expect(c.signIn).toBeFunction();
+    expect(c.switchTenant).toBeFunction();
+  });
+
+  describe('signup', () => {
+    it('returns cookies in Playwright-compatible format', async () => {
+      const result = await client.signup({
+        email: `test-signup-${Date.now()}@test.local`,
+        password: 'TestPassword123!',
+      });
+
+      expect(result.cookies.length).toBeGreaterThan(0);
+
+      for (const cookie of result.cookies) {
+        expect(cookie).toHaveProperty('name');
+        expect(cookie).toHaveProperty('value');
+        expect(cookie).toHaveProperty('domain');
+        expect(cookie).toHaveProperty('path');
+        expect(typeof cookie.name).toBe('string');
+        expect(typeof cookie.value).toBe('string');
+        expect(cookie.domain).toBe('localhost');
+        expect(cookie.path).toBe('/');
+      }
+    });
+
+    it('returns the session cookie (vertz.sid)', async () => {
+      const result = await client.signup({
+        email: `test-signup-sid-${Date.now()}@test.local`,
+        password: 'TestPassword123!',
+      });
+
+      const sidCookie = result.cookies.find((c) => c.name === 'vertz.sid');
+      expect(sidCookie).toBeDefined();
+      expect(sidCookie?.value.length).toBeGreaterThan(0);
+    });
+
+    it('throws on invalid credentials', async () => {
+      // Sign up same email twice → second should fail
+      const email = `test-dup-${Date.now()}@test.local`;
+      await client.signup({ email, password: 'TestPassword123!' });
+
+      await expect(client.signup({ email, password: 'TestPassword123!' })).rejects.toThrow();
+    });
+  });
+
+  describe('signIn', () => {
+    it('returns cookies after signing in with valid credentials', async () => {
+      const email = `test-signin-${Date.now()}@test.local`;
+      const password = 'TestPassword123!';
+
+      // Sign up first
+      await client.signup({ email, password });
+
+      // Then sign in
+      const result = await client.signIn({ email, password });
+
+      expect(result.cookies.length).toBeGreaterThan(0);
+
+      const sidCookie = result.cookies.find((c) => c.name === 'vertz.sid');
+      expect(sidCookie).toBeDefined();
+      expect(sidCookie?.value.length).toBeGreaterThan(0);
+    });
+
+    it('throws on wrong password', async () => {
+      const email = `test-signin-bad-${Date.now()}@test.local`;
+      await client.signup({ email, password: 'TestPassword123!' });
+
+      await expect(client.signIn({ email, password: 'WrongPassword!' })).rejects.toThrow();
+    });
+  });
+
+  describe('switchTenant', () => {
+    it('returns updated cookies with tenant context', async () => {
+      const email = `test-tenant-${Date.now()}@test.local`;
+      const { cookies } = await client.signup({ email, password: 'TestPassword123!' });
+
+      const result = await client.switchTenant({ tenantId: TEST_TENANT_ID, cookies });
+
+      expect(result.cookies.length).toBeGreaterThan(0);
+
+      const sidCookie = result.cookies.find((c) => c.name === 'vertz.sid');
+      expect(sidCookie).toBeDefined();
+      expect(sidCookie?.value.length).toBeGreaterThan(0);
+    });
+
+    it('throws when user does not have tenant membership', async () => {
+      const email = `test-tenant-bad-${Date.now()}@test.local`;
+      const { cookies } = await client.signup({ email, password: 'TestPassword123!' });
+
+      await expect(
+        client.switchTenant({ tenantId: 'tenant-nonexistent', cookies }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/testing/src/auth-client.ts
+++ b/packages/testing/src/auth-client.ts
@@ -1,0 +1,113 @@
+/** Configuration for the auth testing client. */
+export interface AuthClientConfig {
+  /** Base URL of the running server (e.g. `http://localhost:3000`). */
+  baseURL: string;
+}
+
+/** A cookie in the format expected by Playwright's `context.addCookies()`. */
+export interface AuthCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+}
+
+/** Result returned by auth client methods. */
+export interface AuthClientResult {
+  cookies: AuthCookie[];
+}
+
+/** Programmatic auth client for E2E test setup. */
+export interface AuthClient {
+  signup(input: { email: string; password: string }): Promise<AuthClientResult>;
+  signIn(input: { email: string; password: string }): Promise<AuthClientResult>;
+  switchTenant(input: { tenantId: string; cookies: AuthCookie[] }): Promise<AuthClientResult>;
+}
+
+/**
+ * Extract Set-Cookie headers from a Response into Playwright-compatible
+ * cookie objects.
+ */
+function extractCookies(res: Response, baseURL: string): AuthCookie[] {
+  const cookies: AuthCookie[] = [];
+  const url = new URL(baseURL);
+
+  for (const header of res.headers.getSetCookie()) {
+    const [nameValue] = header.split(';');
+    if (!nameValue) continue;
+    const eqIdx = nameValue.indexOf('=');
+    if (eqIdx > 0) {
+      cookies.push({
+        name: nameValue.slice(0, eqIdx),
+        value: nameValue.slice(eqIdx + 1),
+        domain: url.hostname,
+        path: '/',
+      });
+    }
+  }
+
+  return cookies;
+}
+
+/** Format AuthCookie[] into a Cookie header string. */
+function cookieHeader(cookies: AuthCookie[]): string {
+  return cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+}
+
+/** POST to an auth endpoint and return parsed cookies, or throw on error. */
+async function authPost(
+  baseURL: string,
+  path: string,
+  body: Record<string, unknown>,
+  cookies?: AuthCookie[],
+): Promise<AuthClientResult> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-VTZ-Request': '1',
+  };
+  if (cookies) {
+    headers.Cookie = cookieHeader(cookies);
+  }
+
+  const res = await fetch(`${baseURL}/api/auth${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Auth ${path} failed (${res.status}): ${text}`);
+  }
+
+  return { cookies: extractCookies(res, baseURL) };
+}
+
+/**
+ * Creates a programmatic auth client for server-side / E2E test usage.
+ *
+ * Wraps the Vertz auth HTTP endpoints, handles cookie parsing, and returns
+ * cookies in Playwright-compatible format.
+ *
+ * @example
+ * ```ts
+ * const client = createAuthClient({ baseURL: 'http://localhost:3000' });
+ * const { cookies } = await client.signup({ email: 'test@test.local', password: 'Pass123!' });
+ * await context.addCookies(cookies); // Playwright browser context
+ * ```
+ */
+export function createAuthClient(config: AuthClientConfig): AuthClient {
+  const { baseURL } = config;
+
+  return {
+    async signup(input) {
+      return authPost(baseURL, '/signup', input);
+    },
+    async signIn(input) {
+      return authPost(baseURL, '/signin', input);
+    },
+    async switchTenant(input) {
+      return authPost(baseURL, '/switch-tenant', { tenantId: input.tenantId }, input.cookies);
+    },
+  };
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,3 +1,5 @@
+export type { AuthClient, AuthClientConfig, AuthClientResult, AuthCookie } from './auth-client';
+export { createAuthClient } from './auth-client';
 export type {
   RequestOptions,
   RouteMapEntry,


### PR DESCRIPTION
## Summary

- Add `createAuthClient({ baseURL })` to `@vertz/testing` — a programmatic auth client for E2E test setup
- Wraps auth HTTP endpoints (`signup`, `signIn`, `switchTenant`) and returns cookies in Playwright-compatible format
- Update Linear clone E2E tests to use the new client, eliminating ~60 lines of raw fetch + cookie parsing boilerplate

## Public API Changes

**Additions** (`@vertz/testing`):
- `createAuthClient(config: AuthClientConfig): AuthClient` — factory function
- `AuthClient` interface with `signup`, `signIn`, `switchTenant` methods
- `AuthCookie` type — Playwright-compatible `{ name, value, domain, path }`
- `AuthClientResult` type — `{ cookies: AuthCookie[] }`

**No breaking changes.**

## Before / After

```typescript
// BEFORE — raw fetch in every E2E test file
const signupRes = await fetch(`${baseURL}/api/auth/signup`, {
  method: 'POST',
  headers: { 'Content-Type': 'application/json', 'X-VTZ-Request': '1' },
  body: JSON.stringify({ email, password }),
});
const cookies = extractCookies(signupRes, baseURL); // hand-rolled helper
const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ');
const switchRes = await fetch(`${baseURL}/api/auth/switch-tenant`, { ... });

// AFTER — first-party testing client
const client = createAuthClient({ baseURL });
const { cookies: signupCookies } = await client.signup({ email, password });
const { cookies } = await client.switchTenant({ tenantId, cookies: signupCookies });
await context.addCookies(cookies);
```

## Test plan

- [x] 8 unit tests covering all methods (happy path + error paths)
- [x] Tests start a real auth server (random port) with tenant switching
- [x] Verifies cookies are in Playwright-compatible format (`name`, `value`, `domain`, `path`)
- [x] Error paths: duplicate signup, wrong password, denied tenant membership
- [x] All existing tests still pass (30/30)
- [ ] Linear clone E2E tests pass with running server (requires dev server, not runnable in CI without the full app)

Fixes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)