### PR TITLE
fix(theme-shadcn): ContextMenu too thin, missing padding around items

### DIFF
--- a/.changeset/contextmenu-spacing-fix.md
+++ b/.changeset/contextmenu-spacing-fix.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+fix(theme-shadcn): ContextMenu content has min-width, all-sided padding, and visual consistency with DropdownMenu

--- a/packages/theme-shadcn/src/__tests__/context-menu.test.ts
+++ b/packages/theme-shadcn/src/__tests__/context-menu.test.ts
@@ -26,6 +26,16 @@ describe('context-menu styles', () => {
     expect(cm.css).toContain('vz-zoom-in');
     expect(cm.css).toContain('vz-zoom-out');
   });
+
+  it('content has min-width for reasonable sizing', () => {
+    expect(cm.css).toContain('min-width');
+  });
+
+  it('content has padding on all sides (not just vertical)', () => {
+    // Content should use p:1 (all-sided padding), not just py:1
+    // This ensures items have spacing from the container border
+    expect(cm.css).toMatch(/padding:\s*0\.25rem/);
+  });
 });
 
 // ── Themed Component ──────────────────────────────────────

--- a/packages/theme-shadcn/src/styles/context-menu.ts
+++ b/packages/theme-shadcn/src/styles/context-menu.ts
@@ -18,11 +18,16 @@ export function createContextMenuStyles(): CSSOutput<ContextMenuBlocks> {
       'overflow-hidden',
       'bg:popover',
       'text:popover-foreground',
-      'rounded:md',
-      'border:1',
-      'border:border',
-      'shadow:md',
-      'py:1',
+      'rounded:lg',
+      'w:fit',
+      'p:1',
+      {
+        '&': {
+          'box-shadow':
+            '0 0 0 1px color-mix(in oklch, var(--color-foreground) 10%, transparent), 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+          'min-width': '8rem',
+        },
+      },
       {
         '&[data-state="open"]': [animationDecl('vz-zoom-in 150ms ease-out forwards')],
       },
@@ -33,19 +38,30 @@ export function createContextMenuStyles(): CSSOutput<ContextMenuBlocks> {
     cmItem: [
       'flex',
       'items:center',
-      'px:2',
-      'py:1.5',
+      'gap:1.5',
+      'px:1.5',
+      'py:1',
       'text:sm',
       'cursor:pointer',
-      'rounded:sm',
+      'rounded:md',
       'outline-none',
       { '&:hover': ['bg:accent', 'text:accent-foreground'] },
       { '&:focus': ['bg:accent', 'text:accent-foreground'] },
       { '&[data-disabled]': ['pointer-events-none', 'opacity:0.5'] },
     ],
     cmGroup: ['py:1'],
-    cmLabel: ['px:2', 'py:1.5', 'text:xs', 'font:semibold', 'text:muted-foreground'],
-    cmSeparator: ['mx:1', 'my:1', 'border-t:1', 'border:muted', { '&': { height: '1px' } }],
+    cmLabel: ['px:1.5', 'py:1', 'text:xs', 'font:medium', 'text:muted-foreground'],
+    cmSeparator: [
+      'my:1',
+      'bg:border',
+      {
+        '&': {
+          'margin-left': '-0.25rem',
+          'margin-right': '-0.25rem',
+          height: '1px',
+        },
+      },
+    ],
   });
   return {
     content: s.cmContent,


### PR DESCRIPTION
## Summary

- Aligned ContextMenu styles with DropdownMenu for visual consistency
- Added `min-width: 8rem` to prevent the menu from being too narrow
- Changed `py:1` to `p:1` on content so items have padding from all container edges
- Updated item, label, and separator styles to match DropdownMenu conventions

## Public API Changes

None — internal CSS styling only.

## Test plan

- [x] Existing context-menu style tests pass (13/13)
- [x] New test: content has `min-width` for reasonable sizing
- [x] New test: content has padding on all sides (not just vertical)
- [x] Typecheck clean
- [x] Biome lint clean

Fixes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)