### PR TITLE
fix(theme-shadcn): enable floating positioning for menubar submenus

### DIFF
--- a/.changeset/menubar-submenu-positioning.md
+++ b/.changeset/menubar-submenu-positioning.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Fix menubar submenus being mispositioned and pushing sibling items by enabling floating positioning (`bottom-start` placement) in the themed menubar component

--- a/packages/theme-shadcn/src/__tests__/menubar.test.ts
+++ b/packages/theme-shadcn/src/__tests__/menubar.test.ts
@@ -242,4 +242,81 @@ describe('themed Menubar (JSX component)', () => {
     expect(typeof Menubar.Label).toBe('function');
     expect(typeof Menubar.Separator).toBe('function');
   });
+
+  it('uses fixed positioning on content when menu is opened (#1612)', async () => {
+    const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
+    const styles = createMenubarStyles();
+    const Menubar = createThemedMenubar(styles);
+
+    const root = Menubar({
+      children: () => {
+        const menu = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [menu];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[aria-haspopup="menu"]') as HTMLElement;
+    trigger.click();
+    // Wait for computePosition promise to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    const content = root.querySelector('[role="menu"]') as HTMLElement;
+    expect(content.getAttribute('data-state')).toBe('open');
+    // Floating positioning should set position: fixed on the content
+    expect(content.style.position).toBe('fixed');
+  });
+
+  it('does not shift sibling menubar items when a menu opens (#1612)', async () => {
+    const { createThemedMenubar } = await import('../components/primitives/menubar');
+    const { ComposedMenubar } = await import('@vertz/ui-primitives');
+    const styles = createMenubarStyles();
+    const Menubar = createThemedMenubar(styles);
+
+    const root = Menubar({
+      children: () => {
+        const file = ComposedMenubar.Menu({
+          value: 'file',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['File'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+            });
+            return [t, c];
+          },
+        });
+        const edit = ComposedMenubar.Menu({
+          value: 'edit',
+          children: () => {
+            const t = ComposedMenubar.Trigger({ children: ['Edit'] });
+            const c = ComposedMenubar.Content({
+              children: () => [ComposedMenubar.Item({ value: 'undo', children: ['Undo'] })],
+            });
+            return [t, c];
+          },
+        });
+        return [file, edit];
+      },
+    });
+    container.appendChild(root);
+
+    const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+    trigger.click();
+    // Wait for computePosition promise to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Content should use fixed positioning (out of normal flow)
+    const content = root.querySelector('[role="menu"]') as HTMLElement;
+    expect(content.style.position).toBe('fixed');
+  });
 });

--- a/packages/theme-shadcn/src/components/primitives/menubar.ts
+++ b/packages/theme-shadcn/src/components/primitives/menubar.ts
@@ -79,7 +79,7 @@ export function createThemedMenubar(styles: MenubarStyleClasses): ThemedMenubarC
   });
 
   function MenubarRoot({ children, onSelect }: MenubarRootProps): HTMLElement {
-    return Styled({ children, onSelect });
+    return Styled({ children, onSelect, positioning: { placement: 'bottom-start' } });
   }
 
   return Object.assign(MenubarRoot, {

--- a/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
+++ b/packages/ui-primitives/src/menubar/__tests__/menubar-composed.test.ts
@@ -363,6 +363,67 @@ describe('Composed Menubar', () => {
     });
   });
 
+  describe('Given a Menubar with positioning prop', () => {
+    it('Then content gets fixed positioning when opened', async () => {
+      const root = ComposedMenubar({
+        positioning: { placement: 'bottom-start' },
+        children: () => {
+          const file = ComposedMenubar.Menu({
+            value: 'file',
+            children: () => {
+              const t = ComposedMenubar.Trigger({ children: ['File'] });
+              const c = ComposedMenubar.Content({
+                children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+              });
+              return [t, c];
+            },
+          });
+          return [file];
+        },
+      });
+      container.appendChild(root);
+
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      trigger.click();
+      // Wait for computePosition promise to resolve
+      await new Promise((r) => setTimeout(r, 10));
+
+      const content = root.querySelector('[role="menu"]') as HTMLElement;
+      expect(content.getAttribute('data-state')).toBe('open');
+      expect(content.style.position).toBe('fixed');
+    });
+
+    it('Then uses dismiss handler for click-outside instead of document listener', () => {
+      const root = ComposedMenubar({
+        positioning: { placement: 'bottom-start' },
+        children: () => {
+          const file = ComposedMenubar.Menu({
+            value: 'file',
+            children: () => {
+              const t = ComposedMenubar.Trigger({ children: ['File'] });
+              const c = ComposedMenubar.Content({
+                children: () => [ComposedMenubar.Item({ value: 'new', children: ['New'] })],
+              });
+              return [t, c];
+            },
+          });
+          return [file];
+        },
+      });
+      container.appendChild(root);
+
+      const trigger = root.querySelector('[data-value="file"]') as HTMLElement;
+      trigger.click();
+
+      const content = root.querySelector('[role="menu"]') as HTMLElement;
+      expect(content.getAttribute('data-state')).toBe('open');
+
+      // Click outside should dismiss via the dismiss handler (uses pointerdown)
+      document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      expect(content.getAttribute('data-state')).toBe('closed');
+    });
+  });
+
   describe('Given a Menubar rendered inside a disposal scope', () => {
     describe('When the disposal scope cleanups are run', () => {
       it('Then removeEventListener is called for the trigger handlers', () => {


### PR DESCRIPTION
## Summary

- **Fixes #1612** — Menubar submenus were mispositioned and pushing sibling items
- The themed menubar (`createThemedMenubar`) was not passing the `positioning` prop to the composed menubar primitive, causing content panels to render in normal document flow
- Added `positioning: { placement: 'bottom-start' }` to the themed menubar factory, matching how `HoverCard` and other floating components handle positioning

## Public API Changes

None — this is an internal fix. The themed `Menubar` component API is unchanged.

## Test plan

- [x] New test: themed menubar content gets `position: fixed` when opened
- [x] New test: opening a menu does not shift sibling menubar items
- [x] New test: composed menubar positioning prop applies fixed positioning
- [x] New test: composed menubar with positioning uses dismiss handler for click-outside
- [x] All existing menubar tests pass (42 in ui-primitives, 17 in theme-shadcn)
- [x] Full quality gates pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)