### PR TITLE
test(ui-primitives): add keyboard navigation tests for menubar #1528

### DIFF
--- a/.changeset/menubar-keyboard-nav.md
+++ b/.changeset/menubar-keyboard-nav.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Add ArrowUp/ArrowDown item navigation and Space key selection to Menubar content keyboard handler

--- a/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
+++ b/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
@@ -396,4 +396,128 @@ describe('Composed Menubar', () => {
       expect(fileContent.getAttribute('data-state')).toBe('closed');
     });
   });
+
+  describe('Given Enter is pressed on a trigger', () => {
+    it('Then opens the menu and focuses the first item', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+
+      trigger.focus();
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      const firstItem = content.querySelector('[data-value="new"]') as HTMLElement;
+      expect(document.activeElement).toBe(firstItem);
+    });
+  });
+
+  describe('Given Space is pressed on a trigger', () => {
+    it('Then opens the menu and focuses the first item', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+
+      trigger.focus();
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      const firstItem = content.querySelector('[data-value="new"]') as HTMLElement;
+      expect(document.activeElement).toBe(firstItem);
+    });
+  });
+
+  describe('Given a menu is open and ArrowDown is pressed in the content', () => {
+    it('Then focuses the next menu item', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const items = content.querySelectorAll('[role="menuitem"]');
+      const firstItem = items[0] as HTMLElement;
+      const secondItem = items[1] as HTMLElement;
+
+      expect(document.activeElement).toBe(firstItem);
+
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      expect(document.activeElement).toBe(secondItem);
+    });
+
+    it('Then wraps around to the first item from the last', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const items = content.querySelectorAll('[role="menuitem"]');
+      const firstItem = items[0] as HTMLElement;
+      const secondItem = items[1] as HTMLElement;
+
+      // Move to second item
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      expect(document.activeElement).toBe(secondItem);
+
+      // Wrap to first
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      expect(document.activeElement).toBe(firstItem);
+    });
+  });
+
+  describe('Given a menu is open and ArrowUp is pressed in the content', () => {
+    it('Then focuses the previous menu item', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const items = content.querySelectorAll('[role="menuitem"]');
+      const firstItem = items[0] as HTMLElement;
+      const secondItem = items[1] as HTMLElement;
+
+      // Move to second item first
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      expect(document.activeElement).toBe(secondItem);
+
+      // ArrowUp back to first
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      expect(document.activeElement).toBe(firstItem);
+    });
+
+    it('Then wraps around to the last item from the first', () => {
+      const root = renderMenubar();
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const items = content.querySelectorAll('[role="menuitem"]');
+      const firstItem = items[0] as HTMLElement;
+      const secondItem = items[1] as HTMLElement;
+
+      expect(document.activeElement).toBe(firstItem);
+
+      // Wrap to last
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      expect(document.activeElement).toBe(secondItem);
+    });
+  });
+
+  describe('Given a menu is open and Space is pressed on a focused item', () => {
+    it('Then fires onSelect and closes the menu', () => {
+      const onSelect = vi.fn();
+      const root = renderMenubar({ onSelect });
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      const content = root.querySelectorAll('[role="menu"]')[0] as HTMLElement;
+
+      trigger.click();
+      const item = content.querySelector('[data-value="new"]') as HTMLElement;
+      item.focus();
+      content.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      expect(onSelect).toHaveBeenCalledWith('new');
+      expect(content.getAttribute('data-state')).toBe('closed');
+    });
+  });
 });

--- a/packages/ui-primitives/src/menubar/menubar-composed.tsx
+++ b/packages/ui-primitives/src/menubar/menubar-composed.tsx
@@ -227,7 +227,7 @@ function MenubarContent({ children, className: cls, class: classProp }: SlotProp
         return;
       }
 
-      if (isKey(event, Keys.Enter)) {
+      if (isKey(event, Keys.Enter, Keys.Space)) {
         event.preventDefault();
         const items = [...contentEl.querySelectorAll<HTMLElement>('[role="menuitem"]')];
         const active = items.find((item) => item === document.activeElement);
@@ -238,6 +238,17 @@ function MenubarContent({ children, className: cls, class: classProp }: SlotProp
             barCtx.closeAll();
           }
         }
+        return;
+      }
+
+      if (isKey(event, Keys.ArrowDown, Keys.ArrowUp)) {
+        event.preventDefault();
+        const items = [...contentEl.querySelectorAll<HTMLElement>('[role="menuitem"]')];
+        if (items.length === 0) return;
+        const currentIdx = items.indexOf(document.activeElement as HTMLElement);
+        const direction = isKey(event, Keys.ArrowDown) ? 1 : -1;
+        const nextIdx = (((currentIdx + direction) % items.length) + items.length) % items.length;
+        items[nextIdx]?.focus();
         return;
       }
 


### PR DESCRIPTION
## Summary

- Add tests for Enter/Space on trigger to open menu
- Add tests for ArrowDown/ArrowUp navigation within menu items (with wrapping)
- Add test for Space key selection on focused item
- Implement missing ArrowDown/ArrowUp item navigation in content keydown handler
- Implement missing Space key selection in content keydown handler

## Public API Changes

No public API changes. Internal keyboard handler now supports ArrowDown/ArrowUp for item navigation and Space for item selection, matching WAI-ARIA menubar pattern expectations.

Fixes #1528

## Test plan

- [x] ArrowLeft/ArrowRight navigates between menu triggers (pre-existing tests)
- [x] ArrowDown opens menu and focuses first item (pre-existing test)
- [x] Enter on trigger opens menu and focuses first item (new)
- [x] Space on trigger opens menu and focuses first item (new)
- [x] ArrowDown navigates to next menu item (new)
- [x] ArrowDown wraps from last to first item (new)
- [x] ArrowUp navigates to previous menu item (new)
- [x] ArrowUp wraps from first to last item (new)
- [x] Enter selects focused item (pre-existing test)
- [x] Space selects focused item (new)
- [x] Escape closes the active menu (pre-existing test)
- [x] All 799 ui-primitives tests pass
- [x] All 15 theme-shadcn menubar tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)