### PR TITLE
fix(theme-shadcn): hide dialog:not([open]) in globals to prevent SSR flash

### DIFF
--- a/.changeset/dialog-ssr-flash-fix.md
+++ b/.changeset/dialog-ssr-flash-fix.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Add global CSS rule to hide `dialog:not([open])` elements, preventing content flash during SSR-to-hydration transition

--- a/packages/theme-shadcn/src/__tests__/globals.test.ts
+++ b/packages/theme-shadcn/src/__tests__/globals.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { configureThemeBase } from '../base';
+
+describe('theme globals', () => {
+  it('hides dialog elements without open attribute to prevent SSR flash', () => {
+    const { globals } = configureThemeBase();
+    expect(globals.css).toContain('dialog:not([open])');
+    expect(globals.css).toContain('display: none');
+  });
+});

--- a/packages/theme-shadcn/src/base.ts
+++ b/packages/theme-shadcn/src/base.ts
@@ -93,6 +93,11 @@ export function configureThemeBase(config?: ThemeConfig): ResolvedThemeBase {
       color: 'var(--color-foreground)',
       backgroundColor: 'var(--color-background)',
     },
+    // Native <dialog> — hide when not [open] so component-level
+    // `display: grid` styles don't flash content during SSR-to-hydration.
+    'dialog:not([open])': {
+      display: 'none',
+    },
     // Native checkbox — styled to match shadcn design tokens so
     // <input type="checkbox"> looks correct without a custom component.
     'input[type="checkbox"]': {


### PR DESCRIPTION
## Summary

- Add a global CSS rule `dialog:not([open]) { display: none }` to the theme globals to prevent dialog content from flashing during SSR-to-hydration transitions
- Component-level styles set `display: grid` on dialog panels, which overrides the browser UA `dialog:not([open])` rule. During SSR-to-hydration, this causes a brief flash of dialog content before the component CSS is fully parsed
- The global rule loads early (in the theme globals `<style>` tag) and prevents the flash

Fixes #1519

## Public API Changes

None — internal CSS change only.

## Test plan

- [x] New test in `packages/theme-shadcn/src/__tests__/globals.test.ts` verifies the global CSS contains `dialog:not([open])` with `display: none`
- [x] All existing theme-shadcn tests continue to pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)