### PR TITLE
fix(theme-shadcn): constrain popover/dropdown-menu content width #1521

### DIFF
--- a/.changeset/popover-dropdown-fit-content.md
+++ b/.changeset/popover-dropdown-fit-content.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Fix Popover and DropdownMenu content panels taking full width instead of fitting content

--- a/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
@@ -31,6 +31,10 @@ describe('popover', () => {
   it('CSS does not use display:none for animated states', () => {
     expect(popover.css).not.toContain('display: none');
   });
+
+  it('CSS constrains content width to fit-content', () => {
+    expect(popover.css).toContain('fit-content');
+  });
 });
 
 describe('alert-dialog', () => {
@@ -305,6 +309,12 @@ describe('dropdown-menu', () => {
     const dm = createDropdownMenuStyles();
     expect(dm.css).toContain('vz-zoom-in');
     expect(dm.css).toContain('vz-zoom-out');
+  });
+
+  it('CSS constrains content width to fit-content', () => {
+    const { createDropdownMenuStyles } = require('../styles/dropdown-menu');
+    const dm = createDropdownMenuStyles();
+    expect(dm.css).toContain('fit-content');
   });
 });
 

--- a/packages/theme-shadcn/src/styles/dropdown-menu.ts
+++ b/packages/theme-shadcn/src/styles/dropdown-menu.ts
@@ -19,6 +19,7 @@ export function createDropdownMenuStyles(): CSSOutput<DropdownMenuBlocks> {
       'bg:popover',
       'text:popover-foreground',
       'rounded:lg',
+      'w:fit',
       'p:1',
       // Nova: ring-1 ring-foreground/10 instead of border, shadow-md, min-w-32
       {

--- a/packages/theme-shadcn/src/styles/popover.ts
+++ b/packages/theme-shadcn/src/styles/popover.ts
@@ -15,6 +15,7 @@ export function createPopoverStyles(): CSSOutput<PopoverBlocks> {
       'bg:popover',
       'text:popover-foreground',
       'rounded:lg',
+      'w:fit',
       'flex',
       'flex-col',
       'gap:2.5',


### PR DESCRIPTION
## Summary

- Add `w:fit` (`width: fit-content`) to popover and dropdown-menu content styles so content panels size to their children instead of stretching to fill the parent container
- After the compound component rewrite (#1525), the content `<div>` is a block-level element that takes full width by default — this restores the expected contained behavior

## Public API Changes

None — internal CSS-only change. No API surface affected.

## Test plan

- [x] Added tests asserting `fit-content` appears in generated CSS for both popover and dropdown-menu content
- [x] All 467 theme-shadcn tests pass
- [x] Typecheck clean
- [x] Lint clean

Fixes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)