### PR TITLE
fix(ui): Select dropdown animation (#1615)

### DIFF
--- a/.changeset/select-dropdown-animation.md
+++ b/.changeset/select-dropdown-animation.md
@@ -1,0 +1,6 @@
+---
+'@vertz/theme-shadcn': patch
+'@vertz/ui-primitives': patch
+---
+
+Fix Select dropdown open/close animation: correct keyframe names and defer display:none until exit animation completes

--- a/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
@@ -128,6 +128,15 @@ describe('select', () => {
     expect(select.css).toContain('vz-zoom-out');
   });
 
+  it('CSS uses correct slide keyframe names for directional open animations', () => {
+    // data-side="bottom" → slide in from top, data-side="top" → slide in from bottom
+    expect(select.css).toContain('vz-slide-in-from-top');
+    expect(select.css).toContain('vz-slide-in-from-bottom');
+    // Must NOT reference non-existent keyframe names
+    expect(select.css).not.toContain('vz-slide-down-in');
+    expect(select.css).not.toContain('vz-slide-up-in');
+  });
+
   it('CSS does not use display:none for animated content states', () => {
     // display:none is allowed for the indicator (hidden until selected),
     // but not for the content panel animated open/close states.

--- a/packages/theme-shadcn/src/styles/select.ts
+++ b/packages/theme-shadcn/src/styles/select.ts
@@ -80,21 +80,21 @@ export function createSelectStyles(): CSSOutput<SelectBlocks> {
       },
       {
         '&[data-state="open"][data-side="bottom"]': [
-          animationDecl('vz-slide-down-in 100ms ease-out forwards'),
+          animationDecl('vz-slide-in-from-top 150ms ease-out forwards'),
         ],
       },
       {
         '&[data-state="open"][data-side="top"]': [
-          animationDecl('vz-slide-up-in 100ms ease-out forwards'),
+          animationDecl('vz-slide-in-from-bottom 150ms ease-out forwards'),
         ],
       },
       {
         '&[data-state="open"]:not([data-side])': [
-          animationDecl('vz-zoom-in 100ms ease-out forwards'),
+          animationDecl('vz-zoom-in 150ms ease-out forwards'),
         ],
       },
       {
-        '&[data-state="closed"]': [animationDecl('vz-zoom-out 100ms ease-out forwards')],
+        '&[data-state="closed"]': [animationDecl('vz-zoom-out 150ms ease-out forwards')],
       },
     ],
     selectItem: [

--- a/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
+++ b/packages/ui-primitives/src/select/__tests__/select-composed.test.ts
@@ -528,4 +528,53 @@ describe('Composed Select', () => {
       expect(pos === 'fixed' || pos === 'absolute').toBe(true);
     });
   });
+
+  describe('Given an open Select (#1615)', () => {
+    describe('When the dropdown is closed while an animation is playing', () => {
+      it('Then defers display:none until the exit animation completes', async () => {
+        const root = ComposedSelect({
+          children: () => {
+            const t = ComposedSelect.Trigger({ children: ['Pick'] });
+            const c = ComposedSelect.Content({
+              children: () => [ComposedSelect.Item({ value: 'a', children: ['A'] })],
+            });
+            return [t, c];
+          },
+        });
+        container.appendChild(root);
+
+        // Open the select
+        const trigger = root.querySelector('[role="combobox"]') as HTMLElement;
+        trigger!.click();
+
+        const listbox = root.querySelector('[role="listbox"]') as HTMLElement;
+        expect(listbox!.style.display).not.toBe('none');
+
+        // Mock a running CSS animation on the content
+        let resolveAnim!: () => void;
+        const animFinished = new Promise<void>((resolve) => {
+          resolveAnim = resolve;
+        });
+        listbox!.getAnimations = () => [{ finished: animFinished } as unknown as Animation];
+
+        // Close the select
+        trigger!.click();
+
+        // data-state should be "closed" immediately (triggers CSS exit animation)
+        expect(listbox!.getAttribute('data-state')).toBe('closed');
+        // aria-hidden should be set immediately for screen readers
+        expect(listbox!.getAttribute('aria-hidden')).toBe('true');
+        // But display should NOT be "none" yet — animation still running
+        expect(listbox!.style.display).not.toBe('none');
+
+        // Finish the animation
+        resolveAnim();
+        await animFinished;
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Now display should be "none"
+        expect(listbox!.style.display).toBe('none');
+      });
+    });
+  });
 });

--- a/packages/ui-primitives/src/select/select-composed.tsx
+++ b/packages/ui-primitives/src/select/select-composed.tsx
@@ -7,6 +7,7 @@
 
 import type { ChildValue, Ref } from '@vertz/ui';
 import { createContext, onMount, ref, useContext } from '@vertz/ui';
+import { setHiddenAnimated } from '../utils/aria';
 import { createDismiss } from '../utils/dismiss';
 import type { FloatingOptions } from '../utils/floating';
 import { createFloatingPosition } from '../utils/floating';
@@ -303,18 +304,25 @@ function ComposedSelectRoot({
     trigger.setAttribute('data-state', nowOpen ? 'open' : 'closed');
   }
 
-  function syncContentAttrs(nowOpen: boolean): void {
+  function showContent(): void {
     const content = getContentEl();
     if (!content) return;
-    content.setAttribute('data-state', nowOpen ? 'open' : 'closed');
-    content.setAttribute('aria-hidden', nowOpen ? 'false' : 'true');
-    content.style.display = nowOpen ? '' : 'none';
+    content.setAttribute('data-state', 'open');
+    content.setAttribute('aria-hidden', 'false');
+    content.style.display = '';
+  }
+
+  function hideContent(): void {
+    const content = getContentEl();
+    if (!content) return;
+    content.setAttribute('data-state', 'closed');
+    setHiddenAnimated(content, true);
   }
 
   function open(): void {
     isOpen = true;
     syncTriggerAttrs(true);
-    syncContentAttrs(true);
+    showContent();
 
     const contentEl = getContentEl();
     const triggerEl = getTriggerEl();
@@ -350,15 +358,7 @@ function ComposedSelectRoot({
   function close(): void {
     isOpen = false;
     syncTriggerAttrs(false);
-    syncContentAttrs(false);
-
-    // Reset floating position styles
-    const contentEl = getContentEl();
-    if (contentEl) {
-      contentEl.style.position = '';
-      contentEl.style.left = '';
-      contentEl.style.top = '';
-    }
+    hideContent();
 
     state.floatingCleanup?.();
     state.floatingCleanup = null;


### PR DESCRIPTION
## Summary

- Fix Select dropdown having no open/close animation due to non-existent CSS keyframe names (`vz-slide-down-in` / `vz-slide-up-in` → `vz-slide-in-from-top` / `vz-slide-in-from-bottom`)
- Use `setHiddenAnimated()` in composed Select close path to defer `display: none` until exit animation completes (previously set instantly, preventing close animation)
- Normalize animation duration to 150ms for consistency with other components

## Public API Changes

None — CSS-only + internal behavior fix.

## Test plan

- [x] Theme style test: verifies correct keyframe names in CSS output and absence of old names
- [x] Composed select test: verifies `display:none` is deferred until animation completes on close
- [x] All 872 ui-primitives tests pass
- [x] All select-related theme-shadcn tests pass (11/11)
- [x] Pre-push quality gates: 82/82 tasks successful

Fixes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)