### PR TITLE
fix(theme-shadcn): override dialog UA constraints for Sheet viewport sizing #1522

### DIFF
--- a/.changeset/sheet-viewport-sizing.md
+++ b/.changeset/sheet-viewport-sizing.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Fix Sheet panels not taking full viewport height/width after native dialog rewrite. Left/right panels now set `height: 100dvh` and `max-height: none`; top/bottom panels set `width: 100dvw` and `max-width: none` to override the `<dialog>` UA stylesheet constraints.

--- a/packages/theme-shadcn/src/__tests__/sheet.test.ts
+++ b/packages/theme-shadcn/src/__tests__/sheet.test.ts
@@ -50,6 +50,30 @@ describe('sheet styles', () => {
     expect(sheet.css).toContain('::backdrop');
     expect(sheet.css).toContain('backdrop-filter');
   });
+
+  it('left/right panels fill full viewport height and override dialog UA constraints', () => {
+    // left panel block has inset: 0 auto 0 0 — check it also has height + max-height override
+    const leftBlock = sheet.css.split('}').find((b) => b.includes('inset: 0 auto 0 0'));
+    expect(leftBlock).toContain('height: 100dvh');
+    expect(leftBlock).toContain('max-height: none');
+
+    // right panel block has inset: 0 0 0 auto
+    const rightBlock = sheet.css.split('}').find((b) => b.includes('inset: 0 0 0 auto'));
+    expect(rightBlock).toContain('height: 100dvh');
+    expect(rightBlock).toContain('max-height: none');
+  });
+
+  it('top/bottom panels fill full viewport width and override dialog UA constraints', () => {
+    // top panel block has inset: 0 0 auto 0
+    const topBlock = sheet.css.split('}').find((b) => b.includes('inset: 0 0 auto 0'));
+    expect(topBlock).toContain('width: 100dvw');
+    expect(topBlock).toContain('max-width: none');
+
+    // bottom panel block has inset: auto 0 0 0
+    const bottomBlock = sheet.css.split('}').find((b) => b.includes('inset: auto 0 0 0'));
+    expect(bottomBlock).toContain('width: 100dvw');
+    expect(bottomBlock).toContain('max-width: none');
+  });
 });
 
 describe('themed Sheet', () => {

--- a/packages/theme-shadcn/src/styles/sheet.ts
+++ b/packages/theme-shadcn/src/styles/sheet.ts
@@ -67,6 +67,8 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           inset: '0 auto 0 0',
           width: '75%',
           'max-width': '24rem',
+          height: '100dvh',
+          'max-height': 'none',
           margin: '0',
           outline: 'none',
           border: 'none',
@@ -99,6 +101,8 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
           inset: '0 0 0 auto',
           width: '75%',
           'max-width': '24rem',
+          height: '100dvh',
+          'max-height': 'none',
           margin: '0',
           outline: 'none',
           border: 'none',
@@ -129,6 +133,8 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
       {
         '&': {
           inset: '0 0 auto 0',
+          width: '100dvw',
+          'max-width': 'none',
           margin: '0',
           outline: 'none',
           border: 'none',
@@ -159,6 +165,8 @@ export function createSheetStyles(): CSSOutput<SheetBlocks> {
       {
         '&': {
           inset: 'auto 0 0 0',
+          width: '100dvw',
+          'max-width': 'none',
           margin: '0',
           outline: 'none',
           border: 'none',


### PR DESCRIPTION
## Summary
- Left/right Sheet panels now set `height: 100dvh` + `max-height: none` to fill the full viewport height
- Top/bottom Sheet panels now set `width: 100dvw` + `max-width: none` to fill the full viewport width
- These overrides prevent the native `<dialog>` UA stylesheet from constraining panel dimensions after the compound component rewrite (#1525)

## Public API Changes
None — internal CSS-only fix.

## Test plan
- [x] Added test: left/right panels contain `height: 100dvh` and `max-height: none` in generated CSS
- [x] Added test: top/bottom panels contain `width: 100dvw` and `max-width: none` in generated CSS
- [x] All 15 sheet tests pass
- [x] Full CI passes (typecheck, lint, test, build)

Fixes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)