### PR TITLE
fix(server): increase forgot-password race timeout for CI

### DIFF
--- a/packages/server/src/auth/__tests__/handler-edge-cases.test.ts
+++ b/packages/server/src/auth/__tests__/handler-edge-cases.test.ts
@@ -443,7 +443,7 @@ describe('Email Verification Handler Edge Cases', () => {
 
     const race = await Promise.race([
       pendingResponse.then(() => 'resolved'),
-      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 25)),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 500)),
     ]);
 
     releaseSend?.();


### PR DESCRIPTION
## Summary

- Fix flaky CI test: `forgot-password does not wait for delivery callback before responding`
- Increased `Promise.race` timeout from 25ms to 500ms — CI runners are too slow for 25ms
- The test logic is unchanged: it still verifies the handler responds before the delivery callback (held by `releaseSend`), just with enough headroom for slow runners

## Test plan

- [x] `bun test packages/server/src/auth/__tests__/handler-edge-cases.test.ts` — 52 pass, 0 fail
- [x] Pre-push quality gates pass (lint, typecheck, test, build)