### PR TITLE
fix(theme-shadcn): HoverCard missing padding and styling

### DIFF
--- a/.changeset/hovercard-styling-fix.md
+++ b/.changeset/hovercard-styling-fix.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Fix HoverCard styling: upgrade border-radius to lg, add outline-none, add zoom animation alongside fade for consistent appearance with other floating components

--- a/examples/component-catalog/src/demos/hover-card.tsx
+++ b/examples/component-catalog/src/demos/hover-card.tsx
@@ -13,17 +13,15 @@ export function HoverCardDemo() {
             </span>
           </HoverCard.Trigger>
           <HoverCard.Content>
-            <div style="padding: 16px; width: 280px;">
-              <h4 style="font-size: 14px; font-weight: 600; margin: 0 0 4px; color: var(--color-foreground);">
-                Vertz Framework
-              </h4>
-              <p style="font-size: 13px; color: var(--color-muted-foreground); margin: 0 0 8px;">
-                The full-stack TypeScript framework designed for LLM-first development.
-              </p>
-              <p style="font-size: 12px; color: var(--color-muted-foreground); margin: 0;">
-                Joined December 2025
-              </p>
-            </div>
+            <h4 style="font-size: 14px; font-weight: 600; margin: 0 0 4px; color: var(--color-foreground);">
+              Vertz Framework
+            </h4>
+            <p style="font-size: 13px; color: var(--color-muted-foreground); margin: 0 0 8px;">
+              The full-stack TypeScript framework designed for LLM-first development.
+            </p>
+            <p style="font-size: 12px; color: var(--color-muted-foreground); margin: 0;">
+              Joined December 2025
+            </p>
           </HoverCard.Content>
         </HoverCard>
       </div>

--- a/packages/theme-shadcn/src/__tests__/hover-card.test.ts
+++ b/packages/theme-shadcn/src/__tests__/hover-card.test.ts
@@ -15,6 +15,21 @@ describe('hover-card styles', () => {
     expect(typeof styles.css).toBe('string');
     expect(styles.css.length).toBeGreaterThan(0);
   });
+
+  it('CSS contains outline:none for content', () => {
+    expect(styles.css).toContain('outline: none');
+  });
+
+  it('CSS uses lg border-radius (0.5rem) consistent with other floating components', () => {
+    expect(styles.css).toContain('0.5rem');
+  });
+
+  it('CSS contains both fade and zoom animations for open/close states', () => {
+    expect(styles.css).toContain('vz-fade-in');
+    expect(styles.css).toContain('vz-fade-out');
+    expect(styles.css).toContain('vz-zoom-in');
+    expect(styles.css).toContain('vz-zoom-out');
+  });
 });
 
 describe('themed HoverCard', () => {

--- a/packages/theme-shadcn/src/styles/hover-card.ts
+++ b/packages/theme-shadcn/src/styles/hover-card.ts
@@ -11,21 +11,26 @@ export function createHoverCardStyles(): CSSOutput<HoverCardBlocks> {
   const s = css({
     hoverCardContent: [
       'z:50',
-      'rounded:md',
+      'rounded:lg',
       'border:1',
       'border:border',
       'bg:popover',
       'text:popover-foreground',
       'shadow:md',
+      'outline-none',
       'p:4',
       {
         '&': { width: '16rem' },
       },
       {
-        '&[data-state="open"]': [animationDecl('vz-fade-in 150ms ease-out forwards')],
+        '&[data-state="open"]': [
+          animationDecl('vz-fade-in 150ms ease-out forwards, vz-zoom-in 150ms ease-out forwards'),
+        ],
       },
       {
-        '&[data-state="closed"]': [animationDecl('vz-fade-out 150ms ease-out forwards')],
+        '&[data-state="closed"]': [
+          animationDecl('vz-fade-out 150ms ease-out forwards, vz-zoom-out 150ms ease-out forwards'),
+        ],
       },
     ],
   });


### PR DESCRIPTION
## Summary

- Upgrade HoverCard `border-radius` from `md` (0.375rem) to `lg` (0.5rem) to match other floating components (Popover, DropdownMenu)
- Add `outline-none` to prevent browser default focus outline on the dialog element
- Add `vz-zoom-in`/`vz-zoom-out` animation alongside existing fade for consistent open/close transitions matching shadcn/ui Nova reference
- Remove redundant inline `padding: 16px; width: 280px` wrapper div in component-catalog demo (theme now handles this)

## Public API Changes

No breaking changes. The `createHoverCardStyles()` function produces different CSS output (visual improvement only).

## Test plan

- [x] New tests verify `outline: none` is present in generated CSS
- [x] New tests verify `border-radius: 0.5rem` (lg) in generated CSS
- [x] New tests verify both `vz-fade-in/out` and `vz-zoom-in/out` animations
- [x] All 10 hover-card tests pass
- [x] All 483 theme-shadcn tests pass
- [x] Typecheck clean
- [x] Biome lint clean

Fixes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)