### PR TITLE
fix(fetch,codegen): wire credentials through FetchClient and generated client

### DIFF
--- a/packages/codegen/src/generators/__tests__/client-generator.test.ts
+++ b/packages/codegen/src/generators/__tests__/client-generator.test.ts
@@ -247,6 +247,29 @@ describe('ClientGenerator', () => {
       expect(clientFile?.content).not.toContain('optimistic');
     });
 
+    it('passes credentials include to FetchClient by default', () => {
+      const ir = createBasicIR([
+        {
+          entityName: 'user',
+          operations: [
+            {
+              kind: 'list',
+              method: 'GET',
+              path: '/user',
+              operationId: 'listUser',
+              outputSchema: 'UserResponse',
+            },
+          ],
+          actions: [],
+        },
+      ]);
+
+      const files = generator.generate(ir, { outputDir: '.vertz', options: {} });
+      const clientFile = files.find((f) => f.path === 'client.ts');
+
+      expect(clientFile?.content).toContain("credentials: 'include'");
+    });
+
     it('includes ClientOptions with headers and timeoutMs', () => {
       const ir = createBasicIR([]);
 

--- a/packages/codegen/src/generators/client-generator.ts
+++ b/packages/codegen/src/generators/client-generator.ts
@@ -101,7 +101,7 @@ export class ClientGenerator implements Generator {
 
       if (entities.length > 0) {
         lines.push(
-          `  const client = new FetchClient({ baseURL: ${baseURLDefault}, headers: options.headers, timeoutMs: options.timeoutMs });`,
+          `  const client = new FetchClient({ baseURL: ${baseURLDefault}, headers: options.headers, timeoutMs: options.timeoutMs, credentials: 'include' });`,
         );
         if (hasMutations) {
           lines.push(

--- a/packages/fetch/src/client.test.ts
+++ b/packages/fetch/src/client.test.ts
@@ -842,6 +842,58 @@ describe('FetchClient parse and validation errors', () => {
   });
 });
 
+describe('FetchClient credentials', () => {
+  it('passes credentials to fetch for relative URL requests', async () => {
+    const mockFetch = mock().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), { status: 200 }),
+    );
+
+    const client = new FetchClient({
+      baseURL: '/api',
+      credentials: 'include',
+      fetch: mockFetch,
+    });
+
+    await client.get('/users');
+
+    const [, initArg] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(initArg.credentials).toBe('include');
+  });
+
+  it('passes credentials to fetch for absolute URL requests', async () => {
+    const mockFetch = mock().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), { status: 200 }),
+    );
+
+    const client = new FetchClient({
+      baseURL: 'http://localhost:3000',
+      credentials: 'include',
+      fetch: mockFetch,
+    });
+
+    await client.get('/users');
+
+    const [request] = mockFetch.mock.calls[0] as [Request];
+    expect(request.credentials).toBe('include');
+  });
+
+  it('does not set credentials when not configured', async () => {
+    const mockFetch = mock().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), { status: 200 }),
+    );
+
+    const client = new FetchClient({
+      baseURL: '/api',
+      fetch: mockFetch,
+    });
+
+    await client.get('/users');
+
+    const [, initArg] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(initArg.credentials).toBeUndefined();
+  });
+});
+
 describe('FetchClient relative URL handling', () => {
   it('passes relative URL string to fetch instead of Request object', async () => {
     const mockFetch = mock().mockResolvedValue(

--- a/packages/fetch/src/client.ts
+++ b/packages/fetch/src/client.ts
@@ -81,6 +81,7 @@ export class FetchClient {
           headers,
           body: serializedBody,
           signal,
+          credentials: this.config.credentials,
         });
 
         if (options?.body !== undefined) {
@@ -101,6 +102,7 @@ export class FetchClient {
               headers: authedRequest.headers,
               body: serializedBody,
               signal: authedRequest.signal,
+              credentials: this.config.credentials,
             })
           : await this.fetchFn(authedRequest);
 
@@ -226,6 +228,7 @@ export class FetchClient {
       headers,
       body: serializedBody,
       signal,
+      credentials: this.config.credentials,
     });
 
     const authedRequest = await this.applyAuth(request);
@@ -238,6 +241,7 @@ export class FetchClient {
           headers: authedRequest.headers,
           body: serializedBody,
           signal: authedRequest.signal,
+          credentials: this.config.credentials,
         })
       : await this.fetchFn(authedRequest);
 


### PR DESCRIPTION
## Summary

Fixes #1444

- **`FetchClient`** had `credentials` in its `FetchClientConfig` type but never passed it through to `fetch()` calls — session cookies were silently dropped
- **`ClientGenerator`** (codegen) created `new FetchClient({...})` without `credentials`, so generated clients had no cookie support
- Now `credentials: 'include'` is generated by default, ensuring session cookies are sent with all entity API requests

## Changes

- `packages/fetch/src/client.ts`: Pass `this.config.credentials` to `Request` constructor and `fetch()` init in both `request()` and `requestStream()`
- `packages/codegen/src/generators/client-generator.ts`: Add `credentials: 'include'` to the generated `FetchClient` constructor call
- Tests added for both changes

## Public API Changes

- `FetchClient`: The `credentials` field in `FetchClientConfig` now actually works (was a no-op before). No breaking change — behavior only changes if you explicitly set it.
- Generated `createClient()`: Now includes `credentials: 'include'` by default, enabling cookie-based auth out of the box.

## Test plan

- [x] `FetchClient` passes `credentials` to fetch for relative URL requests
- [x] `FetchClient` passes `credentials` to fetch for absolute URL requests  
- [x] `FetchClient` omits `credentials` when not configured
- [x] Generated client includes `credentials: 'include'` in FetchClient constructor
- [x] All 410 tests in `@vertz/fetch` and `@vertz/codegen` pass
- [x] Full quality gates pass (lint, typecheck, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)