### PR TITLE
fix(theme-shadcn): reset list-style on breadcrumb ol (#1609)

### DIFF
--- a/.changeset/breadcrumb-list-style-reset.md
+++ b/.changeset/breadcrumb-list-style-reset.md
@@ -1,0 +1,5 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+Reset list-style, margin, and padding on breadcrumb ol to prevent numbered list markers from overlapping text

--- a/packages/theme-shadcn/src/__tests__/breadcrumb.test.ts
+++ b/packages/theme-shadcn/src/__tests__/breadcrumb.test.ts
@@ -18,6 +18,11 @@ describe('breadcrumb styles', () => {
     expect(typeof breadcrumb.css).toBe('string');
     expect(breadcrumb.css).toContain(':hover');
   });
+
+  it('list styles reset list-style, margin, and padding for ol', () => {
+    expect(breadcrumb.css).toContain('list-style');
+    expect(breadcrumb.css).toContain('none');
+  });
 });
 
 describe('Breadcrumb component', () => {

--- a/packages/theme-shadcn/src/styles/breadcrumb.ts
+++ b/packages/theme-shadcn/src/styles/breadcrumb.ts
@@ -21,6 +21,13 @@ export function createBreadcrumbStyles(): CSSOutput<BreadcrumbBlocks> {
       'gap:1.5',
       'text:sm',
       'text:muted-foreground',
+      {
+        '&': {
+          'list-style': 'none',
+          margin: '0',
+          padding: '0',
+        },
+      },
     ],
     breadcrumbItem: ['inline-flex', 'items:center', 'gap:1.5'],
     breadcrumbLink: ['transition:colors', 'text:foreground', { '&:hover': ['text:foreground'] }],


### PR DESCRIPTION
## Summary

- Reset `list-style: none`, `margin: 0`, `padding: 0` on the breadcrumb `<ol>` element in `createBreadcrumbStyles()` to prevent default numbered list markers from overlapping text
- Follows the same pattern used in pagination styles

## Public API Changes

None — internal CSS fix only.

## Test plan

- [x] Added test verifying `list-style` and `none` appear in generated CSS
- [x] All existing breadcrumb tests still pass
- [x] Quality gates green (test + typecheck + lint)

Fixes #1609