### PR TITLE
fix(auth): migrate from symmetric JWT (HS256) to asymmetric key pairs (RS256)

### DIFF
--- a/.changeset/migrate-jwt-to-rs256.md
+++ b/.changeset/migrate-jwt-to-rs256.md
@@ -1,0 +1,5 @@
+---
+'@vertz/server': patch
+---
+
+Migrate JWT from symmetric HS256 to asymmetric RS256 key pairs. Config now accepts `privateKey`/`publicKey` PEM strings instead of `jwtSecret`. Dev mode auto-generates RSA key pair to `.vertz/`. Public key exposed at `/.well-known/jwks.json`.

--- a/examples/linear/src/api/auth.ts
+++ b/examples/linear/src/api/auth.ts
@@ -6,7 +6,6 @@ const APP_URL = process.env.APP_URL ?? 'http://localhost:3001';
 export const auth = defineAuth({
   session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d', cookie: { secure: false } },
   emailPassword: {},
-  jwtSecret: process.env.JWT_SECRET ?? 'linear-clone-dev-secret-at-least-32-chars!!',
   providers: [
     github({
       clientId: process.env.GITHUB_CLIENT_ID ?? '',

--- a/packages/docs/guides/server/auth.mdx
+++ b/packages/docs/guides/server/auth.mdx
@@ -93,10 +93,14 @@ const auth = createAuth({
 });
 ```
 
-### JWT secret
+### RSA key pair
 
-- **Production:** You must provide `jwtSecret`. The auth system throws if it's missing.
-- **Development:** A secret is auto-generated and saved to `.vertz/jwt-secret`. Add `.vertz/` to your `.gitignore`.
+All JWT operations use RS256 asymmetric keys.
+
+- **Production:** You must provide `privateKey` and `publicKey` (PEM strings). The auth system throws if they're missing.
+- **Development:** A key pair is auto-generated and saved to `.vertz/jwt-private.pem` and `.vertz/jwt-public.pem`. Add `.vertz/` to your `.gitignore`.
+
+The public key is served at `GET /api/auth/.well-known/jwks.json` for external verification.
 
 ## Server-side API
 

--- a/packages/docs/guides/testing.mdx
+++ b/packages/docs/guides/testing.mdx
@@ -122,7 +122,7 @@ export const app = createServer({
   auth: {
     session: { strategy: 'jwt', ttl: '15m', cookie: { secure: false } },
     emailPassword: {}, // Enables signup/signin endpoints
-    jwtSecret: process.env.JWT_SECRET ?? 'dev-secret-at-least-32-characters!!',
+    // RS256 key pair — auto-generated in dev mode, required in production
   },
 });
 ```

--- a/packages/integration-tests/src/__tests__/auth-access-set.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-access-set.test.ts
@@ -14,6 +14,7 @@
  * Uses public package imports only (@vertz/server, @vertz/ui/auth).
  */
 import { afterEach, describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import {
   computeAccessSet,
   computeEntityAccess,
@@ -28,6 +29,12 @@ import {
 } from '@vertz/server';
 // Client-side imports
 import { signal } from '@vertz/ui';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 // ============================================================================
 // Setup — entity-centric config
@@ -74,7 +81,8 @@ function createTestAuth() {
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s' },
     emailPassword: { enabled: true },
-    jwtSecret: 'integration-test-secret-32-chars!!',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     access: {
       definition: accessDef,
       roleStore,

--- a/packages/integration-tests/src/__tests__/auth-dual-token.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-dual-token.test.ts
@@ -7,8 +7,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import type { AuthConfig, AuthInstance, SessionInfo } from '@vertz/server';
 import { createAuth } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -17,7 +24,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'integration-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     isProduction: false,
     ...overrides,
   });

--- a/packages/integration-tests/src/__tests__/auth-email-verification.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-email-verification.test.ts
@@ -5,8 +5,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import type { AuthConfig, AuthInstance } from '@vertz/server';
 import { createAuth } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 function createTestAuth(overrides?: Partial<AuthConfig>): {
   auth: AuthInstance;
@@ -22,7 +29,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'integration-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     isProduction: false,
     emailVerification: {
       enabled: true,

--- a/packages/integration-tests/src/__tests__/auth-entity-bridge.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-entity-bridge.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import type {
   AuthCallbackContext,
   AuthConfig,
@@ -14,6 +15,12 @@ import type {
   OnUserCreatedPayload,
 } from '@vertz/server';
 import { createAuth, InMemoryOAuthAccountStore, InMemoryUserStore } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,7 +58,8 @@ function createMockProvider(overrides?: Partial<OAuthProvider>): OAuthProvider {
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
-    jwtSecret: 'auth-entity-bridge-test-secret-at-least-32!!',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     isProduction: false,
     oauthEncryptionKey: 'test-oauth-encryption-key-at-least-32!',
     ...overrides,

--- a/packages/integration-tests/src/__tests__/auth-mfa.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-mfa.test.ts
@@ -4,8 +4,16 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import type { AuthConfig, AuthInstance } from '@vertz/server';
 import { checkFva, createAuth, InMemoryMFAStore } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
 // TOTP code generation — internal import for test verification only
 // (In a real app, the user would use an authenticator app)
 import { generateTotpCode } from '../../../server/src/auth/totp';
@@ -17,7 +25,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'mfa-integration-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     isProduction: false,
     mfa: { enabled: true, issuer: 'VertzTest' },
     oauthEncryptionKey: 'mfa-integration-encryption-key-32-chars!!!',

--- a/packages/integration-tests/src/__tests__/auth-oauth.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-oauth.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import type {
   AuthConfig,
   AuthInstance,
@@ -14,6 +15,12 @@ import type {
   OAuthUserInfo,
 } from '@vertz/server';
 import { createAuth, InMemoryOAuthAccountStore, InMemoryUserStore } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 function createMockProvider(overrides?: Partial<OAuthProvider>): OAuthProvider {
   return {
@@ -42,7 +49,8 @@ function createMockProvider(overrides?: Partial<OAuthProvider>): OAuthProvider {
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
-    jwtSecret: 'integration-test-secret-at-least-32-chars!!',
+    privateKey: TEST_PRIVATE_KEY as string,
+    publicKey: TEST_PUBLIC_KEY as string,
     isProduction: false,
     oauthEncryptionKey: 'test-oauth-encryption-key-at-least-32!',
 

--- a/packages/integration-tests/src/__tests__/reactive-invalidation.test.ts
+++ b/packages/integration-tests/src/__tests__/reactive-invalidation.test.ts
@@ -11,6 +11,7 @@
  * Uses public package imports only (@vertz/server).
  */
 import { describe, expect, it } from 'bun:test';
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
 import type { AccessEvent, ResourceRef } from '@vertz/server';
 import {
   computeAccessSet,
@@ -23,6 +24,12 @@ import {
   InMemoryFlagStore,
   InMemoryRoleAssignmentStore,
 } from '@vertz/server';
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 // ============================================================================
 // Setup — entity-centric config
@@ -256,7 +263,7 @@ describe('Feature Flag Store + Layer 1 (public imports)', () => {
 describe('Access Event Broadcaster (public imports)', () => {
   it('createAccessEventBroadcaster creates broadcaster with expected API', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: 'test-secret-minimum-32-characters-long',
+      publicKey: createPublicKey(TEST_PUBLIC_KEY as string),
     });
 
     expect(typeof broadcaster.handleUpgrade).toBe('function');
@@ -269,7 +276,7 @@ describe('Access Event Broadcaster (public imports)', () => {
 
   it('broadcastFlagToggle formats correct AccessEvent', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: 'test-secret-minimum-32-characters-long',
+      publicKey: createPublicKey(TEST_PUBLIC_KEY as string),
     });
 
     // Create a mock ws to verify the broadcast payload

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -223,7 +223,8 @@ const auth = createAuth({
     ttl: '7d',
     cookie: { name: 'session', httpOnly: true, secure: true },
   },
-  jwtSecret: process.env.AUTH_SECRET!,
+  privateKey: process.env.AUTH_PRIVATE_KEY!,
+  publicKey: process.env.AUTH_PUBLIC_KEY!,
   emailPassword: {
     enabled: true,
     password: { minLength: 8, requireUppercase: true },
@@ -237,16 +238,17 @@ const auth = createAuth({
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `session` | `SessionConfig` | *required* | Session strategy, TTL, and cookie settings |
-| `jwtSecret` | `string` | — | JWT signing secret. **Required in production** |
-| `jwtAlgorithm` | `'HS256' \| 'HS384' \| 'HS512' \| 'RS256'` | `'HS256'` | JWT signing algorithm |
+| `privateKey` | `string` | — | RSA private key (PKCS#8 PEM). **Required in production** |
+| `publicKey` | `string` | — | RSA public key (SPKI PEM). **Required in production** |
 | `emailPassword` | `EmailPasswordConfig` | — | Password requirements and rate limiting |
 | `claims` | `(user: AuthUser) => Record<string, unknown>` | — | Custom JWT claims |
 | `isProduction` | `boolean` | auto-detected | Override production mode detection |
+| `devKeyPath` | `string` | `.vertz` | Directory for auto-generated dev key pair |
 
 ### Production Mode
 
 By default, `createAuth` auto-detects production mode from `NODE_ENV`. In production mode:
-- `jwtSecret` is **required** (throws if missing)
+- RSA key pair (`privateKey` + `publicKey`) is **required** (throws if missing)
 - CSRF validation is enforced on state-changing requests
 
 On edge runtimes where `process` is unavailable (Cloudflare Workers, Deno Deploy), the default is **production** (secure-by-default). Pass `isProduction: false` explicitly for development:
@@ -255,13 +257,14 @@ On edge runtimes where `process` is unavailable (Cloudflare Workers, Deno Deploy
 // Edge runtime — defaults to production (secure)
 const auth = createAuth({
   session: { strategy: 'jwt', ttl: '7d' },
-  jwtSecret: env.AUTH_SECRET, // required — no fallback
+  privateKey: env.AUTH_PRIVATE_KEY, // required — no fallback
+  publicKey: env.AUTH_PUBLIC_KEY,
 });
 
 // Edge runtime in development — opt in explicitly
 const auth = createAuth({
   session: { strategy: 'jwt', ttl: '7d' },
-  isProduction: false, // uses insecure default secret
+  isProduction: false, // auto-generates RSA key pair
 });
 ```
 
@@ -274,6 +277,7 @@ Auth generates endpoints:
 | `POST` | `/api/auth/signout` | Invalidate session |
 | `GET` | `/api/auth/session` | Get current session |
 | `POST` | `/api/auth/refresh` | Refresh JWT |
+| `GET` | `/api/auth/.well-known/jwks.json` | Public key (JWKS) |
 
 Server-side API:
 

--- a/packages/server/src/__tests__/auth/auth.test.ts
+++ b/packages/server/src/__tests__/auth/auth.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from '../../auth/__tests__/test-keys';
 import { createAuth, hashPassword, validatePassword, verifyPassword } from '../../auth/index';
 import type { AuthConfig } from '../auth/types';
 
@@ -101,7 +102,8 @@ describe('Auth Module', () => {
         emailPassword: {
           enabled: true,
         },
-        jwtSecret: 'test-secret-key-for-testing',
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
       };
     });
 

--- a/packages/server/src/__tests__/request-handler.test.ts
+++ b/packages/server/src/__tests__/request-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { d } from '@vertz/db';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from '../auth/__tests__/test-keys';
 import type { AuthConfig } from '../auth/types';
 import { createServer } from '../create-server';
 
@@ -74,7 +75,8 @@ function createMockDatabaseClient() {
 
 const authConfig: AuthConfig = {
   session: { strategy: 'jwt', ttl: '7d' },
-  jwtSecret: 'test-secret-for-request-handler-tests',
+  privateKey: TEST_PRIVATE_KEY,
+  publicKey: TEST_PUBLIC_KEY,
   emailPassword: { enabled: true },
 };
 

--- a/packages/server/src/auth/__tests__/access-event-broadcaster.test.ts
+++ b/packages/server/src/auth/__tests__/access-event-broadcaster.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
+import { createPrivateKey, createPublicKey } from 'node:crypto';
 import * as jose from 'jose';
 import type { AccessWsData } from '../access-event-broadcaster';
 import { createAccessEventBroadcaster } from '../access-event-broadcaster';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createMockServer() {
   const upgraded: Array<{ data: AccessWsData }> = [];
@@ -31,12 +33,12 @@ function createMockWs(config: MockWsConfig) {
   };
 }
 
-const TEST_SECRET = 'test-secret-for-broadcaster-tests-minimum-32chars';
+const testPublicKey = createPublicKey(TEST_PUBLIC_KEY);
 
 describe('createAccessEventBroadcaster', () => {
   it('returns broadcaster with all required methods', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     expect(typeof broadcaster.handleUpgrade).toBe('function');
@@ -53,7 +55,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade returns false for non-matching path', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
     const server = createMockServer();
     const request = new Request('http://localhost/api/other');
@@ -65,7 +67,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade returns false for missing cookie', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
     const server = createMockServer();
     const request = new Request('http://localhost/api/auth/access-events');
@@ -76,7 +78,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade calls server.upgrade with correct data for valid JWT', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
     const server = createMockServer();
 
@@ -88,10 +90,10 @@ describe('createAccessEventBroadcaster', () => {
       jti: 'token-1',
       sid: 'session-1',
     })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'RS256' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(new TextEncoder().encode(TEST_SECRET));
+      .sign(createPrivateKey(TEST_PRIVATE_KEY));
 
     const request = new Request('http://localhost/api/auth/access-events', {
       headers: { cookie: `vertz.sid=${jwt}` },
@@ -105,7 +107,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastFlagToggle sends to all connections with matching orgId', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -131,7 +133,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastLimitUpdate sends correct payload', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -150,7 +152,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastRoleChange sends to connections with matching userId', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -174,7 +176,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastPlanChange sends to all connections for affected org', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -195,7 +197,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('getConnectionCount returns correct count', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     expect(broadcaster.getConnectionCount).toBe(0);
@@ -212,7 +214,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('connection cleanup on close', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -233,7 +235,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('websocket.message ignores pong responses silently', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -246,7 +248,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('websocket.message ignores non-pong messages', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -260,7 +262,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade returns false for invalid JWT', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
     const server = createMockServer();
 
@@ -275,7 +277,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade extracts cookie from multiple cookies', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
     const server = createMockServer();
 
@@ -286,10 +288,10 @@ describe('createAccessEventBroadcaster', () => {
       jti: 'token-2',
       sid: 'session-2',
     })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'RS256' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(new TextEncoder().encode(TEST_SECRET));
+      .sign(createPrivateKey(TEST_PRIVATE_KEY));
 
     const request = new Request('http://localhost/api/auth/access-events', {
       headers: { cookie: `other=value; vertz.sid=${jwt}; another=test` },
@@ -302,7 +304,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade with custom path', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
       path: '/custom/ws',
     });
     const server = createMockServer();
@@ -319,10 +321,10 @@ describe('createAccessEventBroadcaster', () => {
       jti: 'token-1',
       sid: 'session-1',
     })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'RS256' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(new TextEncoder().encode(TEST_SECRET));
+      .sign(createPrivateKey(TEST_PRIVATE_KEY));
 
     const req2 = new Request('http://localhost/custom/ws', {
       headers: { cookie: `vertz.sid=${jwt}` },
@@ -332,7 +334,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('handleUpgrade with custom cookie name', async () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
       cookieName: 'my-session',
     });
     const server = createMockServer();
@@ -344,10 +346,10 @@ describe('createAccessEventBroadcaster', () => {
       jti: 'token-1',
       sid: 'session-1',
     })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'RS256' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(new TextEncoder().encode(TEST_SECRET));
+      .sign(createPrivateKey(TEST_PRIVATE_KEY));
 
     // Wrong cookie name
     const req1 = new Request('http://localhost/api/auth/access-events', {
@@ -364,7 +366,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastToOrg is no-op when no connections for org', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     // No connections — should not throw
@@ -373,7 +375,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('broadcastToUser is no-op when no connections for user', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     // No connections — should not throw
@@ -382,7 +384,7 @@ describe('createAccessEventBroadcaster', () => {
 
   it('closing last connection for org removes org entry', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -400,7 +402,7 @@ describe('createAccessEventBroadcaster', () => {
 describe('plan event broadcasts', () => {
   it('broadcastPlanAssigned sends plan:assigned event to org connections', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -421,7 +423,7 @@ describe('plan event broadcasts', () => {
 
   it('broadcastAddonAttached sends addon_attached event to org connections', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -438,7 +440,7 @@ describe('plan event broadcasts', () => {
 
   it('broadcastAddonDetached sends addon_detached event to org connections', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -455,7 +457,7 @@ describe('plan event broadcasts', () => {
 
   it('broadcastLimitReset sends limit_reset event to org connections', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });
@@ -473,7 +475,7 @@ describe('plan event broadcasts', () => {
 
   it('new event types do not reach connections for other orgs', () => {
     const broadcaster = createAccessEventBroadcaster({
-      jwtSecret: TEST_SECRET,
+      publicKey: testPublicKey,
     });
 
     const ws1 = createMockWs({ data: { userId: 'user-1', orgId: 'org-1' } });

--- a/packages/server/src/auth/__tests__/access-set-jwt.test.ts
+++ b/packages/server/src/auth/__tests__/access-set-jwt.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test';
+import { createPrivateKey, createPublicKey } from 'node:crypto';
 import type { AccessSet } from '../access-set';
 import { InMemoryClosureStore } from '../closure-store';
 import { defineAccess } from '../define-access';
 import { createAuth } from '../index';
 import { verifyJWT } from '../jwt';
 import { InMemoryRoleAssignmentStore } from '../role-assignment-store';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 const accessDef = defineAccess({
   entities: {
@@ -35,7 +37,8 @@ function createTestAuth(options?: {
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s' },
     emailPassword: { enabled: true },
-    jwtSecret: 'test-secret-at-least-32-chars-long',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     access: {
       definition: accessDef,
       roleStore,
@@ -61,8 +64,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload).not.toBeNull();
     expect(payload?.acl).toBeDefined();
@@ -90,8 +92,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload).not.toBeNull();
     expect(payload?.acl).toBeDefined();
@@ -110,8 +111,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload?.acl?.set).toBeDefined();
     expect(payload?.acl?.overflow).toBe(false);
@@ -129,8 +129,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload?.acl?.hash).toBeTruthy();
     expect(typeof payload?.acl?.hash).toBe('string');
@@ -141,7 +140,8 @@ describe('JWT acl claim', () => {
     const auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-at-least-32-chars-long',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
     });
 
     const result = await auth.api.signUp({
@@ -153,8 +153,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload?.acl).toBeUndefined();
   });
@@ -174,11 +173,7 @@ describe('JWT acl claim', () => {
     const tokens = signUpResult.data.tokens;
     expect(tokens).toBeDefined();
 
-    const initialPayload = await verifyJWT(
-      tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
-    );
+    const initialPayload = await verifyJWT(tokens?.jwt ?? '', createPublicKey(TEST_PUBLIC_KEY));
     expect(
       initialPayload?.acl?.set?.entitlements['organization:create-project']?.allowed,
     ).toBeFalsy();
@@ -193,8 +188,7 @@ describe('JWT acl claim', () => {
 
     const refreshedPayload = await verifyJWT(
       refreshResult.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(refreshedPayload?.acl?.set?.entitlements['organization:create-project']?.allowed).toBe(
       true,
@@ -311,7 +305,8 @@ describe('JWT acl claim', () => {
     const auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-at-least-32-chars-long',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       access: {
         definition: overflowAccessDef,
         roleStore,
@@ -328,8 +323,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload).not.toBeNull();
     expect(payload?.acl?.overflow).toBe(true);
@@ -345,7 +339,8 @@ describe('JWT acl claim', () => {
     const auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-at-least-32-chars-long',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       claims: (user) => ({ customField: `hello-${user.email}` }),
       access: {
         definition: accessDef,
@@ -363,8 +358,7 @@ describe('JWT acl claim', () => {
 
     const payload = await verifyJWT(
       result.data.tokens?.jwt ?? '',
-      'test-secret-at-least-32-chars-long',
-      'HS256',
+      createPublicKey(TEST_PUBLIC_KEY),
     );
     expect(payload).not.toBeNull();
     expect(payload?.acl).toBeDefined();

--- a/packages/server/src/auth/__tests__/cookie-config.test.ts
+++ b/packages/server/src/auth/__tests__/cookie-config.test.ts
@@ -3,10 +3,11 @@ import { existsSync, rmSync } from 'node:fs';
 import { buildOAuthStateCookie } from '../cookies';
 import { createAuth } from '../index';
 import type { AuthConfig } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 /**
  * Minimal valid auth config for testing cookie validation.
- * Uses a dev secret since most tests run in non-production mode.
+ * Uses a dev key pair since most tests run in non-production mode.
  */
 function baseConfig(overrides?: Partial<AuthConfig>): AuthConfig {
   return {
@@ -15,7 +16,8 @@ function baseConfig(overrides?: Partial<AuthConfig>): AuthConfig {
       ttl: '1h',
       ...overrides?.session,
     },
-    jwtSecret: 'test-secret-at-least-32-characters-long',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     ...overrides,
   };
@@ -138,51 +140,52 @@ describe('cookie config security validations', () => {
   });
 });
 
-describe('JWT secret handling', () => {
-  const testSecretDir = '/tmp/vertz-test-jwt-secret';
+describe('RSA key pair handling', () => {
+  const testKeyDir = '/tmp/vertz-test-jwt-keys';
 
   beforeEach(() => {
-    if (existsSync(testSecretDir)) {
-      rmSync(testSecretDir, { recursive: true });
+    if (existsSync(testKeyDir)) {
+      rmSync(testKeyDir, { recursive: true });
     }
   });
 
   afterEach(() => {
-    if (existsSync(testSecretDir)) {
-      rmSync(testSecretDir, { recursive: true });
+    if (existsSync(testKeyDir)) {
+      rmSync(testKeyDir, { recursive: true });
     }
   });
 
-  it('throws when jwtSecret is missing in production', () => {
+  it('throws when RSA key pair is missing in production', () => {
     expect(() =>
       createAuth({
         session: { strategy: 'jwt', ttl: '1h' },
         isProduction: true,
       }),
-    ).toThrow('jwtSecret is required in production');
+    ).toThrow('RSA key pair is required in production');
   });
 
-  it('auto-generates and persists a dev secret when jwtSecret is missing in dev mode', () => {
+  it('auto-generates and persists dev keys when key pair is missing in dev mode', () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
 
-    // Should not throw — generates a secret automatically
+    // Should not throw — generates keys automatically
     expect(() =>
       createAuth({
         session: { strategy: 'jwt', ttl: '1h' },
         isProduction: false,
-        devSecretPath: testSecretDir,
+        devKeyPath: testKeyDir,
       }),
     ).not.toThrow();
 
-    // Should have persisted the secret
-    expect(existsSync(`${testSecretDir}/jwt-secret`)).toBe(true);
+    // Should have persisted the keys
+    expect(existsSync(`${testKeyDir}/jwt-private.pem`)).toBe(true);
+    expect(existsSync(`${testKeyDir}/jwt-public.pem`)).toBe(true);
 
     warnSpy.mockRestore();
     logSpy.mockRestore();
   });
 
-  it('reuses persisted dev secret across createAuth calls', () => {
+  it('reuses persisted dev keys across createAuth calls', () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
 
@@ -190,7 +193,7 @@ describe('JWT secret handling', () => {
     createAuth({
       session: { strategy: 'jwt', ttl: '1h' },
       isProduction: false,
-      devSecretPath: testSecretDir,
+      devKeyPath: testKeyDir,
     });
 
     // Second call reads from file (no "Generated" message)
@@ -198,7 +201,7 @@ describe('JWT secret handling', () => {
     createAuth({
       session: { strategy: 'jwt', ttl: '1h' },
       isProduction: false,
-      devSecretPath: testSecretDir,
+      devKeyPath: testKeyDir,
     });
 
     warnSpy.mockRestore();

--- a/packages/server/src/auth/__tests__/csrf.test.ts
+++ b/packages/server/src/auth/__tests__/csrf.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 // Helper to create an auth instance in production mode
 function createProductionAuth() {
   return createAuth({
     session: { strategy: 'jwt', ttl: '7d' },
-    jwtSecret: 'test-secret-at-least-32-chars-long!!',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: true,
   });
 }
@@ -14,7 +16,8 @@ function createProductionAuth() {
 function createDevAuth() {
   return createAuth({
     session: { strategy: 'jwt', ttl: '7d' },
-    jwtSecret: 'test-secret-at-least-32-chars-long!!',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
   });
 }

--- a/packages/server/src/auth/__tests__/dual-token.test.ts
+++ b/packages/server/src/auth/__tests__/dual-token.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthConfig, AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -13,7 +14,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'dual-token-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     ...overrides,
   });
@@ -229,7 +231,8 @@ describe('Dual-Token Issuance', () => {
 
     const authWithStore = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
-      jwtSecret: 'dual-token-test-secret-at-least-32-chars',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
       userStore,
     });

--- a/packages/server/src/auth/__tests__/email-verification-routes.test.ts
+++ b/packages/server/src/auth/__tests__/email-verification-routes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(opts?: {
   onSend?: (user: { email: string }, token: string) => Promise<void>;
@@ -16,7 +17,8 @@ function createTestAuth(opts?: {
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
     emailPassword: { enabled: true },
-    jwtSecret: 'test-secret-for-email-verification-testing-1234567890',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     emailVerification: {
       enabled: true,
@@ -188,7 +190,8 @@ describe('Email Verification Routes', () => {
     const disabledAuth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-email-verification-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
     });
     auth = disabledAuth;
@@ -203,7 +206,8 @@ describe('Email Verification Routes', () => {
     const disabledAuth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-email-verification-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
     });
     auth = disabledAuth;

--- a/packages/server/src/auth/__tests__/handler-edge-cases.test.ts
+++ b/packages/server/src/auth/__tests__/handler-edge-cases.test.ts
@@ -10,6 +10,7 @@ import type {
   SignUpInput,
   TokenInput,
 } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 /**
  * Tests for HTTP handler edge cases — error paths, 404 routes, middleware,
@@ -20,7 +21,8 @@ function createTestAuth() {
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
     emailPassword: { enabled: true },
-    jwtSecret: 'test-secret-for-handler-edge-cases-testing-1234567890',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
   });
   return auth;
@@ -31,7 +33,8 @@ function createTestAuthWithEmailVerification() {
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
     emailPassword: { enabled: true },
-    jwtSecret: 'test-secret-for-handler-edge-cases-testing-1234567890',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     emailVerification: {
       enabled: true,
@@ -418,7 +421,8 @@ describe('Email Verification Handler Edge Cases', () => {
     auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-handler-edge-cases-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
       passwordReset: {
         enabled: true,
@@ -536,7 +540,8 @@ describe('MFA Handler — Not Authenticated', () => {
     auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-handler-edge-cases-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
       mfa: { enabled: true, issuer: 'TestApp' },
       oauthEncryptionKey: 'mfa-encryption-key-at-least-32-chars-long!!',

--- a/packages/server/src/auth/__tests__/jwt.test.ts
+++ b/packages/server/src/auth/__tests__/jwt.test.ts
@@ -1,12 +1,15 @@
 /**
- * JWT utility tests — parseDuration, createJWT, verifyJWT
+ * JWT utility tests — parseDuration, createJWT, verifyJWT (RS256)
  */
 
 import { describe, expect, it } from 'bun:test';
+import { createPrivateKey, createPublicKey, generateKeyPairSync } from 'node:crypto';
 import { createJWT, parseDuration, verifyJWT } from '../jwt';
 import type { AuthUser } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
-const TEST_SECRET = 'jwt-test-secret-at-least-32-characters-long';
+const privateKey = createPrivateKey(TEST_PRIVATE_KEY);
+const publicKey = createPublicKey(TEST_PUBLIC_KEY);
 
 const testUser: AuthUser = {
   id: 'user-123',
@@ -49,19 +52,19 @@ describe('parseDuration', () => {
 });
 
 describe('createJWT', () => {
-  it('creates a valid JWT string', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256');
+  it('creates a valid JWT string with RS256', async () => {
+    const jwt = await createJWT(testUser, privateKey, 60_000);
     expect(jwt).toBeDefined();
     expect(jwt.split('.')).toHaveLength(3);
   });
 
   it('includes custom claims', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256', () => ({
+    const jwt = await createJWT(testUser, privateKey, 60_000, () => ({
       jti: 'test-jti',
       sid: 'test-sid',
     }));
 
-    const payload = await verifyJWT(jwt, TEST_SECRET, 'HS256');
+    const payload = await verifyJWT(jwt, publicKey);
     expect(payload?.jti).toBe('test-jti');
     expect(payload?.sid).toBe('test-sid');
   });
@@ -69,12 +72,12 @@ describe('createJWT', () => {
 
 describe('verifyJWT', () => {
   it('returns payload for valid token', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256', () => ({
+    const jwt = await createJWT(testUser, privateKey, 60_000, () => ({
       jti: 'jti-1',
       sid: 'sid-1',
     }));
 
-    const payload = await verifyJWT(jwt, TEST_SECRET, 'HS256');
+    const payload = await verifyJWT(jwt, publicKey);
     expect(payload).not.toBeNull();
     expect(payload?.sub).toBe('user-123');
     expect(payload?.email).toBe('test@example.com');
@@ -84,7 +87,7 @@ describe('verifyJWT', () => {
   });
 
   it('returns null for expired token', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 1, 'HS256', () => ({
+    const jwt = await createJWT(testUser, privateKey, 1, () => ({
       jti: 'jti-exp',
       sid: 'sid-exp',
     }));
@@ -92,41 +95,49 @@ describe('verifyJWT', () => {
     // Wait for expiration
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
-    const payload = await verifyJWT(jwt, TEST_SECRET, 'HS256');
+    const payload = await verifyJWT(jwt, publicKey);
     expect(payload).toBeNull();
   });
 
-  it('returns null for wrong secret', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256', () => ({
+  it('returns null for wrong key', async () => {
+    const jwt = await createJWT(testUser, privateKey, 60_000, () => ({
       jti: 'jti-2',
       sid: 'sid-2',
     }));
 
-    const payload = await verifyJWT(jwt, 'wrong-secret-at-least-32-characters', 'HS256');
+    // Generate a different key pair
+    const { publicKey: otherPub } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const otherPublicKey = createPublicKey(otherPub);
+
+    const payload = await verifyJWT(jwt, otherPublicKey);
     expect(payload).toBeNull();
   });
 
   it('returns null for tampered token', async () => {
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256', () => ({
+    const jwt = await createJWT(testUser, privateKey, 60_000, () => ({
       jti: 'jti-3',
       sid: 'sid-3',
     }));
 
     const tampered = `${jwt.slice(0, -5)}XXXXX`;
-    const payload = await verifyJWT(tampered, TEST_SECRET, 'HS256');
+    const payload = await verifyJWT(tampered, publicKey);
     expect(payload).toBeNull();
   });
 
   it('returns null for garbage input', async () => {
-    const payload = await verifyJWT('not-a-jwt', TEST_SECRET, 'HS256');
+    const payload = await verifyJWT('not-a-jwt', publicKey);
     expect(payload).toBeNull();
   });
 
   it('returns null when required claims are missing (no jti/sid)', async () => {
     // Create a JWT without jti and sid claims
-    const jwt = await createJWT(testUser, TEST_SECRET, 60_000, 'HS256');
+    const jwt = await createJWT(testUser, privateKey, 60_000);
 
-    const payload = await verifyJWT(jwt, TEST_SECRET, 'HS256');
+    const payload = await verifyJWT(jwt, publicKey);
     expect(payload).toBeNull();
   });
 });

--- a/packages/server/src/auth/__tests__/mfa-challenge.test.ts
+++ b/packages/server/src/auth/__tests__/mfa-challenge.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import { generateTotpCode } from '../totp';
 import type { AuthConfig, AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -14,7 +15,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'mfa-challenge-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     mfa: { enabled: true, issuer: 'TestApp' },
     oauthEncryptionKey: 'mfa-encryption-key-at-least-32-chars-long!!',

--- a/packages/server/src/auth/__tests__/mfa-routes.test.ts
+++ b/packages/server/src/auth/__tests__/mfa-routes.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import { generateTotpCode } from '../totp';
 import type { AuthConfig, AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -14,7 +15,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'mfa-test-secret-at-least-32-characters-long',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     mfa: { enabled: true, issuer: 'TestApp' },
     oauthEncryptionKey: 'mfa-encryption-key-at-least-32-chars-long!!',

--- a/packages/server/src/auth/__tests__/oauth-routes.test.ts
+++ b/packages/server/src/auth/__tests__/oauth-routes.test.ts
@@ -7,6 +7,7 @@ import { createAuth } from '../index';
 import { InMemoryOAuthAccountStore } from '../oauth-account-store';
 import type { AuthConfig, OAuthProvider } from '../types';
 import { InMemoryUserStore } from '../user-store';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createMockProvider(overrides?: Partial<OAuthProvider>): OAuthProvider {
   return {
@@ -44,7 +45,8 @@ function createMockProvider(overrides?: Partial<OAuthProvider>): OAuthProvider {
 function createTestAuth(overrides?: Partial<AuthConfig>): ReturnType<typeof createAuth> {
   return createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
-    jwtSecret: 'oauth-test-secret-at-least-32-characters!!',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     oauthEncryptionKey: 'test-oauth-encryption-key-at-least-32!',
 

--- a/packages/server/src/auth/__tests__/on-user-created.test.ts
+++ b/packages/server/src/auth/__tests__/on-user-created.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthConfig, AuthInstance, OnUserCreatedPayload } from '../types';
 import { InMemoryUserStore } from '../user-store';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
-    jwtSecret: 'on-user-created-test-secret-at-least-32-chars!!',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     ...overrides,
   });

--- a/packages/server/src/auth/__tests__/password-reset-routes.test.ts
+++ b/packages/server/src/auth/__tests__/password-reset-routes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(opts?: { tokenTtl?: string; revokeSessionsOnReset?: boolean }) {
   const sentEmails: { email: string; token: string }[] = [];
@@ -8,7 +9,8 @@ function createTestAuth(opts?: { tokenTtl?: string; revokeSessionsOnReset?: bool
   const auth = createAuth({
     session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
     emailPassword: { enabled: true },
-    jwtSecret: 'test-secret-for-password-reset-testing-1234567890',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     passwordReset: {
       enabled: true,
@@ -273,7 +275,8 @@ describe('Password Reset Routes', () => {
     auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-password-reset-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
     });
 
@@ -289,7 +292,8 @@ describe('Password Reset Routes', () => {
     auth = createAuth({
       session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
       emailPassword: { enabled: true },
-      jwtSecret: 'test-secret-for-password-reset-testing-1234567890',
+      privateKey: TEST_PRIVATE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
       isProduction: false,
     });
 

--- a/packages/server/src/auth/__tests__/resolve-session-for-ssr.test.ts
+++ b/packages/server/src/auth/__tests__/resolve-session-for-ssr.test.ts
@@ -3,12 +3,12 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { createPrivateKey, createPublicKey } from 'node:crypto';
 import { createJWT } from '../jwt';
 import { resolveSessionForSSR } from '../resolve-session-for-ssr';
 import type { AuthUser } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
-const TEST_SECRET = 'jwt-test-secret-at-least-32-characters-long';
-const TEST_ALGORITHM = 'HS256';
 const COOKIE_NAME = 'vertz.sid';
 
 const testUser: AuthUser = {
@@ -30,7 +30,7 @@ function createRequest(cookieHeader?: string): Request {
 async function createValidJWT(
   customClaims?: (user: AuthUser) => Record<string, unknown>,
 ): Promise<string> {
-  return createJWT(testUser, TEST_SECRET, 60_000, TEST_ALGORITHM, (user) => ({
+  return createJWT(testUser, createPrivateKey(TEST_PRIVATE_KEY), 60_000, (user) => ({
     jti: 'jti-test',
     sid: 'sid-test',
     ...customClaims?.(user),
@@ -39,8 +39,7 @@ async function createValidJWT(
 
 function createResolver() {
   return resolveSessionForSSR({
-    jwtSecret: TEST_SECRET,
-    jwtAlgorithm: TEST_ALGORITHM,
+    publicKey: createPublicKey(TEST_PUBLIC_KEY),
     cookieName: COOKIE_NAME,
   });
 }
@@ -115,7 +114,7 @@ describe('resolveSessionForSSR', () => {
     describe('When resolveSessionForSSR is called', () => {
       it('Then returns null', async () => {
         // Create JWT with 1ms TTL and wait for expiration
-        const jwt = await createJWT(testUser, TEST_SECRET, 1, TEST_ALGORITHM, () => ({
+        const jwt = await createJWT(testUser, createPrivateKey(TEST_PRIVATE_KEY), 1, () => ({
           jti: 'jti-expired',
           sid: 'sid-expired',
         }));
@@ -244,8 +243,7 @@ describe('resolveSessionForSSR', () => {
       const jwt = await createValidJWT();
       const request = createRequest(`custom.sid=${jwt}`);
       const resolver = resolveSessionForSSR({
-        jwtSecret: TEST_SECRET,
-        jwtAlgorithm: TEST_ALGORITHM,
+        publicKey: createPublicKey(TEST_PUBLIC_KEY),
         cookieName: 'custom.sid',
       });
 

--- a/packages/server/src/auth/__tests__/session-management.test.ts
+++ b/packages/server/src/auth/__tests__/session-management.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthConfig, AuthInstance, SessionInfo } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -13,7 +14,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'session-mgmt-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     ...overrides,
   });

--- a/packages/server/src/auth/__tests__/step-up.test.ts
+++ b/packages/server/src/auth/__tests__/step-up.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import { generateTotpCode } from '../totp';
 import type { AuthConfig, AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -14,7 +15,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'step-up-test-secret-at-least-32-characters!',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     mfa: { enabled: true, issuer: 'TestApp' },
     oauthEncryptionKey: 'step-up-encryption-key-at-least-32-chars!!!',

--- a/packages/server/src/auth/__tests__/switch-tenant.test.ts
+++ b/packages/server/src/auth/__tests__/switch-tenant.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthInstance, SwitchTenantInput } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,7 +51,8 @@ describe('Feature: Tenant switching (POST /auth/switch-tenant)', () => {
       auth = createAuth({
         session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
         emailPassword: { enabled: true },
-        jwtSecret: 'test-secret-for-switch-tenant-testing-1234567890',
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
         isProduction: false,
       });
     });
@@ -79,7 +81,8 @@ describe('Feature: Tenant switching (POST /auth/switch-tenant)', () => {
       auth = createAuth({
         session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
         emailPassword: { enabled: true },
-        jwtSecret: 'test-secret-for-switch-tenant-testing-1234567890',
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
         isProduction: false,
         tenant: {
           verifyMembership: async (_userId: string, tenantId: string) => {
@@ -138,7 +141,8 @@ describe('Feature: Tenant switching (POST /auth/switch-tenant)', () => {
       auth = createAuth({
         session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
         emailPassword: { enabled: true },
-        jwtSecret: 'test-secret-for-switch-tenant-testing-1234567890',
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
         isProduction: false,
         tenant: {
           verifyMembership: async () => true,
@@ -167,7 +171,8 @@ describe('Feature: Tenant switching (POST /auth/switch-tenant)', () => {
       auth = createAuth({
         session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
         emailPassword: { enabled: true },
-        jwtSecret: 'test-secret-for-switch-tenant-testing-1234567890',
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
         isProduction: false,
         tenant: {
           verifyMembership: async (_userId: string, tenantId: string) => {

--- a/packages/server/src/auth/__tests__/test-keys.ts
+++ b/packages/server/src/auth/__tests__/test-keys.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared RSA key pair for auth tests.
+ * Generated once at module load, reused across all test files.
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+export const TEST_PRIVATE_KEY = privateKey as string;
+export const TEST_PUBLIC_KEY = publicKey as string;

--- a/packages/server/src/auth/__tests__/token-refresh.test.ts
+++ b/packages/server/src/auth/__tests__/token-refresh.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { createAuth } from '../index';
 import type { AuthConfig, AuthInstance } from '../types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
   return createAuth({
@@ -13,7 +14,8 @@ function createTestAuth(overrides?: Partial<AuthConfig>): AuthInstance {
       ttl: '60s',
       refreshTtl: '7d',
     },
-    jwtSecret: 'token-refresh-test-secret-at-least-32-chars',
+    privateKey: TEST_PRIVATE_KEY,
+    publicKey: TEST_PUBLIC_KEY,
     isProduction: false,
     ...overrides,
   });

--- a/packages/server/src/auth/access-event-broadcaster.ts
+++ b/packages/server/src/auth/access-event-broadcaster.ts
@@ -5,6 +5,7 @@
  * (flag toggles, limit updates, role changes, plan changes) to affected clients.
  */
 
+import type { KeyObject } from 'node:crypto';
 import { verifyJWT } from './jwt';
 
 // ============================================================================
@@ -34,8 +35,8 @@ export interface AccessWsData {
 }
 
 export interface AccessEventBroadcasterConfig {
-  jwtSecret: string;
-  jwtAlgorithm?: string;
+  /** RSA public key for JWT verification. */
+  publicKey: KeyObject;
   /** WebSocket upgrade path. Defaults to '/api/auth/access-events'. */
   path?: string;
   /** Cookie name for session JWT. Defaults to 'vertz.sid'. */
@@ -86,12 +87,7 @@ interface BunWebSocket<T> {
 export function createAccessEventBroadcaster(
   config: AccessEventBroadcasterConfig,
 ): AccessEventBroadcaster {
-  const {
-    jwtSecret,
-    jwtAlgorithm = 'HS256',
-    path = '/api/auth/access-events',
-    cookieName = 'vertz.sid',
-  } = config;
+  const { publicKey, path = '/api/auth/access-events', cookieName = 'vertz.sid' } = config;
 
   // Connection tracking: orgId -> Set<ws>, userId -> Set<ws>
   const connectionsByOrg = new Map<string, Set<BunWebSocket<AccessWsData>>>();
@@ -193,7 +189,7 @@ export function createAccessEventBroadcaster(
     if (!token) return false;
 
     try {
-      const payload = await verifyJWT(token, jwtSecret, jwtAlgorithm);
+      const payload = await verifyJWT(token, publicKey);
       if (!payload || !payload.sub) return false;
 
       // Extract orgId from JWT claims — look for org, orgId, or default to ''

--- a/packages/server/src/auth/cloud-create-server.test.ts
+++ b/packages/server/src/auth/cloud-create-server.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
 
 describe('createServer — cloud mode branching', () => {
   describe('Given cloud.projectId is set and VERTZ_CLOUD_TOKEN is available', () => {
-    it('then returns a ServerInstance without requiring jwtSecret or auth config', () => {
+    it('then returns a ServerInstance without requiring key pair or auth config', () => {
       process.env.VERTZ_CLOUD_TOKEN = 'vtk_ci_token';
 
       const server = createServer({
@@ -181,7 +181,7 @@ describe('createServer — cloud mode branching', () => {
     it('then does NOT require clientId/clientSecret on providers', () => {
       process.env.VERTZ_CLOUD_TOKEN = 'vtk_ci_token';
 
-      // Cloud mode — no providers needed, no jwtSecret needed
+      // Cloud mode — no providers needed, no key pair needed
       const server = createServer({
         cloud: { projectId: 'proj_cstest', cloudBaseUrl },
       });
@@ -218,7 +218,8 @@ describe('createServer — cloud mode branching', () => {
         cloud: { projectId: 'proj_cstest', cloudBaseUrl },
         auth: {
           session: { strategy: 'jwt', ttl: '1h' },
-          jwtSecret: 'should-be-ignored',
+          privateKey: 'should-be-ignored',
+          publicKey: 'should-be-ignored',
         },
       });
 

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -3,6 +3,12 @@
  * Dual-token sessions, email/password authentication
  */
 
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  type KeyObject,
+} from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { BadRequestException } from '@vertz/core';
@@ -25,6 +31,7 @@ import {
   ok,
   type Result,
 } from '@vertz/errors';
+import { exportJWK } from 'jose';
 import { computeAccessSet, type EncodedAccessSet, encodeAccessSet } from './access-set';
 import {
   buildMfaChallengeCookie,
@@ -99,8 +106,8 @@ export function createAuth(config: AuthConfig): AuthInstance {
   const {
     session,
     emailPassword,
-    jwtSecret: configJwtSecret,
-    jwtAlgorithm = 'HS256',
+    privateKey: configPrivateKey,
+    publicKey: configPublicKey,
     claims,
   } = config;
 
@@ -110,28 +117,43 @@ export function createAuth(config: AuthConfig): AuthInstance {
     (typeof process === 'undefined' ||
       (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test'));
 
-  // Validate JWT secret - throw in production, auto-generate in development
-  let jwtSecret: string;
+  // Validate RSA key pair - throw in production, auto-generate in development
+  let privateKey: KeyObject;
+  let publicKey: KeyObject;
 
-  if (configJwtSecret) {
-    jwtSecret = configJwtSecret;
+  if (configPrivateKey && configPublicKey) {
+    privateKey = createPrivateKey(configPrivateKey);
+    publicKey = createPublicKey(configPublicKey);
+  } else if (configPrivateKey || configPublicKey) {
+    throw new Error(
+      'Both privateKey and publicKey must be provided together. Provide both PEM strings via createAuth({ privateKey: "...", publicKey: "..." }).',
+    );
   } else if (isProduction) {
     throw new Error(
-      'jwtSecret is required in production. Provide it via createAuth({ jwtSecret: "..." }).',
+      'RSA key pair is required in production. Provide privateKey and publicKey PEM strings via createAuth({ privateKey: "...", publicKey: "..." }).',
     );
   } else {
-    const secretDir = config.devSecretPath ?? join(process.cwd(), '.vertz');
-    const secretFile = join(secretDir, 'jwt-secret');
+    const keyDir = config.devKeyPath ?? join(process.cwd(), '.vertz');
+    const privateKeyFile = join(keyDir, 'jwt-private.pem');
+    const publicKeyFile = join(keyDir, 'jwt-public.pem');
 
-    if (existsSync(secretFile)) {
-      jwtSecret = readFileSync(secretFile, 'utf-8').trim();
+    if (existsSync(privateKeyFile) && existsSync(publicKeyFile)) {
+      privateKey = createPrivateKey(readFileSync(privateKeyFile, 'utf-8'));
+      publicKey = createPublicKey(readFileSync(publicKeyFile, 'utf-8'));
     } else {
-      jwtSecret = crypto.randomUUID() + crypto.randomUUID();
-      mkdirSync(secretDir, { recursive: true });
-      writeFileSync(secretFile, jwtSecret, 'utf-8');
+      const keyPair = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      mkdirSync(keyDir, { recursive: true });
+      writeFileSync(privateKeyFile, keyPair.privateKey as string, 'utf-8');
+      writeFileSync(publicKeyFile, keyPair.publicKey as string, 'utf-8');
       console.warn(
-        `[Auth] Auto-generated dev JWT secret at ${secretFile}. Add this path to .gitignore.`,
+        `[Auth] Auto-generated dev RSA key pair at ${keyDir}. Add this path to .gitignore.`,
       );
+      privateKey = createPrivateKey(keyPair.privateKey);
+      publicKey = createPublicKey(keyPair.publicKey);
     }
   }
 
@@ -278,7 +300,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
       }
     }
 
-    const jwt = await createJWT(user, jwtSecret, ttlMs, jwtAlgorithm, () => ({
+    const jwt = await createJWT(user, privateKey, ttlMs, () => ({
       ...userClaims,
       ...fvaClaim,
       ...tenantClaim,
@@ -551,7 +573,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
     }
 
     // Phase 2: JWT-only verification — no session Map lookup
-    const payload = await verifyJWT(token, jwtSecret, jwtAlgorithm);
+    const payload = await verifyJWT(token, publicKey);
     if (!payload) {
       return ok(null);
     }
@@ -628,7 +650,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
       const currentTokens = await sessionStore.getCurrentTokens(storedSession.id);
       if (currentTokens) {
         // Decode (without verify) to get the payload for the response
-        const payload = await verifyJWT(currentTokens.jwt, jwtSecret, jwtAlgorithm);
+        const payload = await verifyJWT(currentTokens.jwt, publicKey);
         // Even if JWT is expired, return the cached tokens — the client will get
         // a fresh JWT on the next refresh after the grace period ends
         return ok({
@@ -652,7 +674,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
     let existingFva: number | undefined;
     const oldTokens = await sessionStore.getCurrentTokens(storedSession.id);
     if (oldTokens) {
-      const oldPayload = await verifyJWT(oldTokens.jwt, jwtSecret, jwtAlgorithm);
+      const oldPayload = await verifyJWT(oldTokens.jwt, publicKey);
       existingFva = oldPayload?.fva;
     }
 
@@ -2422,6 +2444,28 @@ export function createAuth(config: AuthConfig): AuthInstance {
         );
       }
 
+      // =================================================================
+      // JWKS Endpoint
+      // =================================================================
+
+      // Route: GET /api/auth/.well-known/jwks.json
+      if (method === 'GET' && path === '/.well-known/jwks.json') {
+        const jwk = await exportJWK(publicKey);
+        return new Response(
+          JSON.stringify({
+            keys: [{ ...jwk, use: 'sig', alg: 'RS256' }],
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, max-age=3600',
+              ...securityHeaders(),
+            },
+          },
+        );
+      }
+
       return new Response(JSON.stringify({ error: 'Not found' }), {
         status: 404,
         headers: { 'Content-Type': 'application/json' },
@@ -2489,8 +2533,7 @@ export function createAuth(config: AuthConfig): AuthInstance {
       pendingMfaSecrets.clear();
     },
     resolveSessionForSSR: createSSRResolver({
-      jwtSecret,
-      jwtAlgorithm,
+      publicKey,
       cookieName: cookieConfig.name || 'vertz.sid',
     }),
   };

--- a/packages/server/src/auth/jwt.ts
+++ b/packages/server/src/auth/jwt.ts
@@ -1,7 +1,8 @@
 /**
- * JWT utilities — creation and verification
+ * JWT utilities — creation and verification using RS256 asymmetric keys
  */
 
+import type { KeyObject } from 'node:crypto';
 import * as jose from 'jose';
 import type { AuthUser, SessionPayload } from './types';
 
@@ -22,9 +23,8 @@ export function parseDuration(duration: string | number): number {
 
 export async function createJWT(
   user: AuthUser,
-  secret: string,
+  privateKey: KeyObject,
   ttl: number,
-  algorithm: string,
   customClaims?: (user: AuthUser) => Record<string, unknown>,
 ): Promise<string> {
   const claims = customClaims ? customClaims(user) : {};
@@ -35,22 +35,21 @@ export async function createJWT(
     role: user.role,
     ...claims,
   })
-    .setProtectedHeader({ alg: algorithm })
+    .setProtectedHeader({ alg: 'RS256' })
     .setIssuedAt()
     .setExpirationTime(`${Math.floor(ttl / 1000)}s`)
-    .sign(new TextEncoder().encode(secret));
+    .sign(privateKey);
 
   return jwt;
 }
 
 export async function verifyJWT(
   token: string,
-  secret: string,
-  algorithm: string,
+  publicKey: KeyObject,
 ): Promise<SessionPayload | null> {
   try {
-    const { payload } = await jose.jwtVerify(token, new TextEncoder().encode(secret), {
-      algorithms: [algorithm],
+    const { payload } = await jose.jwtVerify(token, publicKey, {
+      algorithms: ['RS256'],
     });
     // Runtime validation: ensure required Phase 2 claims are present
     if (

--- a/packages/server/src/auth/resolve-session-for-ssr.test.ts
+++ b/packages/server/src/auth/resolve-session-for-ssr.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
+import { createPublicKey } from 'node:crypto';
 import type { CloudJWTVerifier } from './cloud-jwt-verifier';
 import { type ResolveSessionForSSRConfig, resolveSessionForSSR } from './resolve-session-for-ssr';
 import type { SessionPayload } from './types';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './__tests__/test-keys';
 
 // --- Helpers ---
 
@@ -102,40 +104,38 @@ describe('resolveSessionForSSR with cloudVerifier', () => {
   });
 });
 
-describe('resolveSessionForSSR with jwtSecret (backward compat)', () => {
-  describe('Given resolveSessionForSSR with jwtSecret', () => {
-    it('then verifies using symmetric HS256', async () => {
-      // Use the existing verifyJWT path
+describe('resolveSessionForSSR with publicKey', () => {
+  describe('Given resolveSessionForSSR with publicKey', () => {
+    it('then verifies using RS256', async () => {
       const resolve = resolveSessionForSSR({
-        jwtSecret: 'test-secret-at-least-32-chars-long!',
-        jwtAlgorithm: 'HS256',
+        publicKey: createPublicKey(TEST_PUBLIC_KEY),
         cookieName: 'vertz.sid',
       });
 
-      // Without a real HS256 token, this should return null (verification fails)
-      const result = await resolve(makeRequest('vertz.sid=invalid.hs256.token'));
+      // Without a real RS256 token, this should return null (verification fails)
+      const result = await resolve(makeRequest('vertz.sid=invalid.rs256.token'));
       expect(result).toBeNull();
     });
   });
 });
 
 describe('resolveSessionForSSR config validation', () => {
-  describe('Given neither jwtSecret nor cloudVerifier', () => {
+  describe('Given neither publicKey nor cloudVerifier', () => {
     it('then throws configuration error at construction time', () => {
       expect(() => {
         resolveSessionForSSR({
           cookieName: 'vertz.sid',
         } as ResolveSessionForSSRConfig);
-      }).toThrow('requires either jwtSecret');
+      }).toThrow('requires either publicKey');
     });
   });
 
-  describe('Given both jwtSecret and cloudVerifier', () => {
+  describe('Given both publicKey and cloudVerifier', () => {
     it('then throws configuration error at construction time', () => {
       const verifier = makeMockVerifier(validPayload);
       expect(() => {
         resolveSessionForSSR({
-          jwtSecret: 'some-secret',
+          publicKey: createPublicKey(TEST_PUBLIC_KEY),
           cloudVerifier: verifier,
           cookieName: 'vertz.sid',
         });

--- a/packages/server/src/auth/resolve-session-for-ssr.ts
+++ b/packages/server/src/auth/resolve-session-for-ssr.ts
@@ -6,16 +6,15 @@
  * this is a hydration hint, not an authorization gate.
  */
 
+import type { KeyObject } from 'node:crypto';
 import type { AccessCheckData, AccessSet } from './access-set';
 import type { CloudJWTVerifier } from './cloud-jwt-verifier';
 import { verifyJWT } from './jwt';
 import type { AclClaim, SessionPayload } from './types';
 
 export interface ResolveSessionForSSRConfig {
-  /** Symmetric secret for HS256 verification (self-hosted mode). */
-  jwtSecret?: string;
-  /** Algorithm for symmetric verification — defaults to 'HS256'. */
-  jwtAlgorithm?: string;
+  /** RSA public key for RS256 verification (self-hosted mode). */
+  publicKey?: KeyObject;
   /** Cloud JWT verifier for RS256 verification (cloud mode). */
   cloudVerifier?: CloudJWTVerifier;
   cookieName: string;
@@ -75,16 +74,16 @@ function extractAccessSet(acl: AclClaim): AccessSet | null {
 export function resolveSessionForSSR(
   config: ResolveSessionForSSRConfig,
 ): (request: Request) => Promise<SSRSessionResult | null> {
-  const { jwtSecret, jwtAlgorithm = 'HS256', cloudVerifier, cookieName } = config;
+  const { publicKey, cloudVerifier, cookieName } = config;
 
   // Validate: exactly one verification method must be provided
-  if (!jwtSecret && !cloudVerifier) {
+  if (!publicKey && !cloudVerifier) {
     throw new Error(
-      'resolveSessionForSSR requires either jwtSecret (self-hosted) or cloudVerifier (cloud mode).',
+      'resolveSessionForSSR requires either publicKey (self-hosted) or cloudVerifier (cloud mode).',
     );
   }
-  if (jwtSecret && cloudVerifier) {
-    throw new Error('resolveSessionForSSR accepts either jwtSecret or cloudVerifier, not both.');
+  if (publicKey && cloudVerifier) {
+    throw new Error('resolveSessionForSSR accepts either publicKey or cloudVerifier, not both.');
   }
 
   return async (request: Request): Promise<SSRSessionResult | null> => {
@@ -97,12 +96,12 @@ export function resolveSessionForSSR(
     const token = cookieEntry.trim().slice(`${cookieName}=`.length);
     if (!token) return null;
 
-    // Verify JWT — cloud verifier (RS256) or symmetric (HS256)
+    // Verify JWT — cloud verifier (RS256 via JWKS) or local public key (RS256)
     let payload: SessionPayload | null;
     if (cloudVerifier) {
       payload = await cloudVerifier.verify(token);
     } else {
-      payload = await verifyJWT(token, jwtSecret!, jwtAlgorithm);
+      payload = await verifyJWT(token, publicKey!);
     }
     if (!payload) return null;
 

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -323,22 +323,24 @@ export interface PasswordResetStore {
 export interface AuthConfig {
   session: SessionConfig;
   emailPassword?: EmailPasswordConfig;
-  jwtSecret?: string; // For JWT signing - required for JWT strategy
-  jwtAlgorithm?: 'HS256' | 'HS384' | 'HS512';
+  /** RSA private key in PKCS#8 PEM format for JWT signing. Required in production. */
+  privateKey?: string;
+  /** RSA public key in SPKI PEM format for JWT verification. Required in production. */
+  publicKey?: string;
   /** Custom claims function for JWT payload */
   claims?: (user: AuthUser) => Record<string, unknown>;
   /**
    * Whether the app runs in production mode.
-   * Controls security enforcement (JWT secret requirement, CSRF validation).
+   * Controls security enforcement (key pair requirement, CSRF validation).
    * Defaults to true when process.env is unavailable (secure-by-default for edge runtimes).
    */
   isProduction?: boolean;
   /**
-   * Directory to persist auto-generated dev JWT secret.
+   * Directory to persist auto-generated dev RSA key pair.
    * Defaults to `.vertz` in the current working directory.
-   * Only used in non-production mode when jwtSecret is not provided.
+   * Only used in non-production mode when keys are not provided.
    */
-  devSecretPath?: string;
+  devKeyPath?: string;
   /** Pluggable session store — defaults to InMemorySessionStore */
   sessionStore?: SessionStore;
   /** Pluggable rate limit store — defaults to InMemoryRateLimitStore */


### PR DESCRIPTION
## Summary

Fixes #1447

- Replace `jwtSecret`/`jwtAlgorithm` config with `privateKey`/`publicKey` PEM strings (RS256)
- Remove all HS256/HS384/HS512 algorithm options — RS256 only
- Dev mode auto-generates RSA key pair to `.vertz/jwt-private.pem` and `.vertz/jwt-public.pem`
- Public key exposed at `GET /api/auth/.well-known/jwks.json` for external verification
- Linear clone example updated (removed `jwtSecret`, uses dev auto-generation)
- Docs and README updated to reflect new config

## Public API Changes

### Breaking

| Before | After |
|--------|-------|
| `jwtSecret: string` | `privateKey: string` (PKCS#8 PEM) |
| — | `publicKey: string` (SPKI PEM) |
| `jwtAlgorithm: 'HS256' \| 'HS384' \| 'HS512'` | Removed (RS256 hardcoded) |
| `devSecretPath: string` | `devKeyPath: string` |
| Dev generates `.vertz/jwt-secret` | Dev generates `.vertz/jwt-private.pem` + `.vertz/jwt-public.pem` |

### Additions

- `GET /api/auth/.well-known/jwks.json` — serves public key in JWKS format

### Internal

- `createJWT(user, privateKey: KeyObject, ttl, customClaims?)` — signs with RS256
- `verifyJWT(token, publicKey: KeyObject)` — verifies with RS256
- `ResolveSessionForSSRConfig.publicKey: KeyObject` replaces `jwtSecret`/`jwtAlgorithm`
- `AccessEventBroadcasterConfig.publicKey: KeyObject` replaces `jwtSecret`/`jwtAlgorithm`

## Test plan

- [x] All 1596 server package tests pass
- [x] All 49 auth-related integration tests pass
- [x] Typecheck clean for `@vertz/server` and `@vertz/integration-tests`
- [x] Biome lint/format clean
- [x] Pre-push quality gates passed (82/82 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)