### PR TITLE
fix(ui-primitives): select click-outside dismiss, chevron SVG, floating dropdown

### DIFF
--- a/.changeset/select-dismiss-chevron-float.md
+++ b/.changeset/select-dismiss-chevron-float.md
@@ -1,0 +1,6 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+---
+
+Fix Select: click-outside dismiss, add chevron SVG icon, float dropdown over content

--- a/packages/theme-shadcn/src/styles/select.ts
+++ b/packages/theme-shadcn/src/styles/select.ts
@@ -53,6 +53,15 @@ export function createSelectStyles(): CSSOutput<SelectBlocks> {
       { '&:disabled': ['pointer-events-none', 'opacity:0.5'] },
       { '&[data-state="open"]': ['border:ring'] },
       { [DARK]: [bgOpacity('input', 30)] },
+      // Chevron icon — muted, no-shrink
+      {
+        '& [data-part="chevron"]': {
+          opacity: '0.5',
+          'flex-shrink': '0',
+          display: 'flex',
+          'align-items': 'center',
+        },
+      },
     ],
     selectContent: [
       'z:50',

--- a/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
+++ b/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
@@ -385,4 +385,108 @@ describe('Composed Select', () => {
       expect(separator).not.toBeNull();
     });
   });
+
+  describe('Given an open Select without explicit positioning (#1523)', () => {
+    describe('When a pointerdown event fires outside the Select', () => {
+      it('Then closes the dropdown', () => {
+        const root = ComposedSelect({
+          children: () => {
+            const t = ComposedSelect.Trigger({ children: ['Pick'] });
+            const c = ComposedSelect.Content({
+              children: () => [ComposedSelect.Item({ value: 'a', children: ['A'] })],
+            });
+            return [t, c];
+          },
+        });
+        container.appendChild(root);
+
+        // Open the select
+        const trigger = root.querySelector('[role="combobox"]') as HTMLElement;
+        trigger!.click();
+        expect(trigger!.getAttribute('aria-expanded')).toBe('true');
+
+        // Click outside
+        const outside = document.createElement('div');
+        document.body.appendChild(outside);
+        outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        outside.remove();
+
+        expect(trigger!.getAttribute('aria-expanded')).toBe('false');
+        const listbox = root.querySelector('[role="listbox"]') as HTMLElement;
+        expect(listbox!.style.display).toBe('none');
+      });
+    });
+
+    describe('When Escape is pressed while the content is focused', () => {
+      it('Then closes the dropdown', () => {
+        const root = ComposedSelect({
+          children: () => {
+            const t = ComposedSelect.Trigger({ children: ['Pick'] });
+            const c = ComposedSelect.Content({
+              children: () => [ComposedSelect.Item({ value: 'a', children: ['A'] })],
+            });
+            return [t, c];
+          },
+        });
+        container.appendChild(root);
+
+        // Open
+        const trigger = root.querySelector('[role="combobox"]') as HTMLElement;
+        trigger!.click();
+        expect(trigger!.getAttribute('aria-expanded')).toBe('true');
+
+        // Press Escape on the content
+        const listbox = root.querySelector('[role="listbox"]') as HTMLElement;
+        listbox!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+        expect(trigger!.getAttribute('aria-expanded')).toBe('false');
+      });
+    });
+  });
+
+  describe('Given a Select trigger (#1523)', () => {
+    it('Then the chevron element contains an SVG down-arrow icon', () => {
+      const root = ComposedSelect({
+        children: () => {
+          const t = ComposedSelect.Trigger({ children: ['Pick'] });
+          const c = ComposedSelect.Content({
+            children: () => [ComposedSelect.Item({ value: 'a', children: ['A'] })],
+          });
+          return [t, c];
+        },
+      });
+      container.appendChild(root);
+
+      const chevron = root.querySelector('[data-part="chevron"]') as HTMLElement;
+      expect(chevron).not.toBeNull();
+      const svg = chevron!.querySelector('svg');
+      expect(svg).not.toBeNull();
+    });
+  });
+
+  describe('Given an open Select without explicit positioning (#1523)', () => {
+    it('Then the content has fixed or absolute positioning to float over content', async () => {
+      const root = ComposedSelect({
+        children: () => {
+          const t = ComposedSelect.Trigger({ children: ['Pick'] });
+          const c = ComposedSelect.Content({
+            children: () => [ComposedSelect.Item({ value: 'a', children: ['A'] })],
+          });
+          return [t, c];
+        },
+      });
+      container.appendChild(root);
+
+      // Open the select
+      const trigger = root.querySelector('[role="combobox"]') as HTMLElement;
+      trigger!.click();
+
+      // Wait for computePosition to resolve (async floating-ui computation)
+      await Promise.resolve();
+
+      const listbox = root.querySelector('[role="listbox"]') as HTMLElement;
+      const pos = listbox!.style.position;
+      expect(pos === 'fixed' || pos === 'absolute').toBe(true);
+    });
+  });
 });

--- a/packages/ui-primitives/src/select/select-composed.tsx
+++ b/packages/ui-primitives/src/select/select-composed.tsx
@@ -107,7 +107,22 @@ function SelectTrigger({ children, className: cls, class: classProp }: SlotProps
       }}
     >
       {children ?? ctx.selectedValue()}
-      <span data-part="chevron" />
+      <span data-part="chevron">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </span>
     </button>
   );
 }
@@ -302,15 +317,21 @@ function ComposedSelectRoot({
     const triggerEl = getTriggerEl();
     if (!contentEl) return;
 
-    if (positioning && triggerEl) {
-      const result = createFloatingPosition(triggerEl, contentEl, positioning);
+    // Always set up floating positioning (defaults to bottom-start, fixed).
+    // Set position immediately to prevent layout shift before async computation.
+    contentEl.style.position = 'fixed';
+    if (triggerEl) {
+      const floatingOpts = positioning ?? {};
+      const result = createFloatingPosition(triggerEl, contentEl, floatingOpts);
       state.floatingCleanup = result.cleanup;
-      state.dismissCleanup = createDismiss({
-        onDismiss: close,
-        insideElements: [triggerEl, contentEl],
-        escapeKey: false,
-      });
     }
+
+    // Always set up dismiss (click-outside + Escape key).
+    const insideElements = [contentEl, ...(triggerEl ? [triggerEl] : [])];
+    state.dismissCleanup = createDismiss({
+      onDismiss: close,
+      insideElements,
+    });
 
     // Focus selected item or content
     const items = [...contentEl.querySelectorAll<HTMLElement>('[role="option"]')];
@@ -327,6 +348,14 @@ function ComposedSelectRoot({
     isOpen = false;
     syncTriggerAttrs(false);
     syncContentAttrs(false);
+
+    // Reset floating position styles
+    const contentEl = getContentEl();
+    if (contentEl) {
+      contentEl.style.position = '';
+      contentEl.style.left = '';
+      contentEl.style.top = '';
+    }
 
     state.floatingCleanup?.();
     state.floatingCleanup = null;


### PR DESCRIPTION
## Summary

Fixes three issues with the Select component after the compound component rewrite (#1523):

- **Click-outside dismiss**: `createDismiss()` was only set up when `positioning` prop was provided. Now always activated on open, regardless of positioning configuration.
- **Escape key dismiss**: Enabled document-level Escape handler via `createDismiss()` (previously `escapeKey: false`). Works alongside the content's own keydown listener.
- **Missing chevron SVG**: Added inline Lucide-style chevron-down SVG inside the trigger's `data-part="chevron"` span. Theme styles now include opacity and flex-shrink for the chevron.
- **Layout shift on open**: Always applies `position: fixed` immediately on open and sets up `createFloatingPosition()` with sensible defaults. Position styles are cleaned up on close.

## Public API Changes

None — all changes are internal behavior fixes. The `positioning` prop remains optional and still allows overriding floating options.

## Files Changed

- `packages/ui-primitives/src/select/select-composed.tsx` — core fixes
- `packages/ui-primitives/src/select/__tests__/select-composed.test.ts` — 4 new tests
- `packages/theme-shadcn/src/styles/select.ts` — chevron styling
- `.changeset/select-dismiss-chevron-float.md` — changeset

## Test plan

- [x] Click outside open Select closes dropdown (pointerdown event)
- [x] Escape key closes dropdown
- [x] Chevron span contains SVG element
- [x] Content has fixed positioning when open (no layout shift)
- [x] All 781 existing ui-primitives tests pass
- [x] All 465 theme-shadcn tests pass
- [x] Typecheck clean
- [x] Pre-push quality gates green

Fixes #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)