### PR TITLE
chore(examples): migrate to registerTheme + @vertz/ui/components

### DIFF
--- a/examples/component-catalog/src/demos/accordion.tsx
+++ b/examples/component-catalog/src/demos/accordion.tsx
@@ -1,7 +1,5 @@
+import { Accordion } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Accordion } = themeComponents.primitives;
 
 export function AccordionDemo() {
   return (

--- a/examples/component-catalog/src/demos/alert-dialog.tsx
+++ b/examples/component-catalog/src/demos/alert-dialog.tsx
@@ -1,8 +1,5 @@
+import { AlertDialog, Button } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button } = themeComponents;
-const { AlertDialog } = themeComponents.primitives;
 
 export function AlertDialogDemo() {
   return (

--- a/examples/component-catalog/src/demos/alert.tsx
+++ b/examples/component-catalog/src/demos/alert.tsx
@@ -1,7 +1,5 @@
+import { Alert as AlertSuite } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Alert: AlertSuite } = themeComponents;
 
 export function AlertDemo() {
   return (

--- a/examples/component-catalog/src/demos/avatar.tsx
+++ b/examples/component-catalog/src/demos/avatar.tsx
@@ -1,7 +1,5 @@
+import { Avatar as AvatarSuite } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Avatar: AvatarSuite } = themeComponents;
 
 export function AvatarDemo() {
   return (

--- a/examples/component-catalog/src/demos/badge.tsx
+++ b/examples/component-catalog/src/demos/badge.tsx
@@ -1,7 +1,5 @@
+import { Badge } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Badge } = themeComponents;
 
 export function BadgeDemo() {
   return (

--- a/examples/component-catalog/src/demos/button.tsx
+++ b/examples/component-catalog/src/demos/button.tsx
@@ -1,7 +1,5 @@
+import { Button } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button } = themeComponents;
 
 export function ButtonDemo() {
   return (

--- a/examples/component-catalog/src/demos/card.tsx
+++ b/examples/component-catalog/src/demos/card.tsx
@@ -1,7 +1,5 @@
+import { Button, Card as CardSuite } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Card: CardSuite, Button } = themeComponents;
 
 export function CardDemo() {
   return (

--- a/examples/component-catalog/src/demos/checkbox.tsx
+++ b/examples/component-catalog/src/demos/checkbox.tsx
@@ -1,7 +1,5 @@
+import { Checkbox } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Checkbox } = themeComponents.primitives;
 
 export function CheckboxDemo() {
   return (

--- a/examples/component-catalog/src/demos/dialog.tsx
+++ b/examples/component-catalog/src/demos/dialog.tsx
@@ -1,8 +1,5 @@
+import { Button, Dialog, Input, Label } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button, Input, Label } = themeComponents;
-const { Dialog } = themeComponents.primitives;
 
 export function DialogDemo() {
   return (

--- a/examples/component-catalog/src/demos/dropdown-menu.tsx
+++ b/examples/component-catalog/src/demos/dropdown-menu.tsx
@@ -1,8 +1,5 @@
+import { Button, DropdownMenu } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button } = themeComponents;
-const { DropdownMenu } = themeComponents.primitives;
 
 export function DropdownMenuDemo() {
   return (

--- a/examples/component-catalog/src/demos/form-group.tsx
+++ b/examples/component-catalog/src/demos/form-group.tsx
@@ -1,7 +1,5 @@
+import { FormGroup as FormGroupSuite, Input, Label } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { FormGroup: FormGroupSuite, Label, Input } = themeComponents;
 
 export function FormGroupDemo() {
   return (

--- a/examples/component-catalog/src/demos/input.tsx
+++ b/examples/component-catalog/src/demos/input.tsx
@@ -1,7 +1,5 @@
+import { Input } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Input } = themeComponents;
 
 export function InputDemo() {
   return (

--- a/examples/component-catalog/src/demos/label.tsx
+++ b/examples/component-catalog/src/demos/label.tsx
@@ -1,7 +1,5 @@
+import { Input, Label } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Label, Input } = themeComponents;
 
 export function LabelDemo() {
   return (

--- a/examples/component-catalog/src/demos/popover.tsx
+++ b/examples/component-catalog/src/demos/popover.tsx
@@ -1,8 +1,5 @@
+import { Button, Input, Label, Popover } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button, Input, Label } = themeComponents;
-const { Popover } = themeComponents.primitives;
 
 export function PopoverDemo() {
   return (

--- a/examples/component-catalog/src/demos/progress.tsx
+++ b/examples/component-catalog/src/demos/progress.tsx
@@ -1,7 +1,5 @@
+import { Progress } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Progress } = themeComponents.primitives;
 
 export function ProgressDemo() {
   return (

--- a/examples/component-catalog/src/demos/radio-group.tsx
+++ b/examples/component-catalog/src/demos/radio-group.tsx
@@ -1,7 +1,5 @@
+import { RadioGroup } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { RadioGroup } = themeComponents.primitives;
 
 export function RadioGroupDemo() {
   return (

--- a/examples/component-catalog/src/demos/select.tsx
+++ b/examples/component-catalog/src/demos/select.tsx
@@ -1,7 +1,5 @@
+import { Select } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Select } = themeComponents.primitives;
 
 export function SelectDemo() {
   return (

--- a/examples/component-catalog/src/demos/separator.tsx
+++ b/examples/component-catalog/src/demos/separator.tsx
@@ -1,7 +1,5 @@
+import { Separator } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Separator } = themeComponents;
 
 export function SeparatorDemo() {
   return (

--- a/examples/component-catalog/src/demos/sheet.tsx
+++ b/examples/component-catalog/src/demos/sheet.tsx
@@ -1,8 +1,5 @@
+import { Button, Input, Label, Sheet } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button, Label, Input } = themeComponents;
-const { Sheet } = themeComponents.primitives;
 
 export function SheetDemo() {
   return (

--- a/examples/component-catalog/src/demos/skeleton.tsx
+++ b/examples/component-catalog/src/demos/skeleton.tsx
@@ -1,7 +1,5 @@
+import { Skeleton as SkeletonSuite } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Skeleton: SkeletonSuite } = themeComponents;
 
 export function SkeletonDemo() {
   return (

--- a/examples/component-catalog/src/demos/slider.tsx
+++ b/examples/component-catalog/src/demos/slider.tsx
@@ -1,7 +1,5 @@
+import { Slider } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Slider } = themeComponents.primitives;
 
 export function SliderDemo() {
   let steppedValue = 25;

--- a/examples/component-catalog/src/demos/switch.tsx
+++ b/examples/component-catalog/src/demos/switch.tsx
@@ -1,8 +1,5 @@
+import { Label, Switch } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Label } = themeComponents;
-const { Switch } = themeComponents.primitives;
 
 export function SwitchDemo() {
   return (

--- a/examples/component-catalog/src/demos/table.tsx
+++ b/examples/component-catalog/src/demos/table.tsx
@@ -1,7 +1,5 @@
+import { Table as T } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Table: T } = themeComponents;
 
 export function TableDemo() {
   return (

--- a/examples/component-catalog/src/demos/tabs.tsx
+++ b/examples/component-catalog/src/demos/tabs.tsx
@@ -1,7 +1,5 @@
+import { Tabs } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Tabs } = themeComponents.primitives;
 
 export function TabsDemo() {
   return (

--- a/examples/component-catalog/src/demos/textarea.tsx
+++ b/examples/component-catalog/src/demos/textarea.tsx
@@ -1,7 +1,5 @@
+import { Textarea } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Textarea } = themeComponents;
 
 export function TextareaDemo() {
   return (

--- a/examples/component-catalog/src/demos/toast.tsx
+++ b/examples/component-catalog/src/demos/toast.tsx
@@ -1,8 +1,5 @@
+import { Button, Toast } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button } = themeComponents;
-const { Toast } = themeComponents.primitives;
 
 export function ToastDemo() {
   const t = Toast({});

--- a/examples/component-catalog/src/demos/toggle.tsx
+++ b/examples/component-catalog/src/demos/toggle.tsx
@@ -1,7 +1,5 @@
+import { Toggle } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Toggle } = themeComponents.primitives;
 
 export function ToggleDemo() {
   return (

--- a/examples/component-catalog/src/demos/tooltip.tsx
+++ b/examples/component-catalog/src/demos/tooltip.tsx
@@ -1,8 +1,5 @@
+import { Button, Tooltip } from '@vertz/ui/components';
 import { demoStyles } from '../styles/catalog';
-import { themeComponents } from '../styles/theme';
-
-const { Button } = themeComponents;
-const { Tooltip } = themeComponents.primitives;
 
 export function TooltipDemo() {
   return (

--- a/examples/component-catalog/src/styles/theme.ts
+++ b/examples/component-catalog/src/styles/theme.ts
@@ -1,11 +1,13 @@
 import { configureTheme } from '@vertz/theme-shadcn';
+import { registerTheme } from '@vertz/ui';
 
-const { theme, globals, styles, components } = configureTheme({
+const config = configureTheme({
   palette: 'zinc',
   radius: 'md',
 });
 
-export const catalogTheme = theme;
-export const themeGlobals = globals;
-export const themeStyles = styles;
-export const themeComponents = components;
+registerTheme(config);
+
+export const catalogTheme = config.theme;
+export const themeGlobals = config.globals;
+export const themeStyles = config.styles;

--- a/examples/linear/src/styles/theme.ts
+++ b/examples/linear/src/styles/theme.ts
@@ -7,13 +7,15 @@
  */
 
 import { configureTheme } from '@vertz/theme-shadcn';
+import { registerTheme } from '@vertz/ui';
 
-const { theme, globals, styles, components } = configureTheme({
+const config = configureTheme({
   palette: 'zinc',
   radius: 'md',
 });
 
-export const linearTheme = theme;
-export const themeGlobals = globals;
-export const themeStyles = styles;
-export const themeComponents = components;
+registerTheme(config);
+
+export const linearTheme = config.theme;
+export const themeGlobals = config.globals;
+export const themeStyles = config.styles;

--- a/examples/task-manager/src/styles/theme.ts
+++ b/examples/task-manager/src/styles/theme.ts
@@ -7,13 +7,15 @@
  */
 
 import { configureTheme } from '@vertz/theme-shadcn';
+import { registerTheme } from '@vertz/ui';
 
-const { theme, globals, styles, components } = configureTheme({
+const config = configureTheme({
   palette: 'zinc',
   radius: 'md',
 });
 
-export const taskManagerTheme = theme;
-export const themeGlobals = globals;
-export const themeStyles = styles;
-export const themeComponents = components;
+registerTheme(config);
+
+export const taskManagerTheme = config.theme;
+export const themeGlobals = config.globals;
+export const themeStyles = config.styles;

--- a/packages/ui/src/theme/registry.ts
+++ b/packages/ui/src/theme/registry.ts
@@ -1,8 +1,7 @@
 /** Input type for registerTheme(). Compatible with configureTheme() output. */
 export interface RegisterThemeInput {
   components: {
-    primitives?: Record<string, unknown>;
-    [key: string]: unknown;
+    primitives?: object;
   };
 }
 


### PR DESCRIPTION
Fixes #1471

## Summary

- Migrate all three example apps (component-catalog, linear, task-manager) from the old `configureTheme()` + `themeComponents` destructuring pattern to `registerTheme()` + `import { ... } from '@vertz/ui/components'`
- Fix `RegisterThemeInput` type to accept typed interfaces without index signatures (was rejecting `ThemeComponents`/`ThemedPrimitives`)

## Public API Changes

- `RegisterThemeInput.components.primitives` changed from `Record<string, unknown>` to `object` — more permissive, accepts typed interfaces from `@vertz/theme-shadcn`
- `RegisterThemeInput.components` removed `[key: string]: unknown` index signature — structural typing handles extra properties naturally

## Test plan

- [x] Theme registry tests pass (13 tests)
- [x] Component-catalog typechecks clean
- [x] Task-manager typechecks clean
- [x] Linear typechecks clean (pre-existing `api.auth` error unrelated)
- [x] Full quality gates pass via pre-push hook (lint, typecheck, test, build)
- [x] No remaining `themeComponents` imports in the three migrated examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)