### PR TITLE
refactor(linear): prototype activeForm pattern for create/edit forms

### DIFF
--- a/examples/linear/src/components/manage-labels-dialog.tsx
+++ b/examples/linear/src/components/manage-labels-dialog.tsx
@@ -1,3 +1,4 @@
+import { s } from '@vertz/schema';
 import type { DialogHandle } from '@vertz/ui';
 import { css, form, query } from '@vertz/ui';
 import { Button } from '@vertz/ui/components';
@@ -48,20 +49,38 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
   let isCreating = false;
   let selectedColor = LABEL_COLORS[0].value;
 
-  const createForm = form(api.labels.create, {
-    initial: { projectId, name: '', color: LABEL_COLORS[0].value },
-    onSuccess: () => {
-      isCreating = false;
-      editingLabel = null;
-      selectedColor = LABEL_COLORS[0].value;
-    },
-  });
+  // --- Two form() instances: one for create, one for update ---
 
-  const resetForm = () => {
+  const resetState = () => {
     editingLabel = null;
     isCreating = false;
     selectedColor = LABEL_COLORS[0].value;
   };
+
+  const createForm = form(api.labels.create, {
+    initial: { projectId, name: '', color: LABEL_COLORS[0].value },
+    onSuccess: resetState,
+  });
+
+  // Bind the update SDK method: form() expects (body) => ..., but api.labels.update
+  // takes (id, body). We wrap it so the id is read from editingLabel at submission time.
+  const boundUpdate = Object.assign(
+    (body: { name: string; color: string }) => api.labels.update(editingLabel?.id ?? '', body),
+    { url: api.labels.update.url, method: api.labels.update.method },
+  );
+
+  const updateForm = form(boundUpdate, {
+    schema: s.object({ name: s.string().min(1), color: s.string().min(1) }),
+    initial: () => ({
+      name: editingLabel?.name ?? '',
+      color: editingLabel?.color ?? LABEL_COLORS[0].value,
+    }),
+    onSuccess: resetState,
+  });
+
+  // Reactive: compiler wraps this as computed() since it reads editingLabel (a signal).
+  // The <form> tag binds to whichever form is active — action, method, onSubmit all swap.
+  const activeForm = editingLabel ? updateForm : createForm;
 
   const handleDelete = async (labelId: string) => {
     await api.labels.delete(labelId);
@@ -74,17 +93,8 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
   };
 
   const startCreate = () => {
-    resetForm();
+    resetState();
     isCreating = true;
-  };
-
-  const handleUpdate = async () => {
-    if (!editingLabel) return;
-    const nameInput = document.querySelector<HTMLInputElement>('#label-name');
-    const name = nameInput?.value?.trim();
-    if (!name) return;
-    await api.labels.update(editingLabel.id, { name, color: selectedColor });
-    resetForm();
   };
 
   return (
@@ -129,14 +139,14 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
           ))}
         </div>
 
-        {isCreating && !editingLabel && (
+        {isCreating && (
           <form
-            action={createForm.action}
-            method={createForm.method}
-            onSubmit={createForm.onSubmit}
+            action={activeForm.action}
+            method={activeForm.method}
+            onSubmit={activeForm.onSubmit}
             className={styles.formContainer}
           >
-            <input type="hidden" name="projectId" value={projectId} />
+            {!editingLabel && <input type="hidden" name="projectId" value={projectId} />}
             <input type="hidden" name="color" value={selectedColor} />
             <div className={formStyles.field}>
               <label className={labelStyles.base} htmlFor="label-name">
@@ -148,8 +158,8 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
                 name="name"
                 placeholder="Label name"
               />
-              {createForm.name.error && (
-                <span className={formStyles.error}>{createForm.name.error}</span>
+              {activeForm.name.error && (
+                <span className={formStyles.error}>{activeForm.name.error}</span>
               )}
             </div>
             <div className={styles.colorGrid}>
@@ -167,57 +177,25 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
               ))}
             </div>
             <div className={dialogStyles.footer}>
-              <Button intent="outline" size="sm" onClick={resetForm}>
+              <Button intent="outline" size="sm" onClick={resetState}>
                 Cancel
               </Button>
               <Button
                 type="submit"
                 intent="primary"
                 size="sm"
-                disabled={createForm.submitting.value}
+                disabled={activeForm.submitting.value}
               >
-                {createForm.submitting ? 'Creating...' : 'Create'}
+                {editingLabel
+                  ? activeForm.submitting
+                    ? 'Updating...'
+                    : 'Update'
+                  : activeForm.submitting
+                    ? 'Creating...'
+                    : 'Create'}
               </Button>
             </div>
           </form>
-        )}
-
-        {isCreating && editingLabel && (
-          <div className={styles.formContainer}>
-            <div className={formStyles.field}>
-              <label className={labelStyles.base} htmlFor="label-name">
-                Name
-              </label>
-              <input
-                className={inputStyles.base}
-                id="label-name"
-                placeholder="Label name"
-                value={editingLabel.name}
-              />
-            </div>
-            <div className={styles.colorGrid}>
-              {LABEL_COLORS.map((c) => (
-                <button
-                  type="button"
-                  key={c.value}
-                  className={c.value === selectedColor ? styles.colorSelected : styles.colorButton}
-                  style={`background-color: ${c.value}`}
-                  aria-label={c.name}
-                  onClick={() => {
-                    selectedColor = c.value;
-                  }}
-                />
-              ))}
-            </div>
-            <div className={dialogStyles.footer}>
-              <Button intent="outline" size="sm" onClick={resetForm}>
-                Cancel
-              </Button>
-              <Button intent="primary" size="sm" onClick={handleUpdate}>
-                Update
-              </Button>
-            </div>
-          </div>
         )}
 
         <footer className={dialogStyles.footer}>


### PR DESCRIPTION
## Summary

- Replaces the imperative `handleUpdate()` + `document.querySelector` pattern with a second `form()` instance for label editing
- Both `createForm` and `updateForm` share a single `<form>` tag via a reactive `activeForm` ternary: `const activeForm = editingLabel ? updateForm : createForm`
- The compiler wraps `activeForm` as a `computed()` since it reads `editingLabel` (a signal), so `action`, `method`, and `onSubmit` swap reactively when toggling between create/edit mode
- Eliminates duplicated form UI — color grid, name input, and buttons appear once
- Net -22 lines (45 added, 67 removed)

## Pattern notes

This is a **prototype** of the "two forms, one `<form>` tag" pattern for combined create/edit UIs. Key observations:

1. **`boundUpdate` wrapper** — SDK update methods take `(id, body)` but `form()` expects `(body) => ...`. We wrap with `Object.assign` to preserve `.url`/`.method` and read the id from reactive state at submission time.
2. **Explicit `schema`** — The wrapped method loses `.meta`, so we provide a schema explicitly via `s.object(...)`.
3. **Shared field access** — `activeForm.name.error` works because both forms have `name` and `color` fields.
4. **Conditional hidden fields** — `projectId` is only rendered in create mode.

**Recommended convention**: For production code, prefer **separate `CreateDialog` / `EditDialog` components** — full type safety, no unions. This combined pattern is an escape hatch for cases like inline editing where splitting doesn't make sense.

## Public API Changes

None — this is an example app change only.

## Test plan

- [x] Lint passes (`biome check`)
- [x] Pre-existing tests still pass (39 pass, 2 pre-existing codegen failures)
- [x] No new typecheck errors introduced (pre-existing codegen errors remain)
- [ ] Manual test: create label via the form, edit label via the form, verify reactive form swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)