### PR TITLE
fix(ui-compiler): respect nested scope shadowing in signal/computed transforms #1520

### DIFF
--- a/.changeset/fix-callback-scope-shadowing.md
+++ b/.changeset/fix-callback-scope-shadowing.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-compiler': patch
+---
+
+Fix signal/computed transforms incorrectly adding .value to callback-local variables that shadow component-level names

--- a/packages/ui-compiler/src/transformers/__tests__/list-transformer.test.ts
+++ b/packages/ui-compiler/src/transformers/__tests__/list-transformer.test.ts
@@ -164,6 +164,81 @@ function App() {
     });
   });
 
+  describe('callback-local const shadowing component-level names', () => {
+    it('does not add .value to callback const that shadows a component-level computed', () => {
+      const result = compile(
+        `
+function App() {
+  let count = 0;
+  const doubled = count * 2;
+  const items = [1, 2, 3];
+  return (
+    <div>
+      <span>{doubled}</span>
+      {items.map((v) => {
+        const doubled = v * 2;
+        return <span>{doubled}</span>;
+      })}
+    </div>
+  );
+}
+        `.trim(),
+      );
+
+      // The component-level doubled should have .value (it's a computed)
+      // But the callback-local doubled should NOT have .value
+      const renderFn = result.code.slice(result.code.indexOf('(v) =>'));
+      expect(renderFn).toContain('const doubled = v * 2');
+      expect(renderFn).not.toContain('doubled.value');
+    });
+
+    it('does not add .value to callback const that shadows a component-level signal', () => {
+      const result = compile(
+        `
+function App() {
+  let status = 'idle';
+  const items = ['a', 'b'];
+  return (
+    <div>
+      <span>{status}</span>
+      {items.map((item) => {
+        const status = item === 'a' ? 'active' : 'inactive';
+        return <span>{status}</span>;
+      })}
+    </div>
+  );
+}
+        `.trim(),
+      );
+
+      // The callback-local status should NOT have .value
+      const renderFn = result.code.slice(result.code.indexOf('(item) =>'));
+      expect(renderFn).not.toContain('status.value');
+    });
+
+    it('does not add .value to callback parameter that shadows a component-level signal', () => {
+      const result = compile(
+        `
+function App() {
+  let items: string[] = [];
+  return (
+    <ul>
+      {items.map((items) => {
+        return <li>{items}</li>;
+      })}
+    </ul>
+  );
+}
+        `.trim(),
+      );
+
+      // The callback parameter 'items' shadows the signal — should NOT get .value inside callback
+      const renderFn = result.code.slice(result.code.indexOf('(items) =>'));
+      // Inside the render function, 'items' refers to the callback parameter (a string)
+      expect(renderFn).not.toContain('items.value');
+    });
+  });
+
   describe('import generation', () => {
     it('adds __list to internals import', () => {
       const result = compile(

--- a/packages/ui-compiler/src/transformers/computed-transformer.ts
+++ b/packages/ui-compiler/src/transformers/computed-transformer.ts
@@ -1,7 +1,7 @@
 import type MagicString from 'magic-string';
 import { type Node, type SourceFile, SyntaxKind } from 'ts-morph';
 import type { ComponentInfo, VariableInfo } from '../types';
-import { findBodyNode } from '../utils';
+import { findBodyNode, isShadowedInNestedScope } from '../utils';
 
 /**
  * Transform `const x = expr` → `const x = computed(() => expr)` when classified as computed.
@@ -147,6 +147,11 @@ function transformComputedReads(source: MagicString, bodyNode: Node, computeds: 
 
     // Skip binding elements
     if (parent.isKind(SyntaxKind.BindingElement)) {
+      return;
+    }
+
+    // Skip identifiers shadowed by a nested scope (callback parameter or local variable)
+    if (isShadowedInNestedScope(node, name, bodyNode)) {
       return;
     }
 

--- a/packages/ui-compiler/src/transformers/signal-transformer.ts
+++ b/packages/ui-compiler/src/transformers/signal-transformer.ts
@@ -1,7 +1,7 @@
 import type MagicString from 'magic-string';
 import { type Node, type SourceFile, SyntaxKind } from 'ts-morph';
 import type { ComponentInfo, VariableInfo } from '../types';
-import { findBodyNode } from '../utils';
+import { findBodyNode, isShadowedInNestedScope } from '../utils';
 
 /**
  * Transform `let x = val` → `const x = signal(val)` and all reads/writes
@@ -138,6 +138,11 @@ function transformReferences(
       return;
     }
 
+    // Skip identifiers shadowed by a nested scope (callback parameter or local variable)
+    if (isShadowedInNestedScope(node, name, bodyNode)) {
+      return;
+    }
+
     // Use overwrite so source.slice() includes the .value transform
     source.overwrite(node.getStart(), node.getEnd(), `${name}.value`);
   });
@@ -206,6 +211,9 @@ function transformSignalApiProperties(
     if (!current.isKind(SyntaxKind.Identifier)) return;
     const rootName = current.getText();
 
+    // Skip if root identifier is shadowed by a nested scope
+    if (isShadowedInNestedScope(current, rootName, bodyNode)) return;
+
     // Root must have fieldSignalProperties
     const fieldSignalProps = fieldSignalPropVars.get(rootName);
     if (!fieldSignalProps) return;
@@ -266,6 +274,9 @@ function transformSignalApiProperties(
     // Check if the object is a signal API variable
     if (!objExpr.isKind(SyntaxKind.Identifier)) return;
     const varName = objExpr.getText();
+
+    // Skip if the variable is shadowed by a nested scope
+    if (isShadowedInNestedScope(objExpr, varName, bodyNode)) return;
 
     const signalProps = signalApiVars.get(varName);
     if (!signalProps || !signalProps.has(propName)) return;

--- a/packages/ui-compiler/src/utils.ts
+++ b/packages/ui-compiler/src/utils.ts
@@ -23,17 +23,84 @@ export function findBodyNode(sourceFile: SourceFile, component: ComponentInfo): 
 export function isInNestedFunction(node: Node, boundaryNode: Node): boolean {
   let current = node.getParent();
   while (current && current !== boundaryNode) {
-    if (
-      current.isKind(SyntaxKind.ArrowFunction) ||
-      current.isKind(SyntaxKind.FunctionExpression) ||
-      current.isKind(SyntaxKind.FunctionDeclaration) ||
-      current.isKind(SyntaxKind.MethodDeclaration) ||
-      current.isKind(SyntaxKind.Constructor) ||
-      current.isKind(SyntaxKind.GetAccessor) ||
-      current.isKind(SyntaxKind.SetAccessor)
-    ) {
+    if (isFunctionLike(current)) {
       return true;
     }
+    current = current.getParent();
+  }
+  return false;
+}
+
+function isFunctionLike(node: Node): boolean {
+  return (
+    node.isKind(SyntaxKind.ArrowFunction) ||
+    node.isKind(SyntaxKind.FunctionExpression) ||
+    node.isKind(SyntaxKind.FunctionDeclaration) ||
+    node.isKind(SyntaxKind.MethodDeclaration) ||
+    node.isKind(SyntaxKind.Constructor) ||
+    node.isKind(SyntaxKind.GetAccessor) ||
+    node.isKind(SyntaxKind.SetAccessor)
+  );
+}
+
+/**
+ * Check if an identifier is shadowed by a declaration in a nested scope
+ * between the identifier and the component body boundary.
+ *
+ * Walks up from the node to bodyNode. At each function boundary, checks
+ * if the function has a parameter with the same name. At each block scope,
+ * checks if a variable declaration with the same name exists.
+ *
+ * This prevents signal/computed transforms from incorrectly adding .value
+ * to callback-local variables or parameters that shadow component-level names.
+ */
+export function isShadowedInNestedScope(node: Node, name: string, bodyNode: Node): boolean {
+  let current = node.getParent();
+  while (current && current !== bodyNode) {
+    // Check function parameters
+    if (isFunctionLike(current)) {
+      const fn = current;
+      if ('getParameters' in fn && typeof fn.getParameters === 'function') {
+        for (const param of fn.getParameters()) {
+          const nameNode = param.getNameNode();
+          if (nameNode.isKind(SyntaxKind.Identifier) && nameNode.getText() === name) {
+            return true;
+          }
+          // Check destructured parameters
+          if (nameNode.isKind(SyntaxKind.ObjectBindingPattern)) {
+            for (const el of nameNode.getElements()) {
+              if (el.getName() === name) return true;
+            }
+          }
+          if (nameNode.isKind(SyntaxKind.ArrayBindingPattern)) {
+            for (const el of nameNode.getElements()) {
+              if (el.isKind(SyntaxKind.BindingElement) && el.getName() === name) return true;
+            }
+          }
+        }
+      }
+    }
+
+    // Check variable declarations in blocks
+    if (current.isKind(SyntaxKind.Block)) {
+      for (const stmt of current.getStatements()) {
+        // Only check statements that appear BEFORE the node's position
+        // to handle temporal dead zone correctly. But for correctness of
+        // shadowing analysis, any declaration in the block means the name
+        // is local to this scope (hoisting for let/const creates TDZ, not
+        // access to outer scope).
+        if (!stmt.isKind(SyntaxKind.VariableStatement)) continue;
+        const declList = stmt.getChildrenOfKind(SyntaxKind.VariableDeclarationList)[0];
+        if (!declList) continue;
+        for (const decl of declList.getDeclarations()) {
+          const declName = decl.getNameNode();
+          if (declName.isKind(SyntaxKind.Identifier) && declName.getText() === name) {
+            return true;
+          }
+        }
+      }
+    }
+
     current = current.getParent();
   }
   return false;


### PR DESCRIPTION
## Summary

- Fix signal and computed transformers incorrectly adding `.value` to identifiers inside nested scopes (callbacks, arrow functions) that shadow component-level reactive variable names
- Add `isShadowedInNestedScope()` utility that checks function parameters and block-scoped variable declarations for shadowing before applying reactive transforms
- The `transformReferences` (SignalTransformer), `transformComputedReads` (ComputedTransformer), and `transformSignalApiProperties` now correctly skip identifiers that are shadowed by a closer scope

## What was broken

When a callback-local `const` (or parameter) had the **same name** as a component-level signal or computed, the compiler incorrectly added `.value` to the callback-local references:

```tsx
function App() {
  let status = 'idle'; // signal
  return (
    <div>
      {items.map((item) => {
        const status = item === 'a' ? 'active' : 'inactive'; // plain string!
        return <span>{status}</span>; // ❌ compiled to status.value → undefined
      })}
    </div>
  );
}
```

The same issue affected callback parameters shadowing signals:
```tsx
{items.map((items) => <li>{items}</li>)} // ❌ items.value on callback param
```

## Public API Changes

None — this is a compiler bug fix with no API surface changes.

## Test plan

- [x] Test: callback const shadowing component-level computed does not get `.value`
- [x] Test: callback const shadowing component-level signal does not get `.value`  
- [x] Test: callback parameter shadowing component-level signal does not get `.value`
- [x] Verified 0 new test failures vs main baseline (326 pass vs 323 on main — delta is 3 new tests)
- [x] Full turbo quality gates pass (82/82 tasks)

Fixes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)