### PR TITLE
fix(linear): handle dialog stack.open result as error-value, not try/catch

### DIFF
--- a/examples/linear/src/pages/issue-list-page.tsx
+++ b/examples/linear/src/pages/issue-list-page.tsx
@@ -31,12 +31,8 @@ export function IssueListPage() {
       : issues.data?.items.filter((i) => i.status === statusFilter);
 
   const handleNewIssue = async () => {
-    try {
-      const created = await stack.open(CreateIssueDialog, { projectId });
-      if (created) issues.refetch();
-    } catch {
-      // Dialog dismissed — no action needed
-    }
+    const result = await stack.open(CreateIssueDialog, { projectId });
+    if (result.ok && result.data) issues.refetch();
   };
 
   return (

--- a/examples/linear/src/pages/project-board-page.tsx
+++ b/examples/linear/src/pages/project-board-page.tsx
@@ -32,12 +32,8 @@ export function ProjectBoardPage() {
   }));
 
   const handleNewIssue = async () => {
-    try {
-      const created = await stack.open(CreateIssueDialog, { projectId });
-      if (created) issues.refetch();
-    } catch {
-      // Dialog dismissed — no action needed
-    }
+    const result = await stack.open(CreateIssueDialog, { projectId });
+    if (result.ok && result.data) issues.refetch();
   };
 
   return (

--- a/examples/linear/src/pages/projects-page.tsx
+++ b/examples/linear/src/pages/projects-page.tsx
@@ -19,12 +19,8 @@ export function ProjectsPage() {
   const stack = useDialogStack();
 
   const handleNewProject = async () => {
-    try {
-      const created = await stack.open(CreateProjectDialog, {});
-      if (created) projects.refetch();
-    } catch {
-      // Dialog dismissed — no action needed
-    }
+    const result = await stack.open(CreateProjectDialog, {});
+    if (result.ok && result.data) projects.refetch();
   };
 
   return (


### PR DESCRIPTION
## Summary

- Replace `try/catch` with proper `DialogResult` handling in 3 pages: `issue-list-page.tsx`, `projects-page.tsx`, `project-board-page.tsx`
- `stack.open()` returns `Promise<DialogResult<T>>` (discriminated union `{ ok: true, data: T } | { ok: false }`), never rejects — try/catch was incorrect
- Also found and fixed a third occurrence in `project-board-page.tsx` not mentioned in the issue

## Public API Changes

None — internal example code only.

## Test plan

- [x] Quality gates pass (lint, typecheck, build, test — all cached/green)
- [ ] Manual: open Linear clone, create issue/project via dialog, verify refetch works
- [ ] Manual: dismiss dialog via Escape/cancel, verify no error and no refetch

Fixes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)