### PR TITLE
fix(ui): register __on event listener cleanup with disposal scope (#1641)

### DIFF
--- a/.changeset/fix-form-onsubmit-dialog.md
+++ b/.changeset/fix-form-onsubmit-dialog.md
@@ -1,0 +1,7 @@
+---
+'@vertz/ui': patch
+---
+
+fix(ui): register __on event listener cleanup with disposal scope
+
+Event listeners attached via `__on()` (the compiler's output for `onClick`, `onSubmit`, etc.) now register their cleanup function with the current disposal scope. This ensures listeners are properly removed when components or dialogs are unmounted, preventing memory leaks in dynamically-opened dialogs.

--- a/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
+++ b/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { createContext, getContextScope, useContext } from '../../component/context';
+import { __element } from '../../dom/element';
+import { __on } from '../../dom/events';
+import { form, type SdkMethod } from '../../form/form';
 import type { DialogHandle, DialogStack } from '../dialog-stack';
 import { createDialogStack, DialogStackContext, useDialogStack } from '../dialog-stack';
 
@@ -354,6 +357,111 @@ describe('DialogStack', () => {
 
     const result = await promise;
     expect(result).toEqual({ ok: false });
+  });
+
+  it('form onSubmit handler fires inside dynamically-opened dialog', () => {
+    const stack = createDialogStack(container);
+    let preventDefaultCalled = false;
+
+    function FormDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      const formEl = document.createElement('form');
+      __on(formEl, 'submit', (e: Event) => {
+        e.preventDefault();
+        preventDefaultCalled = true;
+      });
+      return formEl;
+    }
+
+    stack.open(FormDialog, {});
+
+    const formEl = container.querySelector('form')!;
+    expect(formEl).toBeTruthy();
+    formEl.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(preventDefaultCalled).toBe(true);
+  });
+
+  it('form() onSubmit handler prevents default inside dialog (compiled path)', () => {
+    const stack = createDialogStack(container);
+    let preventDefaultCalled = false;
+
+    const mockSdkMethod = Object.assign(
+      (_body: unknown) => Promise.resolve({ ok: true, data: { id: '1' } }),
+      { url: '/api/test', method: 'POST' },
+    ) as unknown as SdkMethod<{ title: string }, { id: string }>;
+
+    function FormDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      const taskForm = form(mockSdkMethod);
+
+      // Simulate compiled output: __element + __on + __bindElement
+      const formEl = __element('form') as HTMLFormElement;
+      {
+        const __v = taskForm.action;
+        if (__v != null && __v !== false)
+          formEl.setAttribute('action', __v === true ? '' : (__v as string));
+      }
+      {
+        const __v = taskForm.method;
+        if (__v != null && __v !== false)
+          formEl.setAttribute('method', __v === true ? '' : (__v as string));
+      }
+      __on(formEl, 'submit', taskForm.onSubmit);
+      taskForm.__bindElement(formEl);
+
+      const inputEl = __element('input') as HTMLInputElement;
+      inputEl.setAttribute('name', 'title');
+      formEl.appendChild(inputEl);
+
+      return formEl;
+    }
+
+    stack.open(FormDialog, {});
+
+    const formEl = container.querySelector('form')! as HTMLFormElement;
+    expect(formEl).toBeTruthy();
+    expect(formEl.getAttribute('action')).toBe('/api/test');
+    expect(formEl.getAttribute('method')).toBe('POST');
+
+    const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+    const originalPreventDefault = submitEvent.preventDefault.bind(submitEvent);
+    submitEvent.preventDefault = () => {
+      preventDefaultCalled = true;
+      originalPreventDefault();
+    };
+    formEl.dispatchEvent(submitEvent);
+
+    expect(preventDefaultCalled).toBe(true);
+  });
+
+  it('event listeners are cleaned up when dialog closes', async () => {
+    const stack = createDialogStack(container);
+    let clickCount = 0;
+
+    function ClickDialog({ dialog }: { dialog: DialogHandle<void> }) {
+      const btn = document.createElement('button');
+      __on(btn, 'click', () => {
+        clickCount++;
+      });
+      const closeBtn = document.createElement('button');
+      closeBtn.setAttribute('data-testid', 'close');
+      closeBtn.addEventListener('click', () => dialog.close());
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(btn);
+      wrapper.appendChild(closeBtn);
+      return wrapper;
+    }
+
+    const promise = stack.open(ClickDialog, {});
+    const btn = container.querySelector('button')!;
+    btn.click();
+    expect(clickCount).toBe(1);
+
+    // Close the dialog — cleanups should run
+    container.querySelector('[data-testid="close"]')!.click();
+    await promise;
+
+    // After close, the listener should have been removed via disposal scope cleanup
+    btn.click();
+    expect(clickCount).toBe(1);
   });
 
   it('useDialogStack captures context scope eagerly for use in event handlers', () => {

--- a/packages/ui/src/dom/__tests__/events.test.ts
+++ b/packages/ui/src/dom/__tests__/events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { popScope, pushScope, runCleanups } from '../../runtime/disposal';
 import { __on } from '../events';
 
 describe('__on', () => {
@@ -23,5 +24,36 @@ describe('__on', () => {
     cleanup();
     el.click();
     expect(clickCount).toBe(1);
+  });
+
+  it('registers cleanup with the current disposal scope', () => {
+    const el = document.createElement('button');
+    let clickCount = 0;
+
+    const scope = pushScope();
+    __on(el, 'click', () => {
+      clickCount++;
+    });
+    popScope();
+
+    // Handler works while scope is alive
+    el.click();
+    expect(clickCount).toBe(1);
+
+    // Running scope cleanups removes the listener
+    runCleanups(scope);
+    el.click();
+    expect(clickCount).toBe(1);
+  });
+
+  it('works without a disposal scope (no error)', () => {
+    const el = document.createElement('button');
+    let clicked = false;
+    // No pushScope — _tryOnCleanup silently discards
+    __on(el, 'click', () => {
+      clicked = true;
+    });
+    el.click();
+    expect(clicked).toBe(true);
   });
 });

--- a/packages/ui/src/dom/events.ts
+++ b/packages/ui/src/dom/events.ts
@@ -1,10 +1,19 @@
+import { _tryOnCleanup } from '../runtime/disposal';
+
 /**
  * Bind an event handler to an element.
  * Returns a cleanup function to remove the listener.
+ *
+ * Registers the cleanup with the current disposal scope (if any) so that
+ * event listeners are automatically removed when the owning component or
+ * dialog is unmounted. Without this, listeners on dynamically-mounted
+ * elements (e.g., forms inside useDialogStack dialogs) would leak.
  *
  * Compiler output target for event bindings (onClick, onInput, etc.).
  */
 export function __on(el: HTMLElement, event: string, handler: EventListener): () => void {
   el.addEventListener(event, handler);
-  return () => el.removeEventListener(event, handler);
+  const cleanup = () => el.removeEventListener(event, handler);
+  _tryOnCleanup(cleanup);
+  return cleanup;
 }


### PR DESCRIPTION
## Summary

- **Fixed** `__on()` (the compiler's output for `onClick`, `onSubmit`, etc.) to register its cleanup function with the current disposal scope via `_tryOnCleanup()`
- Event listeners attached in dynamically-mounted components (e.g., forms inside `useDialogStack()` dialogs) are now properly cleaned up when the component/dialog unmounts
- Added tests verifying form `onSubmit` handlers work correctly inside dialogs opened via `useDialogStack()`
- Added tests verifying event listener cleanup via disposal scope

## What changed

**`packages/ui/src/dom/events.ts`** — The `__on()` function now calls `_tryOnCleanup(cleanup)` to register the `removeEventListener` cleanup with the active disposal scope. Previously, the cleanup was returned but never registered, causing event listener leaks on dynamically-mounted elements.

## Public API Changes

None — `__on()` is an internal compiler target, not a public API.

## Test plan

- [x] `__on` registers cleanup with disposal scope
- [x] `__on` works without a disposal scope (no error)
- [x] Form `onSubmit` handler fires inside dynamically-opened dialog
- [x] Form `onSubmit` with `form()` API prevents default inside dialog
- [x] Event listeners are cleaned up when dialog closes
- [x] All 2311 existing `@vertz/ui` tests pass
- [x] All 781 `@vertz/ui-compiler` tests pass

Fixes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)