### PR TITLE
fix(server): remove unnecessary `as any` cast on db in createServer

### DIFF
--- a/examples/linear/src/api/server.ts
+++ b/examples/linear/src/api/server.ts
@@ -14,7 +14,6 @@ import { entities } from './entities';
 export const app = createServer({
   basePath: '/api',
   entities,
-  // biome-ignore lint/suspicious/noExplicitAny: DatabaseClient model variance
-  db: db as any,
+  db,
   auth,
 });

--- a/packages/server/src/__tests__/create-server.test-d.ts
+++ b/packages/server/src/__tests__/create-server.test-d.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'bun:test';
+import { createDb, d } from '@vertz/db';
+import { authModels, createServer, type ServerInstance } from '..';
+
+// ---------------------------------------------------------------------------
+// Type test: createDb() return is assignable to createServer({ db }) without cast
+// Regression: https://github.com/vertz-dev/vertz/issues/1446
+// ---------------------------------------------------------------------------
+
+const usersTable = d.table('users', {
+  id: d.text().primary(),
+  tenantId: d.text().default(''),
+  name: d.text(),
+  email: d.text().unique(),
+});
+
+const usersModel = d.model(usersTable);
+
+const db = createDb({
+  models: {
+    ...authModels,
+    users: usersModel,
+  },
+  dialect: 'sqlite',
+  path: ':memory:',
+});
+
+describe('createServer db parameter type', () => {
+  it('accepts DatabaseClient from createDb() without cast', () => {
+    // This must compile without `as any` — the db parameter should accept
+    // any DatabaseClient regardless of its specific model types.
+    const app = createServer({
+      entities: [],
+      db,
+      auth: {
+        session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d' },
+        emailPassword: {},
+      },
+    });
+
+    // Verify the overload resolves to ServerInstance (db + auth provided)
+    void (app satisfies ServerInstance);
+  });
+
+  it('rejects non-DatabaseClient objects for the db parameter', () => {
+    // @ts-expect-error — plain object is not a DatabaseClient or EntityDbAdapter
+    createServer({
+      entities: [],
+      db: { notADatabase: true },
+      auth: {
+        session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d' },
+        emailPassword: {},
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the `as any` cast on the `db` parameter in `examples/linear/src/api/server.ts`
- The cast was unnecessary — `DatabaseClientLike` (the structural type used by `ServerConfig.db`) already accepts any `DatabaseClient<TModels>` via its index signature and covariant `_internals` property
- Adds a type-level regression test (`create-server.test-d.ts`) that verifies `createDb()` return type is assignable to `createServer({ db })` without a cast

## Public API Changes

None — this is a cast removal in an example, not a framework API change.

## Test plan

- [x] Type test: `createServer({ db })` accepts `DatabaseClient` from `createDb()` without cast
- [x] Type test: `createServer({ db })` rejects non-DatabaseClient objects (`@ts-expect-error`)
- [x] Server package typecheck passes
- [x] All 1596 server tests pass
- [x] Full quality gates pass (lint + typecheck + test + build)

Fixes #1446