### PR TITLE
feat(server): add defineAuth() and defineEntities() for extractable config

### DIFF
--- a/.changeset/define-auth-extractable.md
+++ b/.changeset/define-auth-extractable.md
@@ -1,0 +1,5 @@
+---
+'@vertz/server': patch
+---
+
+feat(server): add defineAuth() and defineEntities() for extractable, type-safe config

--- a/examples/linear/src/api/auth.ts
+++ b/examples/linear/src/api/auth.ts
@@ -1,0 +1,53 @@
+import { defineAuth, github } from '@vertz/server';
+import { SEED_TENANT_ID } from './schema';
+
+const APP_URL = process.env.APP_URL ?? 'http://localhost:3001';
+
+export const auth = defineAuth({
+  session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d', cookie: { secure: false } },
+  emailPassword: {},
+  jwtSecret: process.env.JWT_SECRET ?? 'linear-clone-dev-secret-at-least-32-chars!!',
+  providers: [
+    github({
+      clientId: process.env.GITHUB_CLIENT_ID ?? '',
+      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
+      redirectUrl: `${APP_URL}/api/auth/oauth/github/callback`,
+    }),
+  ],
+  oauthEncryptionKey: process.env.OAUTH_ENCRYPTION_KEY,
+  oauthSuccessRedirect: '/projects',
+  oauthErrorRedirect: '/login',
+
+  // Tenant switching — enables POST /api/auth/switch-tenant.
+  // In a real app verifyMembership would check a tenant_members table.
+  // Here we auto-assign every user to the default seed tenant.
+  tenant: {
+    verifyMembership: async (_userId, tenantId) => {
+      return tenantId === SEED_TENANT_ID;
+    },
+  },
+
+  // Bridge auth → entity: populate the developer's users table from GitHub profile.
+  // Also handles email/password signups (for dev/E2E testing).
+  // tenantId is set explicitly because the session has no tenant yet at signup time.
+  onUserCreated: async (payload, ctx) => {
+    if (payload.provider) {
+      const profile = payload.profile as Record<string, unknown>;
+      await ctx.entities.users.create({
+        id: payload.user.id,
+        tenantId: SEED_TENANT_ID,
+        email: payload.user.email,
+        name: (profile.name as string) ?? (profile.login as string),
+        avatarUrl: profile.avatar_url as string,
+      });
+    } else {
+      await ctx.entities.users.create({
+        id: payload.user.id,
+        tenantId: SEED_TENANT_ID,
+        email: payload.user.email,
+        name: payload.user.email.split('@')[0],
+        avatarUrl: null,
+      });
+    }
+  },
+});

--- a/examples/linear/src/api/entities/index.ts
+++ b/examples/linear/src/api/entities/index.ts
@@ -1,0 +1,7 @@
+import { defineEntities } from '@vertz/server';
+import { comments } from './comments.entity';
+import { issues } from './issues.entity';
+import { projects } from './projects.entity';
+import { users } from './users.entity';
+
+export const entities = defineEntities([users, projects, issues, comments]);

--- a/examples/linear/src/api/server.ts
+++ b/examples/linear/src/api/server.ts
@@ -6,67 +6,15 @@
  * - Entity registry proxy for onUserCreated callback
  */
 
-import { createServer, github } from '@vertz/server';
+import { createServer } from '@vertz/server';
+import { auth } from './auth';
 import { db } from './db';
-import { comments } from './entities/comments.entity';
-import { issues } from './entities/issues.entity';
-import { projects } from './entities/projects.entity';
-import { users } from './entities/users.entity';
-import { SEED_TENANT_ID } from './schema';
-
-const APP_URL = process.env.APP_URL ?? 'http://localhost:3001';
+import { entities } from './entities';
 
 export const app = createServer({
   basePath: '/api',
-  entities: [users, projects, issues, comments],
+  entities,
   // biome-ignore lint/suspicious/noExplicitAny: DatabaseClient model variance
   db: db as any,
-  auth: {
-    session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d', cookie: { secure: false } },
-    emailPassword: {},
-    jwtSecret: process.env.JWT_SECRET ?? 'linear-clone-dev-secret-at-least-32-chars!!',
-    providers: [
-      github({
-        clientId: process.env.GITHUB_CLIENT_ID ?? '',
-        clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
-        redirectUrl: `${APP_URL}/api/auth/oauth/github/callback`,
-      }),
-    ],
-    oauthEncryptionKey: process.env.OAUTH_ENCRYPTION_KEY,
-    oauthSuccessRedirect: '/projects',
-    oauthErrorRedirect: '/login',
-
-    // Tenant switching — enables POST /api/auth/switch-tenant.
-    // In a real app verifyMembership would check a tenant_members table.
-    // Here we auto-assign every user to the default seed tenant.
-    tenant: {
-      verifyMembership: async (_userId, tenantId) => {
-        return tenantId === SEED_TENANT_ID;
-      },
-    },
-
-    // Bridge auth → entity: populate the developer's users table from GitHub profile.
-    // Also handles email/password signups (for dev/E2E testing).
-    // tenantId is set explicitly because the session has no tenant yet at signup time.
-    onUserCreated: async (payload, ctx) => {
-      if (payload.provider) {
-        const profile = payload.profile as Record<string, unknown>;
-        await ctx.entities.users.create({
-          id: payload.user.id,
-          tenantId: SEED_TENANT_ID,
-          email: payload.user.email,
-          name: (profile.name as string) ?? (profile.login as string),
-          avatarUrl: profile.avatar_url as string,
-        });
-      } else {
-        await ctx.entities.users.create({
-          id: payload.user.id,
-          tenantId: SEED_TENANT_ID,
-          email: payload.user.email,
-          name: payload.user.email.split('@')[0],
-          avatarUrl: null,
-        });
-      }
-    },
-  },
+  auth,
 });

--- a/packages/server/src/__tests__/define-auth.test-d.ts
+++ b/packages/server/src/__tests__/define-auth.test-d.ts
@@ -1,0 +1,32 @@
+import type { AuthConfig } from '../auth/types';
+import type { EntityDefinition } from '../entity/types';
+import { defineAuth, defineEntities } from '../index';
+
+// defineAuth returns AuthConfig
+const auth = defineAuth({
+  session: { strategy: 'jwt', ttl: '15m' },
+});
+const _authCheck: AuthConfig = auth;
+
+// defineAuth accepts all AuthConfig fields
+defineAuth({
+  session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d' },
+  emailPassword: { enabled: true },
+  jwtSecret: 'some-secret',
+  providers: [],
+  onUserCreated: async () => {},
+});
+
+// @ts-expect-error - session is required
+defineAuth({});
+
+// @ts-expect-error - strategy must be a valid SessionStrategy
+defineAuth({ session: { strategy: 'invalid', ttl: '15m' } });
+
+// defineEntities returns EntityDefinition[]
+const entities = defineEntities([]);
+const _entitiesCheck: EntityDefinition[] = entities;
+
+// defineEntities result can be passed to a function expecting EntityDefinition[]
+function consume(_e: EntityDefinition[]): void {}
+consume(defineEntities([]));

--- a/packages/server/src/__tests__/define-auth.test.ts
+++ b/packages/server/src/__tests__/define-auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import type { AuthConfig } from '../auth/types';
+import type { EntityDefinition } from '../entity/types';
+import { defineAuth, defineEntities } from '../index';
+
+describe('defineAuth', () => {
+  it('returns the same config object it receives', () => {
+    const config = {
+      session: { strategy: 'jwt' as const, ttl: '15m' },
+      emailPassword: { enabled: true },
+      jwtSecret: 'test-secret-that-is-at-least-32-chars!!',
+    };
+
+    const result = defineAuth(config);
+
+    expect(result).toBe(config);
+  });
+
+  it('result is assignable to AuthConfig', () => {
+    const result = defineAuth({
+      session: { strategy: 'jwt', ttl: '15m' },
+    });
+
+    // Prove the return type satisfies AuthConfig
+    const _check: AuthConfig = result;
+    expect(_check).toBe(result);
+  });
+});
+
+describe('defineEntities', () => {
+  it('returns the same array it receives', () => {
+    const entities: EntityDefinition[] = [];
+    const result = defineEntities(entities);
+
+    expect(result).toBe(entities);
+  });
+
+  it('result is assignable to EntityDefinition[]', () => {
+    const result = defineEntities([]);
+    const _check: EntityDefinition[] = result;
+    expect(_check).toBe(result);
+  });
+});

--- a/packages/server/src/define-auth.ts
+++ b/packages/server/src/define-auth.ts
@@ -1,0 +1,23 @@
+import type { AuthConfig } from './auth/types';
+
+/**
+ * Identity function that preserves the full AuthConfig type.
+ *
+ * Allows defining auth configuration in a separate file
+ * while retaining full type inference and autocomplete:
+ *
+ * ```ts
+ * // auth.ts
+ * export const auth = defineAuth({
+ *   session: { strategy: 'jwt', ttl: '15m' },
+ *   emailPassword: { enabled: true },
+ * });
+ *
+ * // server.ts
+ * import { auth } from './auth';
+ * createServer({ db, auth, entities: [...] });
+ * ```
+ */
+export function defineAuth(config: AuthConfig): AuthConfig {
+  return config;
+}

--- a/packages/server/src/define-entities.ts
+++ b/packages/server/src/define-entities.ts
@@ -1,0 +1,20 @@
+import type { EntityDefinition } from './entity/types';
+
+/**
+ * Identity function that preserves the EntityDefinition[] type.
+ *
+ * Allows defining entities in a separate file while retaining
+ * full type inference:
+ *
+ * ```ts
+ * // entities.ts
+ * export const entities = defineEntities([users, projects, issues]);
+ *
+ * // server.ts
+ * import { entities } from './entities';
+ * createServer({ db, auth, entities });
+ * ```
+ */
+export function defineEntities(entities: EntityDefinition[]): EntityDefinition[] {
+  return entities;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -243,6 +243,9 @@ export { content, isContentDescriptor } from './content';
 // Server — wraps core's createServer with entity route generation
 export type { CloudServerConfig, ServerConfig, ServerInstance } from './create-server';
 export { createServer } from './create-server';
+// Config helpers — identity functions for extractable, type-safe config
+export { defineAuth } from './define-auth';
+export { defineEntities } from './define-entities';
 // Entity API
 export type {
   AccessRule,


### PR DESCRIPTION
## Summary

- Add `defineAuth()` and `defineEntities()` identity functions that enable defining server config in separate files while preserving full type inference and autocomplete
- Update Linear clone example to use the extractable pattern — auth config moved to `auth.ts`, entity list moved to `entities/index.ts`
- Export both functions from `@vertz/server`

## Public API Changes

### Additions
- `defineAuth(config: AuthConfig): AuthConfig` — type-safe identity function for extractable auth config
- `defineEntities(entities: EntityDefinition[]): EntityDefinition[]` — type-safe identity function for extractable entity lists

### Usage
```ts
// auth.ts
import { defineAuth, github } from '@vertz/server';
export const auth = defineAuth({
  session: { strategy: 'jwt', ttl: '15m' },
  providers: [github({ clientId: '...', clientSecret: '...' })],
});

// entities.ts
import { defineEntities } from '@vertz/server';
export const entities = defineEntities([users, projects, issues]);

// server.ts
import { auth } from './auth';
import { entities } from './entities';
createServer({ db, auth, entities });
```

## Test plan

- [x] Runtime tests: `defineAuth` returns same config object, `defineEntities` returns same array
- [x] Type-level tests: full AuthConfig inference, `@ts-expect-error` on missing required fields and invalid values
- [x] All 85 existing server tests pass
- [x] Typecheck clean on `@vertz/server`
- [x] Pre-push quality gates pass (82/82 tasks)

Fixes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)