### PR TITLE
fix(orchestrator): exclude ready-for-review issues

### DIFF
--- a/tools/orchestrator/src/github.ts
+++ b/tools/orchestrator/src/github.ts
@@ -53,7 +53,7 @@ export async function fetchEligibleIssues(): Promise<Issue[]> {
   return issues
     .filter((issue) => {
       const names = new Set(issue.labels.map((l) => l.name));
-      return !names.has('in-progress') && !names.has('blocked');
+      return !names.has('in-progress') && !names.has('blocked') && !names.has('ready-for-review');
     })
     .sort((a, b) => priorityOf(a) - priorityOf(b));
 }


### PR DESCRIPTION
## Summary

- Filter orchestrator eligible issue list to exclude `ready-for-review` labels alongside `in-progress` and `blocked`
- Prevents re-dispatching issues that already have passing PRs ready for human review
- Improves issue triage by only picking up issues that need agent work

## Test plan

- Run `bun run src/orchestrator.ts --dry-run` to verify #1427 and #1426 are now excluded from the eligible list
- Issues #1285, #1217, and others without `ready-for-review` should still appear