### PR TITLE
fix(ui-primitives): fix dialog close animation not playing with native <dialog>

### DIFF
--- a/.changeset/dialog-close-animation.md
+++ b/.changeset/dialog-close-animation.md
@@ -1,0 +1,6 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+---
+
+Fix dialog close animation not playing with native `<dialog>`. Reorder close logic to call hideDialog() before updating reactive state, force reflow to start CSS animation, prevent native close on Escape, and add ::backdrop fade-out animation.

--- a/packages/theme-shadcn/src/styles/alert-dialog.ts
+++ b/packages/theme-shadcn/src/styles/alert-dialog.ts
@@ -70,6 +70,12 @@ export function createAlertDialogStyles(): CSSOutput<AlertDialogBlocks> {
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
         },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 100ms ease-out forwards',
+        },
         '@media (min-width: 640px)': { 'max-width': '24rem' },
       },
       {

--- a/packages/theme-shadcn/src/styles/dialog.ts
+++ b/packages/theme-shadcn/src/styles/dialog.ts
@@ -72,6 +72,12 @@ export function createDialogStyles(): CSSOutput<DialogBlocks> {
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
         },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 100ms ease-out forwards',
+        },
         '@media (min-width: 640px)': { 'max-width': '24rem' },
       },
       {

--- a/packages/theme-shadcn/src/styles/sheet.ts
+++ b/packages/theme-shadcn/src/styles/sheet.ts
@@ -77,6 +77,12 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
         },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
+        },
       },
       {
         '&[data-state="open"]': [animationDecl('vz-slide-in-from-left 300ms ease-out forwards')],
@@ -103,6 +109,12 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
         },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
+        },
       },
       {
         '&[data-state="open"]': [animationDecl('vz-slide-in-from-right 300ms ease-out forwards')],
@@ -127,6 +139,12 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
         },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
+        },
       },
       {
         '&[data-state="open"]': [animationDecl('vz-slide-in-from-top 300ms ease-out forwards')],
@@ -150,6 +168,12 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           'background-color': 'oklch(0 0 0 / 10%)',
           'backdrop-filter': 'blur(4px)',
           '-webkit-backdrop-filter': 'blur(4px)',
+        },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 100ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
         },
       },
       {

--- a/packages/ui-primitives/src/alert-dialog/__tests__/alert-dialog-composed.test.ts
+++ b/packages/ui-primitives/src/alert-dialog/__tests__/alert-dialog-composed.test.ts
@@ -235,6 +235,29 @@ describe('Composed AlertDialog', () => {
     });
   });
 
+  describe('Given an open AlertDialog', () => {
+    describe('When close is triggered via Cancel button', () => {
+      it('Then sets data-state to closed but defers dialog.close() for animation', () => {
+        const { root, triggerBtn, cancelEl } = createAlertDialogTree();
+        container.appendChild(root);
+
+        triggerBtn.click();
+        const panel = getConnectedPanel(root);
+        expect(panel.open).toBe(true);
+
+        const closeSpy = vi.spyOn(panel, 'close');
+
+        cancelEl.click();
+
+        expect(panel.getAttribute('data-state')).toBe('closed');
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        panel.dispatchEvent(new Event('animationend'));
+        expect(closeSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('Given an AlertDialog.Trigger rendered outside AlertDialog', () => {
     describe('When the component mounts', () => {
       it('Then throws an error', () => {

--- a/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
+++ b/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
@@ -266,12 +266,15 @@ function ComposedAlertDialogRoot({
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
+    // Force reflow so the browser starts the CSS close animation
+    // before any subsequent reactive updates.
+    void el.offsetHeight;
     const onEnd = () => {
       el.removeEventListener('animationend', onEnd);
       if (el.open) el.close();
     };
     el.addEventListener('animationend', onEnd);
-    setTimeout(onEnd, 150);
+    setTimeout(onEnd, 200);
   }
 
   function open(): void {
@@ -281,8 +284,8 @@ function ComposedAlertDialogRoot({
   }
 
   function close(): void {
-    isOpen = false;
     hideDialog();
+    isOpen = false;
     onOpenChange?.(false);
   }
 

--- a/packages/ui-primitives/src/dialog/__tests__/dialog-composed.test.ts
+++ b/packages/ui-primitives/src/dialog/__tests__/dialog-composed.test.ts
@@ -225,6 +225,65 @@ describe('Composed Dialog', () => {
     });
   });
 
+  describe('Given an open dialog', () => {
+    describe('When close is triggered via Close button', () => {
+      it('Then sets data-state to closed but defers dialog.close() for animation', () => {
+        const { root, triggerBtn, closeEl } = createDialogTree();
+        container.appendChild(root);
+
+        triggerBtn.click();
+        const panel = getConnectedPanel(root);
+        expect(panel.open).toBe(true);
+        expect(panel.getAttribute('data-state')).toBe('open');
+
+        // Spy on dialog.close() to track when it's called
+        const closeSpy = vi.spyOn(panel, 'close');
+
+        closeEl.click();
+
+        // data-state should be "closed" immediately (triggers CSS animation)
+        expect(panel.getAttribute('data-state')).toBe('closed');
+
+        // But dialog.close() should NOT have been called yet — animation is pending
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        // Simulate animationend — browser fires this after the CSS animation completes
+        panel.dispatchEvent(new Event('animationend'));
+
+        // Now dialog.close() should have been called
+        expect(closeSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('When close is triggered via Escape key', () => {
+      it('Then prevents native close and defers dialog.close() for animation', () => {
+        const { root, triggerBtn } = createDialogTree();
+        container.appendChild(root);
+
+        triggerBtn.click();
+        const panel = getConnectedPanel(root);
+        expect(panel.open).toBe(true);
+
+        const closeSpy = vi.spyOn(panel, 'close');
+        const cancelEvent = new Event('cancel', { bubbles: true, cancelable: true });
+        panel.dispatchEvent(cancelEvent);
+
+        // Cancel event must be prevented to stop native close before animation
+        expect(cancelEvent.defaultPrevented).toBe(true);
+
+        // data-state should be "closed" immediately
+        expect(panel.getAttribute('data-state')).toBe('closed');
+
+        // dialog.close() should be deferred
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        // After animation ends, dialog closes
+        panel.dispatchEvent(new Event('animationend'));
+        expect(closeSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('Given a Dialog.Trigger rendered outside Dialog', () => {
     describe('When the component mounts', () => {
       it('Then throws an error', () => {

--- a/packages/ui-primitives/src/dialog/dialog-composed.tsx
+++ b/packages/ui-primitives/src/dialog/dialog-composed.tsx
@@ -140,9 +140,9 @@ function DialogContent({
       aria-describedby={ctx.descriptionId}
       data-state={ctx.isOpen ? 'open' : 'closed'}
       class={combined || undefined}
-      onCancel={() => {
-        // Browser closes the dialog natively on Escape.
-        // Sync our reactive state to match.
+      onCancel={(e: Event) => {
+        // Prevent native close so the CSS exit animation can play.
+        e.preventDefault();
         ctx.close();
       }}
       onClick={(e: MouseEvent) => {
@@ -278,12 +278,15 @@ function ComposedDialogRoot({ children, classes, onOpenChange }: ComposedDialogP
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
+    // Force reflow so the browser starts the CSS close animation
+    // before any subsequent reactive updates.
+    void el.offsetHeight;
     const onEnd = () => {
       el.removeEventListener('animationend', onEnd);
       if (el.open) el.close();
     };
     el.addEventListener('animationend', onEnd);
-    setTimeout(onEnd, 150);
+    setTimeout(onEnd, 200);
   }
 
   function open(): void {
@@ -293,8 +296,8 @@ function ComposedDialogRoot({ children, classes, onOpenChange }: ComposedDialogP
   }
 
   function close(): void {
-    isOpen = false;
     hideDialog();
+    isOpen = false;
     onOpenChange?.(false);
   }
 

--- a/packages/ui-primitives/src/sheet/__tests__/sheet-composed.test.ts
+++ b/packages/ui-primitives/src/sheet/__tests__/sheet-composed.test.ts
@@ -230,6 +230,51 @@ describe('Composed Sheet', () => {
     });
   });
 
+  describe('Given an open Sheet', () => {
+    describe('When close is triggered via Close button', () => {
+      it('Then sets data-state to closed but defers dialog.close() for animation', () => {
+        const { root, triggerBtn, closeEl } = createSheetTree();
+        container.appendChild(root);
+
+        triggerBtn.click();
+        const panel = getConnectedPanel(root);
+        expect(panel.open).toBe(true);
+
+        const closeSpy = vi.spyOn(panel, 'close');
+
+        closeEl.click();
+
+        expect(panel.getAttribute('data-state')).toBe('closed');
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        panel.dispatchEvent(new Event('animationend'));
+        expect(closeSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('When close is triggered via Escape key', () => {
+      it('Then prevents native close and defers dialog.close() for animation', () => {
+        const { root, triggerBtn } = createSheetTree();
+        container.appendChild(root);
+
+        triggerBtn.click();
+        const panel = getConnectedPanel(root);
+        expect(panel.open).toBe(true);
+
+        const closeSpy = vi.spyOn(panel, 'close');
+        const cancelEvent = new Event('cancel', { bubbles: true, cancelable: true });
+        panel.dispatchEvent(cancelEvent);
+
+        expect(cancelEvent.defaultPrevented).toBe(true);
+        expect(panel.getAttribute('data-state')).toBe('closed');
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        panel.dispatchEvent(new Event('animationend'));
+        expect(closeSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('Given a Sheet.Trigger rendered outside Sheet', () => {
     describe('When the component mounts', () => {
       it('Then throws an error', () => {

--- a/packages/ui-primitives/src/sheet/sheet-composed.tsx
+++ b/packages/ui-primitives/src/sheet/sheet-composed.tsx
@@ -126,7 +126,10 @@ function SheetContent({
       data-side={ctx.side}
       data-state={ctx.isOpen ? 'open' : 'closed'}
       class={combined || undefined}
-      onCancel={() => ctx.close()}
+      onCancel={(e: Event) => {
+        e.preventDefault();
+        ctx.close();
+      }}
       onClick={(e: MouseEvent) => {
         if (e.target === dialogRef.current) ctx.close();
       }}
@@ -243,12 +246,15 @@ function ComposedSheetRoot({
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
+    // Force reflow so the browser starts the CSS close animation
+    // before any subsequent reactive updates.
+    void el.offsetHeight;
     const onEnd = () => {
       el.removeEventListener('animationend', onEnd);
       if (el.open) el.close();
     };
     el.addEventListener('animationend', onEnd);
-    setTimeout(onEnd, 150);
+    setTimeout(onEnd, 350);
   }
 
   function open(): void {
@@ -258,8 +264,8 @@ function ComposedSheetRoot({
   }
 
   function close(): void {
-    isOpen = false;
     hideDialog();
+    isOpen = false;
     onOpenChange?.(false);
   }
 


### PR DESCRIPTION
## Summary

Fixes #1518 — Dialog close animation (fade-out/zoom-out) wasn't visibly playing after the compound component rewrite to native `<dialog>` + `showModal()`.

**Three root causes:**
1. `close()` updated reactive state (`isOpen = false`) before `hideDialog()`, so by the time `hideDialog()` ran, the browser had already batched the `data-state` attribute change without a reflow — the CSS animation never started. **Fix:** call `hideDialog()` before `isOpen = false`.
2. No forced reflow between `setAttribute('data-state', 'closed')` and the `animationend` listener, so the browser could optimize away the animation. **Fix:** `void el.offsetHeight` after `setAttribute`.
3. The JSX `onCancel` handler in Dialog and Sheet didn't call `preventDefault()`, allowing the browser to natively close the dialog (removing it from the top layer) before the exit animation could play. **Fix:** `e.preventDefault()` in all `onCancel` handlers.

**Also adds `::backdrop` fade-out animation** — the `::backdrop` pseudo-element now fades out in sync with the panel animation for Dialog, AlertDialog, and Sheet.

## Public API Changes

None — internal behavior fix only.

## Changed Files

- `packages/ui-primitives/src/dialog/dialog-composed.tsx` — reorder close(), force reflow, fix onCancel
- `packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx` — same fixes
- `packages/ui-primitives/src/sheet/sheet-composed.tsx` — same fixes
- `packages/theme-shadcn/src/styles/dialog.ts` — add `::backdrop` open/close animations
- `packages/theme-shadcn/src/styles/alert-dialog.ts` — add `::backdrop` open/close animations
- `packages/theme-shadcn/src/styles/sheet.ts` — add `::backdrop` open/close animations (all 4 sides)
- Tests for all three components verifying animation deferral behavior

## Test plan

- [x] Dialog: close via X button sets `data-state="closed"` and defers `dialog.close()` until `animationend`
- [x] Dialog: Escape key prevents native close and defers `dialog.close()` until animation
- [x] AlertDialog: close via Cancel button defers `dialog.close()` until `animationend`
- [x] Sheet: close via X button defers `dialog.close()` until `animationend`
- [x] Sheet: Escape key prevents native close and defers `dialog.close()` until animation
- [x] All 782 ui-primitives tests pass
- [x] All 465 theme-shadcn tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)