### PR TITLE
docs(db): fix stale SQLite import paths and add dialect examples

### DIFF
--- a/packages/docs/guides/db/overview.mdx
+++ b/packages/docs/guides/db/overview.mdx
@@ -96,7 +96,7 @@ export function createD1Db(d1: D1Database) {
 |--------|-----------|---------------|--------------|
 | `dialect` | `'postgres'` (default) | `'sqlite'` | `'sqlite'` |
 | Connection | `url: string` | `path: string` | `d1: D1Database` |
-| Migrations | CLI (`vertz db migrate`) | `migrations: { autoApply: true }` | Manual (wrangler) |
+| Migrations | CLI (`vertz db migrate`) | `migrations: { autoApply: true }` | Not available (`autoApply` is disallowed for D1 — use wrangler migrations) |
 | Transactions | `db.transaction()` | `db.transaction()` | Not supported (use `D1Database.batch()`) |
 
 <Note>

--- a/packages/docs/guides/db/queries.mdx
+++ b/packages/docs/guides/db/queries.mdx
@@ -7,16 +7,19 @@ The database client provides typed CRUD operations derived from your schema. Eve
 
 ## Creating the client
 
-```ts
+<CodeGroup>
+```ts PostgreSQL
 import { createDb } from 'vertz/db';
 
-// PostgreSQL
 const db = createDb({
   url: process.env.DATABASE_URL!,
   models: { users: usersModel, tasks: tasksModel },
 });
+```
 
-// SQLite (local file or in-memory)
+```ts SQLite (local file)
+import { createDb } from 'vertz/db';
+
 const db = createDb({
   dialect: 'sqlite',
   path: '.vertz/data/app.db', // or ':memory:'
@@ -24,6 +27,7 @@ const db = createDb({
   migrations: { autoApply: true },
 });
 ```
+</CodeGroup>
 
 Each model becomes a property on `db` with typed query methods. The query API is identical across all dialects — only the `createDb()` options differ.
 


### PR DESCRIPTION
## Summary

- Fix stale `vertz/db/sqlite` and `vertz/db/d1` sub-path references in db docs (removed in #1385)
- Add "Database support" section to overview with CodeGroup showing PostgreSQL, SQLite (local), and D1 setup
- Add SQLite example to queries "Creating the client" section
- Document `autoApply` migrations behavior and SQLite value conversion
- Clarify that D1 disallows `autoApply` at the type level

## Public API Changes

None — docs only.

## Context

An LLM using the latest `@vertz/db@0.2.21` tried to import from `vertz/db/sqlite` (following the docs) and failed because the sub-path was removed when `createDb()` was unified. The code works correctly — only the documentation was stale.

## Test plan

- [x] Verified all documented APIs match `CreateDbOptions` types in `database.ts`
- [x] Verified no remaining stale sub-path references (`vertz/db/sqlite`, `vertz/db/d1`) in docs
- [x] Verified `vertz/db/sql` sub-path still exists in `package.json` exports
- [x] All existing SQLite tests pass (10/10)
- [x] Quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)