### PR TITLE
fix(examples): fix seed tests + Calendar dropdown test assertions (#1589)

### DIFF
--- a/examples/linear/src/api/seed.test.ts
+++ b/examples/linear/src/api/seed.test.ts
@@ -29,7 +29,7 @@ describe('seedDatabase', () => {
         issues: issuesModel,
         comments: commentsModel,
         labels: labelsModel,
-        issueLabels: issueLabelsModel,
+        'issue-labels': issueLabelsModel,
       },
       dialect: 'sqlite',
       path: dbPath,
@@ -132,7 +132,7 @@ describe('seedDatabase', () => {
 
       it('Then assigns labels to some issues via issue_labels', async () => {
         await seedDatabase(client);
-        const count = unwrap(await client.issueLabels.count());
+        const count = unwrap(await client['issue-labels'].count());
         expect(count).toBeGreaterThan(0);
       });
 


### PR DESCRIPTION
## Summary

- **Seed tests**: Fixed model key mismatch in `examples/linear/src/api/seed.test.ts` — the test registered `issueLabelsModel` as `issueLabels` (camelCase) but `seedDatabase()` expects `'issue-labels'` (kebab-case), matching the production `db.ts`. This caused all 16 seed tests to fail.
- **Calendar dropdown tests**: Fixed 3 pre-existing test failures in `packages/ui-primitives` caused by interaction between #1585 (Calendar dropdowns) and #1588 (IDL property assignment). Tests now verify behavior through grid dates instead of relying on `select.value` which doesn't work in happy-dom when `option.selected` is set on detached elements. Filed #1596 for the underlying framework issue.

## Public API Changes

None — test-only changes.

## Test plan

- [x] All 33 seed+schema tests pass in `examples/linear/src/api/`
- [x] All 65 Calendar tests pass in `packages/ui-primitives/src/calendar/`
- [x] Full ui-primitives test suite passes (859/859)
- [x] Pre-push quality gates pass (lint, typecheck, test, build)

Fixes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)