### PR TITLE
fix(ui-primitives): carousel crash — rootEl.querySelectorAll is not a function

### DIFF
--- a/.changeset/fix-carousel-rootel.md
+++ b/.changeset/fix-carousel-rootel.md
@@ -1,0 +1,10 @@
+---
+'@vertz/ui-primitives': patch
+---
+
+fix(ui-primitives): carousel crash — rootEl.querySelectorAll is not a function
+
+Switch ComposedCarousel to use Provider callback pattern instead of JSX pattern.
+The JSX pattern assigned the Provider result to a const, which the compiler wrapped
+in computed() — making rootEl a signal instead of an HTMLElement, causing
+querySelectorAll to fail.

--- a/packages/ui-primitives/src/carousel/carousel-composed.tsx
+++ b/packages/ui-primitives/src/carousel/carousel-composed.tsx
@@ -122,6 +122,39 @@ export interface ComposedCarouselProps {
 
 export type CarouselClassKey = keyof CarouselClasses;
 
+/**
+ * Initialize slide attributes (aria-hidden, data-state, aria-label) and
+ * button disabled states on the root element. Called once after the DOM tree
+ * is constructed and on every navigation.
+ */
+function initCarouselDOM(
+  rootEl: HTMLElement,
+  currentIndex: number,
+  loop: boolean,
+  orientation: string,
+): void {
+  const slides = [...rootEl.querySelectorAll<HTMLElement>('[data-carousel-slide]')];
+  const slideCount = slides.length;
+  for (let i = 0; i < slideCount; i++) {
+    const slide = slides[i];
+    if (!slide) continue;
+    slide.setAttribute('aria-hidden', String(i !== currentIndex));
+    slide.setAttribute('aria-label', `Slide ${i + 1} of ${slideCount}`);
+    slide.setAttribute('data-state', i === currentIndex ? 'active' : 'inactive');
+  }
+
+  const prevBtn = rootEl.querySelector('[data-carousel-prev]') as HTMLButtonElement | null;
+  const nextBtn = rootEl.querySelector('[data-carousel-next]') as HTMLButtonElement | null;
+  if (!loop && prevBtn) prevBtn.disabled = currentIndex <= 0;
+  if (!loop && nextBtn) nextBtn.disabled = currentIndex >= slideCount - 1;
+
+  const viewport = rootEl.querySelector('[data-carousel-viewport]') as HTMLElement | null;
+  if (viewport) {
+    const prop = orientation === 'horizontal' ? 'translateX' : 'translateY';
+    viewport.style.transform = `${prop}(-${currentIndex * 100}%)`;
+  }
+}
+
 function ComposedCarouselRoot({
   children,
   classes,
@@ -132,33 +165,9 @@ function ComposedCarouselRoot({
 }: ComposedCarouselProps) {
   let currentIndex = defaultIndex;
 
-  function getSlides(rootEl: HTMLElement): HTMLElement[] {
-    return [...rootEl.querySelectorAll<HTMLElement>('[data-carousel-slide]')];
-  }
-
-  function updateDOM(rootEl: HTMLElement): void {
-    const slides = getSlides(rootEl);
-    const slideCount = slides.length;
-    slides.forEach((slide, i) => {
-      slide.setAttribute('aria-hidden', String(i !== currentIndex));
-      slide.setAttribute('aria-label', `Slide ${i + 1} of ${slideCount}`);
-      slide.setAttribute('data-state', i === currentIndex ? 'active' : 'inactive');
-    });
-
-    const prevBtn = rootEl.querySelector('[data-carousel-prev]') as HTMLButtonElement | null;
-    const nextBtn = rootEl.querySelector('[data-carousel-next]') as HTMLButtonElement | null;
-    if (!loop && prevBtn) prevBtn.disabled = currentIndex <= 0;
-    if (!loop && nextBtn) nextBtn.disabled = currentIndex >= slideCount - 1;
-
-    const viewport = rootEl.querySelector('[data-carousel-viewport]') as HTMLElement | null;
-    if (viewport) {
-      const prop = orientation === 'horizontal' ? 'translateX' : 'translateY';
-      viewport.style.transform = `${prop}(-${currentIndex * 100}%)`;
-    }
-  }
-
   function goTo(rootEl: HTMLElement, index: number): void {
-    const slideCount = getSlides(rootEl).length;
+    const slides = rootEl.querySelectorAll('[data-carousel-slide]');
+    const slideCount = slides.length;
     if (slideCount === 0) return;
     let next = index;
     if (loop) {
@@ -168,7 +177,7 @@ function ComposedCarouselRoot({
     }
     if (next === currentIndex) return;
     currentIndex = next;
-    updateDOM(rootEl);
+    initCarouselDOM(rootEl, currentIndex, loop, orientation);
     onSlideChange?.(next);
   }
 
@@ -201,8 +210,16 @@ function ComposedCarouselRoot({
 
   const translateProp = orientation === 'horizontal' ? 'translateX' : 'translateY';
 
-  const el = (
-    <CarouselContext.Provider value={ctx}>
+  // Use a plain object ref to capture the root element — the compiler
+  // does not transform object property assignments into signals.
+  const _ref = { root: null as HTMLElement | null };
+
+  // Use Provider callback pattern to set context, then build the DOM tree.
+  // This avoids assigning the Provider JSX result to a const, which the
+  // compiler wraps in computed() — causing rootEl.querySelectorAll to fail
+  // because the computed value may not be an HTMLElement (#1613).
+  CarouselContext.Provider(ctx, () => {
+    _ref.root = (
       <div
         role="region"
         aria-roledescription="carousel"
@@ -220,13 +237,13 @@ function ComposedCarouselRoot({
           {children}
         </div>
       </div>
-    </CarouselContext.Provider>
-  );
+    ) as HTMLElement;
+  });
 
-  // Initialize slide attributes after DOM tree is constructed.
-  updateDOM(el as HTMLElement);
+  const rootEl = _ref.root as HTMLElement;
+  initCarouselDOM(rootEl, currentIndex, loop, orientation);
 
-  return el;
+  return rootEl;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix Carousel crash (`rootEl.querySelectorAll is not a function`) by switching from Provider JSX pattern to callback pattern
- The JSX pattern assigned the Provider result to `const el`, which the Vertz compiler wrapped in `computed()` — making `el` a signal instead of an HTMLElement
- Extract `initCarouselDOM` to module scope and use a plain object ref (`_ref.root`) to capture the root element without compiler signal transformation

## Public API Changes

None — internal implementation change only. The `ComposedCarousel` API surface is unchanged.

## Test plan

- [x] All 50 carousel tests pass (both low-level and composed)
- [x] Theme-shadcn carousel integration tests pass (12 tests)
- [x] Full pre-push quality gates pass (lint, typecheck, test, build)
- [x] Built dist verified: no `computed()` wrapping around Provider call
- [x] Manual dist verification: carousel renders, slides navigable, button states correct

Fixes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)