### PR TITLE
feat(biome): lint rule to flag try/catch around error-as-value APIs

### DIFF
--- a/biome-plugins/__tests__/no-try-catch-result.test.ts
+++ b/biome-plugins/__tests__/no-try-catch-result.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'bun:test';
+import { resolve } from 'node:path';
+
+/**
+ * Tests for the no-try-catch-result GritQL rule.
+ *
+ * Runs biome lint on fixture strings and checks that the rule:
+ * - Flags try/catch wrapping `.open()` calls (error-as-value APIs)
+ * - Does NOT flag try/catch around non-Result APIs (fetch, fs, etc.)
+ * - Does NOT flag `.open()` calls outside try/catch
+ */
+
+const PROJECT_ROOT = resolve(import.meta.dir, '../..');
+const PLUGIN_PATH = resolve(PROJECT_ROOT, 'biome-plugins/no-try-catch-result.grit');
+
+async function lintFixture(code: string): Promise<string> {
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tmpDir = `/tmp/biome-test-${id}`;
+  const configPath = `${tmpDir}/biome.json`;
+  const fixturePath = `${tmpDir}/fixture.ts`;
+
+  await Bun.write(
+    configPath,
+    JSON.stringify({
+      $schema: 'https://biomejs.dev/schemas/2.3.14/schema.json',
+      plugins: [PLUGIN_PATH],
+      linter: { enabled: true, rules: { recommended: false } },
+    }),
+  );
+  await Bun.write(fixturePath, code);
+
+  const proc = Bun.spawn(['bunx', 'biome', 'lint', '--config-path', tmpDir, fixturePath], {
+    cwd: PROJECT_ROOT,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+  return stdout + stderr;
+}
+
+describe('no-try-catch-result', () => {
+  it('flags try/catch wrapping stack.open()', async () => {
+    const output = await lintFixture(`
+      async function _handler() {
+        try {
+          const result = await stack.open(Dialog, {});
+        } catch {
+          // dismissed
+        }
+      }
+    `);
+    expect(output).toContain('error-as-value');
+  });
+
+  it('flags try/catch with catch param wrapping dialogs.open()', async () => {
+    const output = await lintFixture(`
+      async function _handler() {
+        try {
+          const result = await dialogs.open(Dialog, {});
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    `);
+    expect(output).toContain('error-as-value');
+  });
+
+  it('does NOT flag .open() outside try/catch', async () => {
+    const output = await lintFixture(`
+      async function _handler() {
+        const result = await stack.open(Dialog, {});
+        if (result.ok) doSomething();
+      }
+    `);
+    expect(output).not.toContain('error-as-value');
+  });
+
+  it('flags try/catch/finally wrapping .open()', async () => {
+    const output = await lintFixture(`
+      async function _handler() {
+        try {
+          const result = await stack.open(Dialog, {});
+        } catch {
+          // dismissed
+        } finally {
+          cleanup();
+        }
+      }
+    `);
+    expect(output).toContain('error-as-value');
+  });
+
+  it('does NOT flag try/catch around non-Result APIs', async () => {
+    const output = await lintFixture(`
+      async function _handler() {
+        try {
+          const data = await fetch('/api');
+        } catch (e) {
+          handleError(e);
+        }
+      }
+    `);
+    expect(output).not.toContain('error-as-value');
+  });
+});

--- a/biome-plugins/no-try-catch-result.grit
+++ b/biome-plugins/no-try-catch-result.grit
@@ -1,0 +1,22 @@
+// Prevent try/catch around error-as-value APIs.
+// APIs like stack.open() and dialogs.open() return Result types — errors
+// are values, not exceptions. Wrapping them in try/catch silently ignores
+// the error path. Use `if (result.ok)` instead.
+or {
+  `try { $body } catch { $_ }` as $try where {
+    $body <: contains `$_obj.open($_args)`,
+    register_diagnostic(span=$try, message="Do not wrap error-as-value APIs in try/catch. APIs like stack.open() return Result types — use `if (result.ok)` instead of try/catch.", severity="warn")
+  },
+  `try { $body } catch ($e) { $_ }` as $try where {
+    $body <: contains `$_obj.open($_args)`,
+    register_diagnostic(span=$try, message="Do not wrap error-as-value APIs in try/catch. APIs like stack.open() return Result types — use `if (result.ok)` instead of try/catch.", severity="warn")
+  },
+  `try { $body } catch { $_ } finally { $_ }` as $try where {
+    $body <: contains `$_obj.open($_args)`,
+    register_diagnostic(span=$try, message="Do not wrap error-as-value APIs in try/catch. APIs like stack.open() return Result types — use `if (result.ok)` instead of try/catch.", severity="warn")
+  },
+  `try { $body } catch ($e) { $_ } finally { $_ }` as $try where {
+    $body <: contains `$_obj.open($_args)`,
+    register_diagnostic(span=$try, message="Do not wrap error-as-value APIs in try/catch. APIs like stack.open() return Result types — use `if (result.ok)` instead of try/catch.", severity="warn")
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -67,14 +67,14 @@
       "linter": {
         "rules": {
           "a11y": {
-            "noRedundantRoles": "off",
-            "useSemanticElements": "off",
             "noNoninteractiveElementToInteractiveRole": "off",
+            "noRedundantRoles": "off",
+            "noStaticElementInteractions": "off",
+            "useAriaPropsForRole": "off",
+            "useAriaPropsSupportedByRole": "off",
             "useFocusableInteractive": "off",
             "useKeyWithClickEvents": "off",
-            "useAriaPropsForRole": "off",
-            "noStaticElementInteractions": "off",
-            "useAriaPropsSupportedByRole": "off"
+            "useSemanticElements": "off"
           }
         }
       }
@@ -87,7 +87,8 @@
     "./biome-plugins/no-throw-plain-error.grit",
     "./biome-plugins/no-wrong-effect.grit",
     "./biome-plugins/no-querymatch-destructure.grit",
-    "./biome-plugins/no-body-jsx.grit"
+    "./biome-plugins/no-body-jsx.grit",
+    "./biome-plugins/no-try-catch-result.grit"
   ],
   "vcs": {
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Adds `no-try-catch-result` GritQL plugin that detects try/catch blocks wrapping `.open()` calls (dialog stack API)
- These APIs return Result types — errors are values, not exceptions. Wrapping them in try/catch silently ignores the error path
- Registered as `warn` severity (consistent with other GritQL plugins)
- Includes test suite validating true positives and false negative avoidance

## Public API Changes

None — this is a lint rule addition, no runtime code changes.

## What it catches

```tsx
// FLAGGED — try/catch around error-as-value API
try {
  const result = await stack.open(CreateDialog, {});
  if (result) doSomething();
} catch {
  // dismissed — silently swallowed
}

// CORRECT — use Result pattern
const result = await stack.open(CreateDialog, {});
if (result.ok) {
  doSomething(result.data);
}
```

Currently detects 3 instances in `examples/linear/` (the known anti-pattern from the issue).

## Test plan

- [x] Test: flags try/catch wrapping `stack.open()`
- [x] Test: flags try/catch with catch param wrapping `dialogs.open()`
- [x] Test: flags try/catch/finally wrapping `.open()`
- [x] Test: does NOT flag `.open()` outside try/catch
- [x] Test: does NOT flag try/catch around non-Result APIs (fetch, etc.)
- [x] Full lint passes (no new errors introduced)

Fixes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)