### PR TITLE
feat(db): support column-level validation constraints (min, max, regex)

### DIFF
--- a/.changeset/column-validation-constraints.md
+++ b/.changeset/column-validation-constraints.md
@@ -1,0 +1,16 @@
+---
+'@vertz/db': patch
+---
+
+feat(db): support column-level validation constraints (min, max, regex) in schema
+
+Added `.min()`, `.max()`, and `.regex()` chainable methods to column builders so validation
+constraints can be defined directly on the DB schema. These constraints flow through
+`tableToSchemas()` to `@vertz/schema` validators for automatic API-level validation.
+
+- `d.text().min(1).max(5).regex(/^[A-Z]+$/)` — string length and pattern constraints
+- `d.integer().min(0).max(100)` — numeric range constraints
+- Type-safe scoping: `.regex()` only available on string columns, `.min()`/`.max()` only on
+  string and numeric columns via `StringColumnBuilder` and `NumericColumnBuilder` interfaces
+- Constraints survive chaining with existing builders (`.unique()`, `.nullable()`, etc.)
+- Constraints are application-level only — they do NOT affect migrations or SQL DDL

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -5,7 +5,9 @@ import type {
   EnumMeta,
   FormatMeta,
   JsonbValidator,
+  NumericColumnBuilder,
   SerialMeta,
+  StringColumnBuilder,
   VarcharMeta,
 } from './schema/column';
 import { createColumn, createSerialColumn } from './schema/column';
@@ -26,19 +28,21 @@ interface EnumSchemaLike<T extends readonly string[]> {
 
 export const d: {
   uuid(): ColumnBuilder<string, DefaultMeta<'uuid'>>;
-  text(): ColumnBuilder<string, DefaultMeta<'text'>>;
-  varchar<TLength extends number>(length: TLength): ColumnBuilder<string, VarcharMeta<TLength>>;
-  email(): ColumnBuilder<string, FormatMeta<'text', 'email'>>;
+  text(): StringColumnBuilder<string, DefaultMeta<'text'>>;
+  varchar<TLength extends number>(
+    length: TLength,
+  ): StringColumnBuilder<string, VarcharMeta<TLength>>;
+  email(): StringColumnBuilder<string, FormatMeta<'text', 'email'>>;
   boolean(): ColumnBuilder<boolean, DefaultMeta<'boolean'>>;
-  integer(): ColumnBuilder<number, DefaultMeta<'integer'>>;
+  integer(): NumericColumnBuilder<number, DefaultMeta<'integer'>>;
   bigint(): ColumnBuilder<bigint, DefaultMeta<'bigint'>>;
   decimal<TPrecision extends number, TScale extends number>(
     precision: TPrecision,
     scale: TScale,
   ): ColumnBuilder<string, DecimalMeta<TPrecision, TScale>>;
-  real(): ColumnBuilder<number, DefaultMeta<'real'>>;
-  doublePrecision(): ColumnBuilder<number, DefaultMeta<'double precision'>>;
-  serial(): ColumnBuilder<number, SerialMeta>;
+  real(): NumericColumnBuilder<number, DefaultMeta<'real'>>;
+  doublePrecision(): NumericColumnBuilder<number, DefaultMeta<'double precision'>>;
+  serial(): NumericColumnBuilder<number, SerialMeta>;
   timestamp(): ColumnBuilder<Date, DefaultMeta<'timestamp with time zone'>>;
   date(): ColumnBuilder<string, DefaultMeta<'date'>>;
   time(): ColumnBuilder<string, DefaultMeta<'time'>>;
@@ -91,20 +95,40 @@ export const d: {
   ): ModelDef<TTable, TRelations>;
 } = {
   uuid: () => createColumn<string, DefaultMeta<'uuid'>>('uuid'),
-  text: () => createColumn<string, DefaultMeta<'text'>>('text'),
+  text: () =>
+    createColumn<string, DefaultMeta<'text'>>('text') as unknown as StringColumnBuilder<
+      string,
+      DefaultMeta<'text'>
+    >,
   varchar: <TLength extends number>(length: TLength) =>
-    createColumn<string, VarcharMeta<TLength>>('varchar', { length }),
-  email: () => createColumn<string, FormatMeta<'text', 'email'>>('text', { format: 'email' }),
+    createColumn<string, VarcharMeta<TLength>>('varchar', {
+      length,
+    }) as unknown as StringColumnBuilder<string, VarcharMeta<TLength>>,
+  email: () =>
+    createColumn<string, FormatMeta<'text', 'email'>>('text', {
+      format: 'email',
+    }) as unknown as StringColumnBuilder<string, FormatMeta<'text', 'email'>>,
   boolean: () => createColumn<boolean, DefaultMeta<'boolean'>>('boolean'),
-  integer: () => createColumn<number, DefaultMeta<'integer'>>('integer'),
+  integer: () =>
+    createColumn<number, DefaultMeta<'integer'>>('integer') as unknown as NumericColumnBuilder<
+      number,
+      DefaultMeta<'integer'>
+    >,
   bigint: () => createColumn<bigint, DefaultMeta<'bigint'>>('bigint'),
   decimal: <TPrecision extends number, TScale extends number>(
     precision: TPrecision,
     scale: TScale,
   ) => createColumn<string, DecimalMeta<TPrecision, TScale>>('decimal', { precision, scale }),
-  real: () => createColumn<number, DefaultMeta<'real'>>('real'),
-  doublePrecision: () => createColumn<number, DefaultMeta<'double precision'>>('double precision'),
-  serial: () => createSerialColumn(),
+  real: () =>
+    createColumn<number, DefaultMeta<'real'>>('real') as unknown as NumericColumnBuilder<
+      number,
+      DefaultMeta<'real'>
+    >,
+  doublePrecision: () =>
+    createColumn<number, DefaultMeta<'double precision'>>(
+      'double precision',
+    ) as unknown as NumericColumnBuilder<number, DefaultMeta<'double precision'>>,
+  serial: () => createSerialColumn() as unknown as NumericColumnBuilder<number, SerialMeta>,
   timestamp: () =>
     createColumn<Date, DefaultMeta<'timestamp with time zone'>>('timestamp with time zone'),
   date: () => createColumn<string, DefaultMeta<'date'>>('date'),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -124,6 +124,8 @@ export type {
   FormatMeta,
   InferColumnType,
   JsonbValidator,
+  NumericColumnBuilder,
+  StringColumnBuilder,
   VarcharMeta,
 } from './schema/column';
 export { defineAnnotations } from './schema/define-annotations';

--- a/packages/db/src/schema-derive/column-mapper.ts
+++ b/packages/db/src/schema-derive/column-mapper.ts
@@ -1,5 +1,5 @@
 import type { SchemaAny } from '@vertz/schema';
-import { s } from '@vertz/schema';
+import { NumberSchema, StringSchema, s } from '@vertz/schema';
 import type { ColumnMetadata } from '../schema/column';
 
 /**
@@ -16,6 +16,9 @@ export function columnToSchema(meta: ColumnMetadata): SchemaAny {
   } else {
     schema = mapSqlType(meta);
   }
+
+  // Apply application-level validation constraints
+  schema = applyConstraints(schema, meta);
 
   if (meta.nullable) {
     schema = schema.nullable();
@@ -62,6 +65,36 @@ function mapSqlType(meta: ColumnMetadata): SchemaAny {
     default:
       throw new TypeError(`Unknown column type: ${meta.sqlType}`);
   }
+}
+
+function applyConstraints(schema: SchemaAny, meta: ColumnMetadata): SchemaAny {
+  let result = schema;
+
+  // String constraints
+  if (result instanceof StringSchema) {
+    if (meta._minLength != null) {
+      result = (result as StringSchema).min(meta._minLength);
+    }
+    // _maxLength overrides varchar length for validation
+    if (meta._maxLength != null) {
+      result = (result as StringSchema).max(meta._maxLength);
+    }
+    if (meta._regex != null) {
+      result = (result as StringSchema).regex(meta._regex);
+    }
+  }
+
+  // Numeric constraints
+  if (result instanceof NumberSchema) {
+    if (meta._minValue != null) {
+      result = (result as NumberSchema).min(meta._minValue);
+    }
+    if (meta._maxValue != null) {
+      result = (result as NumberSchema).max(meta._maxValue);
+    }
+  }
+
+  return result;
 }
 
 function mapEnum(meta: ColumnMetadata): SchemaAny {

--- a/packages/db/src/schema-derive/table-to-schemas.test.ts
+++ b/packages/db/src/schema-derive/table-to-schemas.test.ts
@@ -412,6 +412,144 @@ describe('tableToSchemas', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Validation constraints
+  // -------------------------------------------------------------------------
+
+  describe('string validation constraints', () => {
+    const constrained = d.table('constrained', {
+      id: d.uuid().primary(),
+      key: d
+        .text()
+        .min(1)
+        .max(5)
+        .regex(/^[A-Z0-9]+$/i),
+      title: d.text().min(1),
+    });
+
+    it('rejects empty string below min length', () => {
+      const { createBody } = tableToSchemas(constrained);
+      const result = createBody.safeParse({ key: '', title: 'Test' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects string exceeding max length', () => {
+      const { createBody } = tableToSchemas(constrained);
+      const result = createBody.safeParse({ key: 'ABCDEF', title: 'Test' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects string not matching regex', () => {
+      const { createBody } = tableToSchemas(constrained);
+      const result = createBody.safeParse({ key: 'AB!', title: 'Test' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts valid string matching all constraints', () => {
+      const { createBody } = tableToSchemas(constrained);
+      const result = createBody.safeParse({ key: 'ABC', title: 'Test' });
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects empty title below min length', () => {
+      const { createBody } = tableToSchemas(constrained);
+      const result = createBody.safeParse({ key: 'ABC', title: '' });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('numeric validation constraints', () => {
+    const metrics = d.table('metrics', {
+      id: d.uuid().primary(),
+      score: d.integer().min(0).max(100),
+      rating: d.real().min(0).max(5),
+    });
+
+    it('rejects value below min', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: -1, rating: 3.0 });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects value above max', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: 101, rating: 3.0 });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts values within range', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: 50, rating: 3.0 });
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects rating below min', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: 50, rating: -0.1 });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects rating above max', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: 50, rating: 5.1 });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts boundary values (inclusive min/max)', () => {
+      const { createBody } = tableToSchemas(metrics);
+      const result = createBody.safeParse({ score: 0, rating: 5 });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('varchar with explicit constraints', () => {
+    it('uses _minLength from explicit .min() on varchar', () => {
+      const tbl = d.table('t', {
+        id: d.uuid().primary(),
+        code: d.varchar(255).min(1),
+      });
+      const { createBody } = tableToSchemas(tbl);
+      expect(createBody.safeParse({ code: '' }).ok).toBe(false);
+      expect(createBody.safeParse({ code: 'A' }).ok).toBe(true);
+    });
+
+    it('uses _maxLength when explicitly set, overriding varchar length for validation', () => {
+      const tbl = d.table('t', {
+        id: d.uuid().primary(),
+        code: d.varchar(255).max(5),
+      });
+      const { createBody } = tableToSchemas(tbl);
+      expect(createBody.safeParse({ code: 'ABCDEF' }).ok).toBe(false);
+      expect(createBody.safeParse({ code: 'ABC' }).ok).toBe(true);
+    });
+  });
+
+  describe('email with constraints', () => {
+    const withEmail = d.table('with_email', {
+      id: d.uuid().primary(),
+      email: d.email().min(5).max(100),
+    });
+
+    it('rejects email shorter than min length', () => {
+      const { createBody } = tableToSchemas(withEmail);
+      const result = createBody.safeParse({ email: 'a@b' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts email meeting min length', () => {
+      const { createBody } = tableToSchemas(withEmail);
+      const result = createBody.safeParse({ email: 'a@b.c' });
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects email exceeding max length', () => {
+      const { createBody } = tableToSchemas(withEmail);
+      const longEmail = `${'a'.repeat(90)}@example.com`;
+      const result = createBody.safeParse({ email: longEmail });
+      expect(result.ok).toBe(false);
+    });
+  });
+
   describe('unknown column type', () => {
     it('throws on unrecognized sqlType', () => {
       const weirdTable = d.table('weird', {

--- a/packages/db/src/schema/__tests__/column.test-d.ts
+++ b/packages/db/src/schema/__tests__/column.test-d.ts
@@ -196,6 +196,83 @@ describe('type-level negative tests', () => {
   });
 });
 
+describe('validation constraint type scoping', () => {
+  it('d.text() supports .min(), .max(), .regex()', () => {
+    d.text().min(1);
+    d.text().max(100);
+    d.text().regex(/^[a-z]+$/);
+    d.text().min(1).max(10).regex(/abc/);
+  });
+
+  it('d.varchar() supports .min(), .max(), .regex()', () => {
+    d.varchar(255).min(1);
+    d.varchar(255).max(100);
+    d.varchar(255).regex(/^[a-z]+$/);
+  });
+
+  it('d.email() supports .min() and .max()', () => {
+    d.email().min(5).max(255);
+  });
+
+  it('d.integer() supports .min() and .max()', () => {
+    d.integer().min(0);
+    d.integer().max(100);
+    d.integer().min(0).max(100);
+  });
+
+  it('d.real() supports .min() and .max()', () => {
+    d.real().min(0).max(5);
+  });
+
+  it('d.doublePrecision() supports .min() and .max()', () => {
+    d.doublePrecision().min(-1).max(1);
+  });
+
+  it('d.boolean() does NOT support .min() or .regex()', () => {
+    // @ts-expect-error — boolean has no min
+    d.boolean().min(1);
+    // @ts-expect-error — boolean has no regex
+    d.boolean().regex(/abc/);
+  });
+
+  it('d.integer() does NOT support .regex()', () => {
+    // @ts-expect-error — integer has no regex
+    d.integer().regex(/abc/);
+  });
+
+  it('d.timestamp() does NOT support .min()', () => {
+    // @ts-expect-error — timestamp has no min
+    d.timestamp().min(1);
+  });
+
+  it('d.uuid() does NOT support .min()', () => {
+    // @ts-expect-error — uuid has no min
+    d.uuid().min(1);
+  });
+
+  it('constraint methods survive chaining with base methods', () => {
+    // text: min -> unique -> max must compile
+    d.text().min(1).unique().max(5);
+    // text: unique -> min must compile
+    d.text().unique().min(1);
+    // integer: min -> unique -> max must compile
+    d.integer().min(0).unique().max(100);
+    // text: nullable -> regex must compile
+    d.text().nullable().regex(/abc/);
+  });
+
+  it('type inference is preserved with constraint methods', () => {
+    const col = d.text().min(1).max(10);
+    type _t1 = Expect<Equal<InferColumnType<typeof col>, string>>;
+
+    const col2 = d.integer().min(0).max(100);
+    type _t2 = Expect<Equal<InferColumnType<typeof col2>, number>>;
+
+    const col3 = d.text().min(1).nullable();
+    type _t3 = Expect<Equal<InferColumnType<typeof col3>, string | null>>;
+  });
+});
+
 describe('metadata type-level tracking', () => {
   it('.primary() sets primary to true in metadata type', () => {
     const col = d.uuid().primary();

--- a/packages/db/src/schema/__tests__/column.test.ts
+++ b/packages/db/src/schema/__tests__/column.test.ts
@@ -208,6 +208,100 @@ describe('d.tenant() removed', () => {
   });
 });
 
+describe('string validation constraints', () => {
+  it('.min(n) stores _minLength in metadata', () => {
+    const col = d.text().min(3);
+    expect(col._meta._minLength).toBe(3);
+  });
+
+  it('.max(n) stores _maxLength in metadata', () => {
+    const col = d.text().max(100);
+    expect(col._meta._maxLength).toBe(100);
+  });
+
+  it('.regex(pattern) stores _regex in metadata', () => {
+    const col = d.text().regex(/^[A-Z]+$/);
+    expect(col._meta._regex).toEqual(/^[A-Z]+$/);
+  });
+
+  it('chaining min, max, regex preserves all constraint metadata', () => {
+    const col = d
+      .text()
+      .min(1)
+      .max(5)
+      .regex(/^[A-Z0-9]+$/i);
+    expect(col._meta._minLength).toBe(1);
+    expect(col._meta._maxLength).toBe(5);
+    expect(col._meta._regex).toEqual(/^[A-Z0-9]+$/i);
+  });
+
+  it('constraints survive chaining with standard builders', () => {
+    const col = d.text().min(1).max(10).unique().nullable();
+    expect(col._meta._minLength).toBe(1);
+    expect(col._meta._maxLength).toBe(10);
+    expect(col._meta.unique).toBe(true);
+    expect(col._meta.nullable).toBe(true);
+  });
+
+  it('d.varchar() supports .min()', () => {
+    const col = d.varchar(255).min(1);
+    expect(col._meta._minLength).toBe(1);
+    expect(col._meta.length).toBe(255);
+  });
+
+  it('d.email() supports .min() and .max()', () => {
+    const col = d.email().min(5).max(255);
+    expect(col._meta._minLength).toBe(5);
+    expect(col._meta._maxLength).toBe(255);
+    expect(col._meta.format).toBe('email');
+  });
+
+  it('constraint builders are immutable (do not mutate original)', () => {
+    const original = d.text();
+    const withMin = original.min(3);
+    expect(original._meta._minLength).toBeUndefined();
+    expect(withMin._meta._minLength).toBe(3);
+  });
+});
+
+describe('numeric validation constraints', () => {
+  it('.min(n) stores _minValue in metadata', () => {
+    const col = d.integer().min(0);
+    expect(col._meta._minValue).toBe(0);
+  });
+
+  it('.max(n) stores _maxValue in metadata', () => {
+    const col = d.integer().max(100);
+    expect(col._meta._maxValue).toBe(100);
+  });
+
+  it('chaining min and max preserves both', () => {
+    const col = d.integer().min(0).max(100);
+    expect(col._meta._minValue).toBe(0);
+    expect(col._meta._maxValue).toBe(100);
+  });
+
+  it('d.real() supports .min() and .max()', () => {
+    const col = d.real().min(0).max(5);
+    expect(col._meta._minValue).toBe(0);
+    expect(col._meta._maxValue).toBe(5);
+  });
+
+  it('d.doublePrecision() supports .min() and .max()', () => {
+    const col = d.doublePrecision().min(-1).max(1);
+    expect(col._meta._minValue).toBe(-1);
+    expect(col._meta._maxValue).toBe(1);
+  });
+
+  it('constraints survive chaining with standard builders', () => {
+    const col = d.integer().min(0).max(100).unique().nullable();
+    expect(col._meta._minValue).toBe(0);
+    expect(col._meta._maxValue).toBe(100);
+    expect(col._meta.unique).toBe(true);
+    expect(col._meta.nullable).toBe(true);
+  });
+});
+
 describe('builder immutability', () => {
   it('chainable builders return new instances (do not mutate original)', () => {
     const original = d.text();

--- a/packages/db/src/schema/column.ts
+++ b/packages/db/src/schema/column.ts
@@ -21,6 +21,13 @@ export interface ColumnMetadata {
   readonly enumValues?: readonly string[];
   readonly validator?: JsonbValidator<unknown>;
   readonly generate?: 'cuid' | 'uuid' | 'nanoid';
+
+  // Application-level validation constraints (not stored in migration snapshots)
+  readonly _minLength?: number;
+  readonly _maxLength?: number;
+  readonly _regex?: RegExp;
+  readonly _minValue?: number;
+  readonly _maxValue?: number;
 }
 
 /** Phantom symbol to carry the TypeScript type without a runtime value. */
@@ -65,6 +72,114 @@ export interface ColumnBuilder<TType, TMeta extends ColumnMetadata = ColumnMetad
     }
   >;
   check(sql: string): ColumnBuilder<TType, Omit<TMeta, 'check'> & { readonly check: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Specialized column builders with validation constraint methods
+// ---------------------------------------------------------------------------
+
+/** String column builder — adds .min(), .max(), .regex() for string-type columns. */
+export interface StringColumnBuilder<TType, TMeta extends ColumnMetadata = ColumnMetadata>
+  extends ColumnBuilder<TType, TMeta> {
+  min(n: number): StringColumnBuilder<TType, TMeta>;
+  max(n: number): StringColumnBuilder<TType, TMeta>;
+  regex(pattern: RegExp): StringColumnBuilder<TType, TMeta>;
+
+  // Redeclare base methods to preserve StringColumnBuilder return type through chaining
+  primary(options?: {
+    generate?: 'cuid' | 'uuid' | 'nanoid';
+    generated?: boolean;
+  }): StringColumnBuilder<
+    TType,
+    Omit<TMeta, 'primary' | 'hasDefault' | 'generate'> & {
+      readonly primary: true;
+      readonly hasDefault: true;
+      readonly generate?: 'cuid' | 'uuid' | 'nanoid';
+    }
+  >;
+  unique(): StringColumnBuilder<TType, Omit<TMeta, 'unique'> & { readonly unique: true }>;
+  nullable(): StringColumnBuilder<
+    TType | null,
+    Omit<TMeta, 'nullable'> & { readonly nullable: true }
+  >;
+  default(
+    value: TType | 'now',
+  ): StringColumnBuilder<
+    TType,
+    Omit<TMeta, 'hasDefault'> & { readonly hasDefault: true; readonly defaultValue: TType | 'now' }
+  >;
+  is<TFlag extends string>(
+    flag: TFlag,
+  ): StringColumnBuilder<
+    TType,
+    Omit<TMeta, '_annotations'> & {
+      readonly _annotations: TMeta['_annotations'] & { readonly [K in TFlag]: true };
+    }
+  >;
+  readOnly(): StringColumnBuilder<TType, Omit<TMeta, 'isReadOnly'> & { readonly isReadOnly: true }>;
+  autoUpdate(): StringColumnBuilder<
+    TType,
+    Omit<TMeta, 'isAutoUpdate' | 'isReadOnly' | 'hasDefault'> & {
+      readonly isAutoUpdate: true;
+      readonly isReadOnly: true;
+      readonly hasDefault: true;
+    }
+  >;
+  check(sql: string): StringColumnBuilder<TType, Omit<TMeta, 'check'> & { readonly check: string }>;
+}
+
+/** Numeric column builder — adds .min(), .max() for numeric-type columns. */
+export interface NumericColumnBuilder<TType, TMeta extends ColumnMetadata = ColumnMetadata>
+  extends ColumnBuilder<TType, TMeta> {
+  min(n: number): NumericColumnBuilder<TType, TMeta>;
+  max(n: number): NumericColumnBuilder<TType, TMeta>;
+
+  // Redeclare base methods to preserve NumericColumnBuilder return type through chaining
+  primary(options?: {
+    generate?: 'cuid' | 'uuid' | 'nanoid';
+    generated?: boolean;
+  }): NumericColumnBuilder<
+    TType,
+    Omit<TMeta, 'primary' | 'hasDefault' | 'generate'> & {
+      readonly primary: true;
+      readonly hasDefault: true;
+      readonly generate?: 'cuid' | 'uuid' | 'nanoid';
+    }
+  >;
+  unique(): NumericColumnBuilder<TType, Omit<TMeta, 'unique'> & { readonly unique: true }>;
+  nullable(): NumericColumnBuilder<
+    TType | null,
+    Omit<TMeta, 'nullable'> & { readonly nullable: true }
+  >;
+  default(
+    value: TType | 'now',
+  ): NumericColumnBuilder<
+    TType,
+    Omit<TMeta, 'hasDefault'> & { readonly hasDefault: true; readonly defaultValue: TType | 'now' }
+  >;
+  is<TFlag extends string>(
+    flag: TFlag,
+  ): NumericColumnBuilder<
+    TType,
+    Omit<TMeta, '_annotations'> & {
+      readonly _annotations: TMeta['_annotations'] & { readonly [K in TFlag]: true };
+    }
+  >;
+  readOnly(): NumericColumnBuilder<
+    TType,
+    Omit<TMeta, 'isReadOnly'> & { readonly isReadOnly: true }
+  >;
+  autoUpdate(): NumericColumnBuilder<
+    TType,
+    Omit<TMeta, 'isAutoUpdate' | 'isReadOnly' | 'hasDefault'> & {
+      readonly isAutoUpdate: true;
+      readonly isReadOnly: true;
+      readonly hasDefault: true;
+    }
+  >;
+  check(
+    sql: string,
+  ): NumericColumnBuilder<TType, Omit<TMeta, 'check'> & { readonly check: string }>;
 }
 
 export type InferColumnType<C> = C extends ColumnBuilder<infer T, ColumnMetadata> ? T : never;
@@ -113,15 +228,38 @@ export type FormatMeta<TSqlType extends string, TFormat extends string> = Defaul
   readonly format: TFormat;
 };
 
+/**
+ * Internal runtime shape for column builders. Includes constraint methods
+ * so TypeScript recognizes them inside the implementation. The public API uses
+ * StringColumnBuilder / NumericColumnBuilder / ColumnBuilder to scope visibility.
+ */
+interface ColumnBuilderImpl {
+  readonly _meta: ColumnMetadata;
+  primary(options?: {
+    generate?: 'cuid' | 'uuid' | 'nanoid';
+    generated?: boolean;
+  }): ColumnBuilderImpl;
+  unique(): ColumnBuilderImpl;
+  nullable(): ColumnBuilderImpl;
+  default(value: unknown): ColumnBuilderImpl;
+  is(flag: string): ColumnBuilderImpl;
+  readOnly(): ColumnBuilderImpl;
+  autoUpdate(): ColumnBuilderImpl;
+  check(sql: string): ColumnBuilderImpl;
+  min(n: number): ColumnBuilderImpl;
+  max(n: number): ColumnBuilderImpl;
+  regex(pattern: RegExp): ColumnBuilderImpl;
+}
+
 function cloneWith(
-  source: ColumnBuilder<unknown, ColumnMetadata>,
+  source: ColumnBuilderImpl,
   metaOverrides: Record<string, unknown>,
-): ColumnBuilder<unknown, ColumnMetadata> {
+): ColumnBuilderImpl {
   return createColumnWithMeta({ ...source._meta, ...metaOverrides });
 }
 
-function createColumnWithMeta(meta: ColumnMetadata): ColumnBuilder<unknown, ColumnMetadata> {
-  const col: ColumnBuilder<unknown, ColumnMetadata> = {
+function createColumnWithMeta(meta: ColumnMetadata): ColumnBuilderImpl {
+  const col: ColumnBuilderImpl = {
     _meta: meta,
     primary(options?: { generate?: 'cuid' | 'uuid' | 'nanoid'; generated?: boolean }) {
       const meta: Record<string, unknown> = { primary: true, hasDefault: true };
@@ -130,47 +268,54 @@ function createColumnWithMeta(meta: ColumnMetadata): ColumnBuilder<unknown, Colu
       } else if (this._meta.sqlType === 'uuid' && options?.generated !== false) {
         meta.generate = 'uuid';
       }
-      return cloneWith(this, meta) as ReturnType<ColumnBuilder<unknown, ColumnMetadata>['primary']>;
+      return cloneWith(this, meta);
     },
     unique() {
-      return cloneWith(this, { unique: true }) as ReturnType<
-        ColumnBuilder<unknown, ColumnMetadata>['unique']
-      >;
+      return cloneWith(this, { unique: true });
     },
     nullable() {
-      return cloneWith(this, { nullable: true }) as ReturnType<
-        ColumnBuilder<unknown, ColumnMetadata>['nullable']
-      >;
+      return cloneWith(this, { nullable: true });
     },
     default(value: unknown) {
-      return cloneWith(this, { hasDefault: true, defaultValue: value }) as ReturnType<
-        ColumnBuilder<unknown, ColumnMetadata>['default']
-      >;
+      return cloneWith(this, { hasDefault: true, defaultValue: value });
     },
     is(flag: string) {
       return createColumnWithMeta({
         ...this._meta,
         _annotations: { ...this._meta._annotations, [flag]: true as const },
-      }) as ReturnType<ColumnBuilder<unknown, ColumnMetadata>['is']>;
+      });
     },
     readOnly() {
-      return cloneWith(this, { isReadOnly: true }) as ReturnType<
-        ColumnBuilder<unknown, ColumnMetadata>['readOnly']
-      >;
+      return cloneWith(this, { isReadOnly: true });
     },
     autoUpdate() {
       return cloneWith(this, {
         isAutoUpdate: true,
         isReadOnly: true,
         hasDefault: true,
-      }) as ReturnType<ColumnBuilder<unknown, ColumnMetadata>['autoUpdate']>;
+      });
     },
     check(sql: string) {
-      return cloneWith(this, { check: sql }) as ReturnType<
-        ColumnBuilder<unknown, ColumnMetadata>['check']
-      >;
+      return cloneWith(this, { check: sql });
     },
-  } as ColumnBuilder<unknown, ColumnMetadata>;
+    min(n: number) {
+      const sqlType = this._meta.sqlType;
+      if (sqlType === 'text' || sqlType === 'varchar') {
+        return cloneWith(this, { _minLength: n });
+      }
+      return cloneWith(this, { _minValue: n });
+    },
+    max(n: number) {
+      const sqlType = this._meta.sqlType;
+      if (sqlType === 'text' || sqlType === 'varchar') {
+        return cloneWith(this, { _maxLength: n });
+      }
+      return cloneWith(this, { _maxValue: n });
+    },
+    regex(pattern: RegExp) {
+      return cloneWith(this, { _regex: pattern });
+    },
+  };
   return col;
 }
 
@@ -195,7 +340,7 @@ export function createColumn<TType, TMeta extends ColumnMetadata>(
   return createColumnWithMeta({
     ...defaultMeta(sqlType),
     ...extra,
-  }) as ColumnBuilder<TType, TMeta>;
+  }) as unknown as ColumnBuilder<TType, TMeta>;
 }
 
 export type SerialMeta = {
@@ -221,5 +366,5 @@ export function createSerialColumn(): ColumnBuilder<number, SerialMeta> {
     isReadOnly: false,
     isAutoUpdate: false,
     check: null,
-  }) as ColumnBuilder<number, SerialMeta>;
+  }) as unknown as ColumnBuilder<number, SerialMeta>;
 }

--- a/plans/db-column-validation-constraints.md
+++ b/plans/db-column-validation-constraints.md
@@ -1,0 +1,402 @@
+# Design Doc: Column-Level Validation Constraints in `@vertz/db`
+
+**Status:** Approved (post-review v2)
+**Author:** claude
+**Feature:** Column-level validation constraints [#1470]
+**Related:** #1450 (SDK-generated schemas for forms), #1449 (client codegen integration)
+
+---
+
+## 1. API Surface
+
+### 1.1 String constraint methods on `d.text()`, `d.varchar()`, and `d.email()`
+
+```ts
+const projects = d.table('projects', {
+  key: d.text().min(1).max(5).regex(/^[A-Z0-9]+$/i),
+  title: d.text().min(1),
+  description: d.text().nullable(),
+  slug: d.text().min(3).max(50).regex(/^[a-z0-9-]+$/),
+  contactEmail: d.email().min(5).max(255),
+});
+```
+
+New chainable methods on string columns (`text`, `varchar`, `email`):
+
+```ts
+.min(n: number)          // Minimum string length
+.max(n: number)          // Maximum string length
+.regex(pattern: RegExp)  // Must match regular expression
+```
+
+`d.varchar(n)` already carries an implicit `max(n)` via the `length` metadata. An explicit `.max()` overrides the semantic constraint for validation — the `length` stays for SQL DDL, but `.max()` controls the `@vertz/schema` validator. If `.max()` is not called on a `varchar`, the existing `length` is used for validation (current behavior, preserved).
+
+**Guidance:** Use `.min()` / `.max()` / `.regex()` for application-level validation (API + SDK + forms). Use `.check(sql)` for database-level enforcement.
+
+### 1.2 Numeric constraint methods on `d.integer()`, `d.real()`, `d.doublePrecision()`, `d.serial()`
+
+```ts
+const metrics = d.table('metrics', {
+  score: d.integer().min(0).max(100),
+  rating: d.real().min(0).max(5),
+  priority: d.integer().min(0).max(4),
+});
+```
+
+New chainable methods on numeric columns:
+
+```ts
+.min(n: number)     // Minimum value (inclusive, maps to gte)
+.max(n: number)     // Maximum value (inclusive, maps to lte)
+```
+
+**Excluded types:** `d.decimal()` (TS type is `string` — use `.check(sql)` or manual schema for decimal validation) and `d.bigint()` (TS type is `bigint`, not `number` — type mismatch with `@vertz/schema` NumberSchema). These may be added in a follow-up.
+
+### 1.3 Type-safe constraint scoping
+
+Constraints are scoped to the column types they make sense for. You cannot call `.regex()` on an integer column or `.min()` with different semantics across types:
+
+```ts
+d.text().min(3)          // ✓ min string length = 3
+d.text().regex(/^[A-Z]/) // ✓ must match pattern
+d.email().min(5)         // ✓ min email length = 5
+d.integer().min(0)       // ✓ value >= 0
+d.integer().max(100)     // ✓ value <= 100
+
+// These should NOT compile:
+d.integer().regex(/abc/) // ✗ regex is string-only
+d.boolean().min(1)       // ✗ min makes no sense on boolean
+d.timestamp().max(5)     // ✗ max makes no sense on timestamp
+```
+
+This is achieved by adding the constraint methods only to `StringColumnBuilder` and `NumericColumnBuilder` sub-interfaces, not to the base `ColumnBuilder`.
+
+**Type-chaining strategy:** At the runtime level, ALL column builders have `min()`, `max()`, `regex()` methods (they just set metadata). At the type level, only `StringColumnBuilder` and `NumericColumnBuilder` expose them. Each sub-interface redeclares the base chainable methods (`.unique()`, `.nullable()`, `.default()`, etc.) to return the specialized type, ensuring constraint methods survive chaining in any order: `d.text().min(1).unique().max(5)` compiles correctly.
+
+### 1.4 Full example — Linear clone before/after
+
+**Before (manual schemas):**
+
+```ts
+// schema.ts
+const projects = d.table('projects', {
+  id: d.uuid().primary({ generate: 'uuid' }),
+  name: d.text(),
+  key: d.text().unique(),
+  // ...
+});
+
+// create-project-dialog.tsx — manual schema
+const createProjectSchema = createProjectsInputSchema.extend({
+  key: s.string().min(1).max(5).regex(/^[A-Z0-9]+$/i),
+});
+```
+
+**After (constraints on DB schema, no manual schemas):**
+
+```ts
+// schema.ts — single source of truth
+const projects = d.table('projects', {
+  id: d.uuid().primary({ generate: 'uuid' }),
+  name: d.text().min(1),
+  key: d.text().min(1).max(5).regex(/^[A-Z0-9]+$/i).unique(),
+  // ...
+});
+
+// create-project-dialog.tsx — uses generated schema directly
+const taskForm = form(projectsApi.create);
+// No manual schema needed. Change max(5) to max(8)?
+// One place. Enforced everywhere.
+```
+
+---
+
+## 2. Manifesto Alignment
+
+### Principles addressed
+
+1. **"If it builds, it works"** — Validation constraints are defined once at the schema layer and enforced everywhere (API, SDK, UI). No mismatch between manual schemas and DB definitions.
+
+2. **"One way to do things"** — Today there are two sources of validation truth: the DB schema (type + nullable + default) and manual Zod schemas (min/max/regex). This change collapses them into one: the DB schema IS the validation source.
+
+3. **"AI agents are first-class users"** — An LLM defining a table with `d.text().min(1).max(5).regex(...)` gets validation for free. No need to discover and maintain a separate schema file.
+
+4. **"No ceilings"** — Rather than accepting that DB schemas can't carry validation metadata, we extend them.
+
+### Tradeoffs
+
+- **Convention over configuration:** We're being opinionated that validation belongs at the schema layer, not scattered across form components. This is the right call — it's the single source of truth principle.
+
+- **Explicit over implicit:** Constraints are explicitly declared on each column. No magic defaults (except existing `varchar(n)` → `max(n)` which is preserved).
+
+---
+
+## 3. Non-Goals
+
+- **SQL-level CHECK constraints from validation metadata.** The `.min()`, `.max()`, `.regex()` methods are for application-level validation only. They do NOT generate SQL `CHECK` constraints. The existing `.check(sql)` method remains for SQL-level constraints. Rationale: regex patterns are not portable across SQL dialects, and application-level validation gives better error messages.
+
+- **String transformations (`.trim()`, `.toLowerCase()`).** These are `@vertz/schema` runtime transforms, not declarative constraints. They don't belong on the DB schema definition. Users can apply them in custom schemas or middleware.
+
+- **Cross-field validation.** Constraints like "endDate must be after startDate" require cross-field context. This is out of scope — use custom action validation for that.
+
+- **Array element constraints.** `d.textArray().min(1)` (minimum array length) or element-level constraints are deferred. Current scope is scalar columns only.
+
+- **Custom error messages on DB constraints.** The `@vertz/schema` methods support custom messages (`s.string().min(1, 'Required')`). DB-level constraints use framework default messages. Custom messages can be added via `.extend()` on generated schemas if needed. Tracked as a potential follow-up.
+
+- **`d.decimal()` and `d.bigint()` constraints.** `decimal` has TS type `string` (can't map to NumberSchema), `bigint` has type mismatch with NumberSchema. Deferred to follow-up if needed.
+
+---
+
+## 4. Unknowns
+
+1. **Regex serialization in codegen.** `RegExp` objects need to be serialized to source code strings for the codegen output. `regex.toString()` produces `/pattern/flags` which is valid JS. **Resolution:** Use `RegExp.prototype.toString()` directly in codegen output. Verified: `new RegExp(/^[A-Z]+$/i).toString()` → `"/^[A-Z]+$/i"`.
+
+2. **Regex in migration snapshots.** Should `ColumnSnapshot` store regex patterns? **Resolution:** No. Validation constraints are application-level only — they don't affect the database schema or migrations. `ColumnSnapshot` is unchanged.
+
+3. **Codegen constraint extraction.** The compiler uses ts-morph static analysis which cannot extract runtime `ColumnMetadata` values (like `_minLength: 1`). **Resolution:** Deferred to a follow-up issue. This PR delivers Phase 1 (server-side validation via `tableToSchemas()`) which is independently valuable. Phase 2 (codegen) requires either: (a) a runtime evaluation pass in the codegen pipeline, (b) encoding constraints at the type level, or (c) a separate metadata extraction step. This needs its own design doc.
+
+---
+
+## 5. Type Flow Map
+
+```
+d.text().min(1).max(5).regex(/^[A-Z]+$/)
+  │
+  ▼
+StringColumnBuilder<string, DefaultMeta<'text'>>
+  │  (constraint methods return StringColumnBuilder —
+  │   constraints are stored in metadata, not in the type parameter)
+  ▼
+ColumnMetadata { sqlType: 'text', _minLength: 1, _maxLength: 5, _regex: /^[A-Z]+$/ }
+  │
+  └──▶ columnToSchema(meta)  →  s.string().min(1).max(5).regex(/^[A-Z]+$/)
+        └──▶ tableToSchemas(table)  →  DerivedSchemas { createBody, updateBody, responseSchema }
+              └──▶ Entity layer (API validation at runtime)
+
+
+d.integer().min(0).max(100)
+  │
+  ▼
+NumericColumnBuilder<number, DefaultMeta<'integer'>>
+  │
+  ▼
+ColumnMetadata { sqlType: 'integer', _minValue: 0, _maxValue: 100 }
+  │
+  └──▶ columnToSchema(meta)  →  s.number().int().min(0).max(100)
+        └──▶ tableToSchemas(table)  →  DerivedSchemas { ... }
+```
+
+### Dead generic check
+
+- `ColumnBuilder<TType, TMeta>` — `TType` flows to `InferColumnType<C>` for table type inference. Unchanged.
+- `TMeta` flows to `_meta` property for runtime metadata access. Constraint fields are added to `ColumnMetadata` interface. `TMeta` already carries concrete metadata — no new generics.
+- No new generics introduced. Constraints are metadata values, not type parameters.
+
+---
+
+## 6. E2E Acceptance Test
+
+```typescript
+import { describe, it, expect } from 'bun:test';
+import { d } from '@vertz/db';
+import { tableToSchemas } from '@vertz/db/schema-derive';
+
+describe('Feature: Column-level validation constraints', () => {
+  describe('Given a table with string constraints (min, max, regex)', () => {
+    const projects = d.table('projects', {
+      id: d.uuid().primary(),
+      key: d.text().min(1).max(5).regex(/^[A-Z0-9]+$/i),
+      title: d.text().min(1),
+      description: d.text().nullable(),
+    });
+
+    describe('When generating create schemas via tableToSchemas()', () => {
+      const { createBody } = tableToSchemas(projects);
+
+      it('Then rejects empty key (below min length)', () => {
+        const result = createBody.safeParse({ key: '', title: 'Test' });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then rejects key exceeding max length', () => {
+        const result = createBody.safeParse({ key: 'ABCDEF', title: 'Test' });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then rejects key not matching regex', () => {
+        const result = createBody.safeParse({ key: 'AB!', title: 'Test' });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then accepts valid key', () => {
+        const result = createBody.safeParse({ key: 'ABC', title: 'Test' });
+        expect(result.ok).toBe(true);
+      });
+
+      it('Then rejects empty title (below min length)', () => {
+        const result = createBody.safeParse({ key: 'ABC', title: '' });
+        expect(result.ok).toBe(false);
+      });
+    });
+  });
+
+  describe('Given a table with numeric constraints (min, max)', () => {
+    const metrics = d.table('metrics', {
+      id: d.uuid().primary(),
+      score: d.integer().min(0).max(100),
+      rating: d.real().min(0).max(5),
+    });
+
+    describe('When generating create schemas via tableToSchemas()', () => {
+      const { createBody } = tableToSchemas(metrics);
+
+      it('Then rejects score below min', () => {
+        const result = createBody.safeParse({ score: -1, rating: 3.0 });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then rejects score above max', () => {
+        const result = createBody.safeParse({ score: 101, rating: 3.0 });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then accepts score within range', () => {
+        const result = createBody.safeParse({ score: 50, rating: 3.0 });
+        expect(result.ok).toBe(true);
+      });
+
+      it('Then rejects rating below min', () => {
+        const result = createBody.safeParse({ score: 50, rating: -0.1 });
+        expect(result.ok).toBe(false);
+      });
+
+      it('Then rejects rating above max', () => {
+        const result = createBody.safeParse({ score: 50, rating: 5.1 });
+        expect(result.ok).toBe(false);
+      });
+    });
+  });
+
+  describe('Given constraint metadata on columns', () => {
+    it('Then min/max/regex are stored in column metadata', () => {
+      const col = d.text().min(1).max(5).regex(/^[A-Z]+$/);
+      expect(col._meta._minLength).toBe(1);
+      expect(col._meta._maxLength).toBe(5);
+      expect(col._meta._regex).toEqual(/^[A-Z]+$/);
+    });
+
+    it('Then numeric min/max are stored in column metadata', () => {
+      const col = d.integer().min(0).max(100);
+      expect(col._meta._minValue).toBe(0);
+      expect(col._meta._maxValue).toBe(100);
+    });
+
+    it('Then constraints survive chaining with other builders', () => {
+      const col = d.text().min(1).max(10).unique().nullable();
+      expect(col._meta._minLength).toBe(1);
+      expect(col._meta._maxLength).toBe(10);
+      expect(col._meta.unique).toBe(true);
+      expect(col._meta.nullable).toBe(true);
+    });
+  });
+
+  // Type-level tests
+  describe('Given type-safety constraints', () => {
+    it('Then d.text() accepts .min(), .max(), .regex()', () => {
+      d.text().min(1);
+      d.text().max(100);
+      d.text().regex(/^[a-z]+$/);
+      d.text().min(1).max(10).regex(/abc/);
+    });
+
+    it('Then d.email() accepts .min(), .max()', () => {
+      d.email().min(5).max(255);
+    });
+
+    it('Then d.integer() accepts .min(), .max()', () => {
+      d.integer().min(0);
+      d.integer().max(100);
+      d.integer().min(0).max(100);
+    });
+
+    it('Then d.boolean() does NOT accept .min() or .regex()', () => {
+      // @ts-expect-error — boolean has no min
+      d.boolean().min(1);
+      // @ts-expect-error — boolean has no regex
+      d.boolean().regex(/abc/);
+    });
+
+    it('Then d.integer() does NOT accept .regex()', () => {
+      // @ts-expect-error — integer has no regex
+      d.integer().regex(/abc/);
+    });
+
+    it('Then constraint methods survive chaining with base methods', () => {
+      // Must compile — constraint methods available after .unique()
+      d.text().min(1).unique().max(5);
+      d.integer().min(0).unique().max(100);
+    });
+  });
+});
+```
+
+---
+
+## 7. Implementation Plan
+
+### Phase 1: Column metadata + builder methods + type scoping + schema derivation
+
+**Scope:** Add constraint fields to `ColumnMetadata`, constraint methods to column builders with type-safe scoping via `StringColumnBuilder`/`NumericColumnBuilder`, and wire `columnToSchema()` to apply them.
+
+**Files changed:**
+- `packages/db/src/schema/column.ts` — Add `_minLength`, `_maxLength`, `_regex`, `_minValue`, `_maxValue` to `ColumnMetadata`. Add `StringColumnBuilder` and `NumericColumnBuilder` interfaces. Add `min()`, `max()`, `regex()` to runtime `createColumnWithMeta`.
+- `packages/db/src/d.ts` — Update factory function return types to use `StringColumnBuilder` / `NumericColumnBuilder`.
+- `packages/db/src/schema-derive/column-mapper.ts` — Update `columnToSchema()` to apply constraints from metadata.
+
+**Acceptance criteria:** See E2E Acceptance Test above.
+
+### Phase 2: Codegen constraint flow (separate issue)
+
+Deferred. Requires design for how to extract runtime `ColumnMetadata` constraint values in the codegen pipeline (which uses ts-morph static analysis). See Unknown #3.
+
+### Phase 3: Linear clone migration (separate issue)
+
+Deferred. Depends on Phase 2 for full end-to-end value.
+
+---
+
+## 8. Metadata Design
+
+### New fields on `ColumnMetadata`
+
+```ts
+export interface ColumnMetadata {
+  // ... existing fields ...
+
+  // String constraints (text, varchar, email)
+  readonly _minLength?: number;
+  readonly _maxLength?: number;
+  readonly _regex?: RegExp;
+
+  // Numeric constraints (integer, real, doublePrecision, serial)
+  readonly _minValue?: number;
+  readonly _maxValue?: number;
+}
+```
+
+Field names are prefixed with `_` to distinguish them from SQL-level metadata (`length`, `precision`, `scale`) and to indicate they are application-level validation constraints, not database constraints.
+
+### Why separate from `length`?
+
+`varchar(255)` has `length: 255` which controls SQL DDL generation. `_maxLength` controls validation schema generation. For varchar, if `_maxLength` is not set, `length` is used as the fallback (preserving current behavior). This keeps the two concerns cleanly separated while maintaining backward compatibility.
+
+### Migration snapshots — no changes
+
+Validation constraints are NOT stored in `ColumnSnapshot` or `SchemaSnapshot`. They don't affect database structure — only application-level validation. This means:
+- No migration generation for constraint changes
+- No snapshot version bump
+- Adding/removing constraints doesn't trigger a migration diff
+
+### Codegen staleness note
+
+Changing constraints requires re-running codegen to update client-side validation schemas (once Phase 2/codegen is implemented). This is the same class of staleness issue as any codegen output — not unique to this feature.


### PR DESCRIPTION
## Summary

- Add `.min()`, `.max()`, `.regex()` chainable methods to `@vertz/db` column builders so validation constraints can be defined directly on the DB schema
- `StringColumnBuilder` (text, varchar, email): `.min()`, `.max()`, `.regex()`
- `NumericColumnBuilder` (integer, real, doublePrecision, serial): `.min()`, `.max()`
- Type-safe scoping prevents nonsensical constraints at compile time (e.g., `d.boolean().min(1)` is a type error)
- Constraints flow through `columnToSchema()` → `tableToSchemas()` → `@vertz/schema` validators for automatic API-level validation
- Constraints are application-level only — no migration/DDL impact

## Public API Changes

### New methods on string columns
```ts
d.text().min(1).max(5).regex(/^[A-Z0-9]+$/i)
d.varchar(255).min(1)
d.email().min(5).max(255)
```

### New methods on numeric columns
```ts
d.integer().min(0).max(100)
d.real().min(0).max(5)
```

### New exported types
- `StringColumnBuilder<TType, TMeta>` — extends `ColumnBuilder` with string constraint methods
- `NumericColumnBuilder<TType, TMeta>` — extends `ColumnBuilder` with numeric constraint methods

### Breaking changes
- `d.text()`, `d.varchar()`, `d.email()` now return `StringColumnBuilder` instead of `ColumnBuilder` (extends it, so existing code compiles)
- `d.integer()`, `d.real()`, `d.doublePrecision()`, `d.serial()` now return `NumericColumnBuilder` instead of `ColumnBuilder` (extends it, so existing code compiles)

## Design doc

`plans/db-column-validation-constraints.md` — includes API surface, manifesto alignment, non-goals, type flow map, and implementation plan.

## Deferred to follow-up issues

- **Codegen constraint flow** — flowing constraints through the compiler/codegen pipeline to generated SDK schemas (requires design for extracting runtime metadata in static analysis)
- **Linear clone migration** — updating the Linear clone to use DB-level constraints and remove manual schemas

Fixes #1470

## Test plan

- [x] String constraint metadata storage (min, max, regex)
- [x] Numeric constraint metadata storage (min, max)
- [x] Constraints survive chaining with standard builders (unique, nullable, etc.)
- [x] Builder immutability — original column not mutated
- [x] columnToSchema() applies string constraints (min length, max length, regex)
- [x] columnToSchema() applies numeric constraints (min value, max value)
- [x] tableToSchemas() end-to-end with string constraints
- [x] tableToSchemas() end-to-end with numeric constraints
- [x] Email column with constraints flows through tableToSchemas()
- [x] Varchar with explicit .max() overrides length for validation
- [x] Type-level: string columns accept .min(), .max(), .regex()
- [x] Type-level: numeric columns accept .min(), .max()
- [x] Type-level: boolean/timestamp/uuid reject .min() (compile error)
- [x] Type-level: integer rejects .regex() (compile error)
- [x] Type-level: constraint methods survive chaining with base methods
- [x] Type-level: type inference preserved through constraint chaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)