### PR TITLE
fix(linear): fix broken CSS tokens and entity name mismatch #1513

### DIFF
--- a/examples/linear/src/api/db.ts
+++ b/examples/linear/src/api/db.ts
@@ -29,7 +29,7 @@ export const db = createDb({
     issues: issuesModel,
     comments: commentsModel,
     labels: labelsModel,
-    issueLabels: issueLabelsModel,
+    'issue-labels': issueLabelsModel,
   },
   dialect: 'sqlite',
   path: DB_PATH,

--- a/examples/linear/src/api/seed.ts
+++ b/examples/linear/src/api/seed.ts
@@ -27,7 +27,7 @@ type SeedModels = {
   issues: typeof issuesModel;
   comments: typeof commentsModel;
   labels: typeof labelsModel;
-  issueLabels: typeof issueLabelsModel;
+  'issue-labels': typeof issueLabelsModel;
 };
 
 export async function seedDatabase(db: DatabaseClient<SeedModels>) {
@@ -365,7 +365,7 @@ export async function seedDatabase(db: DatabaseClient<SeedModels>) {
 
   // --- Issue Labels (assign some labels to issues) ---
   unwrap(
-    await db.issueLabels.createMany({
+    await db['issue-labels'].createMany({
       data: [
         { id: 'il-1', workspaceId: W, issueId: 'iss-1', labelId: 'lbl-eng-2' },
         { id: 'il-2', workspaceId: W, issueId: 'iss-2', labelId: 'lbl-eng-2' },

--- a/examples/linear/src/api/server.ts
+++ b/examples/linear/src/api/server.ts
@@ -17,3 +17,5 @@ export const app = createServer({
   db,
   auth,
 });
+
+export default app;

--- a/examples/linear/src/components/label-picker.tsx
+++ b/examples/linear/src/components/label-picker.tsx
@@ -19,7 +19,7 @@ const styles = css({
     'text:foreground',
     'transition:colors',
     'hover:bg:accent',
-    'text-align:left',
+    'text:left',
   ],
   active: [
     'flex',
@@ -36,7 +36,7 @@ const styles = css({
     'text:foreground',
     'transition:colors',
     'hover:bg:accent',
-    'text-align:left',
+    'text:left',
   ],
   dot: ['w:2.5', 'h:2.5', 'rounded:full', 'shrink-0'],
   check: ['ml:auto', 'text:muted-foreground', 'text:xs'],

--- a/examples/linear/src/components/manage-labels-dialog.tsx
+++ b/examples/linear/src/components/manage-labels-dialog.tsx
@@ -7,8 +7,8 @@ import type { Label } from '../lib/types';
 import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
 
 const styles = css({
-  list: ['flex', 'flex-col', 'gap:2', 'mb:4', 'max-h:80', 'overflow-y:auto'],
-  item: ['flex', 'items:center', 'gap:2', 'px:3', 'py:2', 'rounded:md', 'bg:muted/50'],
+  list: ['flex', 'flex-col', 'gap:2', 'mb:4', 'max-h:80', 'overflow:hidden'],
+  item: ['flex', 'items:center', 'gap:2', 'px:3', 'py:2', 'rounded:md', 'bg:muted'],
   dot: ['w:3', 'h:3', 'rounded:full', 'shrink-0'],
   name: ['flex-1', 'text:sm', 'text:foreground'],
   actions: ['flex', 'gap:1'],
@@ -22,7 +22,7 @@ const styles = css({
     'border:transparent',
     'cursor:pointer',
     'transition:all',
-    'hover:scale-110',
+    'hover:border:foreground',
   ],
   colorSelected: [
     'w:6',

--- a/examples/linear/src/styles/components.ts
+++ b/examples/linear/src/styles/components.ts
@@ -53,7 +53,7 @@ export const skeletonStyles = css({
   bone: ['rounded:md', 'bg:muted'],
   card: ['rounded:md', 'bg:muted', 'h:20', 'mb:2'],
   line: ['rounded:sm', 'bg:muted', 'h:4', 'mb:2'],
-  lineShort: ['rounded:sm', 'bg:muted', 'h:4', 'w:2/3', 'mb:2'],
+  lineShort: ['rounded:sm', 'bg:muted', 'h:4', 'mb:2'],
 });
 
 export const skeletonAnimation = `background: linear-gradient(90deg, transparent 25%, hsl(var(--muted-foreground) / 0.08) 50%, transparent 75%); background-size: 200% 100%; animation: ${shimmer} 1.5s ease-in-out infinite;`;
@@ -75,6 +75,6 @@ export const errorFallbackStyles = css({
     'cursor:pointer',
     'border:0',
     'transition:colors',
-    'hover:bg:primary/90',
+    'hover:bg:primary.700',
   ],
 });


### PR DESCRIPTION
## Summary

- **Entity name mismatch**: Changed db model key from `issueLabels` to `'issue-labels'` to match the entity name registered via `entity('issue-labels', ...)`. Updated seed file accordingly.
- **Missing default export**: Added `export default app` to `server.ts` — the CLI dev server expects a default export.
- **Invalid CSS tokens**: Replaced 6 unsupported CSS tokens across 3 files:
  - `w:2/3` → removed (fraction widths unsupported)
  - `bg:primary/90` → `bg:primary.700` (slash-opacity unsupported)
  - `text-align:left` → `text:left` (2 occurrences)
  - `overflow-y:auto` → `overflow:hidden`
  - `hover:scale-110` → `hover:border:foreground`
  - `bg:muted/50` → `bg:muted`

## Public API Changes

None — example app only.

## Test plan

- [ ] Linear clone dev server starts without errors
- [ ] All pages render correctly
- [ ] No TokenResolveError at runtime

Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)