### PR TITLE
fix(server): await jwks reload() in refresh() to fix flaky CI

### DIFF
--- a/packages/server/src/auth/jwks-client.ts
+++ b/packages/server/src/auth/jwks-client.ts
@@ -23,7 +23,7 @@ export function createJWKSClient(options: {
       // jose's reload() is marked @ignore in types but exists at runtime.
       // It invalidates the cache so the next getKey call re-fetches.
       if ('reload' in jwks && typeof (jwks as { reload: unknown }).reload === 'function') {
-        (jwks as { reload: () => void }).reload();
+        await (jwks as { reload: () => Promise<void> }).reload();
       }
     },
   };


### PR DESCRIPTION
## Summary

- **Fix:** `refresh()` in `createJWKSClient` was calling jose's `reload()` without `await`, causing a race condition where the JWKS fetch might not complete before the next JWT verification
- This made the `createJWKSClient > forces a re-fetch on next verification after refresh()` test fail flakily on CI (passed locally due to faster localhost fetch)
- Also fixed the incorrect type cast from `() => void` to `() => Promise<void>` which masked the missing await

## Public API Changes

None — `refresh()` was already declared `async` and callers already `await` it. The behavior now matches the contract.

## Test plan

- [x] Existing test `forces a re-fetch on next verification after refresh() is called` passes locally
- [x] Full quality gates pass (test + typecheck + lint)
- [ ] CI passes on this PR (was the failing test on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)