### PR TITLE
fix(compiler): match entities to database models by variable name (#1512)

### DIFF
--- a/packages/compiler/src/analyzers/__tests__/database-analyzer.test.ts
+++ b/packages/compiler/src/analyzers/__tests__/database-analyzer.test.ts
@@ -47,6 +47,7 @@ describe('DatabaseAnalyzer', () => {
       const result = await analyze();
       expect(result.databases).toHaveLength(1);
       expect(result.databases[0]?.modelKeys).toEqual(['users', 'tasks']);
+      expect(result.databases[0]?.modelValues).toEqual(['usersModel', 'tasksModel']);
     });
 
     it('detects with aliased import', async () => {
@@ -278,7 +279,7 @@ const db = createDb({
       return { ...createEmptyAppIR(), ...overrides };
     }
 
-    it('emits ENTITY_MODEL_NOT_REGISTERED when entity name is not in any createDb models', async () => {
+    it('emits ENTITY_MODEL_NOT_REGISTERED when entity model variable is not in any createDb models', async () => {
       const ir = createIR({
         entities: [
           {
@@ -306,6 +307,7 @@ const db = createDb({
         databases: [
           {
             modelKeys: ['users'],
+            modelValues: ['usersModel'],
             sourceFile: 'src/worker.ts',
             sourceLine: 12,
             sourceColumn: 1,
@@ -319,11 +321,11 @@ const db = createDb({
 
       expect(entityModelDiags).toHaveLength(1);
       expect(entityModelDiags[0]?.message).toContain('tasks');
-      expect(entityModelDiags[0]?.suggestion).toContain('users');
+      expect(entityModelDiags[0]?.message).toContain('tasksModel');
       expect(entityModelDiags[0]?.severity).toBe('error');
     });
 
-    it('emits no diagnostic when entity name matches a model key', async () => {
+    it('emits no diagnostic when entity model variable matches a registered model value', async () => {
       const ir = createIR({
         entities: [
           {
@@ -351,6 +353,50 @@ const db = createDb({
         databases: [
           {
             modelKeys: ['users', 'tasks'],
+            modelValues: ['usersModel', 'tasksModel'],
+            sourceFile: 'src/worker.ts',
+            sourceLine: 12,
+            sourceColumn: 1,
+          },
+        ],
+      });
+
+      const validator = new CompletenessValidator();
+      const diagnostics = await validator.validate(ir);
+      const entityModelDiags = diagnostics.filter((d) => d.code === 'ENTITY_MODEL_NOT_REGISTERED');
+
+      expect(entityModelDiags).toHaveLength(0);
+    });
+
+    it('emits no diagnostic when entity name differs from model key but model variable matches', async () => {
+      const ir = createIR({
+        entities: [
+          {
+            name: 'issue-labels',
+            sourceFile: 'src/entities/issue-labels.ts',
+            sourceLine: 5,
+            sourceColumn: 1,
+            modelRef: {
+              variableName: 'issueLabelsModel',
+              schemaRefs: { resolved: false },
+            },
+            access: {
+              list: 'none',
+              get: 'none',
+              create: 'none',
+              update: 'none',
+              delete: 'none',
+              custom: {},
+            },
+            hooks: { before: [], after: [] },
+            actions: [],
+            relations: [],
+          },
+        ],
+        databases: [
+          {
+            modelKeys: ['issueLabels'],
+            modelValues: ['issueLabelsModel'],
             sourceFile: 'src/worker.ts',
             sourceLine: 12,
             sourceColumn: 1,
@@ -393,6 +439,7 @@ const db = createDb({
         databases: [
           {
             modelKeys: [],
+            modelValues: [],
             sourceFile: 'src/worker.ts',
             sourceLine: 12,
             sourceColumn: 1,

--- a/packages/compiler/src/analyzers/database-analyzer.ts
+++ b/packages/compiler/src/analyzers/database-analyzer.ts
@@ -73,8 +73,8 @@ export class DatabaseAnalyzer extends BaseAnalyzer<DatabaseAnalyzerResult> {
     const modelsObj = this.resolveObjectLiteral(modelsValue);
     if (!modelsObj) return null;
 
-    const modelKeys = this.extractModelKeys(modelsObj, loc);
-    return { modelKeys, ...loc };
+    const { keys: modelKeys, values: modelValues } = this.extractModelEntries(modelsObj, loc);
+    return { modelKeys, modelValues, ...loc };
   }
 
   /**
@@ -100,11 +100,16 @@ export class DatabaseAnalyzer extends BaseAnalyzer<DatabaseAnalyzerResult> {
   }
 
   /**
-   * Extracts property keys from a models object, emitting warnings for
-   * spread assignments and computed property names that can't be resolved.
+   * Extracts property keys and value identifiers from a models object,
+   * emitting warnings for spread assignments and computed property names
+   * that can't be resolved.
    */
-  private extractModelKeys(obj: ObjectLiteralExpression, loc: SourceLocation): string[] {
+  private extractModelEntries(
+    obj: ObjectLiteralExpression,
+    loc: SourceLocation,
+  ): { keys: string[]; values: string[] } {
     const keys: string[] = [];
+    const values: string[] = [];
 
     for (const prop of obj.getProperties()) {
       if (prop.isKind(SyntaxKind.PropertyAssignment)) {
@@ -120,9 +125,14 @@ export class DatabaseAnalyzer extends BaseAnalyzer<DatabaseAnalyzerResult> {
           });
         } else {
           keys.push(prop.getName());
+          const init = prop.getInitializerOrThrow();
+          if (init.isKind(SyntaxKind.Identifier)) {
+            values.push(init.getText());
+          }
         }
       } else if (prop.isKind(SyntaxKind.ShorthandPropertyAssignment)) {
         keys.push(prop.getName());
+        values.push(prop.getName());
       } else if (prop.isKind(SyntaxKind.SpreadAssignment)) {
         this.addDiagnostic({
           severity: 'warning',
@@ -136,6 +146,6 @@ export class DatabaseAnalyzer extends BaseAnalyzer<DatabaseAnalyzerResult> {
       }
     }
 
-    return keys;
+    return { keys, values };
   }
 }

--- a/packages/compiler/src/ir/types.ts
+++ b/packages/compiler/src/ir/types.ts
@@ -222,6 +222,7 @@ export interface ResolvedField {
 
 export interface DatabaseIR extends SourceLocation {
   modelKeys: string[];
+  modelValues: string[];
 }
 
 // ── Entity ─────────────────────────────────────────────────────────

--- a/packages/compiler/src/validators/completeness-validator.ts
+++ b/packages/compiler/src/validators/completeness-validator.ts
@@ -304,18 +304,18 @@ export class CompletenessValidator implements Validator {
     // Skip if no createDb() calls found (e.g., using plain EntityDbAdapter)
     if (ir.databases.length === 0) return;
 
-    const allModelKeys = new Set<string>();
+    const allModelValues = new Set<string>();
     for (const db of ir.databases) {
-      for (const key of db.modelKeys) {
-        allModelKeys.add(key);
+      for (const value of db.modelValues) {
+        allModelValues.add(value);
       }
     }
 
     for (const entity of ir.entities) {
-      if (!allModelKeys.has(entity.name)) {
+      if (!allModelValues.has(entity.modelRef.variableName)) {
         const registeredList = ir.databases
           .flatMap((db) =>
-            db.modelKeys.map((key) => `"${key}" (${db.sourceFile}:${db.sourceLine})`),
+            db.modelValues.map((value) => `${value} (${db.sourceFile}:${db.sourceLine})`),
           )
           .join(', ');
 
@@ -324,8 +324,8 @@ export class CompletenessValidator implements Validator {
             severity: 'error',
             code: 'ENTITY_MODEL_NOT_REGISTERED',
             message:
-              `Entity "${entity.name}" is not registered in any createDb() call. ` +
-              `Add "${entity.name}: ${entity.modelRef.variableName}" to the models object in createDb().`,
+              `Entity "${entity.name}" model "${entity.modelRef.variableName}" is not registered in any createDb() call. ` +
+              `Add ${entity.modelRef.variableName} to the models object in createDb().`,
             suggestion: registeredList
               ? `Registered models: ${registeredList}`
               : 'No models registered in any createDb() call.',


### PR DESCRIPTION
## Summary

- Fixed validator comparing entity names against database model keys, causing false positives for kebab-case entity names with camelCase model properties
- Changed `DatabaseIR` to track `modelValues` (variable names) in addition to `modelKeys` (property names)
- Validator now matches `entity.modelRef.variableName` against `modelValues`, the actual semantic link between entities and database models

## Test plan

- [x] All 19 database analyzer tests pass, including new test for kebab-case entity names
- [x] All 818 compiler tests pass
- [x] Typecheck clean
- [x] Quality gates (lint, build, typecheck, test) passed in pre-push hook
- [x] Fixes #1512: codegen in examples/linear will now succeed