### PR TITLE
feat(theme-shadcn): convert menubar factory to JSX component (#1480)

### DIFF
--- a/.changeset/menubar-jsx-component.md
+++ b/.changeset/menubar-jsx-component.md
@@ -1,0 +1,7 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+'@vertz/ui': patch
+---
+
+Convert menubar from factory to declarative JSX component with sub-components (Menubar.Menu, Menubar.Trigger, Menubar.Content, Menubar.Item, Menubar.Group, Menubar.Label, Menubar.Separator)

--- a/packages/theme-shadcn/src/__tests__/menubar.test.ts
+++ b/packages/theme-shadcn/src/__tests__/menubar.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { createMenubarStyles } from '../styles/menubar';
 
 describe('menubar styles', () => {
@@ -40,73 +40,206 @@ describe('menubar styles', () => {
   });
 });
 
-describe('themed Menubar', () => {
-  it('applies root class to menubar element', async () => {
-    const { createThemedMenubar } = await import('../components/primitives/menubar');
-    const styles = createMenubarStyles();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar();
+describe('themed Menubar (JSX component)', () => {
+  let container: HTMLDivElement;
 
-    expect(mb.root.classList.contains(styles.root)).toBe(true);
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
   });
 
-  it('applies trigger and content classes to menu', async () => {
-    const { createThemedMenubar } = await import('../components/primitives/menubar');
-    const styles = createMenubarStyles();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar();
-    const menu = mb.Menu('file', 'File');
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
 
-    expect(menu.trigger.classList.contains(styles.trigger)).toBe(true);
-    expect(menu.content.classList.contains(styles.content)).toBe(true);
+  it('applies root class to menubar element', async () => {
+    const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
+    const styles = createMenubarStyles();
+    const Menubar = createThemedMenubar(styles);
+
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    expect(root.className).toContain(styles.root);
+  });
+
+  it('applies trigger and content classes via composed primitives', async () => {
+    const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
+    const styles = createMenubarStyles();
+    const Menubar = createThemedMenubar(styles);
+
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[aria-haspopup="menu"]') as HTMLElement;
+    expect(trigger.className).toContain(styles.trigger);
+
+    const content = root.querySelector('[role="menu"]') as HTMLElement;
+    expect(content.className).toContain(styles.content);
   });
 
   it('applies item class to items', async () => {
     const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
     const styles = createMenubarStyles();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar();
-    const menu = mb.Menu('file', 'File');
-    const item = menu.Item('new', 'New');
+    const Menubar = createThemedMenubar(styles);
 
-    expect(item.classList.contains(styles.item)).toBe(true);
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const item = root.querySelector('[data-value="new"]') as HTMLElement;
+    expect(item.className).toContain(styles.item);
   });
 
   it('applies separator class', async () => {
     const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
     const styles = createMenubarStyles();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar();
-    const menu = mb.Menu('file', 'File');
-    const sep = menu.Separator();
+    const Menubar = createThemedMenubar(styles);
 
-    expect(sep.classList.contains(styles.separator)).toBe(true);
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => {
+                const i1 = ComposedMenubar.Item({ value: 'new', children: ['New'] });
+                const sep = ComposedMenubar.Separator({});
+                return [i1, sep];
+              },
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const separator = root.querySelector('[role="separator"]') as HTMLElement;
+    expect(separator.className).toContain(styles.separator);
   });
 
   it('preserves primitive behavior — click toggles menu', async () => {
     const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
     const styles = createMenubarStyles();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar();
-    const menu = mb.Menu('file', 'File');
-    menu.Item('new', 'New');
+    const Menubar = createThemedMenubar(styles);
 
-    expect(mb.state.activeMenu.peek()).toBeNull();
-    menu.trigger.click();
-    expect(mb.state.activeMenu.peek()).toBe('file');
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[aria-haspopup="menu"]') as HTMLElement;
+    const content = root.querySelector('[role="menu"]') as HTMLElement;
+
+    expect(content.getAttribute('data-state')).toBe('closed');
+    trigger.click();
+    expect(content.getAttribute('data-state')).toBe('open');
   });
 
   it('passes options through to primitive', async () => {
     const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
     const styles = createMenubarStyles();
     const onSelect = vi.fn();
-    const themedMenubar = createThemedMenubar(styles);
-    const mb = themedMenubar({ onSelect });
-    const menu = mb.Menu('file', 'File');
-    const item = menu.Item('new', 'New');
+    const Menubar = createThemedMenubar(styles);
 
-    menu.trigger.click();
+    const root = Menubar({
+      onSelect,
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[aria-haspopup="menu"]') as HTMLElement;
+    trigger.click();
+    const item = root.querySelector('[data-value="new"]') as HTMLElement;
     item.click();
     expect(onSelect).toHaveBeenCalledWith('new');
+  });
+
+  it('exposes sub-components from ComposedMenubar', async () => {
+    const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const styles = createMenubarStyles();
+    const Menubar = createThemedMenubar(styles);
+
+    expect(typeof Menubar.Menu).toBe('function');
+    expect(typeof Menubar.Trigger).toBe('function');
+    expect(typeof Menubar.Content).toBe('function');
+    expect(typeof Menubar.Item).toBe('function');
+    expect(typeof Menubar.Group).toBe('function');
+    expect(typeof Menubar.Label).toBe('function');
+    expect(typeof Menubar.Separator).toBe('function');
   });
 });

--- a/packages/theme-shadcn/src/components/primitives/index.ts
+++ b/packages/theme-shadcn/src/components/primitives/index.ts
@@ -48,7 +48,15 @@ export type {
 } from './dropdown-menu';
 export { createThemedDropdownMenu } from './dropdown-menu';
 export { createThemedHoverCard } from './hover-card';
-export type { ThemedMenubarResult } from './menubar';
+export type {
+  MenubarGroupProps,
+  MenubarItemProps,
+  MenubarLabelProps,
+  MenubarMenuProps,
+  MenubarRootProps,
+  MenubarSlotProps,
+  ThemedMenubarComponent,
+} from './menubar';
 export { createThemedMenubar } from './menubar';
 export type { ThemedNavigationMenuResult } from './navigation-menu';
 export { createThemedNavigationMenu } from './navigation-menu';

--- a/packages/theme-shadcn/src/components/primitives/menubar.ts
+++ b/packages/theme-shadcn/src/components/primitives/menubar.ts
@@ -1,5 +1,6 @@
-import type { MenubarElements, MenubarOptions, MenubarState } from '@vertz/ui-primitives';
-import { Menubar } from '@vertz/ui-primitives';
+import type { ChildValue } from '@vertz/ui';
+import type { ComposedMenubarProps } from '@vertz/ui-primitives';
+import { ComposedMenubar, withStyles } from '@vertz/ui-primitives';
 
 interface MenubarStyleClasses {
   readonly root: string;
@@ -10,78 +11,85 @@ interface MenubarStyleClasses {
   readonly label: string;
 }
 
-export interface ThemedMenubarResult extends MenubarElements {
-  state: MenubarState;
-  Menu: (
-    value: string,
-    label?: string,
-  ) => {
-    trigger: HTMLButtonElement;
-    content: HTMLDivElement;
-    Item: (value: string, label?: string) => HTMLDivElement;
-    Group: (label: string) => {
-      el: HTMLDivElement;
-      Item: (value: string, label?: string) => HTMLDivElement;
-    };
-    Separator: () => HTMLHRElement;
-  };
+// ── Props ──────────────────────────────────────────────────
+
+export interface MenubarRootProps {
+  onSelect?: (value: string) => void;
+  children?: ChildValue;
 }
 
-export function createThemedMenubar(
-  styles: MenubarStyleClasses,
-): (options?: MenubarOptions) => ThemedMenubarResult {
-  return function themedMenubar(options?: MenubarOptions): ThemedMenubarResult {
-    const result = Menubar.Root(options);
-    result.root.classList.add(styles.root);
+export interface MenubarMenuProps {
+  value: string;
+  children?: ChildValue;
+}
 
-    function themedMenu(
-      value: string,
-      label?: string,
-    ): {
-      trigger: HTMLButtonElement;
-      content: HTMLDivElement;
-      Item: (value: string, label?: string) => HTMLDivElement;
-      Group: (label: string) => {
-        el: HTMLDivElement;
-        Item: (value: string, label?: string) => HTMLDivElement;
-      };
-      Separator: () => HTMLHRElement;
-    } {
-      const menu = result.Menu(value, label);
-      menu.trigger.classList.add(styles.trigger);
-      menu.content.classList.add(styles.content);
+export interface MenubarSlotProps {
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
 
-      return {
-        trigger: menu.trigger,
-        content: menu.content,
-        Item: (val: string, itemLabel?: string) => {
-          const item = menu.Item(val, itemLabel);
-          item.classList.add(styles.item);
-          return item;
-        },
-        Group: (groupLabel: string) => {
-          const group = menu.Group(groupLabel);
-          return {
-            el: group.el,
-            Item: (val: string, itemLabel?: string) => {
-              const item = group.Item(val, itemLabel);
-              item.classList.add(styles.item);
-              return item;
-            },
-          };
-        },
-        Separator: () => {
-          const sep = menu.Separator();
-          sep.classList.add(styles.separator);
-          return sep;
-        },
-      };
-    }
+export interface MenubarItemProps {
+  value: string;
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
 
-    return {
-      root: result.root,
-      state: result.state,
-      Menu: themedMenu,
-    };
-  };
+export interface MenubarGroupProps {
+  label: string;
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
+
+export interface MenubarLabelProps {
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
+
+// ── Component type ─────────────────────────────────────────
+
+export interface ThemedMenubarComponent {
+  (props: MenubarRootProps): HTMLElement;
+  Menu: (props: MenubarMenuProps) => HTMLElement;
+  Trigger: (props: MenubarSlotProps) => HTMLElement;
+  Content: (props: MenubarSlotProps) => HTMLElement;
+  Item: (props: MenubarItemProps) => HTMLElement;
+  Group: (props: MenubarGroupProps) => HTMLElement;
+  Label: (props: MenubarLabelProps) => HTMLElement;
+  Separator: (props: MenubarSlotProps) => HTMLElement;
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+export function createThemedMenubar(styles: MenubarStyleClasses): ThemedMenubarComponent {
+  const Styled = withStyles(ComposedMenubar, {
+    root: styles.root,
+    trigger: styles.trigger,
+    content: styles.content,
+    item: styles.item,
+    group: '',
+    label: styles.label,
+    separator: styles.separator,
+  });
+
+  function MenubarRoot({ children, onSelect }: MenubarRootProps): HTMLElement {
+    return Styled({ children, onSelect } as ComposedMenubarProps);
+  }
+
+  return Object.assign(MenubarRoot, {
+    Menu: ComposedMenubar.Menu,
+    Trigger: ComposedMenubar.Trigger,
+    Content: ComposedMenubar.Content,
+    Item: ComposedMenubar.Item,
+    Group: ComposedMenubar.Group,
+    Label: ComposedMenubar.Label,
+    Separator: ComposedMenubar.Separator,
+  }) as ThemedMenubarComponent;
 }

--- a/packages/theme-shadcn/src/configure.ts
+++ b/packages/theme-shadcn/src/configure.ts
@@ -42,6 +42,7 @@ import { createThemedDrawer } from './components/primitives/drawer';
 import type { ThemedDropdownMenuComponent } from './components/primitives/dropdown-menu';
 import { createThemedDropdownMenu } from './components/primitives/dropdown-menu';
 import { createThemedHoverCard } from './components/primitives/hover-card';
+import type { ThemedMenubarComponent } from './components/primitives/menubar';
 import { createThemedMenubar } from './components/primitives/menubar';
 import { createThemedNavigationMenu } from './components/primitives/navigation-menu';
 import type { ThemedPopoverComponent } from './components/primitives/popover';
@@ -405,8 +406,8 @@ export interface ThemedPrimitives {
   Drawer: ThemedDrawerComponent;
   /** Themed HoverCard — hover-triggered interactive card. */
   hoverCard: ReturnType<typeof createThemedHoverCard>;
-  /** Themed Menubar — horizontal menu bar with dropdowns. */
-  menubar: ReturnType<typeof createThemedMenubar>;
+  /** Themed Menubar — composable JSX component with Menubar.Menu, Menubar.Trigger, Menubar.Content, etc. */
+  Menubar: ThemedMenubarComponent;
   /** Themed NavigationMenu — site navigation with hover dropdowns. */
   navigationMenu: ReturnType<typeof createThemedNavigationMenu>;
   /** Themed ResizablePanel — resizable panel layout with drag handles. */
@@ -603,7 +604,7 @@ export function configureTheme(config?: ThemeConfig): ResolvedTheme {
       datePicker: createThemedDatePicker(datePickerStyles),
       Drawer: createThemedDrawer(drawerStyles),
       hoverCard: createThemedHoverCard(hoverCardStyles),
-      menubar: createThemedMenubar(menubarStyles),
+      Menubar: createThemedMenubar(menubarStyles),
       navigationMenu: createThemedNavigationMenu(navigationMenuStyles),
       resizablePanel: createThemedResizablePanel(resizablePanelStyles),
       scrollArea: createThemedScrollArea(scrollAreaStyles),

--- a/packages/theme-shadcn/src/index.ts
+++ b/packages/theme-shadcn/src/index.ts
@@ -42,6 +42,7 @@ import type { ThemedContextMenuComponent } from './components/primitives/context
 import type { ThemedDialogComponent } from './components/primitives/dialog';
 import type { ThemedDrawerComponent } from './components/primitives/drawer';
 import type { ThemedDropdownMenuComponent } from './components/primitives/dropdown-menu';
+import type { ThemedMenubarComponent } from './components/primitives/menubar';
 import type { ThemedPopoverComponent } from './components/primitives/popover';
 import type { ThemedProgressComponent } from './components/primitives/progress';
 import type { ThemedRadioGroupComponent } from './components/primitives/radio-group';
@@ -91,6 +92,7 @@ declare module '@vertz/ui/components' {
     Tooltip: ThemedTooltipComponent;
     Sheet: ThemedSheetComponent;
     Drawer: ThemedDrawerComponent;
+    Menubar: ThemedMenubarComponent;
 
     // Simple primitives (callable only)
     Calendar: ThemedCalendarComponent;
@@ -109,7 +111,6 @@ declare module '@vertz/ui/components' {
     command: ThemedPrimitives['command'];
     datePicker: ThemedPrimitives['datePicker'];
     hoverCard: ThemedPrimitives['hoverCard'];
-    menubar: ThemedPrimitives['menubar'];
     navigationMenu: ThemedPrimitives['navigationMenu'];
     resizablePanel: ThemedPrimitives['resizablePanel'];
     scrollArea: ThemedPrimitives['scrollArea'];

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -88,6 +88,8 @@ export type { MenuElements, MenuOptions, MenuState } from './menu/menu';
 export { Menu } from './menu/menu';
 export type { MenubarElements, MenubarOptions, MenubarState } from './menubar/menubar';
 export { Menubar } from './menubar/menubar';
+export type { ComposedMenubarProps, MenubarClasses } from './menubar/menubar-composed';
+export { ComposedMenubar } from './menubar/menubar-composed';
 export type {
   NavigationMenuElements,
   NavigationMenuOptions,

--- a/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
+++ b/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { popScope, pushScope, runCleanups } from '@vertz/ui/internals';
+import { ComposedMenubar } from '../menubar-composed';
+
+describe('Composed Menubar', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function renderMenubar(props?: { onSelect?: (value: string) => void }) {
+    const root = ComposedMenubar({
+      onSelect: props?.onSelect,
+      children: () => {
+        const file = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [
+                ComposedMenubar.Item({ value: 'new', children: ['New'] }),
+                ComposedMenubar.Item({ value: 'open', children: ['Open'] }),
+              ],
+            });
+            return [t, c];
+          },
+        });
+        const edit = ComposedMenubar.Menu({
+          value: 'edit',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['Edit'] });
+            const c = ComposedMenubar.Content({
+              children: () => [
+                ComposedMenubar.Item({ value: 'undo', children: ['Undo'] }),
+                ComposedMenubar.Item({ value: 'redo', children: ['Redo'] }),
+              ],
+            });
+            return [t, c];
+          },
+        });
+        return [file, edit];
+      },
+    });
+    container.appendChild(root);
+    return root;
+  }
+
+  describe('Given a Menubar with Menu, Trigger, Content, and Item sub-components', () => {
+    describe('When rendered', () => {
+      it('Then creates a menubar root with role="menubar"', () => {
+        const root = renderMenubar();
+        expect(root.getAttribute('role')).toBe('menubar');
+      });
+
+      it('Then creates triggers with role="menuitem" and aria-haspopup="menu"', () => {
+        const root = renderMenubar();
+        const triggers = root.querySelectorAll('[role="menuitem"][aria-haspopup="menu"]');
+        expect(triggers.length).toBe(2);
+        expect(triggers[0]!.textContent).toContain('File');
+        expect(triggers[1]!.textContent).toContain('Edit');
+      });
+
+      it('Then creates content panels with role="menu"', () => {
+        const root = renderMenubar();
+        const menus = root.querySelectorAll('[role="menu"]');
+        expect(menus.length).toBe(2);
+      });
+
+      it('Then content panels start hidden', () => {
+        const root = renderMenubar();
+        const menus = root.querySelectorAll('[role="menu"]');
+        expect(menus[0]!.getAttribute('aria-hidden')).toBe('true');
+        expect(menus[0]!.getAttribute('data-state')).toBe('closed');
+      });
+    });
+  });
+
+  describe('Given a Menubar with classes prop', () => {
+    describe('When rendered', () => {
+      it('Then applies classes to root, triggers, content, and items', () => {
+        const root = ComposedMenubar({
+          classes: {
+            root: 'styled-root',
+            trigger: 'styled-trigger',
+            content: 'styled-content',
+            item: 'styled-item',
+          },
+          children: () => {
+            const menu = ComposedMenubar.Menu({
+              value: 'file',
+              children: () => {
+                const t = ComposedMenubar.Trigger({ children: ['File'] });
+                const c = ComposedMenubar.Content({
+                  children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+                });
+                return [t, c];
+              },
+            });
+            return [menu];
+          },
+        });
+        container.appendChild(root);
+
+        expect(root.className).toContain('styled-root');
+
+        const trigger = root.querySelector('[role="menuitem"]') as HTMLElement;
+        expect(trigger.className).toContain('styled-trigger');
+
+        const content = root.querySelector('[role="menu"]') as HTMLElement;
+        expect(content.className).toContain('styled-content');
+
+        const item = content.querySelector('[data-value="new"]') as HTMLElement;
+        expect(item.className).toContain('styled-item');
+      });
+    });
+  });
+
+  describe('Given a Menubar trigger is clicked', () => {
+    describe('When clicked once', () => {
+      it('Then opens the corresponding menu', () => {
+        const root = renderMenubar();
+        const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+        const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+        trigger.click();
+
+        expect(content.getAttribute('data-state')).toBe('open');
+        expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      });
+    });
+
+    describe('When clicked again', () => {
+      it('Then closes the menu', () => {
+        const root = renderMenubar();
+        const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+        const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+        trigger.click();
+        trigger.click();
+
+        expect(content.getAttribute('data-state')).toBe('closed');
+        expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      });
+    });
+  });
+
+  describe('Given a second trigger is clicked while a menu is open', () => {
+    it('Then closes the first menu and opens the second', () => {
+      const root = renderMenubar();
+      const fileTrigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const editTrigger = root.querySelector('[data-value="edit"]') as HTMLElement;
+      const menus = root.querySelectorAll('[role="menu"]');
+      const fileMenu = menus[0] as HTMLElement;
+      const editMenu = menus[1] as HTMLElement;
+
+      fileTrigger.click();
+      expect(fileMenu.getAttribute('data-state')).toBe('open');
+
+      editTrigger.click();
+      expect(editMenu.getAttribute('data-state')).toBe('open');
+      expect(fileMenu.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given a menu is open and ArrowDown is pressed on a trigger', () => {
+    it('Then opens the menu and focuses the first item', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+
+      trigger.focus();
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      const firstItem = content.querySelector('[data-value="new"]') as HTMLElement;
+      expect(document.activeElement).toBe(firstItem);
+    });
+  });
+
+  describe('Given a menu is open and Escape is pressed in the content', () => {
+    it('Then closes the menu and returns focus to the trigger', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+      expect(content.getAttribute('data-state')).toBe('closed');
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  describe('Given a menu is open and Enter is pressed on an item', () => {
+    it('Then fires onSelect and closes the menu', () => {
+      const onSelect = vi.fn();
+      const root = renderMenubar({ onSelect });
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const item = content.querySelector('[data-value="new"]') as HTMLElement;
+      item.focus();
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      expect(onSelect).toHaveBeenCalledWith('new');
+      expect(content.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given a menu item is clicked', () => {
+    it('Then fires onSelect and closes the menu', () => {
+      const onSelect = vi.fn();
+      const root = renderMenubar({ onSelect });
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const item = content.querySelector('[data-value="new"]') as HTMLElement;
+      item.click();
+
+      expect(onSelect).toHaveBeenCalledWith('new');
+      expect(content.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given ArrowRight is pressed in menu content', () => {
+    it('Then closes the current menu and opens the next menu', () => {
+      const root = renderMenubar();
+      const fileContent = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      const editContent = root.querySelectorAll('[role="menu"]')[1] as HTMLElement;
+      const fileTrigger = root.querySelector('[data-value="file"]') as HTMLElement;
+
+      fileTrigger.click();
+      expect(fileContent.getAttribute('data-state')).toBe('open');
+
+      fileContent.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+      expect(editContent.getAttribute('data-state')).toBe('open');
+      expect(fileContent.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given ArrowLeft is pressed in menu content', () => {
+    it('Then closes the current menu and opens the previous menu (wrapping)', () => {
+      const root = renderMenubar();
+      const fileContent = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      const fileTrigger = root.querySelector('[data-value="file"]') as HTMLElement;
+
+      fileTrigger.click();
+      fileContent.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+
+      const editContent = root.querySelectorAll('[role="menu"]')[1] as HTMLElement;
+      expect(editContent.getAttribute('data-state')).toBe('open');
+      expect(fileContent.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given click outside the menubar', () => {
+    it('Then closes all menus', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(content.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
+  describe('Given a Menubar with separator', () => {
+    it('Then creates a separator element', () => {
+      const root = ComposedMenubar({
+        children: () => {
+          const menu = ComposedMenubar.Menu({
+            value: 'file',
+            children: () => {
+              const t = ComposedMenubar.Trigger({ children: ['File'] });
+              const c = ComposedMenubar.Content({
+                children: () => {
+                  const i1 = ComposedMenubar.Item({ value: 'a', children: ['A'] });
+                  const sep = ComposedMenubar.Separator({});
+                  const i2 = ComposedMenubar.Item({ value: 'b', children: ['B'] });
+                  return [i1, sep, i2];
+                },
+              });
+              return [t, c];
+            },
+          });
+          return [menu];
+        },
+      });
+      container.appendChild(root);
+
+      const separator = root.querySelector('[role="separator"]');
+      expect(separator).not.toBeNull();
+    });
+  });
+
+  describe('Given a Menubar with groups', () => {
+    it('Then creates groups with items', () => {
+      const root = ComposedMenubar({
+        children: () => {
+          const menu = ComposedMenubar.Menu({
+            value: 'file',
+            children: () => {
+              const t = ComposedMenubar.Trigger({ children: ['File'] });
+              const c = ComposedMenubar.Content({
+                children: () => {
+                  const g = ComposedMenubar.Group({
+                    label: 'Actions',
+                    children: () => [ComposedMenubar.Item({ value: 'cut', children: ['Cut'] })],
+                  });
+                  return [g];
+                },
+              });
+              return [t, c];
+            },
+          });
+          return [menu];
+        },
+      });
+      container.appendChild(root);
+
+      const group = root.querySelector('[role="group"]') as HTMLElement;
+      expect(group).not.toBeNull();
+      expect(group!.getAttribute('aria-label')).toBe('Actions');
+    });
+  });
+
+  describe('Given a Menubar.Menu rendered outside Menubar', () => {
+    it('Then throws an error', () => {
+      expect(() => {
+        ComposedMenubar.Menu({ value: 'test', children: ['Orphan'] });
+      }).toThrow('<Menubar.Menu> must be used inside <Menubar>');
+    });
+  });
+
+  describe('Given a Menubar.Trigger rendered outside Menubar.Menu', () => {
+    it('Then throws an error', () => {
+      expect(() => {
+        ComposedMenubar.Trigger({ children: ['Orphan'] });
+      }).toThrow('<Menubar.Trigger> must be used inside <Menubar.Menu>');
+    });
+  });
+
+  describe('Given a Menubar.Content rendered outside Menubar.Menu', () => {
+    it('Then throws an error', () => {
+      expect(() => {
+        ComposedMenubar.Content({ children: ['Orphan'] });
+      }).toThrow('<Menubar.Content> must be used inside <Menubar.Menu>');
+    });
+  });
+
+  describe('Given a Menubar rendered inside a disposal scope', () => {
+    describe('When the disposal scope cleanups are run', () => {
+      it('Then removeEventListener is called for the trigger handlers', () => {
+        const scope = pushScope();
+        const root = renderMenubar();
+        popScope();
+
+        const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+        const spy = vi.spyOn(trigger, 'removeEventListener');
+        runCleanups(scope);
+
+        expect(spy).toHaveBeenCalledWith('click', expect.any(Function));
+      });
+    });
+  });
+
+  describe('Given ArrowRight on triggers when menu is open', () => {
+    it('Then auto-switches to adjacent menu', () => {
+      const root = renderMenubar();
+      const fileTrigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const fileContent = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      const editContent = root.querySelectorAll('[role="menu"]')[1] as HTMLElement;
+
+      fileTrigger.click();
+      expect(fileContent.getAttribute('data-state')).toBe('open');
+
+      fileTrigger.focus();
+      root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+      expect(editContent.getAttribute('data-state')).toBe('open');
+      expect(fileContent.getAttribute('data-state')).toBe('closed');
+    });
+  });
+});

--- a/packages/ui-primitives/src/menubar/menubar-composed.tsx
+++ b/packages/ui-primitives/src/menubar/menubar-composed.tsx
@@ -1,0 +1,575 @@
+/**
+ * Composed Menubar — fully declarative JSX implementation.
+ * Sub-components self-wire via context. No factory delegation.
+ *
+ * Follows WAI-ARIA menubar pattern with cross-menu keyboard navigation.
+ */
+
+import type { ChildValue } from '@vertz/ui';
+import { createContext, resolveChildren, useContext } from '@vertz/ui';
+import { _tryOnCleanup } from '@vertz/ui/internals';
+import { setDataState, setExpanded, setHidden, setHiddenAnimated } from '../utils/aria';
+import { createDismiss } from '../utils/dismiss';
+import type { FloatingOptions } from '../utils/floating';
+import { createFloatingPosition } from '../utils/floating';
+import { setRovingTabindex } from '../utils/focus';
+import { linkedIds } from '../utils/id';
+import { handleListNavigation, isKey, Keys } from '../utils/keyboard';
+
+// ---------------------------------------------------------------------------
+// Class distribution
+// ---------------------------------------------------------------------------
+
+export interface MenubarClasses {
+  root?: string;
+  trigger?: string;
+  content?: string;
+  item?: string;
+  group?: string;
+  label?: string;
+  separator?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Contexts
+// ---------------------------------------------------------------------------
+
+interface MenubarContextValue {
+  classes?: MenubarClasses;
+  onSelect?: (value: string) => void;
+  positioning?: FloatingOptions;
+  /** @internal — registers a menu's trigger, content, and items */
+  _registerMenu: (
+    value: string,
+    trigger: HTMLButtonElement,
+    content: HTMLDivElement,
+    items: HTMLDivElement[],
+  ) => void;
+}
+
+const MenubarContext = createContext<MenubarContextValue | undefined>(
+  undefined,
+  '@vertz/ui-primitives::MenubarContext',
+);
+
+function useMenubarContext(componentName: string): MenubarContextValue {
+  const ctx = useContext(MenubarContext);
+  if (!ctx) {
+    throw new Error(
+      `<Menubar.${componentName}> must be used inside <Menubar>. ` +
+        'Ensure it is a direct or nested child of the Menubar root component.',
+    );
+  }
+  return ctx;
+}
+
+interface MenuContextValue {
+  menuValue: string;
+  classes?: MenubarClasses;
+  /** @internal — registers the trigger element */
+  _registerTrigger: (el: HTMLButtonElement) => void;
+  /** @internal — registers content children */
+  _registerContent: (children: Node[]) => void;
+  /** @internal — registers an item element */
+  _registerItem: (el: HTMLDivElement) => void;
+  /** @internal — duplicate sub-component detection */
+  _triggerClaimed: boolean;
+  _contentClaimed: boolean;
+}
+
+const MenuContext = createContext<MenuContextValue | undefined>(
+  undefined,
+  '@vertz/ui-primitives::MenubarMenuContext',
+);
+
+function useMenuContext(componentName: string): MenuContextValue {
+  const ctx = useContext(MenuContext);
+  if (!ctx) {
+    throw new Error(
+      `<Menubar.${componentName}> must be used inside <Menubar.Menu>. ` +
+        'Ensure it is a direct or nested child of a Menubar.Menu component.',
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component props
+// ---------------------------------------------------------------------------
+
+interface SlotProps {
+  children?: ChildValue;
+  className?: string;
+  /** @deprecated Use `className` instead. */
+  class?: string;
+}
+
+interface MenuProps extends SlotProps {
+  value: string;
+}
+
+interface ItemProps extends SlotProps {
+  value: string;
+}
+
+interface GroupProps extends SlotProps {
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Element builder — outside component body to avoid computed() wrapping
+// ---------------------------------------------------------------------------
+
+function buildMenuItemEl(
+  value: string,
+  itemClass: string,
+  children: Node[],
+  onItemClick: () => void,
+): HTMLDivElement {
+  return (
+    <div
+      role="menuitem"
+      data-value={value}
+      tabindex="-1"
+      class={itemClass || undefined}
+      onClick={() => {
+        onItemClick();
+      }}
+    >
+      {...children}
+    </div>
+  ) as HTMLDivElement;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function MenubarMenu({ value, children }: MenuProps) {
+  const barCtx = useMenubarContext('Menu');
+
+  const reg: {
+    userTrigger: HTMLButtonElement | null;
+    contentChildren: Node[];
+    items: HTMLDivElement[];
+  } = {
+    userTrigger: null,
+    contentChildren: [],
+    items: [],
+  };
+
+  const menuCtxValue: MenuContextValue = {
+    menuValue: value,
+    classes: barCtx.classes,
+    _registerTrigger: (el: HTMLButtonElement) => {
+      reg.userTrigger = el;
+    },
+    _registerContent: (childNodes: Node[]) => {
+      childNodes.forEach((child) => {
+        reg.contentChildren.push(child);
+      });
+    },
+    _registerItem: (el: HTMLDivElement) => {
+      reg.items.push(el);
+    },
+    _triggerClaimed: false,
+    _contentClaimed: false,
+  };
+
+  // Resolve children to collect registrations
+  const resolvedNodes: Node[] = [];
+  MenuContext.Provider(menuCtxValue, () => {
+    const nodes = resolveChildren(children);
+    nodes.forEach((n) => resolvedNodes.push(n));
+  });
+
+  // Build trigger button
+  const ids = linkedIds('menubar-menu');
+  const triggerClass = barCtx.classes?.trigger;
+  const trigger = (
+    <button
+      type="button"
+      role="menuitem"
+      id={ids.triggerId}
+      aria-controls={ids.contentId}
+      aria-haspopup="menu"
+      data-value={value}
+      aria-expanded="false"
+      data-state="closed"
+      class={triggerClass || undefined}
+    >
+      {reg.userTrigger ? [...(reg.userTrigger.childNodes as unknown as Node[])] : value}
+    </button>
+  ) as HTMLButtonElement;
+
+  // If user provided a trigger, copy its text content into the button
+  if (reg.userTrigger) {
+    // Clear the button and move user trigger children in
+    trigger.textContent = '';
+    while (reg.userTrigger.firstChild) {
+      trigger.appendChild(reg.userTrigger.firstChild);
+    }
+  }
+
+  // Build content panel
+  const contentClass = barCtx.classes?.content;
+  const content = (
+    <div
+      role="menu"
+      id={ids.contentId}
+      aria-hidden="true"
+      data-state="closed"
+      style="display: none"
+      class={contentClass || undefined}
+    >
+      {...reg.contentChildren}
+    </div>
+  ) as HTMLDivElement;
+
+  // Register with the bar
+  barCtx._registerMenu(value, trigger, content, reg.items);
+
+  return (<span style="display: contents" />) as HTMLElement;
+}
+
+function MenubarTrigger({ children }: SlotProps) {
+  const ctx = useMenuContext('Trigger');
+  if (ctx._triggerClaimed) {
+    console.warn('Duplicate <Menubar.Trigger> detected – only the first is used');
+  }
+  ctx._triggerClaimed = true;
+
+  const resolved = resolveChildren(children);
+  // Create a wrapper to carry content — MenubarMenu will extract children
+  const wrapper = (<span style="display: contents">{...resolved}</span>) as HTMLElement;
+  ctx._registerTrigger(wrapper as unknown as HTMLButtonElement);
+
+  return (<span style="display: none" />) as HTMLElement;
+}
+
+function MenubarContent({ children }: SlotProps) {
+  const ctx = useMenuContext('Content');
+  if (ctx._contentClaimed) {
+    console.warn('Duplicate <Menubar.Content> detected – only the first is used');
+  }
+  ctx._contentClaimed = true;
+
+  const resolved = resolveChildren(children);
+  ctx._registerContent(resolved);
+
+  return (<span style="display: none" />) as HTMLElement;
+}
+
+function MenubarItem({ value, children, className: cls, class: classProp }: ItemProps) {
+  const menuCtx = useMenuContext('Item');
+  const effectiveCls = cls ?? classProp;
+
+  const itemClass = [menuCtx.classes?.item, effectiveCls].filter(Boolean).join(' ');
+  const resolved = resolveChildren(children);
+
+  const el = buildMenuItemEl(value, itemClass, resolved, () => {
+    // onSelect is handled via click event delegation on the content panel
+  });
+
+  menuCtx._registerItem(el);
+
+  return el;
+}
+
+function MenubarGroup({ label, children, className: cls, class: classProp }: GroupProps) {
+  const menuCtx = useMenuContext('Group');
+  const effectiveCls = cls ?? classProp;
+
+  const groupClass = [menuCtx.classes?.group, effectiveCls].filter(Boolean).join(' ');
+  const resolved = resolveChildren(children);
+
+  return (
+    <div role="group" aria-label={label} class={groupClass || undefined}>
+      {...resolved}
+    </div>
+  ) as HTMLDivElement;
+}
+
+function MenubarLabel({ children, className: cls, class: classProp }: SlotProps) {
+  const { classes } = useMenuContext('Label');
+  const effectiveCls = cls ?? classProp;
+
+  const labelClass = [classes?.label, effectiveCls].filter(Boolean).join(' ');
+
+  return (
+    <div role="none" class={labelClass || undefined}>
+      {children}
+    </div>
+  ) as HTMLDivElement;
+}
+
+function MenubarSeparator({ className: cls, class: classProp }: SlotProps) {
+  const { classes } = useMenuContext('Separator');
+  const effectiveCls = cls ?? classProp;
+
+  const sepClass = [classes?.separator, effectiveCls].filter(Boolean).join(' ');
+
+  return (<hr role="separator" class={sepClass || undefined} />) as HTMLHRElement;
+}
+
+// ---------------------------------------------------------------------------
+// Root composed component
+// ---------------------------------------------------------------------------
+
+export interface ComposedMenubarProps {
+  children?: ChildValue;
+  classes?: MenubarClasses;
+  onSelect?: (value: string) => void;
+  positioning?: FloatingOptions;
+}
+
+export type MenubarClassKey = keyof MenubarClasses;
+
+function ComposedMenubarRoot({ children, classes, onSelect, positioning }: ComposedMenubarProps) {
+  const triggers: HTMLButtonElement[] = [];
+  const menus: Map<
+    string,
+    { trigger: HTMLButtonElement; content: HTMLDivElement; items: HTMLDivElement[] }
+  > = new Map();
+
+  const state: {
+    activeMenu: string | null;
+    floatingCleanup: (() => void) | null;
+    dismissCleanup: (() => void) | null;
+  } = {
+    activeMenu: null,
+    floatingCleanup: null,
+    dismissCleanup: null,
+  };
+
+  function handleClickOutside(event: MouseEvent): void {
+    const target = event.target as Node;
+    if (!root.contains(target)) {
+      closeAll();
+    }
+  }
+
+  function closeAll(): void {
+    for (const [, menu] of menus) {
+      setExpanded(menu.trigger, false);
+      setDataState(menu.trigger, 'closed');
+      setDataState(menu.content, 'closed');
+      setHiddenAnimated(menu.content, true);
+    }
+    state.activeMenu = null;
+
+    if (positioning) {
+      state.floatingCleanup?.();
+      state.floatingCleanup = null;
+      state.dismissCleanup?.();
+      state.dismissCleanup = null;
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }
+
+  function openMenu(value: string): void {
+    const current = state.activeMenu;
+    if (current && current !== value) {
+      const prev = menus.get(current);
+      if (prev) {
+        setExpanded(prev.trigger, false);
+        setDataState(prev.trigger, 'closed');
+        setDataState(prev.content, 'closed');
+        setHiddenAnimated(prev.content, true);
+      }
+      if (positioning) {
+        state.floatingCleanup?.();
+        state.floatingCleanup = null;
+      }
+    }
+
+    const menu = menus.get(value);
+    if (!menu) return;
+    state.activeMenu = value;
+    setExpanded(menu.trigger, true);
+    setHidden(menu.content, false);
+    setDataState(menu.trigger, 'open');
+    setDataState(menu.content, 'open');
+
+    if (positioning) {
+      const result = createFloatingPosition(menu.trigger, menu.content, positioning);
+      state.floatingCleanup = result.cleanup;
+      if (!state.dismissCleanup) {
+        state.dismissCleanup = createDismiss({
+          onDismiss: closeAll,
+          insideElements: [root],
+          escapeKey: false,
+        });
+      }
+    } else {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    const firstItem = menu.items[0];
+    if (firstItem) {
+      firstItem.setAttribute('tabindex', '0');
+      firstItem.focus();
+    }
+  }
+
+  // Build root element
+  const rootClass = classes?.root;
+  const root = (
+    <div
+      role="menubar"
+      class={rootClass || undefined}
+      onKeydown={(event: KeyboardEvent) => {
+        if (isKey(event, Keys.ArrowLeft, Keys.ArrowRight, Keys.Home, Keys.End)) {
+          const focused = document.activeElement;
+          const triggerIndex = triggers.indexOf(focused as HTMLButtonElement);
+
+          if (triggerIndex >= 0) {
+            const result = handleListNavigation(event, triggers, { orientation: 'horizontal' });
+            if (result && state.activeMenu) {
+              const newTrigger = result as HTMLButtonElement;
+              const menuValue = newTrigger.getAttribute('data-value');
+              if (menuValue) openMenu(menuValue);
+            }
+          }
+        }
+      }}
+    />
+  ) as HTMLDivElement;
+
+  const ctxValue: MenubarContextValue = {
+    classes,
+    onSelect,
+    positioning,
+    _registerMenu: (
+      value: string,
+      trigger: HTMLButtonElement,
+      content: HTMLDivElement,
+      items: HTMLDivElement[],
+    ) => {
+      // Wire trigger click
+      const handleTriggerClick = () => {
+        if (state.activeMenu === value) {
+          closeAll();
+        } else {
+          openMenu(value);
+        }
+      };
+      trigger.addEventListener('click', handleTriggerClick);
+      _tryOnCleanup(() => trigger.removeEventListener('click', handleTriggerClick));
+
+      // Wire trigger keyboard
+      const handleTriggerKeydown = (event: KeyboardEvent) => {
+        if (isKey(event, Keys.ArrowDown, Keys.Enter, Keys.Space)) {
+          event.preventDefault();
+          openMenu(value);
+        }
+      };
+      trigger.addEventListener('keydown', handleTriggerKeydown);
+      _tryOnCleanup(() => trigger.removeEventListener('keydown', handleTriggerKeydown));
+
+      // Wire content keyboard
+      const handleContentKeydown = (event: KeyboardEvent) => {
+        if (isKey(event, Keys.Escape)) {
+          event.preventDefault();
+          event.stopPropagation();
+          closeAll();
+          trigger.focus();
+          return;
+        }
+
+        if (isKey(event, Keys.Enter, Keys.Space)) {
+          event.preventDefault();
+          const active = document.activeElement;
+          const activeItem = items.find((item) => item === active);
+          if (activeItem) {
+            const val = activeItem.getAttribute('data-value');
+            if (val !== null) {
+              onSelect?.(val);
+              closeAll();
+              trigger.focus();
+            }
+          }
+          return;
+        }
+
+        if (isKey(event, Keys.ArrowLeft, Keys.ArrowRight)) {
+          event.preventDefault();
+          const triggerIdx = triggers.indexOf(trigger);
+          let nextIdx: number;
+          if (isKey(event, Keys.ArrowRight)) {
+            nextIdx = (triggerIdx + 1) % triggers.length;
+          } else {
+            nextIdx = (triggerIdx - 1 + triggers.length) % triggers.length;
+          }
+          const nextTrigger = triggers[nextIdx];
+          if (nextTrigger) {
+            nextTrigger.focus();
+            const nextValue = nextTrigger.getAttribute('data-value');
+            if (nextValue) openMenu(nextValue);
+          }
+          return;
+        }
+
+        handleListNavigation(event, items, { orientation: 'vertical' });
+      };
+      content.addEventListener('keydown', handleContentKeydown);
+      _tryOnCleanup(() => content.removeEventListener('keydown', handleContentKeydown));
+
+      // Wire item click → close via event delegation
+      const handleContentClick = (event: Event) => {
+        const target = (event.target as HTMLElement).closest('[role="menuitem"]');
+        if (target && content.contains(target)) {
+          const val = target.getAttribute('data-value');
+          if (val !== null) {
+            onSelect?.(val);
+            closeAll();
+            trigger.focus();
+          }
+        }
+      };
+      content.addEventListener('click', handleContentClick);
+      _tryOnCleanup(() => content.removeEventListener('click', handleContentClick));
+
+      triggers.push(trigger);
+      setRovingTabindex(triggers, 0);
+      menus.set(value, { trigger, content, items });
+      root.appendChild(trigger);
+    },
+  };
+
+  // Resolve children within context
+  MenubarContext.Provider(ctxValue, () => {
+    resolveChildren(children);
+  });
+
+  // Append content panels after all menus are registered
+  for (const [, menu] of menus) {
+    root.appendChild(menu.content);
+  }
+
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Export as callable with sub-component properties
+// ---------------------------------------------------------------------------
+
+export const ComposedMenubar = Object.assign(ComposedMenubarRoot, {
+  Menu: MenubarMenu,
+  Trigger: MenubarTrigger,
+  Content: MenubarContent,
+  Item: MenubarItem,
+  Group: MenubarGroup,
+  Label: MenubarLabel,
+  Separator: MenubarSeparator,
+}) as ((props: ComposedMenubarProps) => HTMLElement) & {
+  __classKeys?: MenubarClassKey;
+  Menu: (props: MenuProps) => HTMLElement;
+  Trigger: (props: SlotProps) => HTMLElement;
+  Content: (props: SlotProps) => HTMLElement;
+  Item: (props: ItemProps) => HTMLElement;
+  Group: (props: GroupProps) => HTMLElement;
+  Label: (props: SlotProps) => HTMLElement;
+  Separator: (props: SlotProps) => HTMLElement;
+};

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -315,9 +315,10 @@ export const hoverCard: ThemeComponentMap['hoverCard'] = /* #__PURE__ */ createP
   'hoverCard',
 ) as ThemeComponentMap['hoverCard'];
 
-export const menubar: ThemeComponentMap['menubar'] = /* #__PURE__ */ createPrimitiveProxy(
-  'menubar',
-) as ThemeComponentMap['menubar'];
+export const Menubar: ThemeComponentMap['Menubar'] = /* #__PURE__ */ createCompoundProxy(
+  'Menubar',
+  ['Menu', 'Trigger', 'Content', 'Item', 'Group', 'Label', 'Separator'],
+) as ThemeComponentMap['Menubar'];
 
 export const navigationMenu: ThemeComponentMap['navigationMenu'] =
   /* #__PURE__ */ createPrimitiveProxy('navigationMenu') as ThemeComponentMap['navigationMenu'];


### PR DESCRIPTION
## Summary

- Create `ComposedMenubar` in `@vertz/ui-primitives` — fully declarative JSX menubar with context-based sub-component wiring (`Menu`, `Trigger`, `Content`, `Item`, `Group`, `Label`, `Separator`)
- Update `@vertz/theme-shadcn` menubar to use `withStyles` + `ComposedMenubar` instead of imperative factory wrapping
- Add PascalCase `Menubar` compound proxy to `@vertz/ui/components` (replaces lowercase `menubar`)

## Public API Changes

**Breaking (pre-v1):** `menubar` lowercase factory replaced with `Menubar` PascalCase JSX component.

Before:
```ts
const mb = primitives.menubar();
const menu = mb.Menu('file', 'File');
menu.Item('new', 'New');
```

After:
```tsx
<Menubar onSelect={handleSelect}>
  <Menubar.Menu value="file">
    <Menubar.Trigger>File</Menubar.Trigger>
    <Menubar.Content>
      <Menubar.Item value="new">New</Menubar.Item>
    </Menubar.Content>
  </Menubar.Menu>
</Menubar>
```

## Test plan

- [x] 22 tests for `ComposedMenubar` in ui-primitives (rendering, ARIA, click toggle, keyboard navigation, cross-menu ArrowLeft/Right, Escape, onSelect, groups, separators, context errors, disposal cleanup)
- [x] 15 tests for themed menubar in theme-shadcn (style classes applied, sub-components exposed, primitive behavior preserved, onSelect forwarding)
- [x] All 653 ui-primitives tests pass
- [x] All 453 theme-shadcn tests pass
- [x] Typecheck clean on all 3 changed packages
- [x] Pre-push quality gates pass (lint + typecheck + test + build)

Fixes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)