### PR TITLE
feat(theme-shadcn): convert carousel factory to JSX component

### DIFF
--- a/.changeset/carousel-jsx-component.md
+++ b/.changeset/carousel-jsx-component.md
@@ -1,0 +1,7 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+'@vertz/ui': patch
+---
+
+Convert carousel from factory pattern to declarative JSX component with Carousel.Slide, Carousel.Previous, and Carousel.Next sub-components

--- a/packages/theme-shadcn/src/__tests__/carousel.test.ts
+++ b/packages/theme-shadcn/src/__tests__/carousel.test.ts
@@ -40,7 +40,7 @@ describe('carousel styles', () => {
 
 describe('themed carousel', () => {
   const styles = createCarouselStyles();
-  const ThemedCarousel = createThemedCarousel({
+  const Carousel = createThemedCarousel({
     root: styles.root,
     viewport: styles.viewport,
     slide: styles.slide,
@@ -48,35 +48,73 @@ describe('themed carousel', () => {
     nextButton: styles.nextButton,
   });
 
-  it('applies root class', () => {
-    const { root } = ThemedCarousel();
+  it('creates a themed carousel component with sub-components', () => {
+    expect(typeof Carousel).toBe('function');
+    expect(typeof Carousel.Slide).toBe('function');
+    expect(typeof Carousel.Previous).toBe('function');
+    expect(typeof Carousel.Next).toBe('function');
+  });
+
+  it('renders a carousel with themed classes', () => {
+    const root = Carousel({
+      children: () => {
+        const s1 = Carousel.Slide({ children: ['Slide 1'] });
+        const s2 = Carousel.Slide({ children: ['Slide 2'] });
+        const prev = Carousel.Previous({ children: ['Prev'] });
+        const next = Carousel.Next({ children: ['Next'] });
+        return [s1, s2, prev, next];
+      },
+    });
+
+    expect(root.getAttribute('role')).toBe('region');
+    expect(root.getAttribute('aria-roledescription')).toBe('carousel');
     expect(root.classList.contains(styles.root)).toBe(true);
   });
 
-  it('applies viewport class', () => {
-    const { viewport } = ThemedCarousel();
-    expect(viewport.classList.contains(styles.viewport)).toBe(true);
-  });
+  it('applies slide class to rendered slides', () => {
+    const root = Carousel({
+      children: () => {
+        const s1 = Carousel.Slide({ children: ['Slide 1'] });
+        return [s1];
+      },
+    });
 
-  it('applies button classes', () => {
-    const { prevButton, nextButton } = ThemedCarousel();
-    expect(prevButton.classList.contains(styles.prevButton)).toBe(true);
-    expect(nextButton.classList.contains(styles.nextButton)).toBe(true);
-  });
-
-  it('applies slide class to created slides', () => {
-    const { Slide } = ThemedCarousel();
-    const slide = Slide();
+    const slide = root.querySelector('[role="group"]') as HTMLElement;
     expect(slide.classList.contains(styles.slide)).toBe(true);
   });
 
-  it('preserves primitive behavior', () => {
-    const { state, Slide, nextButton } = ThemedCarousel();
-    Slide();
-    Slide();
+  it('applies button classes to prev/next buttons', () => {
+    const root = Carousel({
+      children: () => {
+        const s1 = Carousel.Slide({ children: ['Slide 1'] });
+        const prev = Carousel.Previous({ children: ['Prev'] });
+        const next = Carousel.Next({ children: ['Next'] });
+        return [s1, prev, next];
+      },
+    });
 
-    expect(state.currentIndex.peek()).toBe(0);
-    nextButton.click();
-    expect(state.currentIndex.peek()).toBe(1);
+    const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLElement;
+    const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLElement;
+    expect(prevBtn.classList.contains(styles.prevButton)).toBe(true);
+    expect(nextBtn.classList.contains(styles.nextButton)).toBe(true);
+  });
+
+  it('preserves navigation behavior', () => {
+    const root = Carousel({
+      children: () => {
+        const s1 = Carousel.Slide({ children: ['S1'] });
+        const s2 = Carousel.Slide({ children: ['S2'] });
+        const prev = Carousel.Previous({ children: ['Prev'] });
+        const next = Carousel.Next({ children: ['Next'] });
+        return [s1, s2, prev, next];
+      },
+    });
+
+    const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+    nextBtn.click();
+
+    const slides = root.querySelectorAll('[role="group"]');
+    expect(slides[0]?.getAttribute('data-state')).toBe('inactive');
+    expect(slides[1]?.getAttribute('data-state')).toBe('active');
   });
 });

--- a/packages/theme-shadcn/src/components/primitives/carousel.ts
+++ b/packages/theme-shadcn/src/components/primitives/carousel.ts
@@ -1,5 +1,6 @@
-import type { CarouselElements, CarouselOptions, CarouselState } from '@vertz/ui-primitives';
-import { Carousel } from '@vertz/ui-primitives';
+import type { ChildValue } from '@vertz/ui';
+import type { ComposedCarouselProps } from '@vertz/ui-primitives';
+import { ComposedCarousel, withStyles } from '@vertz/ui-primitives';
 
 interface CarouselStyleClasses {
   readonly root: string;
@@ -9,40 +10,62 @@ interface CarouselStyleClasses {
   readonly nextButton: string;
 }
 
-export interface ThemedCarouselResult extends CarouselElements {
-  state: CarouselState;
-  Slide: () => HTMLDivElement;
-  goTo: (index: number) => void;
-  goNext: () => void;
-  goPrev: () => void;
+// ── Props ──────────────────────────────────────────────────
+
+export interface CarouselRootProps {
+  orientation?: 'horizontal' | 'vertical';
+  loop?: boolean;
+  defaultIndex?: number;
+  onSlideChange?: (index: number) => void;
+  children?: ChildValue;
 }
 
-export function createThemedCarousel(
-  styles: CarouselStyleClasses,
-): (options?: CarouselOptions) => ThemedCarouselResult {
-  return function themedCarousel(options?: CarouselOptions): ThemedCarouselResult {
-    const result = Carousel.Root(options);
-    const originalSlide = result.Slide;
+export interface CarouselSlotProps {
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
 
-    result.root.classList.add(styles.root);
-    result.viewport.classList.add(styles.viewport);
-    result.prevButton.classList.add(styles.prevButton);
-    result.nextButton.classList.add(styles.nextButton);
+// ── Component type ─────────────────────────────────────────
 
-    return {
-      root: result.root,
-      viewport: result.viewport,
-      prevButton: result.prevButton,
-      nextButton: result.nextButton,
-      state: result.state,
-      goTo: result.goTo,
-      goNext: result.goNext,
-      goPrev: result.goPrev,
-      Slide: () => {
-        const slide = originalSlide();
-        slide.classList.add(styles.slide);
-        return slide;
-      },
-    };
-  };
+export interface ThemedCarouselComponent {
+  (props: CarouselRootProps): HTMLElement;
+  Slide: (props: CarouselSlotProps) => HTMLElement;
+  Previous: (props: CarouselSlotProps) => HTMLElement;
+  Next: (props: CarouselSlotProps) => HTMLElement;
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+export function createThemedCarousel(styles: CarouselStyleClasses): ThemedCarouselComponent {
+  const StyledCarousel = withStyles(ComposedCarousel, {
+    root: styles.root,
+    viewport: styles.viewport,
+    slide: styles.slide,
+    prevButton: styles.prevButton,
+    nextButton: styles.nextButton,
+  });
+
+  function CarouselRoot({
+    orientation,
+    loop,
+    defaultIndex,
+    onSlideChange,
+    children,
+  }: CarouselRootProps): HTMLElement {
+    return StyledCarousel({
+      children,
+      orientation,
+      loop,
+      defaultIndex,
+      onSlideChange,
+    } as ComposedCarouselProps);
+  }
+
+  return Object.assign(CarouselRoot, {
+    Slide: ComposedCarousel.Slide,
+    Previous: ComposedCarousel.Previous,
+    Next: ComposedCarousel.Next,
+  }) as ThemedCarouselComponent;
 }

--- a/packages/theme-shadcn/src/components/primitives/index.ts
+++ b/packages/theme-shadcn/src/components/primitives/index.ts
@@ -13,7 +13,7 @@ export type {
 } from './alert-dialog';
 export { createThemedAlertDialog } from './alert-dialog';
 export { createThemedCalendar } from './calendar';
-export type { ThemedCarouselResult } from './carousel';
+export type { CarouselRootProps, CarouselSlotProps, ThemedCarouselComponent } from './carousel';
 export { createThemedCarousel } from './carousel';
 export type { CheckboxRootProps, ThemedCheckboxComponent } from './checkbox';
 export { createThemedCheckbox } from './checkbox';

--- a/packages/theme-shadcn/src/configure.ts
+++ b/packages/theme-shadcn/src/configure.ts
@@ -26,6 +26,7 @@ import type { ThemedAlertDialogComponent } from './components/primitives/alert-d
 import { createThemedAlertDialog } from './components/primitives/alert-dialog';
 import type { ThemedCalendarComponent } from './components/primitives/calendar';
 import { createThemedCalendar } from './components/primitives/calendar';
+import type { ThemedCarouselComponent } from './components/primitives/carousel';
 import { createThemedCarousel } from './components/primitives/carousel';
 import type { ThemedCheckboxComponent } from './components/primitives/checkbox';
 import { createThemedCheckbox } from './components/primitives/checkbox';
@@ -390,8 +391,8 @@ export interface ThemedPrimitives {
   Sheet: ThemedSheetComponent;
   /** Themed Calendar — composable JSX component wrapping @vertz/ui-primitives Calendar. */
   Calendar: ThemedCalendarComponent;
-  /** Themed Carousel — slide navigation with prev/next controls. */
-  carousel: ReturnType<typeof createThemedCarousel>;
+  /** Themed Carousel — composable JSX component with Carousel.Slide, Carousel.Previous, Carousel.Next. */
+  Carousel: ThemedCarouselComponent;
   /** Themed Collapsible — expandable/collapsible content section. */
   collapsible: ReturnType<typeof createThemedCollapsible>;
   /** Themed Command — searchable command palette. */
@@ -595,7 +596,7 @@ export function configureTheme(config?: ThemeConfig): ResolvedTheme {
       Tooltip: createThemedTooltip(tooltipStyles),
       Sheet: createThemedSheet(sheetStyles),
       Calendar: createThemedCalendar(calendarStyles),
-      carousel: createThemedCarousel(carouselStyles),
+      Carousel: createThemedCarousel(carouselStyles),
       collapsible: createThemedCollapsible(collapsibleStyles),
       command: createThemedCommand(commandStyles),
       ContextMenu: createThemedContextMenu(contextMenuStyles),

--- a/packages/theme-shadcn/src/index.ts
+++ b/packages/theme-shadcn/src/index.ts
@@ -36,6 +36,7 @@ import type { PaginationComponents } from './components/pagination';
 import type { ThemedAccordionComponent } from './components/primitives/accordion';
 import type { ThemedAlertDialogComponent } from './components/primitives/alert-dialog';
 import type { ThemedCalendarComponent } from './components/primitives/calendar';
+import type { ThemedCarouselComponent } from './components/primitives/carousel';
 import type { ThemedCheckboxComponent } from './components/primitives/checkbox';
 import type { ThemedContextMenuComponent } from './components/primitives/context-menu';
 import type { ThemedDialogComponent } from './components/primitives/dialog';
@@ -100,8 +101,10 @@ declare module '@vertz/ui/components' {
     Toggle: ThemedToggleComponent;
     Toast: ThemedPrimitives['Toast'];
 
+    // Compound primitives (callable + sub-components) — continued
+    Carousel: ThemedCarouselComponent;
+
     // Factory primitives (lowercase)
-    carousel: ThemedPrimitives['carousel'];
     collapsible: ThemedPrimitives['collapsible'];
     command: ThemedPrimitives['command'];
     datePicker: ThemedPrimitives['datePicker'];

--- a/packages/ui-primitives/src/carousel/__tests__/carousel-composed.test.ts
+++ b/packages/ui-primitives/src/carousel/__tests__/carousel-composed.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { ComposedCarousel } from '../carousel-composed';
+
+function renderCarousel(
+  slides: string[],
+  opts: {
+    orientation?: 'horizontal' | 'vertical';
+    loop?: boolean;
+    defaultIndex?: number;
+    onSlideChange?: (index: number) => void;
+  } = {},
+): HTMLElement {
+  return ComposedCarousel({
+    ...opts,
+    children: () => {
+      const slideEls = slides.map((text) => ComposedCarousel.Slide({ children: [text] }));
+      const prev = ComposedCarousel.Previous({ children: ['Prev'] });
+      const next = ComposedCarousel.Next({ children: ['Next'] });
+      return [...slideEls, prev, next];
+    },
+  });
+}
+
+describe('Composed Carousel', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  describe('Given a Carousel with Slide sub-components', () => {
+    describe('When rendered', () => {
+      it('Then root has role="region" and aria-roledescription="carousel"', () => {
+        const root = renderCarousel(['Slide 1']);
+        container.appendChild(root);
+
+        expect(root.getAttribute('role')).toBe('region');
+        expect(root.getAttribute('aria-roledescription')).toBe('carousel');
+      });
+
+      it('Then slides have role="group" and aria-roledescription="slide"', () => {
+        const root = renderCarousel(['Slide 1', 'Slide 2']);
+        container.appendChild(root);
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides.length).toBe(2);
+        for (const slide of slides) {
+          expect(slide.getAttribute('aria-roledescription')).toBe('slide');
+        }
+      });
+
+      it('Then the first slide is active and others are hidden', () => {
+        const root = renderCarousel(['Slide 1', 'Slide 2', 'Slide 3']);
+        container.appendChild(root);
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides[0]?.getAttribute('aria-hidden')).toBe('false');
+        expect(slides[0]?.getAttribute('data-state')).toBe('active');
+        expect(slides[1]?.getAttribute('aria-hidden')).toBe('true');
+        expect(slides[1]?.getAttribute('data-state')).toBe('inactive');
+        expect(slides[2]?.getAttribute('aria-hidden')).toBe('true');
+        expect(slides[2]?.getAttribute('data-state')).toBe('inactive');
+      });
+
+      it('Then slides have "Slide N of M" labels', () => {
+        const root = renderCarousel(['Slide 1', 'Slide 2']);
+        container.appendChild(root);
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides[0]?.getAttribute('aria-label')).toBe('Slide 1 of 2');
+        expect(slides[1]?.getAttribute('aria-label')).toBe('Slide 2 of 2');
+      });
+
+      it('Then renders slide content inside each slide', () => {
+        const root = renderCarousel(['Hello', 'World']);
+        container.appendChild(root);
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides[0]?.textContent).toBe('Hello');
+        expect(slides[1]?.textContent).toBe('World');
+      });
+
+      it('Then defaults data-orientation to horizontal', () => {
+        const root = renderCarousel(['Slide 1']);
+        expect(root.getAttribute('data-orientation')).toBe('horizontal');
+      });
+
+      it('Then sets data-orientation to vertical when specified', () => {
+        const root = renderCarousel(['Slide 1'], { orientation: 'vertical' });
+        expect(root.getAttribute('data-orientation')).toBe('vertical');
+      });
+    });
+  });
+
+  describe('Given a Carousel with next/prev buttons', () => {
+    describe('When the next button is clicked', () => {
+      it('Then advances to the next slide', () => {
+        const root = renderCarousel(['S1', 'S2', 'S3']);
+        container.appendChild(root);
+
+        const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+        nextBtn.click();
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides[0]?.getAttribute('data-state')).toBe('inactive');
+        expect(slides[1]?.getAttribute('data-state')).toBe('active');
+        expect(slides[1]?.getAttribute('aria-hidden')).toBe('false');
+      });
+    });
+
+    describe('When the prev button is clicked', () => {
+      it('Then goes to the previous slide', () => {
+        const root = renderCarousel(['S1', 'S2', 'S3']);
+        container.appendChild(root);
+
+        const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+        const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLButtonElement;
+
+        nextBtn.click();
+        nextBtn.click();
+        prevBtn.click();
+
+        const slides = root.querySelectorAll('[role="group"]');
+        expect(slides[1]?.getAttribute('data-state')).toBe('active');
+        expect(slides[2]?.getAttribute('data-state')).toBe('inactive');
+      });
+    });
+  });
+
+  describe('Given a Carousel without loop mode', () => {
+    it('Then prev is disabled at start and next is disabled at end', () => {
+      const root = renderCarousel(['S1', 'S2']);
+      container.appendChild(root);
+
+      const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLButtonElement;
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+
+      expect(prevBtn.disabled).toBe(true);
+      expect(nextBtn.disabled).toBe(false);
+
+      nextBtn.click();
+      expect(prevBtn.disabled).toBe(false);
+      expect(nextBtn.disabled).toBe(true);
+    });
+  });
+
+  describe('Given a Carousel with loop mode', () => {
+    it('Then wraps from last to first and first to last', () => {
+      const root = renderCarousel(['S1', 'S2', 'S3'], { loop: true });
+      container.appendChild(root);
+
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+      const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLButtonElement;
+
+      // Go to end: 0 -> 1 -> 2 -> 0
+      nextBtn.click();
+      nextBtn.click();
+      nextBtn.click();
+      const slides = root.querySelectorAll('[role="group"]');
+      expect(slides[0]?.getAttribute('data-state')).toBe('active');
+
+      // Wrap backward: 0 -> 2
+      prevBtn.click();
+      expect(slides[2]?.getAttribute('data-state')).toBe('active');
+    });
+
+    it('Then buttons are never disabled', () => {
+      const root = renderCarousel(['S1', 'S2'], { loop: true });
+      container.appendChild(root);
+
+      const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLButtonElement;
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+
+      expect(prevBtn.disabled).toBe(false);
+      expect(nextBtn.disabled).toBe(false);
+    });
+  });
+
+  describe('Given a Carousel with keyboard navigation', () => {
+    it('Then ArrowRight navigates to next slide (horizontal)', () => {
+      const root = renderCarousel(['S1', 'S2']);
+      container.appendChild(root);
+
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+      const slides = root.querySelectorAll('[role="group"]');
+      expect(slides[1]?.getAttribute('data-state')).toBe('active');
+    });
+
+    it('Then ArrowLeft navigates to previous slide (horizontal)', () => {
+      const root = renderCarousel(['S1', 'S2']);
+      container.appendChild(root);
+
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+      nextBtn.click();
+
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+
+      const slides = root.querySelectorAll('[role="group"]');
+      expect(slides[0]?.getAttribute('data-state')).toBe('active');
+    });
+
+    it('Then ArrowDown/ArrowUp navigate slides in vertical orientation', () => {
+      const root = renderCarousel(['S1', 'S2', 'S3'], { orientation: 'vertical' });
+      container.appendChild(root);
+
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      const slides = root.querySelectorAll('[role="group"]');
+      expect(slides[1]?.getAttribute('data-state')).toBe('active');
+
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      expect(slides[0]?.getAttribute('data-state')).toBe('active');
+    });
+  });
+
+  describe('Given a Carousel with an onSlideChange callback', () => {
+    it('Then calls onSlideChange when slide changes', () => {
+      const onSlideChange = vi.fn();
+      const root = renderCarousel(['S1', 'S2'], { onSlideChange });
+      container.appendChild(root);
+
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLButtonElement;
+      nextBtn.click();
+
+      expect(onSlideChange).toHaveBeenCalledTimes(1);
+      expect(onSlideChange).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Given a Carousel with defaultIndex', () => {
+    it('Then starts at the specified slide index', () => {
+      const root = renderCarousel(['S1', 'S2', 'S3'], { defaultIndex: 1 });
+      container.appendChild(root);
+
+      const slides = root.querySelectorAll('[role="group"]');
+      expect(slides[0]?.getAttribute('data-state')).toBe('inactive');
+      expect(slides[1]?.getAttribute('data-state')).toBe('active');
+      expect(slides[2]?.getAttribute('data-state')).toBe('inactive');
+    });
+  });
+
+  describe('Given a Carousel with classes', () => {
+    it('Then applies classes to root, viewport, slides, and buttons', () => {
+      const root = ComposedCarousel({
+        classes: {
+          root: 'carousel-root',
+          viewport: 'carousel-viewport',
+          slide: 'carousel-slide',
+          prevButton: 'carousel-prev',
+          nextButton: 'carousel-next',
+        },
+        children: () => {
+          const s1 = ComposedCarousel.Slide({ children: ['Slide 1'] });
+          const prev = ComposedCarousel.Previous({ children: ['Prev'] });
+          const next = ComposedCarousel.Next({ children: ['Next'] });
+          return [s1, prev, next];
+        },
+      });
+      container.appendChild(root);
+
+      expect(root.classList.contains('carousel-root')).toBe(true);
+
+      const viewport = root.querySelector('[style*="overflow"]') as HTMLElement;
+      expect(viewport.classList.contains('carousel-viewport')).toBe(true);
+
+      const slide = root.querySelector('[role="group"]') as HTMLElement;
+      expect(slide.classList.contains('carousel-slide')).toBe(true);
+
+      const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLElement;
+      expect(prevBtn.classList.contains('carousel-prev')).toBe(true);
+
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLElement;
+      expect(nextBtn.classList.contains('carousel-next')).toBe(true);
+    });
+  });
+
+  describe('Given a Carousel with custom Previous/Next content', () => {
+    it('Then renders custom content inside buttons', () => {
+      const root = ComposedCarousel({
+        children: () => {
+          const s1 = ComposedCarousel.Slide({ children: ['Slide 1'] });
+          const prev = ComposedCarousel.Previous({ children: ['← Back'] });
+          const next = ComposedCarousel.Next({ children: ['Forward →'] });
+          return [s1, prev, next];
+        },
+      });
+      container.appendChild(root);
+
+      const prevBtn = root.querySelector('[aria-label="Previous slide"]') as HTMLElement;
+      const nextBtn = root.querySelector('[aria-label="Next slide"]') as HTMLElement;
+      expect(prevBtn.textContent).toBe('← Back');
+      expect(nextBtn.textContent).toBe('Forward →');
+    });
+  });
+
+  describe('Given a Carousel.Slide used outside Carousel', () => {
+    it('Then throws an error', () => {
+      expect(() => {
+        ComposedCarousel.Slide({ children: ['Slide 1'] });
+      }).toThrow('must be used inside <Carousel>');
+    });
+  });
+
+  describe('Given a Carousel with viewport transform', () => {
+    it('Then applies translateX for horizontal orientation', () => {
+      const root = renderCarousel(['S1', 'S2'], { defaultIndex: 1 });
+      container.appendChild(root);
+
+      const viewport = root.querySelector('[style*="overflow"]') as HTMLElement;
+      expect(viewport.style.transform).toBe('translateX(-100%)');
+    });
+
+    it('Then applies translateY for vertical orientation', () => {
+      const root = renderCarousel(['S1', 'S2'], {
+        orientation: 'vertical',
+        defaultIndex: 1,
+      });
+      container.appendChild(root);
+
+      const viewport = root.querySelector('[style*="overflow"]') as HTMLElement;
+      expect(viewport.style.transform).toBe('translateY(-100%)');
+    });
+  });
+});

--- a/packages/ui-primitives/src/carousel/carousel-composed.tsx
+++ b/packages/ui-primitives/src/carousel/carousel-composed.tsx
@@ -1,0 +1,297 @@
+/**
+ * Composed Carousel — fully declarative JSX component with slide navigation.
+ * Follows WAI-ARIA carousel pattern.
+ * Sub-components self-wire via context. No factory wrapping.
+ */
+
+import type { ChildValue } from '@vertz/ui';
+import { createContext, resolveChildren, useContext } from '@vertz/ui';
+
+// ---------------------------------------------------------------------------
+// Class types
+// ---------------------------------------------------------------------------
+
+export interface CarouselClasses {
+  root?: string;
+  viewport?: string;
+  slide?: string;
+  prevButton?: string;
+  nextButton?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Registration types
+// ---------------------------------------------------------------------------
+
+interface SlideRegistration {
+  children: ChildValue;
+  className: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface CarouselContextValue {
+  classes?: CarouselClasses;
+  _registerSlide: (reg: SlideRegistration) => void;
+  _registerPrevious: (children: ChildValue) => void;
+  _registerNext: (children: ChildValue) => void;
+}
+
+const CarouselContext = createContext<CarouselContextValue | undefined>(
+  undefined,
+  '@vertz/ui-primitives::CarouselContext',
+);
+
+function useCarouselContext(componentName: string): CarouselContextValue {
+  const ctx = useContext(CarouselContext);
+  if (!ctx) {
+    throw new Error(
+      `<Carousel.${componentName}> must be used inside <Carousel>. ` +
+        'Ensure it is a direct or nested child of the Carousel root component.',
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component props
+// ---------------------------------------------------------------------------
+
+interface SlideProps {
+  children?: ChildValue;
+  className?: string;
+  class?: string;
+}
+
+interface SlotProps {
+  children?: ChildValue;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function CarouselSlide({ children, className: cls, class: classProp }: SlideProps) {
+  const ctx = useCarouselContext('Slide');
+  ctx._registerSlide({ children, className: cls ?? classProp });
+  return (<span style="display: contents" />) as HTMLElement;
+}
+
+function CarouselPrevious({ children }: SlotProps) {
+  const ctx = useCarouselContext('Previous');
+  ctx._registerPrevious(children);
+  return (<span style="display: contents" />) as HTMLElement;
+}
+
+function CarouselNext({ children }: SlotProps) {
+  const ctx = useCarouselContext('Next');
+  ctx._registerNext(children);
+  return (<span style="display: contents" />) as HTMLElement;
+}
+
+// ---------------------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------------------
+
+export interface ComposedCarouselProps {
+  children?: ChildValue;
+  classes?: CarouselClasses;
+  orientation?: 'horizontal' | 'vertical';
+  loop?: boolean;
+  defaultIndex?: number;
+  onSlideChange?: (index: number) => void;
+}
+
+export type CarouselClassKey = keyof CarouselClasses;
+
+function ComposedCarouselRoot({
+  children,
+  classes,
+  orientation = 'horizontal',
+  loop = false,
+  defaultIndex = 0,
+  onSlideChange,
+}: ComposedCarouselProps) {
+  // Registration storage — plain object so compiler doesn't signal-transform
+  const reg: {
+    slides: SlideRegistration[];
+    prevChildren: ChildValue;
+    nextChildren: ChildValue;
+  } = { slides: [], prevChildren: undefined, nextChildren: undefined };
+
+  const ctxValue: CarouselContextValue = {
+    classes,
+    _registerSlide: (slideReg) => {
+      reg.slides.push(slideReg);
+    },
+    _registerPrevious: (prevChildren) => {
+      if (reg.prevChildren === undefined) {
+        reg.prevChildren = prevChildren;
+      }
+    },
+    _registerNext: (nextChildren) => {
+      if (reg.nextChildren === undefined) {
+        reg.nextChildren = nextChildren;
+      }
+    },
+  };
+
+  // Phase 1: resolve children to collect registrations
+  CarouselContext.Provider(ctxValue, () => {
+    resolveChildren(children);
+  });
+
+  // Phase 2: build the carousel
+  let currentIndex = defaultIndex;
+  const slideCount = reg.slides.length;
+
+  function goTo(index: number): void {
+    if (slideCount === 0) return;
+    let next = index;
+    if (loop) {
+      next = ((index % slideCount) + slideCount) % slideCount;
+    } else {
+      next = Math.max(0, Math.min(slideCount - 1, index));
+    }
+    if (next === currentIndex) return;
+    currentIndex = next;
+    updateSlideVisibility();
+    onSlideChange?.(next);
+  }
+
+  function goNext(): void {
+    goTo(currentIndex + 1);
+  }
+
+  function goPrev(): void {
+    goTo(currentIndex - 1);
+  }
+
+  function updateSlideVisibility(): void {
+    for (let i = 0; i < slideEls.length; i++) {
+      const slide = slideEls[i];
+      if (!slide) continue;
+      slide.setAttribute('aria-hidden', String(i !== currentIndex));
+      slide.setAttribute('aria-label', `Slide ${i + 1} of ${slideCount}`);
+      slide.setAttribute('data-state', i === currentIndex ? 'active' : 'inactive');
+    }
+    if (!loop && prevButtonEl) {
+      (prevButtonEl as HTMLButtonElement).disabled = currentIndex <= 0;
+    }
+    if (!loop && nextButtonEl) {
+      (nextButtonEl as HTMLButtonElement).disabled = currentIndex >= slideCount - 1;
+    }
+    const translateProp = orientation === 'horizontal' ? 'translateX' : 'translateY';
+    if (viewportEl) {
+      viewportEl.style.transform = `${translateProp}(-${currentIndex * 100}%)`;
+    }
+  }
+
+  const isKey = (e: KeyboardEvent, key: string) => e.key === key;
+
+  function handleKeydown(event: KeyboardEvent): void {
+    const prevKey = orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
+    const nextKey = orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown';
+    if (isKey(event, prevKey)) {
+      event.preventDefault();
+      goPrev();
+    }
+    if (isKey(event, nextKey)) {
+      event.preventDefault();
+      goNext();
+    }
+  }
+
+  // Build slide elements
+  const slideEls: HTMLDivElement[] = [];
+  const slideNodes = reg.slides.map((slideReg, i) => {
+    const resolved = resolveChildren(slideReg.children);
+    const slideClass = [classes?.slide, slideReg.className].filter(Boolean).join(' ') || undefined;
+    const isActive = i === defaultIndex;
+    const el = (
+      <div
+        role="group"
+        aria-roledescription="slide"
+        aria-hidden={isActive ? 'false' : 'true'}
+        aria-label={`Slide ${i + 1} of ${slideCount}`}
+        data-state={isActive ? 'active' : 'inactive'}
+        class={slideClass}
+      >
+        {...resolved}
+      </div>
+    ) as HTMLDivElement;
+    slideEls.push(el);
+    return el;
+  });
+
+  // Resolve prev/next button content
+  const prevContent = resolveChildren(reg.prevChildren);
+  const nextContent = resolveChildren(reg.nextChildren);
+
+  // Build viewport
+  const viewportEl = (
+    <div style="overflow: hidden;" class={classes?.viewport}>
+      {...slideNodes}
+    </div>
+  ) as HTMLDivElement;
+
+  // Build prev/next buttons
+  const prevButtonEl = (
+    <button
+      type="button"
+      aria-label="Previous slide"
+      class={classes?.prevButton}
+      disabled={!loop && defaultIndex <= 0}
+      onClick={goPrev}
+    >
+      {...prevContent}
+    </button>
+  ) as HTMLButtonElement;
+
+  const nextButtonEl = (
+    <button
+      type="button"
+      aria-label="Next slide"
+      class={classes?.nextButton}
+      disabled={!loop && defaultIndex >= slideCount - 1}
+      onClick={goNext}
+    >
+      {...nextContent}
+    </button>
+  ) as HTMLButtonElement;
+
+  // Apply initial transform
+  const translateProp = orientation === 'horizontal' ? 'translateX' : 'translateY';
+  viewportEl.style.transform = `${translateProp}(-${defaultIndex * 100}%)`;
+
+  return (
+    <div
+      role="region"
+      aria-roledescription="carousel"
+      data-orientation={orientation}
+      class={classes?.root}
+      onKeydown={handleKeydown}
+    >
+      {viewportEl}
+      {prevButtonEl}
+      {nextButtonEl}
+    </div>
+  ) as HTMLElement;
+}
+
+// ---------------------------------------------------------------------------
+// Export as callable with sub-component properties
+// ---------------------------------------------------------------------------
+
+export const ComposedCarousel = Object.assign(ComposedCarouselRoot, {
+  Slide: CarouselSlide,
+  Previous: CarouselPrevious,
+  Next: CarouselNext,
+}) as ((props: ComposedCarouselProps) => HTMLElement) & {
+  __classKeys?: CarouselClassKey;
+  Slide: (props: SlideProps) => HTMLElement;
+  Previous: (props: SlotProps) => HTMLElement;
+  Next: (props: SlotProps) => HTMLElement;
+};

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -26,6 +26,8 @@ export type { CalendarClasses, ComposedCalendarProps } from './calendar/calendar
 export { ComposedCalendar } from './calendar/calendar-composed';
 export type { CarouselElements, CarouselOptions, CarouselState } from './carousel/carousel';
 export { Carousel } from './carousel/carousel';
+export type { CarouselClasses, ComposedCarouselProps } from './carousel/carousel-composed';
+export { ComposedCarousel } from './carousel/carousel-composed';
 export type { CheckboxOptions, CheckedState } from './checkbox/checkbox';
 export { Checkbox } from './checkbox/checkbox';
 export type { CheckboxClasses, ComposedCheckboxProps } from './checkbox/checkbox-composed';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -258,6 +258,11 @@ export const Drawer: ThemeComponentMap['Drawer'] = /* #__PURE__ */ createCompoun
   'Handle',
 ]) as ThemeComponentMap['Drawer'];
 
+export const Carousel: ThemeComponentMap['Carousel'] = /* #__PURE__ */ createCompoundProxy(
+  'Carousel',
+  ['Slide', 'Previous', 'Next'],
+) as ThemeComponentMap['Carousel'];
+
 // ---------------------------------------------------------------------------
 // Simple primitives (just callable, no sub-components)
 // ---------------------------------------------------------------------------
@@ -293,10 +298,6 @@ export const Toast: ThemeComponentMap['Toast'] = /* #__PURE__ */ createPrimitive
 // ---------------------------------------------------------------------------
 // Factory primitives (lowercase names, delegated directly)
 // ---------------------------------------------------------------------------
-
-export const carousel: ThemeComponentMap['carousel'] = /* #__PURE__ */ createPrimitiveProxy(
-  'carousel',
-) as ThemeComponentMap['carousel'];
 
 export const collapsible: ThemeComponentMap['collapsible'] = /* #__PURE__ */ createPrimitiveProxy(
   'collapsible',


### PR DESCRIPTION
## Summary

- Add `ComposedCarousel` in `@vertz/ui-primitives` — declarative JSX carousel with `Carousel.Slide`, `Carousel.Previous`, `Carousel.Next` sub-components using context-based registration pattern
- Convert themed carousel in `@vertz/theme-shadcn` from imperative factory (`Carousel.Root()`) to `withStyles()` wrapping the composed primitive
- Promote carousel from lowercase factory proxy to PascalCase compound proxy in `@vertz/ui/components`
- 22 new tests covering rendering, navigation, looping, keyboard nav, orientation, defaultIndex, classes, and custom content

## Public API Changes

**Breaking (pre-v1):** `carousel` (lowercase factory) is replaced by `Carousel` (PascalCase JSX component).

Before:
```ts
import { carousel } from '@vertz/ui/components';
const result = carousel({ loop: true });
const slide = result.Slide();
```

After:
```tsx
import { Carousel } from '@vertz/ui/components';

<Carousel loop>
  <Carousel.Slide>Slide 1</Carousel.Slide>
  <Carousel.Slide>Slide 2</Carousel.Slide>
  <Carousel.Previous>←</Carousel.Previous>
  <Carousel.Next>→</Carousel.Next>
</Carousel>
```

## Test plan

- [x] `ComposedCarousel` renders root with ARIA carousel attributes
- [x] Slides register via context and render with correct ARIA roles
- [x] Next/Previous buttons navigate slides
- [x] Loop mode wraps and buttons are never disabled
- [x] Non-loop mode disables buttons at boundaries
- [x] Keyboard navigation (Arrow keys) works for both orientations
- [x] `onSlideChange` callback fires on navigation
- [x] `defaultIndex` starts at specified slide
- [x] Classes applied to root, viewport, slides, and buttons
- [x] Custom Previous/Next content renders inside buttons
- [x] Sub-components throw when used outside Carousel
- [x] Viewport transform applies correctly for both orientations
- [x] Themed carousel applies style classes via `withStyles()`
- [x] All 653 ui-primitives tests pass, all 452 theme-shadcn tests pass
- [x] Typecheck clean on all 3 affected packages

Fixes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)