### PR TITLE
fix(ui): preserve prototype chain in __list item proxies (#1581)

### DIFF
--- a/.changeset/fix-list-proxy-instanceof.md
+++ b/.changeset/fix-list-proxy-instanceof.md
@@ -1,0 +1,11 @@
+---
+'@vertz/ui': patch
+---
+
+fix(ui): preserve prototype chain in `__list` item proxies (#1581)
+
+`createItemProxy` used `{}` as the Proxy target, which broke `instanceof` checks
+(e.g., `val instanceof Date`) and `Array.isArray()` for proxied list items.
+Changed to use the initial item value as the target and added a `getPrototypeOf`
+trap that reads from the live signal value. Also added a read-only `set` trap to
+prevent accidental mutation of original items through the proxy.

--- a/packages/ui-primitives/src/calendar/__tests__/calendar-composed.test.ts
+++ b/packages/ui-primitives/src/calendar/__tests__/calendar-composed.test.ts
@@ -258,6 +258,30 @@ describe('Composed Calendar', () => {
         const val = onValueChange.mock.calls[0]?.[0] as Date;
         expect(val.getDate()).toBe(10);
       });
+
+      it('Then updates aria-selected on the clicked date (#1581)', () => {
+        const root = ComposedCalendar({
+          defaultMonth: new Date(2024, 5, 1),
+        });
+        container.appendChild(root);
+
+        const btn10 = root.querySelector('button[data-date="2024-06-10"]') as HTMLButtonElement;
+        const btn15 = root.querySelector('button[data-date="2024-06-15"]') as HTMLButtonElement;
+
+        // Before click: no date is selected
+        expect(btn10.getAttribute('aria-selected')).toBeNull();
+        expect(btn15.getAttribute('aria-selected')).toBeNull();
+
+        // Click date 10
+        btn10.click();
+        expect(btn10.getAttribute('aria-selected')).toBe('true');
+        expect(btn15.getAttribute('aria-selected')).toBeNull();
+
+        // Click date 15 — selection moves
+        btn15.click();
+        expect(btn10.getAttribute('aria-selected')).toBeNull();
+        expect(btn15.getAttribute('aria-selected')).toBe('true');
+      });
     });
   });
 

--- a/packages/ui/src/dom/__tests__/list.test.ts
+++ b/packages/ui/src/dom/__tests__/list.test.ts
@@ -747,4 +747,108 @@ describe('__list', () => {
       expect(container.children[1]?.textContent).toBe('A');
     });
   });
+
+  describe('item proxy prototype preservation (#1581)', () => {
+    it('Date items preserve instanceof Date through the proxy', () => {
+      const dates = signal([new Date(2024, 5, 10), new Date(2024, 5, 11)]);
+      const container = document.createElement('div');
+      const receivedItems: unknown[] = [];
+
+      __list(
+        container,
+        dates,
+        (_item, i) => i,
+        (item) => {
+          receivedItems.push(item);
+          const el = document.createElement('span');
+          el.textContent = String(item);
+          return el;
+        },
+      );
+
+      // The item proxy must preserve instanceof so that user code
+      // like `val instanceof Date` works correctly.
+      expect(receivedItems[0] instanceof Date).toBe(true);
+      expect(receivedItems[1] instanceof Date).toBe(true);
+    });
+
+    it('Array items preserve Array.isArray through the proxy', () => {
+      const rows = signal([
+        [1, 2],
+        [3, 4],
+      ]);
+      const container = document.createElement('div');
+      const receivedItems: unknown[] = [];
+
+      __list(
+        container,
+        rows,
+        (_item, i) => i,
+        (item) => {
+          receivedItems.push(item);
+          const el = document.createElement('span');
+          return el;
+        },
+      );
+
+      expect(Array.isArray(receivedItems[0])).toBe(true);
+      expect(Array.isArray(receivedItems[1])).toBe(true);
+    });
+
+    it('instanceof stays correct after key-reuse signal update', () => {
+      const dates = signal([new Date(2024, 0, 1), new Date(2024, 0, 2)]);
+      const container = document.createElement('div');
+      const receivedItems: unknown[] = [];
+
+      __list(
+        container,
+        dates,
+        (_item, i) => i,
+        (item) => {
+          receivedItems.push(item);
+          const el = document.createElement('span');
+          return el;
+        },
+      );
+
+      // Initial: instanceof works
+      expect(receivedItems[0] instanceof Date).toBe(true);
+
+      // Update items with the same keys (index-based) — proxy is reused,
+      // signal value changes, getPrototypeOf should reflect the new value.
+      dates.value = [new Date(2025, 6, 15), new Date(2025, 6, 16)];
+
+      // The proxy from the initial render should still report correct prototype
+      expect(receivedItems[0] instanceof Date).toBe(true);
+      expect(Object.getPrototypeOf(receivedItems[0])).toBe(Date.prototype);
+    });
+
+    it('proxy is read-only — set returns false', () => {
+      const items = signal([{ id: 1, name: 'A' }]);
+      const container = document.createElement('div');
+      let proxyItem: { id: number; name: string } | undefined;
+
+      __list(
+        container,
+        items,
+        (item) => item.id,
+        (item) => {
+          proxyItem = item;
+          const el = document.createElement('span');
+          return el;
+        },
+      );
+
+      // Strict mode would throw, but in non-strict it returns false.
+      // Either way, the original item should not be mutated.
+      const original = items.peek()[0];
+      expect(original).toBeDefined();
+      try {
+        (proxyItem as { id: number; name: string }).name = 'mutated';
+      } catch {
+        // Expected in strict mode
+      }
+      expect(original?.name).toBe('A');
+    });
+  });
 });

--- a/packages/ui/src/dom/list.ts
+++ b/packages/ui/src/dom/list.ts
@@ -8,42 +8,58 @@ import type { DisposeFn, Signal } from '../runtime/signal-types';
  * Property accesses read from `itemSignal.value`, so any domEffect
  * that reads through the proxy automatically subscribes to the signal.
  * When `itemSignal.value` is updated, those effects re-run.
+ *
+ * The initial value is used as the Proxy target to preserve `instanceof`
+ * checks and `Array.isArray()`. The `getPrototypeOf` trap reads from
+ * the live signal value so `instanceof` stays correct after updates.
+ *
+ * Note: `Array.isArray()` checks the target's internal [[Class]] slot,
+ * which is fixed at proxy creation time. If an item changes from array
+ * to non-array (or vice versa) for the same key, `Array.isArray` will
+ * be stale. In practice, __list items maintain stable types per key.
  */
 function createItemProxy<T>(itemSignal: Signal<T>): T {
-  if (typeof itemSignal.peek() !== 'object' || itemSignal.peek() == null) {
+  const initial = itemSignal.peek();
+  if (typeof initial !== 'object' || initial == null) {
     // Primitives and null can't be proxied — return the value directly.
     // These items won't get reactive updates on key reuse.
-    return itemSignal.peek();
+    return initial;
   }
-  return new Proxy(
-    {},
-    {
-      get(_target, prop, receiver) {
-        const current = itemSignal.value;
-        if (current == null) return undefined;
-        const value = Reflect.get(current as object, prop, receiver);
-        if (typeof value === 'function') {
-          return value.bind(current);
-        }
-        return value;
-      },
-      has(_target, prop) {
-        const current = itemSignal.value;
-        if (current == null) return false;
-        return Reflect.has(current as object, prop);
-      },
-      ownKeys() {
-        const current = itemSignal.value;
-        if (current == null) return [];
-        return Reflect.ownKeys(current as object);
-      },
-      getOwnPropertyDescriptor(_target, prop) {
-        const current = itemSignal.value;
-        if (current == null) return undefined;
-        return Reflect.getOwnPropertyDescriptor(current as object, prop);
-      },
+  return new Proxy(initial as object, {
+    get(_target, prop, receiver) {
+      const current = itemSignal.value;
+      if (current == null) return undefined;
+      const value = Reflect.get(current as object, prop, receiver);
+      if (typeof value === 'function') {
+        return value.bind(current);
+      }
+      return value;
     },
-  ) as T;
+    set() {
+      // Items are read-only through the proxy — mutations go through the signal.
+      return false;
+    },
+    has(_target, prop) {
+      const current = itemSignal.value;
+      if (current == null) return false;
+      return Reflect.has(current as object, prop);
+    },
+    ownKeys() {
+      const current = itemSignal.value;
+      if (current == null) return [];
+      return Reflect.ownKeys(current as object);
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      const current = itemSignal.value;
+      if (current == null) return undefined;
+      return Reflect.getOwnPropertyDescriptor(current as object, prop);
+    },
+    getPrototypeOf() {
+      const current = itemSignal.value;
+      if (current == null) return null;
+      return Object.getPrototypeOf(current);
+    },
+  }) as T;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Root cause**: `createItemProxy` in `__list` used `{}` as the Proxy target, destroying the prototype chain. This caused `instanceof Date` and `Array.isArray()` to return `false` for proxied list items.
- **Impact**: Calendar's `isSelectedDate()` uses `val instanceof Date`, which returned `false` for proxied Date items, preventing reactive `aria-selected` attribute updates after clicking a date.
- **Fix**: Use the initial item value as the Proxy target (preserves `instanceof` and `Array.isArray`), add a `getPrototypeOf` trap reading from the live signal value, and add a read-only `set` trap.

## Public API Changes

None — `createItemProxy` is an internal function. The fix makes proxied items behave more correctly (preserving prototype identity), which is a bugfix, not a behavior change.

## Test plan

- [x] New unit tests in `list.test.ts`: Date `instanceof`, `Array.isArray`, key-reuse prototype preservation, proxy read-only behavior
- [x] Calendar integration test: click date → verify `aria-selected` updates
- [x] All existing `__list` tests pass (27 total)
- [x] Full `@vertz/ui` test suite passes (2251 tests)
- [x] Full `@vertz/ui-primitives` test suite passes (836 tests)
- [x] Full CI pipeline passes (82 tasks)

Closes #1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)