### PR TITLE
test(ui-server): improve plugin.ts coverage to 99.54%

### DIFF
--- a/packages/ui-server/src/__tests__/bun-plugin-onload.test.ts
+++ b/packages/ui-server/src/__tests__/bun-plugin-onload.test.ts
@@ -788,6 +788,39 @@ export function Gallery() {
         expect(threw).toBe(true);
       }
     });
+
+    it('uses fallback paths when image file does not exist on disk', async () => {
+      // Reference a non-existent image — computeImageOutputPaths returns null,
+      // triggering the fallback path (lines 342-347) and producing an image
+      // transform source map (line 385).
+      const filePath = project.write(
+        'missing-img.tsx',
+        `
+import { Image } from '@vertz/ui';
+
+export function MissingImg() {
+  return <Image src="./nonexistent.png" width={200} height={150} alt="Missing" />;
+}
+`,
+      );
+
+      const { plugin } = createVertzBunPlugin({
+        projectRoot: project.dir,
+        srcDir: project.srcDir,
+        cssOutDir: project.cssDir,
+        hmr: false,
+        fastRefresh: false,
+      });
+
+      const result = await runPluginOnLoad(plugin, filePath);
+
+      // The transform should succeed — fallback paths are used instead of
+      // crashing, and no image processing is attempted.
+      expect(result.contents).toContain('MissingImg');
+      expect(result.loader).toBe('tsx');
+      // The <Image> should have been replaced with <picture> using fallback paths
+      expect(result.contents).toContain('picture');
+    });
   });
 
   describe('manifest HMR warning logging during updateManifest', () => {


### PR DESCRIPTION
## Summary

- Add test case for image transform fallback path when source file doesn't exist
- Covers uncovered code lines 342-347 (fallback path generation) and 385 (source map chaining)
- Improved `plugin.ts` coverage from 97.92% to 99.54%

## Test plan

- [x] All 891 tests pass in ui-server package
- [x] New test: "uses fallback paths when image file does not exist on disk"
- [x] Typecheck passes
- [x] Linting passes
- [x] Quality gates passed (pre-push checks)