### PR TITLE
test(ui-primitives): add keyboard navigation tests for context-menu #1527

### DIFF
--- a/.changeset/context-menu-keyboard-nav.md
+++ b/.changeset/context-menu-keyboard-nav.md
@@ -1,0 +1,5 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+Add keyboard navigation to composed ContextMenu (ArrowUp/Down, Enter, Escape, Tab)

--- a/packages/ui-primitives/src/context-menu/__tests__/context-menu-composed.test.ts
+++ b/packages/ui-primitives/src/context-menu/__tests__/context-menu-composed.test.ts
@@ -265,6 +265,113 @@ describe('Composed ContextMenu', () => {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // Keyboard navigation tests (#1527)
+  // ---------------------------------------------------------------------------
+
+  function renderMenuWithItems(onSelect?: (value: string) => void) {
+    const root = ComposedContextMenu({
+      onSelect,
+      children: () => {
+        const t = ComposedContextMenu.Trigger({
+          children: [document.createTextNode('Right-click me')],
+        });
+        const c = ComposedContextMenu.Content({
+          children: () => [
+            ComposedContextMenu.Item({ value: 'cut', children: ['Cut'] }),
+            ComposedContextMenu.Item({ value: 'copy', children: ['Copy'] }),
+            ComposedContextMenu.Item({ value: 'paste', children: ['Paste'] }),
+          ],
+        });
+        return [t, c];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[data-part="trigger"]') as HTMLElement;
+    const menu = root.querySelector('[role="menu"]') as HTMLElement;
+
+    function openMenu() {
+      trigger.dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 100, clientY: 200, bubbles: true }),
+      );
+    }
+
+    return { root, trigger, menu, openMenu };
+  }
+
+  describe('Given an open ContextMenu with multiple items', () => {
+    describe('When ArrowDown is pressed', () => {
+      it('Then moves focus to the next menu item', () => {
+        const { menu, openMenu } = renderMenuWithItems();
+        openMenu();
+
+        const items = menu.querySelectorAll('[role="menuitem"]');
+        (items[0] as HTMLElement).focus();
+
+        menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+        expect(document.activeElement).toBe(items[1]);
+      });
+    });
+
+    describe('When ArrowUp is pressed', () => {
+      it('Then moves focus to the previous menu item', () => {
+        const { menu, openMenu } = renderMenuWithItems();
+        openMenu();
+
+        const items = menu.querySelectorAll('[role="menuitem"]');
+        (items[1] as HTMLElement).focus();
+
+        menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+        expect(document.activeElement).toBe(items[0]);
+      });
+    });
+
+    describe('When Enter is pressed on a focused item', () => {
+      it('Then selects the focused item and closes the menu', () => {
+        const onSelect = vi.fn();
+        const { menu, openMenu } = renderMenuWithItems(onSelect);
+        openMenu();
+
+        const items = menu.querySelectorAll('[role="menuitem"]');
+        (items[1] as HTMLElement).focus();
+
+        menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(onSelect).toHaveBeenCalledWith('copy');
+        expect(menu.getAttribute('data-state')).toBe('closed');
+      });
+    });
+
+    describe('When Escape is pressed', () => {
+      it('Then closes the menu without selection', () => {
+        const onSelect = vi.fn();
+        const { menu, openMenu } = renderMenuWithItems(onSelect);
+        openMenu();
+
+        menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(menu.getAttribute('data-state')).toBe('closed');
+      });
+    });
+
+    describe('When Tab is pressed', () => {
+      it('Then closes the menu', () => {
+        const onSelect = vi.fn();
+        const { menu, openMenu } = renderMenuWithItems(onSelect);
+        openMenu();
+
+        menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(menu.getAttribute('data-state')).toBe('closed');
+      });
+    });
+  });
+
   describe('Given a ContextMenu with duplicate Content sub-components', () => {
     it('Then warns about the duplicate', () => {
       const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/ui-primitives/src/context-menu/context-menu-composed.tsx
+++ b/packages/ui-primitives/src/context-menu/context-menu-composed.tsx
@@ -11,6 +11,7 @@ import { createDismiss } from '../utils/dismiss';
 import type { FloatingOptions } from '../utils/floating';
 import { createFloatingPosition, virtualElement } from '../utils/floating';
 import { linkedIds } from '../utils/id';
+import { handleListNavigation, isKey, Keys } from '../utils/keyboard';
 
 // ---------------------------------------------------------------------------
 // Class distribution
@@ -123,6 +124,32 @@ function ContextMenuContent({ children, className: cls, class: classProp }: Slot
       data-state="closed"
       style="display: none"
       class={combined || undefined}
+      onKeydown={(event: KeyboardEvent) => {
+        if (isKey(event, Keys.Escape, Keys.Tab)) {
+          event.preventDefault();
+          ctx.close();
+          return;
+        }
+
+        const el = (event.currentTarget ?? event.target) as HTMLElement;
+        const items = [...el.querySelectorAll<HTMLElement>('[role="menuitem"]')];
+        const focusedIdx = items.indexOf(document.activeElement as HTMLElement);
+
+        if (isKey(event, Keys.Enter, Keys.Space)) {
+          event.preventDefault();
+          const active = items[focusedIdx];
+          if (active) {
+            const val = active.getAttribute('data-value');
+            if (val !== null) {
+              ctx.onSelect?.(val);
+              ctx.close();
+            }
+          }
+          return;
+        }
+
+        handleListNavigation(event, items, { orientation: 'vertical' });
+      }}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary
- Add keyboard navigation (`onKeydown`) to composed ContextMenu Content component, matching the dropdown-menu-composed pattern
- Add 5 keyboard navigation tests: ArrowDown, ArrowUp, Enter, Escape, Tab
- Add changeset for the patch

## Public API Changes
None — this adds an internal keyboard handler to an existing component. No API surface changes.

## Test plan
- [x] ArrowDown moves focus to next menu item
- [x] ArrowUp moves focus to previous menu item
- [x] Enter selects focused item and closes menu
- [x] Escape closes menu without selection
- [x] Tab closes menu
- [x] All 804 existing ui-primitives tests pass
- [x] Typecheck clean
- [x] Lint clean

Fixes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)