### PR TITLE
fix(db): externalize better-sqlite3, improve SQLite fallback errors

### DIFF
--- a/.changeset/fix-sqlite-fallback-electrobun.md
+++ b/.changeset/fix-sqlite-fallback-electrobun.md
@@ -1,0 +1,9 @@
+---
+'@vertz/db': patch
+---
+
+fix(db): externalize better-sqlite3 and improve SQLite fallback error messages
+
+- Externalize `better-sqlite3` from the bundle to prevent hardcoded build-machine paths in the dist (fixes Electrobun and other bundled runtimes)
+- Move `better-sqlite3` to optional `peerDependencies` (same pattern as `postgres`)
+- Extract `resolveLocalSqliteDatabase()` with proper error handling — when both `bun:sqlite` and `better-sqlite3` fail, the error now includes both failure reasons and actionable guidance

--- a/bun.lock
+++ b/bun.lock
@@ -288,9 +288,11 @@
         "typescript": "^5.7.0",
       },
       "peerDependencies": {
+        "better-sqlite3": "^12.0.0",
         "postgres": "^3.4.8",
       },
       "optionalPeers": [
+        "better-sqlite3",
         "postgres",
       ],
     },

--- a/packages/db/bunup.config.ts
+++ b/packages/db/bunup.config.ts
@@ -67,5 +67,6 @@ export default defineConfig({
   format: ['esm'],
   dts: { inferTypes: true },
   clean: true,
+  external: ['better-sqlite3'],
   onSuccess: stripDeadRequireImports,
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -76,9 +76,13 @@
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
+    "better-sqlite3": "^12.0.0",
     "postgres": "^3.4.8"
   },
   "peerDependenciesMeta": {
+    "better-sqlite3": {
+      "optional": true
+    },
     "postgres": {
       "optional": true
     }

--- a/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
+++ b/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
@@ -3,7 +3,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { TableSchemaRegistry } from '../sqlite-driver';
-import { createLocalSqliteDriver } from '../sqlite-driver';
+import { createLocalSqliteDriver, resolveLocalSqliteDatabase } from '../sqlite-driver';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -151,6 +151,79 @@ describe('createLocalSqliteDriver', () => {
         expect(result).toEqual([{ id: 1, active: 1 }]);
 
         await driver.close();
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLocalSqliteDatabase — error handling
+// ---------------------------------------------------------------------------
+
+describe('resolveLocalSqliteDatabase', () => {
+  describe('Given both bun:sqlite and better-sqlite3 are unavailable', () => {
+    describe('When resolving the database', () => {
+      it('Then throws an error mentioning both backends and the db path', () => {
+        const bunError = new Error('bun:sqlite not available');
+        const betterError = new Error('Could not locate the bindings file');
+
+        const failingRequire = (_mod: string) => {
+          throw _mod === 'bun:sqlite' ? bunError : betterError;
+        };
+
+        expect(() => resolveLocalSqliteDatabase(':memory:', failingRequire)).toThrow(
+          /Failed to initialize SQLite/,
+        );
+        expect(() => resolveLocalSqliteDatabase(':memory:', failingRequire)).toThrow(/bun:sqlite/);
+        expect(() => resolveLocalSqliteDatabase(':memory:', failingRequire)).toThrow(
+          /better-sqlite3/,
+        );
+      });
+
+      it('Then includes the database path in the error', () => {
+        const failingRequire = (_mod: string) => {
+          throw new Error('not available');
+        };
+
+        expect(() => resolveLocalSqliteDatabase('/app/data/notes.db', failingRequire)).toThrow(
+          '/app/data/notes.db',
+        );
+      });
+    });
+  });
+
+  describe('Given bun:sqlite succeeds', () => {
+    describe('When resolving the database', () => {
+      it('Then returns the database from bun:sqlite', () => {
+        const mockDb = { prepare: () => {}, exec: () => {}, close: () => {} };
+        function MockDatabase() {
+          return mockDb;
+        }
+        const mockRequire = (mod: string) => {
+          if (mod === 'bun:sqlite') return { Database: MockDatabase };
+          throw new Error('should not reach better-sqlite3');
+        };
+
+        const db = resolveLocalSqliteDatabase(':memory:', mockRequire);
+        expect(db).toBe(mockDb);
+      });
+    });
+  });
+
+  describe('Given bun:sqlite fails but better-sqlite3 succeeds', () => {
+    describe('When resolving the database', () => {
+      it('Then returns the database from better-sqlite3', () => {
+        const mockDb = { prepare: () => {}, exec: () => {}, close: () => {} };
+        function MockDatabase() {
+          return mockDb;
+        }
+        const mockRequire = (mod: string) => {
+          if (mod === 'bun:sqlite') throw new Error('not available');
+          return MockDatabase;
+        };
+
+        const db = resolveLocalSqliteDatabase(':memory:', mockRequire);
+        expect(db).toBe(mockDb);
       });
     });
   });

--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -195,6 +195,55 @@ interface LocalSqliteDatabase {
 }
 
 // ---------------------------------------------------------------------------
+// resolveLocalSqliteDatabase — resolve bun:sqlite or better-sqlite3
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a local SQLite database using bun:sqlite or better-sqlite3.
+ *
+ * Tries bun:sqlite first (Bun runtime), then falls back to better-sqlite3 (Node.js).
+ * If both fail, throws a descriptive error with both failure reasons.
+ *
+ * @param dbPath - Path to SQLite file, or ':memory:' for in-memory
+ * @param requireFn - Optional require function for testing (defaults to global require)
+ * @returns A LocalSqliteDatabase instance
+ */
+export function resolveLocalSqliteDatabase(
+  dbPath: string,
+  requireFn: (mod: string) => unknown = require,
+): LocalSqliteDatabase {
+  let bunSqliteError: unknown;
+
+  try {
+    // Try bun:sqlite first (Bun runtime)
+    const mod = requireFn('bun:sqlite') as { Database: new (path: string) => LocalSqliteDatabase };
+    return new mod.Database(dbPath);
+  } catch (e) {
+    bunSqliteError = e;
+  }
+
+  try {
+    // Fall back to better-sqlite3 (Node.js runtime)
+    const Database = requireFn('better-sqlite3') as new (path: string) => LocalSqliteDatabase;
+    return new Database(dbPath);
+  } catch (betterSqliteError) {
+    const bunMsg =
+      bunSqliteError instanceof Error ? bunSqliteError.message : String(bunSqliteError);
+    const betterMsg =
+      betterSqliteError instanceof Error ? betterSqliteError.message : String(betterSqliteError);
+
+    throw new Error(
+      `Failed to initialize SQLite database at "${dbPath}".\n` +
+        `  bun:sqlite error: ${bunMsg}\n` +
+        `  better-sqlite3 error: ${betterMsg}\n\n` +
+        'To fix this, either:\n' +
+        '  1. Use the Bun runtime (which includes bun:sqlite), or\n' +
+        '  2. Install better-sqlite3: npm install better-sqlite3',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // createLocalSqliteDriver — factory for bun:sqlite / better-sqlite3
 // ---------------------------------------------------------------------------
 
@@ -222,17 +271,7 @@ export function createLocalSqliteDriver(
     }
   }
 
-  let db: LocalSqliteDatabase;
-
-  try {
-    // Try bun:sqlite first (Bun runtime)
-    const { Database } = require('bun:sqlite');
-    db = new Database(dbPath) as LocalSqliteDatabase;
-  } catch {
-    // Fall back to better-sqlite3 (Node.js runtime)
-    const Database = require('better-sqlite3');
-    db = new Database(dbPath) as LocalSqliteDatabase;
-  }
+  const db = resolveLocalSqliteDatabase(dbPath);
 
   // Enable WAL mode for file-based paths (not :memory:)
   if (dbPath !== ':memory:') {


### PR DESCRIPTION
## Summary

Fixes #1250 — `createSqliteAdapter` fails in Electrobun bundled runtime because `better-sqlite3` is fully bundled with hardcoded build-machine paths, and the `bun:sqlite` error is silently swallowed.

- **Externalize `better-sqlite3` from the bundle** — prevents the `bindings` package from embedding hardcoded `__filename` paths that only work on the build machine. The dist now uses a runtime `require("better-sqlite3")` that resolves from `node_modules` correctly in any deployment environment.
- **Move `better-sqlite3` to optional `peerDependencies`** — follows the same pattern as `postgres`. Users on Bun don't need it (bun:sqlite is built-in); users on Node.js install it themselves.
- **Extract `resolveLocalSqliteDatabase()` with dual-error handling** — when both `bun:sqlite` and `better-sqlite3` fail, the error now includes both failure reasons and actionable guidance instead of just the cryptic "Could not locate the bindings file" from the bundled bindings package.

## Public API Changes

- **New export:** `resolveLocalSqliteDatabase(dbPath, requireFn?)` — extracted from `createLocalSqliteDriver` for testability. Takes an optional `requireFn` parameter for dependency injection in tests.
- **No breaking changes** — `createLocalSqliteDriver` behavior is unchanged for working environments. Only the error message format changes when both backends fail.

## Test plan

- [x] New tests for `resolveLocalSqliteDatabase`:
  - Both backends fail → error includes both messages + db path
  - bun:sqlite succeeds → returns bun:sqlite database
  - bun:sqlite fails, better-sqlite3 succeeds → returns better-sqlite3 database
- [x] All existing `createLocalSqliteDriver` tests pass
- [x] All 1303 `@vertz/db` tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Verified dist no longer contains bundled `better-sqlite3` code (was ~800 lines of inlined JS including `bindings` with hardcoded paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)