### PR TITLE
fix(linear): replace raw SQL in seed.test with typed DB client

### DIFF
--- a/examples/linear/src/api/seed.test.ts
+++ b/examples/linear/src/api/seed.test.ts
@@ -1,15 +1,14 @@
-import { Database } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createDb } from '@vertz/db';
+import { unwrap } from '@vertz/schema';
 import { commentsModel, issuesModel, projectsModel, SEED_TENANT_ID, usersModel } from './schema';
 import { seedDatabase } from './seed';
 
 describe('seedDatabase', () => {
   let client: ReturnType<typeof createClient>;
-  let db: Database;
   let tmpDir: string;
 
   function createClient(dbPath: string) {
@@ -34,14 +33,9 @@ describe('seedDatabase', () => {
 
     // Trigger lazy migration to create tables
     await client.projects.count();
-
-    // Open raw bun:sqlite for verification queries
-    db = new Database(dbPath);
-    db.exec('PRAGMA foreign_keys=ON');
   });
 
   afterEach(async () => {
-    db.close();
     await client.close();
     rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -50,83 +44,81 @@ describe('seedDatabase', () => {
     describe('When seedDatabase is called', () => {
       it('Then creates 2 seed users', async () => {
         await seedDatabase(client);
-        const count = db.query('SELECT COUNT(*) as count FROM users').get() as { count: number };
-        expect(count.count).toBe(2);
+        const count = unwrap(await client.users.count());
+        expect(count).toBe(2);
       });
 
       it('Then creates 3 seed projects with keys ENG, DES, DOC', async () => {
         await seedDatabase(client);
-        const projects = db.query('SELECT key FROM projects ORDER BY key').all() as {
-          key: string;
-        }[];
+        const projects = unwrap(
+          await client.projects.list({ select: { key: true }, orderBy: { key: 'asc' } }),
+        );
         expect(projects.map((p) => p.key)).toEqual(['DES', 'DOC', 'ENG']);
       });
 
       it('Then creates 12 seed issues across projects', async () => {
         await seedDatabase(client);
-        const count = db.query('SELECT COUNT(*) as count FROM issues').get() as { count: number };
-        expect(count.count).toBe(12);
+        const count = unwrap(await client.issues.count());
+        expect(count).toBe(12);
       });
 
       it('Then creates 6 issues for the Engineering project', async () => {
         await seedDatabase(client);
-        const count = db
-          .query('SELECT COUNT(*) as count FROM issues WHERE project_id = ?')
-          .get('proj-eng') as { count: number };
-        expect(count.count).toBe(6);
+        const count = unwrap(await client.issues.count({ where: { projectId: 'proj-eng' } }));
+        expect(count).toBe(6);
       });
 
       it('Then creates 10 seed comments across issues', async () => {
         await seedDatabase(client);
-        const count = db.query('SELECT COUNT(*) as count FROM comments').get() as {
-          count: number;
-        };
-        expect(count.count).toBe(10);
+        const count = unwrap(await client.comments.count());
+        expect(count).toBe(10);
       });
 
       it('Then comments reference valid issues and authors', async () => {
         await seedDatabase(client);
-        // Verify a specific comment's relationships
-        const comment = db
-          .query(
-            `SELECT c.body, c.author_id, i.title as issue_title
-             FROM comments c
-             JOIN issues i ON c.issue_id = i.id
-             WHERE c.id = 'com-1'`,
-          )
-          .get() as { body: string; author_id: string; issue_title: string };
-
+        const comment = unwrap(await client.comments.get({ where: { id: 'com-1' } }));
+        if (!comment) throw new Error('Expected comment com-1 to exist');
         expect(comment.body).toContain('CI is green');
-        expect(comment.author_id).toBe('seed-bob');
-        expect(comment.issue_title).toBe('Set up CI pipeline');
+        expect(comment.authorId).toBe('seed-bob');
+
+        const issue = unwrap(await client.issues.get({ where: { id: comment.issueId } }));
+        if (!issue) throw new Error('Expected issue to exist');
+        expect(issue.title).toBe('Set up CI pipeline');
       });
 
       it('Then issues span all statuses', async () => {
         await seedDatabase(client);
-        const statuses = db.query('SELECT DISTINCT status FROM issues ORDER BY status').all() as {
-          status: string;
-        }[];
-        expect(statuses.map((s) => s.status)).toEqual(['backlog', 'done', 'in_progress', 'todo']);
+        const issues = unwrap(
+          await client.issues.list({ select: { status: true }, orderBy: { status: 'asc' } }),
+        );
+        const statuses = [...new Set(issues.map((i) => i.status))];
+        expect(statuses).toEqual(['backlog', 'done', 'in_progress', 'todo']);
       });
 
       it('Then all seed records have timestamps', async () => {
         await seedDatabase(client);
-        for (const table of ['users', 'projects', 'issues', 'comments']) {
-          const rows = db
-            .query(`SELECT created_at FROM ${table} WHERE created_at IS NULL`)
-            .all() as { created_at: string }[];
-          expect(rows).toHaveLength(0);
-        }
+        const users = unwrap(await client.users.list({ select: { createdAt: true } }));
+        expect(users.every((u) => u.createdAt instanceof Date)).toBe(true);
+
+        const projects = unwrap(await client.projects.list({ select: { createdAt: true } }));
+        expect(projects.every((p) => p.createdAt instanceof Date)).toBe(true);
+
+        const issues = unwrap(await client.issues.list({ select: { createdAt: true } }));
+        expect(issues.every((i) => i.createdAt instanceof Date)).toBe(true);
+
+        const comments = unwrap(await client.comments.list({ select: { createdAt: true } }));
+        expect(comments.every((c) => c.createdAt instanceof Date)).toBe(true);
       });
 
       it('Then all seed records have the seed tenant ID', async () => {
         await seedDatabase(client);
-
-        for (const table of ['users', 'projects', 'issues', 'comments']) {
-          const rows = db
-            .query(`SELECT tenant_id FROM ${table} WHERE tenant_id != ?`)
-            .all(SEED_TENANT_ID) as { tenant_id: string }[];
-          expect(rows).toHaveLength(0);
+        for (const countResult of [
+          await client.users.count({ where: { tenantId: { ne: SEED_TENANT_ID } } }),
+          await client.projects.count({ where: { tenantId: { ne: SEED_TENANT_ID } } }),
+          await client.issues.count({ where: { tenantId: { ne: SEED_TENANT_ID } } }),
+          await client.comments.count({ where: { tenantId: { ne: SEED_TENANT_ID } } }),
+        ]) {
+          expect(unwrap(countResult)).toBe(0);
         }
       });
     });
@@ -138,19 +130,13 @@ describe('seedDatabase', () => {
         await seedDatabase(client);
         await seedDatabase(client); // Call again
 
-        const projectCount = db.query('SELECT COUNT(*) as count FROM projects').get() as {
-          count: number;
-        };
-        const issueCount = db.query('SELECT COUNT(*) as count FROM issues').get() as {
-          count: number;
-        };
-        const commentCount = db.query('SELECT COUNT(*) as count FROM comments').get() as {
-          count: number;
-        };
+        const projectCount = unwrap(await client.projects.count());
+        const issueCount = unwrap(await client.issues.count());
+        const commentCount = unwrap(await client.comments.count());
 
-        expect(projectCount.count).toBe(3);
-        expect(issueCount.count).toBe(12);
-        expect(commentCount.count).toBe(10);
+        expect(projectCount).toBe(3);
+        expect(issueCount).toBe(12);
+        expect(commentCount).toBe(10);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Replaced all raw `bun:sqlite` queries in `examples/linear/src/api/seed.test.ts` with typed `@vertz/db` client calls (`count`, `list`, `get`)
- Removed the `Database` import from `bun:sqlite` and the raw SQLite connection setup entirely
- All verification queries now use camelCase field names with full type inference via `unwrap()` from `@vertz/schema`

Fixes #1448

## Public API Changes

None — this is an internal test file change in the example app.

## Test plan

- [x] All 10 existing seed tests pass with typed client calls
- [x] No raw SQL (`bun:sqlite`) remains in the linear example
- [x] No type errors introduced (typecheck clean for seed.test.ts)
- [x] Lint clean (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)