### PR TITLE
fix(theme-shadcn): Drawer renders full-width with dialog UA resets

### DIFF
--- a/.changeset/drawer-dialog-reset.md
+++ b/.changeset/drawer-dialog-reset.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Fix Drawer rendering small at bottom-left by adding dialog UA style resets (margin, width, border, outline), ::backdrop styles, and hidden-when-closed rules to all panel directions

--- a/packages/theme-shadcn/src/__tests__/drawer.test.ts
+++ b/packages/theme-shadcn/src/__tests__/drawer.test.ts
@@ -44,6 +44,51 @@ describe('drawer styles', () => {
     expect(drawer.handle.length).toBeGreaterThan(0);
     expect(drawer.close.length).toBeGreaterThan(0);
   });
+
+  it('panel CSS styles the native dialog backdrop', () => {
+    expect(drawer.css).toContain('::backdrop');
+    expect(drawer.css).toContain('background-color: oklch(0 0 0 / 50%)');
+  });
+
+  it('top/bottom panels fill full viewport width and override dialog UA constraints', () => {
+    const topBlock = drawer.css.split('}').find((b) => b.includes('inset: 0 0 auto 0'));
+    expect(topBlock).toContain('width: 100dvw');
+    expect(topBlock).toContain('max-width: none');
+
+    const bottomBlock = drawer.css.split('}').find((b) => b.includes('inset: auto 0 0 0'));
+    expect(bottomBlock).toContain('width: 100dvw');
+    expect(bottomBlock).toContain('max-width: none');
+  });
+
+  it('left/right panels fill full viewport height and override dialog UA constraints', () => {
+    const leftBlock = drawer.css.split('}').find((b) => b.includes('inset: 0 auto 0 0'));
+    expect(leftBlock).toContain('height: 100dvh');
+    expect(leftBlock).toContain('max-height: none');
+
+    const rightBlock = drawer.css.split('}').find((b) => b.includes('inset: 0 0 0 auto'));
+    expect(rightBlock).toContain('height: 100dvh');
+    expect(rightBlock).toContain('max-height: none');
+  });
+
+  it('all panels reset dialog UA margin and border', () => {
+    const blocks = drawer.css.split('}');
+    const panelBlocks = blocks.filter(
+      (b) =>
+        b.includes('inset: 0 auto 0 0') ||
+        b.includes('inset: 0 0 0 auto') ||
+        b.includes('inset: 0 0 auto 0') ||
+        b.includes('inset: auto 0 0 0'),
+    );
+    for (const block of panelBlocks) {
+      expect(block).toContain('margin: 0');
+      expect(block).toContain('border: none');
+      expect(block).toContain('outline: none');
+    }
+  });
+
+  it('closed dialog panels are hidden', () => {
+    expect(drawer.css).toContain(':not([open]):not([data-state="open"])');
+  });
 });
 
 describe('themed Drawer', () => {

--- a/packages/theme-shadcn/src/styles/drawer.ts
+++ b/packages/theme-shadcn/src/styles/drawer.ts
@@ -62,7 +62,22 @@ export function createDrawerStyles(): CSSOutput<DrawerBlocks> {
           inset: '0 auto 0 0',
           width: '75%',
           'max-width': '24rem',
+          height: '100dvh',
+          'max-height': 'none',
+          margin: '0',
+          outline: 'none',
+          border: 'none',
           'border-radius': '0 0.75rem 0.75rem 0',
+        },
+        '&:not([open]):not([data-state="open"])': { display: 'none' },
+        '&::backdrop': {
+          'background-color': 'oklch(0 0 0 / 50%)',
+        },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 150ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
         },
       },
       {
@@ -80,7 +95,22 @@ export function createDrawerStyles(): CSSOutput<DrawerBlocks> {
           inset: '0 0 0 auto',
           width: '75%',
           'max-width': '24rem',
+          height: '100dvh',
+          'max-height': 'none',
+          margin: '0',
+          outline: 'none',
+          border: 'none',
           'border-radius': '0.75rem 0 0 0.75rem',
+        },
+        '&:not([open]):not([data-state="open"])': { display: 'none' },
+        '&::backdrop': {
+          'background-color': 'oklch(0 0 0 / 50%)',
+        },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 150ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
         },
       },
       {
@@ -96,7 +126,22 @@ export function createDrawerStyles(): CSSOutput<DrawerBlocks> {
       {
         '&': {
           inset: '0 0 auto 0',
+          width: '100dvw',
+          'max-width': 'none',
+          margin: '0',
+          outline: 'none',
+          border: 'none',
           'border-radius': '0 0 0.75rem 0.75rem',
+        },
+        '&:not([open]):not([data-state="open"])': { display: 'none' },
+        '&::backdrop': {
+          'background-color': 'oklch(0 0 0 / 50%)',
+        },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 150ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
         },
       },
       {
@@ -112,7 +157,22 @@ export function createDrawerStyles(): CSSOutput<DrawerBlocks> {
       {
         '&': {
           inset: 'auto 0 0 0',
+          width: '100dvw',
+          'max-width': 'none',
+          margin: '0',
+          outline: 'none',
+          border: 'none',
           'border-radius': '0.75rem 0.75rem 0 0',
+        },
+        '&:not([open]):not([data-state="open"])': { display: 'none' },
+        '&::backdrop': {
+          'background-color': 'oklch(0 0 0 / 50%)',
+        },
+        '&[data-state="open"]::backdrop': {
+          animation: 'vz-fade-in 150ms ease-out forwards',
+        },
+        '&[data-state="closed"]::backdrop': {
+          animation: 'vz-fade-out 300ms ease-out forwards',
         },
       },
       {


### PR DESCRIPTION
## Summary

- Fix Drawer rendering small at bottom-left instead of full-width by adding native `<dialog>` UA style resets to all four panel directions
- Add `::backdrop` styles for overlay effect (the Drawer uses `ComposedSheet` which renders a native `<dialog>` — the `::backdrop` pseudo-element needs explicit styling)
- Add hidden-when-closed rules (`display: none` when not open) to prevent flash of unstyled content

## Root Cause

The Drawer wraps `ComposedSheet`, which uses a native `<dialog>` element with `.showModal()`. The browser's UA stylesheet sets `width: fit-content` and `margin: auto` on `<dialog>`, which overrode the drawer's positioning CSS (`inset: auto 0 0 0`). The Sheet component already had these resets — the Drawer was missing them.

## Changes

**`packages/theme-shadcn/src/styles/drawer.ts`** — Added to all 4 panel directions:
- `margin: 0` — prevents UA centering
- `border: none`, `outline: none` — removes UA decoration
- `width: 100dvw` + `max-width: none` (top/bottom) or `height: 100dvh` + `max-height: none` (left/right) — overrides `fit-content`
- `::backdrop` with `background-color: oklch(0 0 0 / 50%)` and fade animations
- `:not([open]):not([data-state="open"]) { display: none }` — hidden when closed

**`packages/theme-shadcn/src/__tests__/drawer.test.ts`** — 5 new tests verifying:
- Panel CSS styles the native dialog backdrop
- Top/bottom panels fill full viewport width
- Left/right panels fill full viewport height
- All panels reset dialog UA margin and border
- Closed dialog panels are hidden

## Public API Changes

None — this is a CSS-only fix. No API surface changes.

Fixes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)