### PR TITLE
fix(ui-primitives): remove getElementById workarounds from Dialog/AlertDialog/Sheet #1517

### DIFF
--- a/.changeset/hydration-child-ref-fix.md
+++ b/.changeset/hydration-child-ref-fix.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Remove getElementById workarounds from Dialog, AlertDialog, and Sheet composed components. Share dialog ref through context so showModal/close use ref directly instead of document.getElementById. JSX event handlers on CSR-rendered elements inside __child wrappers are already on DOM-connected elements, making the imperative onMount+getElementById wiring unnecessary.

--- a/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
+++ b/packages/ui-primitives/src/alert-dialog/alert-dialog-composed.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ChildValue, Ref } from '@vertz/ui';
-import { createContext, onMount, ref, useContext } from '@vertz/ui';
+import { createContext, ref, useContext } from '@vertz/ui';
 import { linkedIds } from '../utils/id';
 
 // ---------------------------------------------------------------------------
@@ -34,6 +34,7 @@ interface AlertDialogContextValue {
   titleId: string;
   descriptionId: string;
   contentId: string;
+  dialogRef: Ref<HTMLDialogElement>;
   classes?: AlertDialogClasses;
   onAction?: () => void;
   open: () => void;
@@ -94,26 +95,12 @@ function AlertDialogTrigger({ children }: SlotProps) {
 
 function AlertDialogContent({ children, className: cls, class: classProp }: SlotProps) {
   const ctx = useAlertDialogContext('Content');
-  const dialogRef: Ref<HTMLDialogElement> = ref();
   const effectiveCls = cls ?? classProp;
   const combined = [ctx.classes?.content, effectiveCls].filter(Boolean).join(' ');
 
-  // Wire cancel handler on the CONNECTED dialog element.
-  // AlertDialog prevents Escape dismiss entirely.
-  onMount(() => {
-    const el = document.getElementById(ctx.contentId) as HTMLDialogElement | null;
-    if (!el || el.__dialogWired) return;
-    el.__dialogWired = true;
-
-    el.addEventListener('cancel', (e: Event) => {
-      // AlertDialog does NOT dismiss on Escape.
-      e.preventDefault();
-    });
-  });
-
   return (
     <dialog
-      ref={dialogRef}
+      ref={ctx.dialogRef}
       id={ctx.contentId}
       role="alertdialog"
       aria-labelledby={ctx.titleId}
@@ -245,16 +232,13 @@ function ComposedAlertDialogRoot({
   const ids = linkedIds('alertdialog');
   const titleId = `${ids.contentId}-title`;
   const descriptionId = `${ids.contentId}-description`;
+  const dialogRef: Ref<HTMLDialogElement> = ref();
 
   // Reactive state — compiler transforms `let` to signal.
   let isOpen = false;
 
-  function getConnectedDialog(): HTMLDialogElement | null {
-    return document.getElementById(ids.contentId) as HTMLDialogElement | null;
-  }
-
   function showDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || el.open) return;
 
     el.setAttribute('data-state', 'open');
@@ -262,7 +246,7 @@ function ComposedAlertDialogRoot({
   }
 
   function hideDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
@@ -294,6 +278,7 @@ function ComposedAlertDialogRoot({
     titleId,
     descriptionId,
     contentId: ids.contentId,
+    dialogRef,
     classes,
     onAction,
     open,

--- a/packages/ui-primitives/src/dialog/dialog-composed.tsx
+++ b/packages/ui-primitives/src/dialog/dialog-composed.tsx
@@ -5,15 +5,8 @@
  */
 
 import type { ChildValue, Ref } from '@vertz/ui';
-import { createContext, onMount, ref, useContext } from '@vertz/ui';
+import { createContext, ref, useContext } from '@vertz/ui';
 import { linkedIds } from '../utils/id';
-
-// Augment HTMLDialogElement to track whether we've wired imperative handlers.
-declare global {
-  interface HTMLDialogElement {
-    __dialogWired?: boolean;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Class distribution
@@ -39,6 +32,7 @@ interface DialogContextValue {
   titleId: string;
   descriptionId: string;
   contentId: string;
+  dialogRef: Ref<HTMLDialogElement>;
   classes?: DialogClasses;
   open: () => void;
   close: () => void;
@@ -101,39 +95,12 @@ function DialogContent({
   showClose = true,
 }: DialogContentProps) {
   const ctx = useDialogContext('Content');
-  const dialogRef: Ref<HTMLDialogElement> = ref();
   const effectiveCls = cls ?? classProp;
   const combined = [ctx.classes?.content, effectiveCls].filter(Boolean).join(' ');
 
-  // Sync native <dialog> open/close state from reactive signal.
-  // onMount is a no-op during SSR (avoids missing .showModal()).
-  // Read ctx.isOpen BEFORE the null check so the signal is always tracked.
-  // Query the dialog by ID rather than using the ref — during hydration,
-  // the ref may point to an orphaned element while the connected one
-  // is the SSR-claimed element in the DOM.
-  // Wire cancel/click handlers on the CONNECTED dialog element.
-  // JSX event handlers end up on the orphaned element during hydration,
-  // so we attach imperatively to the element found by ID.
-  onMount(() => {
-    const el = document.getElementById(ctx.contentId) as HTMLDialogElement | null;
-    if (!el || el.__dialogWired) return;
-    el.__dialogWired = true;
-
-    el.addEventListener('cancel', (e: Event) => {
-      // Prevent native close so we can animate the exit.
-      e.preventDefault();
-      ctx.close();
-    });
-
-    el.addEventListener('click', (e: MouseEvent) => {
-      // Backdrop click: showModal() makes the <dialog> itself the backdrop target.
-      if (e.target === el) ctx.close();
-    });
-  });
-
   return (
     <dialog
-      ref={dialogRef}
+      ref={ctx.dialogRef}
       id={ctx.contentId}
       role="dialog"
       aria-labelledby={ctx.titleId}
@@ -149,7 +116,7 @@ function DialogContent({
         // Clicking the <dialog> backdrop (not content inside) closes the dialog.
         // When showModal() is used, clicking outside the dialog content but
         // inside the viewport hits the <dialog> element itself as the target.
-        if (e.target === dialogRef.current) ctx.close();
+        if (e.target === ctx.dialogRef.current) ctx.close();
       }}
     >
       {showClose && (
@@ -256,17 +223,14 @@ function ComposedDialogRoot({ children, classes, onOpenChange }: ComposedDialogP
   const ids = linkedIds('dialog');
   const titleId = `${ids.contentId}-title`;
   const descriptionId = `${ids.contentId}-description`;
+  const dialogRef: Ref<HTMLDialogElement> = ref();
 
   // Reactive state — compiler transforms `let` to signal.
   // Passed directly in context so Provider auto-wraps via wrapSignalProps.
   let isOpen = false;
 
-  function getConnectedDialog(): HTMLDialogElement | null {
-    return document.getElementById(ids.contentId) as HTMLDialogElement | null;
-  }
-
   function showDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || el.open) return;
 
     el.setAttribute('data-state', 'open');
@@ -274,7 +238,7 @@ function ComposedDialogRoot({ children, classes, onOpenChange }: ComposedDialogP
   }
 
   function hideDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
@@ -311,6 +275,7 @@ function ComposedDialogRoot({ children, classes, onOpenChange }: ComposedDialogP
     titleId,
     descriptionId,
     contentId: ids.contentId,
+    dialogRef,
     classes,
     open,
     close,

--- a/packages/ui-primitives/src/sheet/sheet-composed.tsx
+++ b/packages/ui-primitives/src/sheet/sheet-composed.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { ChildValue, Ref } from '@vertz/ui';
-import { createContext, onMount, ref, useContext } from '@vertz/ui';
+import { createContext, ref, useContext } from '@vertz/ui';
 import { linkedIds } from '../utils/id';
 import type { SheetSide } from './sheet';
 
@@ -31,6 +31,7 @@ interface SheetContextValue {
   titleId: string;
   descriptionId: string;
   contentId: string;
+  dialogRef: Ref<HTMLDialogElement>;
   side: SheetSide;
   classes?: SheetClasses;
   open: () => void;
@@ -96,28 +97,12 @@ function SheetContent({
 }: SheetContentProps) {
   const ctx = useSheetContext('Content');
 
-  const dialogRef: Ref<HTMLDialogElement> = ref();
   const effectiveCls = cls ?? classProp;
   const combined = [ctx.classes?.content, effectiveCls].filter(Boolean).join(' ');
 
-  onMount(() => {
-    const el = document.getElementById(ctx.contentId) as HTMLDialogElement | null;
-    if (!el || el.__dialogWired) return;
-    el.__dialogWired = true;
-
-    el.addEventListener('cancel', (e: Event) => {
-      e.preventDefault();
-      ctx.close();
-    });
-
-    el.addEventListener('click', (e: MouseEvent) => {
-      if (e.target === el) ctx.close();
-    });
-  });
-
   return (
     <dialog
-      ref={dialogRef}
+      ref={ctx.dialogRef}
       id={ctx.contentId}
       role="dialog"
       aria-modal="true"
@@ -131,7 +116,7 @@ function SheetContent({
         ctx.close();
       }}
       onClick={(e: MouseEvent) => {
-        if (e.target === dialogRef.current) ctx.close();
+        if (e.target === ctx.dialogRef.current) ctx.close();
       }}
     >
       {showClose && (
@@ -226,15 +211,12 @@ function ComposedSheetRoot({
   const ids = linkedIds('sheet');
   const titleId = `${ids.contentId}-title`;
   const descriptionId = `${ids.contentId}-description`;
+  const dialogRef: Ref<HTMLDialogElement> = ref();
 
   let isOpen = false;
 
-  function getConnectedDialog(): HTMLDialogElement | null {
-    return document.getElementById(ids.contentId) as HTMLDialogElement | null;
-  }
-
   function showDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || el.open) return;
 
     el.setAttribute('data-state', 'open');
@@ -242,7 +224,7 @@ function ComposedSheetRoot({
   }
 
   function hideDialog(): void {
-    const el = getConnectedDialog();
+    const el = dialogRef.current;
     if (!el || !el.open) return;
 
     el.setAttribute('data-state', 'closed');
@@ -279,6 +261,7 @@ function ComposedSheetRoot({
     titleId,
     descriptionId,
     contentId: ids.contentId,
+    dialogRef,
     side,
     classes,
     open,

--- a/packages/ui/src/dom/__tests__/hydration-element.test.ts
+++ b/packages/ui/src/dom/__tests__/hydration-element.test.ts
@@ -11,6 +11,7 @@ import {
   __staticText,
   __text,
 } from '../element';
+import { __on } from '../events';
 
 describe('DOM helpers — hydration branches', () => {
   afterEach(() => {
@@ -270,6 +271,70 @@ describe('DOM helpers — hydration branches', () => {
       endHydration();
       text.value = 'updated';
       expect(wrapper.textContent).toBe('updated');
+    });
+
+    it('ref and getElementById point to same element after hydration (#1517)', () => {
+      // __child CSR-renders content during hydration. The CSR-created elements
+      // are appended to the claimed wrapper and ARE connected to the DOM.
+      // Both ref and getElementById should return the same element.
+      const root = document.createElement('div');
+      root.innerHTML =
+        '<span style="display:contents">' +
+        '<dialog id="test-dlg"><button>Close</button></dialog>' +
+        '</span>';
+      document.body.appendChild(root);
+
+      startHydration(root);
+
+      const dialogRef: { current: HTMLElement | undefined } = { current: undefined };
+      __child(() => {
+        const dialog = document.createElement('dialog');
+        dialog.id = 'test-dlg';
+        dialogRef.current = dialog;
+        return dialog;
+      });
+
+      endHydration();
+
+      // ref.current should be the CSR-created element, now in the DOM
+      expect(dialogRef.current).toBeDefined();
+      expect(dialogRef.current?.isConnected).toBe(true);
+      // ref and getElementById should agree
+      expect(document.getElementById('test-dlg')).toBe(dialogRef.current);
+
+      document.body.removeChild(root);
+    });
+
+    it('JSX event handlers fire on CSR element inside __child (#1517)', () => {
+      // Event handlers attached via __on inside __child target CSR elements
+      // that are connected to the DOM via the claimed wrapper.
+      const root = document.createElement('div');
+      root.innerHTML =
+        '<span style="display:contents">' + '<button id="test-btn">Click</button>' + '</span>';
+      document.body.appendChild(root);
+
+      startHydration(root);
+
+      let clicked = false;
+      const wrapper = __child(() => {
+        const btn = document.createElement('button');
+        btn.id = 'test-btn';
+        btn.textContent = 'Click';
+        __on(btn, 'click', () => {
+          clicked = true;
+        });
+        return btn;
+      });
+
+      endHydration();
+
+      // The CSR button is in the DOM and has the event handler
+      const btn = wrapper.querySelector('button')!;
+      expect(btn.isConnected).toBe(true);
+      btn.click();
+      expect(clicked).toBe(true);
+
+      document.body.removeChild(root);
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove `document.getElementById` workarounds from Dialog, AlertDialog, and Sheet composed components
- Share dialog ref through context so `showModal()`/`close()` use `ref.current` directly
- Remove imperative `onMount` + `getElementById` event handler wiring (JSX handlers are already on connected elements)
- Remove `__dialogWired` global augmentation on `HTMLDialogElement`

## Public API Changes

**Internal only** — no public API changes. Context types gain a `dialogRef` field but these are internal to the composed component implementation.

## Root Cause Analysis

During hydration, `__child()` claims the SSR wrapper `<span>`, clears its children, pauses hydration, and CSR-renders fresh content via `domEffect`. The CSR-created elements **are** appended to the claimed wrapper and **are** connected to the DOM. Refs set during this CSR render point to these connected elements, and `document.getElementById()` returns the same element.

The `onMount` + `getElementById` workaround code in the Content sub-components was dead code — `onMount` runs synchronously before the dialog element is created (it's called before the JSX return), so `getElementById` always returned `null` and the imperative handlers were never wired. The JSX event handlers (`onCancel`, `onClick`) attached via `__on()` on the CSR-created dialog were the ones actually handling events.

The `getConnectedDialog()` helper using `getElementById` in the Root components worked correctly but was unnecessary since `ref.current` points to the same connected element.

## Fix

1. Add `dialogRef: Ref<HTMLDialogElement>` to each component's context
2. Content sub-components use `ctx.dialogRef` instead of creating a local ref
3. `showDialog()`/`hideDialog()` use `dialogRef.current` instead of `getElementById`
4. Remove `onMount` + `getElementById` imperative event wiring
5. Remove `__dialogWired` global type augmentation

## Test plan

- [x] New tests: `ref and getElementById point to same element after hydration`
- [x] New tests: `JSX event handlers fire on CSR element inside __child`
- [x] All 32 hydration-element tests pass
- [x] All 786 ui-primitives tests pass (including dialog/sheet/alert-dialog tests)
- [x] All 468 theme-shadcn tests pass
- [x] Typecheck clean on @vertz/ui and @vertz/ui-primitives
- [x] Pre-push quality gates pass (lint + typecheck + test + build)

Fixes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)