### PR TITLE
refactor(linear): rename tenantId column to workspaceId

### DIFF
--- a/.changeset/tenant-column-dynamic.md
+++ b/.changeset/tenant-column-dynamic.md
@@ -1,0 +1,5 @@
+---
+'@vertz/server': patch
+---
+
+Support custom tenant FK column names in entity CRUD pipeline. The tenant column is now resolved from the model's `_tenant` relation FK instead of being hardcoded to `tenantId`. Apps can use `workspaceId`, `orgId`, or any column name as long as the model declares a tenant relation pointing to it.

--- a/examples/linear/TENANT_RETROFIT_DX.md
+++ b/examples/linear/TENANT_RETROFIT_DX.md
@@ -5,52 +5,50 @@ Documenting the experience of adding multi-tenancy to the Linear clone after the
 ## What Was Changed
 
 - **1 new table**: `workspaces` — the tenant root (matching Linear's Workspace concept)
-- **4 tables** gained a `tenantId` column (users, projects, issues, comments)
-- **Relation declarations**: `workspace: d.ref.one(() => workspacesTable, 'tenantId')` on users and projects
+- **4 tables** gained a `workspaceId` column (users, projects, issues, comments)
+- **Relation declarations**: `workspace: d.ref.one(() => workspacesTable, 'workspaceId')` on users and projects
 - **Model options**: `{ tenant: 'workspace' }` on directly-scoped models
 - **Seed data** updated to include a default workspace ID
 - **Server config** gained a `tenant.verifyMembership` callback
-- **`onUserCreated` hook** explicitly sets tenantId for new signups
+- **`onUserCreated` hook** explicitly sets workspaceId for new signups
 - **E2E tests** now call `/api/auth/switch-tenant` after signup
 
 ## Key Design Decision: Workspace as Tenant Root
 
 In Linear, the top-level organizational unit is a **Workspace**, not a generic "tenant". The Vertz framework's tenant scoping system is relation-driven — any table can serve as the tenant root. We chose `workspaces` as the table name to match Linear's domain model.
 
-The `{ tenant: 'workspace' }` model option tells the framework which relation points to the tenant root. The column is still named `tenantId` (the framework convention), but the relation name is `workspace`.
+The `{ tenant: 'workspace' }` model option tells the framework which relation points to the tenant root. The FK column is named `workspaceId` to match the domain language. The framework resolves the column name from the tenant relation's FK, so any name works (`workspaceId`, `orgId`, `tenantId`).
 
 ## What Was Easy
 
-1. **Schema changes** — Adding `tenantId: d.text()` to each table definition was trivial. The schema builder made it a one-line addition per table.
+1. **Schema changes** — Adding `workspaceId: d.text()` to each table definition was trivial. The schema builder made it a one-line addition per table.
 
-2. **Auto-scoping just works** — Zero changes to entity access rules. The framework detected `tenantId` columns and automatically added tenant filtering to all CRUD operations. No manual `rules.where({ tenantId: ... })` needed.
+2. **Auto-scoping just works** — Zero changes to entity access rules. The framework detected the tenant relation and automatically added tenant filtering to all CRUD operations. No manual `rules.where({ workspaceId: ... })` needed.
 
 3. **Entity files untouched** — `users.entity.ts`, `projects.entity.ts`, `issues.entity.ts`, and `comments.entity.ts` required zero modifications. The framework handled everything.
 
-4. **Seed data** — Straightforward: export a constant `SEED_WORKSPACE_ID`, add `tenantId` to each seed record.
+4. **Seed data** — Straightforward: export a constant `SEED_WORKSPACE_ID`, add `workspaceId` to each seed record.
 
 5. **Before hooks preserved** — The existing `before.create` hooks (auto-increment issue numbers, auto-set `createdBy`/`authorId`) continued working without changes. The framework's tenant auto-set runs at a different layer (crud-pipeline) and doesn't interfere.
 
 6. **Custom tenant root name** — The framework doesn't hardcode the table name. `workspaces`, `organizations`, `teams` — any table works as the tenant root as long as the relation declarations point to it.
 
+7. **Custom FK column name** — The framework derives the tenant FK column name from the model's tenant relation. `workspaceId`, `orgId`, or `tenantId` all work — no hardcoded column name convention.
+
 ## What Was Painful
 
-1. **Chicken-and-egg at signup** — When `onUserCreated` fires, the user's session has no `tenantId` yet (they just signed up). The framework's auto-set (`input.tenantId = ctx.tenantId`) is skipped when `ctx.tenantId` is null. So `onUserCreated` must explicitly pass `tenantId` in the create data. This is a footgun — if you forget, the user is created with `tenantId: ''` and becomes invisible to tenant-scoped queries.
+1. **Chicken-and-egg at signup** — When `onUserCreated` fires, the user's session has no tenant yet (they just signed up). The framework's auto-set is skipped when `ctx.tenantId` is null. So `onUserCreated` must explicitly pass `workspaceId` in the create data. This is a footgun — if you forget, the user is created with `workspaceId: ''` and becomes invisible to tenant-scoped queries.
 
 2. **E2E test two-step auth** — After signup, a separate `POST /api/auth/switch-tenant` call is needed before the user can see any tenant-scoped data. This makes the test setup more complex. A `defaultTenantId` option in the auth config (auto-switch on first login) would simplify this.
-
-3. **Column naming convention** — The framework expects the FK column to be named `tenantId` (hardcoded in the entity crud-pipeline). Even though the tenant root is `workspaces`, the column must still be `tenantId`, not `workspaceId`. This could confuse developers who expect the FK to match the referenced table.
 
 ## What the Framework Could Improve
 
 1. **`defaultTenantId` or `onSignup.tenantId`** — Allow setting an initial tenantId during signup so the first session already includes it. This would eliminate the two-step auth flow and the footgun in `onUserCreated`.
 
-2. **Warn on missing tenantId in create** — When a tenant-scoped entity's create is called with no `tenantId` in context AND no `tenantId` in the input data, log a warning or throw. Currently it silently inserts with whatever default the DB has (empty string), creating orphaned records.
-
-3. **Configurable tenant column name** — Allow the framework to derive the FK column name from the relation instead of hardcoding `tenantId`. This would let developers use `workspaceId` or `orgId` as the column name.
+2. **Warn on missing tenant value in create** — When a tenant-scoped entity's create is called with no tenant in context AND no tenant column value in the input data, log a warning or throw. Currently it silently inserts with whatever default the DB has (empty string), creating orphaned records.
 
 ## Verdict
 
-Adding tenant scoping after the fact was **surprisingly easy** at the application layer. The framework's auto-detection of `tenantId` columns and automatic WHERE filtering meant zero changes to entity definitions or access rules. The pain points were around the signup flow (chicken-and-egg with session tenantId) and the hardcoded `tenantId` column name. For a production app, the signup flow would need a proper workspace creation/invitation system anyway, so the `onUserCreated` explicitness is acceptable — but a `defaultTenantId` shortcut for simple single-workspace-per-user apps would significantly reduce friction.
+Adding tenant scoping after the fact was **surprisingly easy** at the application layer. The framework's automatic detection of tenant relations and automatic WHERE filtering meant zero changes to entity definitions or access rules. The pain points were around the signup flow (chicken-and-egg with session tenantId). For a production app, the signup flow would need a proper workspace creation/invitation system anyway, so the `onUserCreated` explicitness is acceptable — but a `defaultTenantId` shortcut for simple single-workspace-per-user apps would significantly reduce friction.
 
 **Total LOC changed: ~30 lines of actual logic** (excluding test updates).

--- a/examples/linear/src/api/auth.ts
+++ b/examples/linear/src/api/auth.ts
@@ -28,13 +28,13 @@ export const auth = defineAuth({
 
   // Bridge auth → entity: populate the developer's users table from GitHub profile.
   // Also handles email/password signups (for dev/E2E testing).
-  // tenantId is set explicitly because the session has no tenant yet at signup time.
+  // workspaceId is set explicitly because the session has no tenant yet at signup time.
   onUserCreated: async (payload, ctx) => {
     if (payload.provider) {
       const profile = payload.profile as Record<string, unknown>;
       await ctx.entities.users.create({
         id: payload.user.id,
-        tenantId: SEED_WORKSPACE_ID,
+        workspaceId: SEED_WORKSPACE_ID,
         email: payload.user.email,
         name: (profile.name as string) ?? (profile.login as string),
         avatarUrl: profile.avatar_url as string,
@@ -42,7 +42,7 @@ export const auth = defineAuth({
     } else {
       await ctx.entities.users.create({
         id: payload.user.id,
-        tenantId: SEED_WORKSPACE_ID,
+        workspaceId: SEED_WORKSPACE_ID,
         email: payload.user.email,
         name: payload.user.email.split('@')[0],
         avatarUrl: null,

--- a/examples/linear/src/api/schema.test.ts
+++ b/examples/linear/src/api/schema.test.ts
@@ -13,10 +13,10 @@ describe('Schema relations', () => {
   });
 
   describe('Given the users model', () => {
-    it('Then it has a workspace relation pointing to workspacesTable via tenantId', () => {
+    it('Then it has a workspace relation pointing to workspacesTable via workspaceId', () => {
       expect(usersModel.relations.workspace).toBeDefined();
       expect(usersModel.relations.workspace._type).toBe('one');
-      expect(usersModel.relations.workspace._foreignKey).toBe('tenantId');
+      expect(usersModel.relations.workspace._foreignKey).toBe('workspaceId');
     });
 
     it('Then it is directly scoped to the workspace', () => {
@@ -25,10 +25,10 @@ describe('Schema relations', () => {
   });
 
   describe('Given the projects model', () => {
-    it('Then it has a workspace relation via tenantId', () => {
+    it('Then it has a workspace relation via workspaceId', () => {
       expect(projectsModel.relations.workspace).toBeDefined();
       expect(projectsModel.relations.workspace._type).toBe('one');
-      expect(projectsModel.relations.workspace._foreignKey).toBe('tenantId');
+      expect(projectsModel.relations.workspace._foreignKey).toBe('workspaceId');
     });
 
     it('Then it has a creator relation to users via createdBy', () => {

--- a/examples/linear/src/api/schema.ts
+++ b/examples/linear/src/api/schema.ts
@@ -23,7 +23,7 @@ export const workspacesModel = d.model(workspacesTable);
 
 export const usersTable = d.table('users', {
   id: d.text().primary(),
-  tenantId: d.text().default(''),
+  workspaceId: d.text().default(''),
   name: d.text(),
   email: d.text().unique(),
   avatarUrl: d.text().nullable(),
@@ -34,7 +34,7 @@ export const usersTable = d.table('users', {
 export const usersModel = d.model(
   usersTable,
   {
-    workspace: d.ref.one(() => workspacesTable, 'tenantId'),
+    workspace: d.ref.one(() => workspacesTable, 'workspaceId'),
   },
   { tenant: 'workspace' },
 );
@@ -45,7 +45,7 @@ export const usersModel = d.model(
 
 export const projectsTable = d.table('projects', {
   id: d.uuid().primary({ generate: 'uuid' }),
-  tenantId: d.text().default(''),
+  workspaceId: d.text().default(''),
   name: d.text(),
   key: d.text().unique(),
   description: d.text().nullable(),
@@ -57,7 +57,7 @@ export const projectsTable = d.table('projects', {
 export const projectsModel = d.model(
   projectsTable,
   {
-    workspace: d.ref.one(() => workspacesTable, 'tenantId'),
+    workspace: d.ref.one(() => workspacesTable, 'workspaceId'),
     creator: d.ref.one(() => usersTable, 'createdBy'),
   },
   { tenant: 'workspace' },
@@ -69,7 +69,7 @@ export const projectsModel = d.model(
 
 export const issuesTable = d.table('issues', {
   id: d.uuid().primary({ generate: 'uuid' }),
-  tenantId: d.text().default(''),
+  workspaceId: d.text().default(''),
   projectId: d.uuid(),
   number: d.integer().default(0),
   title: d.text(),
@@ -93,7 +93,7 @@ export const issuesModel = d.model(issuesTable, {
 
 export const commentsTable = d.table('comments', {
   id: d.uuid().primary({ generate: 'uuid' }),
-  tenantId: d.text().default(''),
+  workspaceId: d.text().default(''),
   issueId: d.uuid(),
   body: d.text(),
   authorId: d.text().default(''),

--- a/examples/linear/src/api/seed.test.ts
+++ b/examples/linear/src/api/seed.test.ts
@@ -126,13 +126,13 @@ describe('seedDatabase', () => {
         expect(comments.every((c) => c.createdAt instanceof Date)).toBe(true);
       });
 
-      it('Then all seed records have the seed workspace ID as tenant_id', async () => {
+      it('Then all seed records have the seed workspace ID as workspaceId', async () => {
         await seedDatabase(client);
         for (const countResult of [
-          await client.users.count({ where: { tenantId: { ne: SEED_WORKSPACE_ID } } }),
-          await client.projects.count({ where: { tenantId: { ne: SEED_WORKSPACE_ID } } }),
-          await client.issues.count({ where: { tenantId: { ne: SEED_WORKSPACE_ID } } }),
-          await client.comments.count({ where: { tenantId: { ne: SEED_WORKSPACE_ID } } }),
+          await client.users.count({ where: { workspaceId: { ne: SEED_WORKSPACE_ID } } }),
+          await client.projects.count({ where: { workspaceId: { ne: SEED_WORKSPACE_ID } } }),
+          await client.issues.count({ where: { workspaceId: { ne: SEED_WORKSPACE_ID } } }),
+          await client.comments.count({ where: { workspaceId: { ne: SEED_WORKSPACE_ID } } }),
         ]) {
           expect(unwrap(countResult)).toBe(0);
         }

--- a/examples/linear/src/api/seed.ts
+++ b/examples/linear/src/api/seed.ts
@@ -48,14 +48,14 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
       data: [
         {
           id: 'seed-alice',
-          tenantId: W,
+          workspaceId: W,
           name: 'Alice Chen',
           email: 'alice@example.com',
           avatarUrl: null,
         },
         {
           id: 'seed-bob',
-          tenantId: W,
+          workspaceId: W,
           name: 'Bob Martinez',
           email: 'bob@example.com',
           avatarUrl: null,
@@ -70,7 +70,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
       data: [
         {
           id: 'proj-eng',
-          tenantId: W,
+          workspaceId: W,
           name: 'Engineering',
           key: 'ENG',
           description: 'Core platform development',
@@ -78,7 +78,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'proj-des',
-          tenantId: W,
+          workspaceId: W,
           name: 'Design',
           key: 'DES',
           description: 'Design system and UI work',
@@ -86,7 +86,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'proj-doc',
-          tenantId: W,
+          workspaceId: W,
           name: 'Documentation',
           key: 'DOC',
           description: 'Docs, guides, and tutorials',
@@ -102,7 +102,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
       data: [
         {
           id: 'iss-1',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 1,
           title: 'Set up CI pipeline',
@@ -114,7 +114,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-2',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 2,
           title: 'Add database migrations',
@@ -126,7 +126,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-3',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 3,
           title: 'API rate limiting',
@@ -138,7 +138,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-4',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 4,
           title: 'Fix memory leak in query cache',
@@ -150,7 +150,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-5',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 5,
           title: 'Upgrade TypeScript to 5.5',
@@ -162,7 +162,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-6',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-eng',
           number: 6,
           title: 'Add error boundary components',
@@ -174,7 +174,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-7',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-des',
           number: 1,
           title: 'Create color token system',
@@ -186,7 +186,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-8',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-des',
           number: 2,
           title: 'Design empty states',
@@ -198,7 +198,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-9',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-des',
           number: 3,
           title: 'Audit accessibility',
@@ -210,7 +210,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-10',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-doc',
           number: 1,
           title: 'Write getting started guide',
@@ -222,7 +222,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-11',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-doc',
           number: 2,
           title: 'Document entity API',
@@ -234,7 +234,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
         },
         {
           id: 'iss-12',
-          tenantId: W,
+          workspaceId: W,
           projectId: 'proj-doc',
           number: 3,
           title: 'Add code examples',
@@ -254,70 +254,70 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
       data: [
         {
           id: 'com-1',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-1',
           body: 'CI is green on all branches. Merging the config PR now.',
           authorId: 'seed-bob',
         },
         {
           id: 'com-2',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-1',
           body: 'Confirmed — builds pass. Moving to done.',
           authorId: 'seed-alice',
         },
         {
           id: 'com-3',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-2',
           body: 'Started with drizzle-kit but hit issues with D1. Switching to manual SQL migrations.',
           authorId: 'seed-alice',
         },
         {
           id: 'com-4',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-4',
           body: "Reproduced with 10k sequential queries. The WeakRef cleanup isn't firing.",
           authorId: 'seed-bob',
         },
         {
           id: 'com-5',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-4',
           body: 'Root cause: the finalizer only runs on GC, which is lazy. Need explicit eviction.',
           authorId: 'seed-alice',
         },
         {
           id: 'com-6',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-7',
           body: 'First pass at tokens is up. Using oklch for perceptual uniformity.',
           authorId: 'seed-alice',
         },
         {
           id: 'com-7',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-10',
           body: 'Draft is ready for review. Covers install, first entity, and dev server.',
           authorId: 'seed-bob',
         },
         {
           id: 'com-8',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-3',
           body: 'Should we use a token bucket or sliding window? Token bucket is simpler.',
           authorId: 'seed-bob',
         },
         {
           id: 'com-9',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-6',
           body: 'The framework should provide ErrorBoundary as a primitive. Opened a separate issue.',
           authorId: 'seed-alice',
         },
         {
           id: 'com-10',
-          tenantId: W,
+          workspaceId: W,
           issueId: 'iss-2',
           body: 'Migration system working. Need to add rollback support before closing.',
           authorId: 'seed-alice',

--- a/packages/server/src/entity/__tests__/crud-pipeline.test.ts
+++ b/packages/server/src/entity/__tests__/crud-pipeline.test.ts
@@ -1200,6 +1200,140 @@ describe('Feature: CRUD pipeline', () => {
     });
   });
 
+  describe('Given a tenant-scoped entity with custom FK column (workspaceId)', () => {
+    const workspacesTable = d.table('workspaces', {
+      id: d.uuid().primary(),
+      name: d.text(),
+    });
+    const projectsTable = d.table('projects', {
+      id: d.uuid().primary(),
+      title: d.text(),
+      workspaceId: d.uuid(),
+    });
+    const projectsModel = d.model(
+      projectsTable,
+      { workspace: d.ref.one(() => workspacesTable, 'workspaceId') },
+      { tenant: 'workspace' },
+    );
+    const def = entity('projects', {
+      model: projectsModel,
+      access: {
+        list: () => true,
+        get: () => true,
+        create: () => true,
+        update: () => true,
+        delete: () => true,
+      },
+    });
+
+    function createCustomTenantStubDb() {
+      const rows: Record<string, Record<string, unknown>> = {
+        'proj-1': { id: 'proj-1', title: 'Proj A', workspaceId: 'ws-a' },
+        'proj-2': { id: 'proj-2', title: 'Proj B', workspaceId: 'ws-b' },
+        'proj-3': { id: 'proj-3', title: 'Proj C', workspaceId: 'ws-a' },
+      };
+      return {
+        get: mock(async (id: string) => rows[id] ?? null),
+        list: mock(
+          async (options?: { where?: Record<string, unknown>; limit?: number; after?: string }) => {
+            let result = Object.values(rows);
+            const where = options?.where;
+            if (where) {
+              result = result.filter((row) =>
+                Object.entries(where).every(([key, value]) => row[key] === value),
+              );
+            }
+            const total = result.length;
+            if (options?.limit !== undefined) {
+              result = result.slice(0, options.limit);
+            }
+            return { data: result, total };
+          },
+        ),
+        create: mock(async (data: Record<string, unknown>) => ({
+          id: 'new-id',
+          ...data,
+        })),
+        update: mock(async (id: string, data: Record<string, unknown>) => ({
+          ...rows[id],
+          ...data,
+        })),
+        delete: mock(async (id: string) => rows[id] ?? null),
+      };
+    }
+
+    describe('When ws-a user calls list()', () => {
+      it('Then only returns projects for ws-a (filters by workspaceId)', async () => {
+        const db = createCustomTenantStubDb();
+        const handlers = createCrudHandlers(def, db);
+        const ctx = makeCtx({ tenantId: 'ws-a' });
+
+        const result = unwrap(await handlers.list(ctx));
+
+        expect(result.body.items).toHaveLength(2);
+        for (const item of result.body.items) {
+          expect(item.workspaceId).toBe('ws-a');
+        }
+      });
+    });
+
+    describe('When ws-a user calls get() for ws-b project', () => {
+      it('Then returns 404 (cross-tenant)', async () => {
+        const db = createCustomTenantStubDb();
+        const handlers = createCrudHandlers(def, db);
+        const ctx = makeCtx({ tenantId: 'ws-a' });
+
+        const result = await handlers.get(ctx, 'proj-2');
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toBeInstanceOf(EntityNotFoundError);
+        }
+      });
+    });
+
+    describe('When ws-a user calls create()', () => {
+      it('Then auto-sets workspaceId from context', async () => {
+        const db = createCustomTenantStubDb();
+        const handlers = createCrudHandlers(def, db);
+        const ctx = makeCtx({ tenantId: 'ws-a' });
+
+        unwrap(await handlers.create(ctx, { title: 'New Project' }));
+
+        const createCall = db.create.mock.calls[0]![0];
+        expect(createCall).toHaveProperty('workspaceId', 'ws-a');
+        expect(createCall).not.toHaveProperty('tenantId');
+      });
+    });
+
+    describe('When ws-a user calls update() on ws-b project', () => {
+      it('Then returns 404 (cross-tenant)', async () => {
+        const db = createCustomTenantStubDb();
+        const handlers = createCrudHandlers(def, db);
+        const ctx = makeCtx({ tenantId: 'ws-a' });
+
+        const result = await handlers.update(ctx, 'proj-2', { title: 'Hacked' });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toBeInstanceOf(EntityNotFoundError);
+        }
+      });
+    });
+
+    describe('When ws-a user calls delete() on ws-b project', () => {
+      it('Then returns 404 (cross-tenant)', async () => {
+        const db = createCustomTenantStubDb();
+        const handlers = createCrudHandlers(def, db);
+        const ctx = makeCtx({ tenantId: 'ws-a' });
+
+        const result = await handlers.delete(ctx, 'proj-2');
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toBeInstanceOf(EntityNotFoundError);
+        }
+      });
+    });
+  });
+
   describe('Given a non-tenant-scoped entity (no tenantId column)', () => {
     describe('When calling list() without tenantId in context', () => {
       it('Then returns all rows (no tenant filter)', async () => {

--- a/packages/server/src/entity/__tests__/entity.test.ts
+++ b/packages/server/src/entity/__tests__/entity.test.ts
@@ -236,12 +236,48 @@ describe('Feature: entity() definition', () => {
         const def = entity('tasks', { model: tenantModel });
         expect(def.tenantScoped).toBe(true);
       });
+
+      it('Then tenantColumn defaults to "tenantId"', () => {
+        const def = entity('tasks', { model: tenantModel });
+        expect(def.tenantColumn).toBe('tenantId');
+      });
     });
 
     describe('When calling entity() with tenantScoped: false', () => {
       it('Then tenantScoped is false', () => {
         const def = entity('tasks', { model: tenantModel, tenantScoped: false });
         expect(def.tenantScoped).toBe(false);
+      });
+
+      it('Then tenantColumn is null', () => {
+        const def = entity('tasks', { model: tenantModel, tenantScoped: false });
+        expect(def.tenantColumn).toBeNull();
+      });
+    });
+  });
+
+  describe('Given a model with a custom tenant FK column via _tenant relation', () => {
+    const orgsTable = d.table('organizations', { id: d.uuid().primary(), name: d.text() });
+    const employeesTable = d.table('employees', {
+      id: d.uuid().primary(),
+      name: d.text(),
+      organizationId: d.uuid(),
+    });
+    const employeesModel = d.model(
+      employeesTable,
+      { organization: d.ref.one(() => orgsTable, 'organizationId') },
+      { tenant: 'organization' },
+    );
+
+    describe('When calling entity() without explicit tenantScoped', () => {
+      it('Then tenantScoped defaults to true', () => {
+        const def = entity('employees', { model: employeesModel });
+        expect(def.tenantScoped).toBe(true);
+      });
+
+      it('Then tenantColumn resolves to the relation FK ("organizationId")', () => {
+        const def = entity('employees', { model: employeesModel });
+        expect(def.tenantColumn).toBe('organizationId');
       });
     });
   });
@@ -251,6 +287,11 @@ describe('Feature: entity() definition', () => {
       it('Then tenantScoped defaults to false', () => {
         const def = entity('users', { model: usersModel });
         expect(def.tenantScoped).toBe(false);
+      });
+
+      it('Then tenantColumn is null', () => {
+        const def = entity('users', { model: usersModel });
+        expect(def.tenantColumn).toBeNull();
       });
     });
   });

--- a/packages/server/src/entity/crud-pipeline.ts
+++ b/packages/server/src/entity/crud-pipeline.ts
@@ -118,6 +118,7 @@ export function createCrudHandlers<TModel extends ModelDef = ModelDef>(
 ): CrudHandlers<TModel> {
   const table = def.model.table;
   const isTenantScoped = def.tenantScoped;
+  const tenantColumn = def.tenantColumn ?? 'tenantId';
   const tenantChain = options?.tenantChain ?? def.tenantChain ?? null;
   const isIndirectlyScoped = tenantChain !== null;
   const queryParentIds = options?.queryParentIds ?? null;
@@ -144,7 +145,7 @@ export function createCrudHandlers<TModel extends ModelDef = ModelDef>(
     if (!isTenantScoped) return true;
     // Indirect scoping uses subquery filtering, not row-level tenantId check
     if (isIndirectlyScoped) return true;
-    return row.tenantId === ctx.tenantId;
+    return row[tenantColumn] === ctx.tenantId;
   }
 
   /** Merges tenant filter into a where clause for list queries. */
@@ -155,7 +156,7 @@ export function createCrudHandlers<TModel extends ModelDef = ModelDef>(
     if (!isTenantScoped) return where;
     // Indirect scoping is handled separately via resolveIndirectTenantWhere
     if (isIndirectlyScoped) return where;
-    return { ...where, tenantId: ctx.tenantId };
+    return { ...where, [tenantColumn]: ctx.tenantId };
   }
 
   /**
@@ -334,9 +335,9 @@ export function createCrudHandlers<TModel extends ModelDef = ModelDef>(
         }
       }
 
-      // Auto-set tenantId from context for tenant-scoped entities
+      // Auto-set tenant column from context for directly scoped entities
       if (isTenantScoped && !isIndirectlyScoped && ctx.tenantId) {
-        input = { ...input, tenantId: ctx.tenantId };
+        input = { ...input, [tenantColumn]: ctx.tenantId };
       }
 
       // Apply before.create hook

--- a/packages/server/src/entity/entity.ts
+++ b/packages/server/src/entity/entity.ts
@@ -1,8 +1,17 @@
 import { deepFreeze } from '@vertz/core';
-import type { ModelDef } from '@vertz/db';
+import type { ModelDef, RelationDef } from '@vertz/db';
 import type { EntityActionDef, EntityConfig, EntityContext, EntityDefinition } from './types';
 
 const ENTITY_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/** Resolves the tenant FK column name from a model's `_tenant` relation. */
+function resolveTenantColumn(model: ModelDef): string | null {
+  if (!model._tenant) return null;
+  const relations = model.relations as Record<string, RelationDef>;
+  const tenantRel = relations[model._tenant];
+  if (!tenantRel || !tenantRel._foreignKey) return null;
+  return tenantRel._foreignKey;
+}
 
 export function entity<
   TModel extends ModelDef,
@@ -25,9 +34,10 @@ export function entity<
     throw new Error('entity() requires a model in the config.');
   }
 
-  // Detect tenantId column in the model to infer tenantScoped default
-  const hasTenantIdColumn = 'tenantId' in config.model.table._columns;
-  const tenantScoped = config.tenantScoped ?? hasTenantIdColumn;
+  // Resolve tenant column from the model's _tenant relation FK, or fallback to 'tenantId' column
+  const tenantColumn = resolveTenantColumn(config.model);
+  const hasTenantColumn = tenantColumn !== null || 'tenantId' in config.model.table._columns;
+  const tenantScoped = config.tenantScoped ?? hasTenantColumn;
 
   // Type erasure: EntityConfig<TModel> validates hooks at the call site.
   // EntityDefinition stores hooks as EntityBeforeHooks/EntityAfterHooks (unknown)
@@ -44,6 +54,7 @@ export function entity<
     expose: config.expose,
     table: config.table ?? name,
     tenantScoped,
+    tenantColumn: tenantScoped ? (tenantColumn ?? 'tenantId') : null,
     tenantChain: null,
   };
   return deepFreeze(def);

--- a/packages/server/src/entity/types.ts
+++ b/packages/server/src/entity/types.ts
@@ -314,8 +314,10 @@ export interface EntityDefinition<TModel extends ModelDef = ModelDef> {
   readonly expose?: ExposeConfig<TModel['table'], TModel>;
   /** DB table name (defaults to entity name). */
   readonly table: string;
-  /** Whether CRUD auto-filters by tenantId. */
+  /** Whether CRUD auto-filters by tenant column. */
   readonly tenantScoped: boolean;
+  /** The tenant FK column name resolved from the model's tenant relation. Null when unscoped. */
+  readonly tenantColumn: string | null;
   /** Relation chain for indirect tenant scoping. Null for direct or unscoped. */
   readonly tenantChain: TenantChain | null;
 }


### PR DESCRIPTION
## Summary

- Make the framework's CRUD pipeline resolve the tenant FK column name dynamically from the model's `_tenant` relation instead of hardcoding `tenantId`
- Rename `tenantId` → `workspaceId` in all Linear clone table schemas, seed data, and tests to align with Linear's domain language
- Update `TENANT_RETROFIT_DX.md` to reflect the improved DX (removed the "column naming convention" pain point)

## Public API Changes

### `@vertz/server` — `EntityDefinition`
- **Addition**: `tenantColumn: string | null` field on `EntityDefinition` — resolved from the model's `_tenant` relation FK, or defaults to `'tenantId'` for backward compatibility
- **No breaking changes** — existing apps using `tenantId` columns continue to work without modification

## Test plan

- [x] New tests: entity with custom tenant FK column (`organizationId`) — verifies `tenantColumn` resolves correctly
- [x] New tests: CRUD pipeline with custom FK column (`workspaceId`) — verifies list filtering, get/update/delete cross-tenant checks, and create auto-set all use the dynamic column
- [x] Existing entity tests pass (484 tests, 0 failures)
- [x] Linear example tests pass (36 tests, 0 failures)
- [x] Typecheck passes for `@vertz/server`
- [x] Lint passes

Fixes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)