### PR TITLE
fix(server): extract auth session middleware and add integration tests

### DIFF
--- a/.changeset/auth-session-middleware.md
+++ b/.changeset/auth-session-middleware.md
@@ -1,0 +1,7 @@
+---
+'@vertz/server': patch
+---
+
+fix(server): extract auth session middleware and add integration tests
+
+`createServer()` with `auth` now auto-wires a session middleware that bridges JWT session data (`userId`, `tenantId`, `roles`) into the entity/service handler context. The inline middleware has been extracted to `createAuthSessionMiddleware()` in the auth module for testability and separation of concerns.

--- a/packages/server/src/auth/__tests__/auth-entity-session.test.ts
+++ b/packages/server/src/auth/__tests__/auth-entity-session.test.ts
@@ -1,0 +1,255 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createDb, d } from '@vertz/db';
+import { createServer, type ServerInstance } from '../../create-server';
+import { entity } from '../../entity/entity';
+import { authModels } from '../auth-models';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const tasksTable = d.table('tasks', {
+  id: d.uuid().primary(),
+  title: d.text(),
+  tenantId: d.text(),
+});
+
+const tasksModel = d.model(tasksTable);
+
+const tasksEntity = entity('tasks', {
+  model: tasksModel,
+  access: {
+    list: (ctx) => ctx.authenticated(),
+    get: (ctx) => ctx.authenticated(),
+    create: (ctx) => ctx.authenticated(),
+    update: (ctx) => ctx.authenticated(),
+    delete: false,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function createSqliteDb() {
+  const rawDb = new Database(':memory:');
+  const queryFn = async <T>(sqlStr: string, params: readonly unknown[]) => {
+    const sqliteSql = sqlStr.replace(/\$\d+/g, '?');
+    const trimmed = sqliteSql.trim();
+    const isSelect = /^\s*SELECT/i.test(trimmed);
+    const hasReturning = /RETURNING/i.test(trimmed);
+    if (isSelect || hasReturning) {
+      const stmt = rawDb.prepare(sqliteSql);
+      const rows = stmt.all(...(params as unknown[])) as T[];
+      return { rows, rowCount: rows.length };
+    }
+    const stmt = rawDb.prepare(sqliteSql);
+    const info = stmt.run(...(params as unknown[]));
+    return { rows: [] as T[], rowCount: info.changes };
+  };
+
+  const d1 = {
+    prepare: () => {
+      throw new Error('stub');
+    },
+  } as unknown as import('@vertz/db').D1Database;
+
+  return {
+    db: createDb({
+      models: { ...authModels, tasks: tasksModel },
+      dialect: 'sqlite',
+      d1,
+      _queryFn: queryFn,
+    }),
+    rawDb,
+  };
+}
+
+function createTasksTable(rawDb: Database) {
+  rawDb.run(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      tenant_id TEXT NOT NULL
+    )
+  `);
+}
+
+function seedTasks(rawDb: Database) {
+  rawDb.run(`INSERT INTO tasks (id, title, tenant_id) VALUES ('1', 'Task A', 'tenant-a')`);
+  rawDb.run(`INSERT INTO tasks (id, title, tenant_id) VALUES ('2', 'Task B', 'tenant-b')`);
+}
+
+// ---------------------------------------------------------------------------
+// Request helpers
+// ---------------------------------------------------------------------------
+
+function makeAuthRequest(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  cookies = '',
+): Request {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Origin: 'http://localhost',
+    'X-VTZ-Request': '1',
+  };
+  if (cookies) {
+    headers.Cookie = cookies;
+  }
+  return new Request(`http://localhost/api/auth${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function makeEntityRequest(
+  method: string,
+  path: string,
+  cookies = '',
+  body?: Record<string, unknown>,
+): Request {
+  const headers: Record<string, string> = {};
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (cookies) {
+    headers.Cookie = cookies;
+  }
+  return new Request(`http://localhost/api${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function getCookies(res: Response): string {
+  return res.headers
+    .getSetCookie()
+    .map((c) => c.split(';')[0])
+    .join('; ');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createServer auto-wires auth session into entity context', () => {
+  let server: ServerInstance;
+  let rawDb: Database;
+
+  beforeEach(async () => {
+    const sqlite = createSqliteDb();
+    rawDb = sqlite.rawDb;
+
+    server = createServer({
+      entities: [tasksEntity],
+      db: sqlite.db,
+      auth: {
+        session: { strategy: 'jwt', ttl: '60s', refreshTtl: '7d' },
+        emailPassword: { enabled: true },
+        privateKey: TEST_PRIVATE_KEY,
+        publicKey: TEST_PUBLIC_KEY,
+        isProduction: false,
+        tenant: {
+          verifyMembership: async (_userId: string, tenantId: string) => {
+            return tenantId === 'tenant-a' || tenantId === 'tenant-b';
+          },
+        },
+      },
+    });
+
+    await server.initialize();
+    createTasksTable(rawDb);
+    seedTasks(rawDb);
+  });
+
+  afterEach(() => {
+    server.auth.dispose();
+    rawDb.close();
+  });
+
+  describe('Given a request with no session', () => {
+    it('returns 403 for authenticated-only entity endpoint', async () => {
+      const res = await server.requestHandler(makeEntityRequest('GET', '/tasks'));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Given a valid session (signed-up user)', () => {
+    it('provides ctx.userId to entity handlers — returns 200', async () => {
+      // Sign up a user via auth handler
+      const signupRes = await server.auth.handler(
+        makeAuthRequest('POST', '/signup', {
+          email: 'alice@example.com',
+          password: 'Password123!',
+        }),
+      );
+      expect(signupRes.status).toBe(201);
+      const cookies = getCookies(signupRes);
+
+      // Entity list should succeed (user is authenticated)
+      const res = await server.requestHandler(makeEntityRequest('GET', '/tasks', cookies));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Given a session with tenantId (after switch-tenant)', () => {
+    it('provides ctx.tenantId to entity handlers — tenant filter applies', async () => {
+      // Sign up
+      const signupRes = await server.auth.handler(
+        makeAuthRequest('POST', '/signup', {
+          email: 'bob@example.com',
+          password: 'Password123!',
+        }),
+      );
+      const signupCookies = getCookies(signupRes);
+
+      // Switch tenant
+      const switchRes = await server.auth.handler(
+        makeAuthRequest('POST', '/switch-tenant', { tenantId: 'tenant-a' }, signupCookies),
+      );
+      expect(switchRes.status).toBe(200);
+      const tenantCookies = getCookies(switchRes);
+
+      // Entity list should filter by tenant-a
+      const res = await server.requestHandler(makeEntityRequest('GET', '/tasks', tenantCookies));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Only task from tenant-a should be returned
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].title).toBe('Task A');
+    });
+  });
+
+  describe('Given a session with tenantId for entity creation', () => {
+    it('auto-sets tenantId on created entity', async () => {
+      // Sign up
+      const signupRes = await server.auth.handler(
+        makeAuthRequest('POST', '/signup', {
+          email: 'charlie@example.com',
+          password: 'Password123!',
+        }),
+      );
+      const signupCookies = getCookies(signupRes);
+
+      // Switch tenant
+      const switchRes = await server.auth.handler(
+        makeAuthRequest('POST', '/switch-tenant', { tenantId: 'tenant-a' }, signupCookies),
+      );
+      const tenantCookies = getCookies(switchRes);
+
+      // Create entity
+      const res = await server.requestHandler(
+        makeEntityRequest('POST', '/tasks', tenantCookies, { title: 'New Task' }),
+      );
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.tenantId).toBe('tenant-a');
+    });
+  });
+});

--- a/packages/server/src/auth/__tests__/session-middleware.test.ts
+++ b/packages/server/src/auth/__tests__/session-middleware.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'bun:test';
+import { ok } from '@vertz/errors';
+import { createAuthSessionMiddleware } from '../session-middleware';
+import type { AuthApi, AuthUser, Session, SessionPayload } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stubAuthApi(sessionResult: ReturnType<AuthApi['getSession']>): AuthApi {
+  return {
+    getSession: () => sessionResult,
+    signUp: () => {
+      throw new Error('stub');
+    },
+    signIn: () => {
+      throw new Error('stub');
+    },
+    signOut: () => {
+      throw new Error('stub');
+    },
+    refreshSession: () => {
+      throw new Error('stub');
+    },
+    listSessions: () => {
+      throw new Error('stub');
+    },
+    revokeSession: () => {
+      throw new Error('stub');
+    },
+    revokeAllSessions: () => {
+      throw new Error('stub');
+    },
+  };
+}
+
+function makeUser(overrides?: Partial<AuthUser>): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'test@example.com',
+    role: 'user',
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makePayload(overrides?: Partial<SessionPayload>): SessionPayload {
+  return {
+    sub: 'user-1',
+    email: 'test@example.com',
+    role: 'user',
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    jti: 'jwt-1',
+    sid: 'session-1',
+    ...overrides,
+  };
+}
+
+function makeSession(user?: Partial<AuthUser>, payload?: Partial<SessionPayload>): Session {
+  return {
+    user: makeUser(user),
+    expiresAt: new Date(Date.now() + 3600000),
+    payload: makePayload(payload),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthSessionMiddleware', () => {
+  describe('Given no raw headers in context', () => {
+    it('returns empty object', async () => {
+      const api = stubAuthApi(Promise.resolve(ok(null)));
+      const mw = createAuthSessionMiddleware(api);
+
+      const result = await mw.handler({});
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('Given raw headers but no valid session', () => {
+    it('returns empty object', async () => {
+      const api = stubAuthApi(Promise.resolve(ok(null)));
+      const mw = createAuthSessionMiddleware(api);
+
+      const result = await mw.handler({
+        raw: { headers: new Headers() },
+      });
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('Given a valid session without tenantId', () => {
+    it('returns userId, null tenantId, and roles', async () => {
+      const session = makeSession();
+      const api = stubAuthApi(Promise.resolve(ok(session)));
+      const mw = createAuthSessionMiddleware(api);
+
+      const result = await mw.handler({
+        raw: { headers: new Headers({ Cookie: 'vertz.sid=fake-jwt' }) },
+      });
+
+      expect(result).toEqual({
+        userId: 'user-1',
+        tenantId: null,
+        roles: ['user'],
+        user: session.user,
+        session,
+      });
+    });
+  });
+
+  describe('Given a valid session with tenantId', () => {
+    it('returns tenantId from JWT payload', async () => {
+      const session = makeSession({}, { tenantId: 'tenant-abc' });
+      const api = stubAuthApi(Promise.resolve(ok(session)));
+      const mw = createAuthSessionMiddleware(api);
+
+      const result = await mw.handler({
+        raw: { headers: new Headers({ Cookie: 'vertz.sid=fake-jwt' }) },
+      });
+
+      expect(result).toEqual({
+        userId: 'user-1',
+        tenantId: 'tenant-abc',
+        roles: ['user'],
+        user: session.user,
+        session,
+      });
+    });
+  });
+
+  describe('Given a session with admin role', () => {
+    it('returns the correct role in roles array', async () => {
+      const session = makeSession({ role: 'admin' }, { role: 'admin' });
+      const api = stubAuthApi(Promise.resolve(ok(session)));
+      const mw = createAuthSessionMiddleware(api);
+
+      const result = await mw.handler({
+        raw: { headers: new Headers({ Cookie: 'vertz.sid=fake-jwt' }) },
+      });
+
+      expect(result).toEqual({
+        userId: 'user-1',
+        tenantId: null,
+        roles: ['admin'],
+        user: session.user,
+        session,
+      });
+    });
+  });
+
+  it('has name "vertz-auth-session"', () => {
+    const api = stubAuthApi(Promise.resolve(ok(null)));
+    const mw = createAuthSessionMiddleware(api);
+    expect(mw.name).toBe('vertz-auth-session');
+  });
+});

--- a/packages/server/src/auth/session-middleware.ts
+++ b/packages/server/src/auth/session-middleware.ts
@@ -1,0 +1,32 @@
+import { createMiddleware } from '@vertz/core';
+import type { AuthApi } from './types';
+
+/**
+ * Creates a middleware that bridges auth session data into the request context.
+ *
+ * Auth's `getSession()` resolves the JWT from cookies and returns user/session data.
+ * This middleware maps that data to the context fields that entity and service
+ * handlers expect: `ctx.userId`, `ctx.tenantId`, `ctx.roles`.
+ *
+ * Registered automatically by `createServer()` when both `db` and `auth` are provided.
+ */
+export function createAuthSessionMiddleware(api: AuthApi) {
+  return createMiddleware({
+    name: 'vertz-auth-session',
+    handler: async (ctx: Record<string, unknown>) => {
+      const raw = ctx.raw as { headers?: Headers } | undefined;
+      if (!raw?.headers) return {};
+
+      const result = await api.getSession(raw.headers);
+      if (!result.ok || !result.data) return {};
+
+      return {
+        userId: result.data.user.id,
+        tenantId: result.data.payload.tenantId ?? null,
+        roles: [result.data.user.role],
+        user: result.data.user,
+        session: result.data,
+      };
+    },
+  });
+}

--- a/packages/server/src/create-server.ts
+++ b/packages/server/src/create-server.ts
@@ -1,8 +1,5 @@
 import type { AppBuilder, AppConfig, EntityRouteEntry } from '@vertz/core';
-import {
-  createServer as coreCreateServer,
-  createMiddleware as createCoreMiddleware,
-} from '@vertz/core';
+import { createServer as coreCreateServer } from '@vertz/core';
 import {
   createDatabaseBridgeAdapter,
   type DatabaseClient,
@@ -21,6 +18,7 @@ import { DbUserStore } from './auth/db-user-store';
 import { createAuth } from './auth/index';
 import { createJWKSClient } from './auth/jwks-client';
 import { resolveSessionForSSR as createSSRResolver } from './auth/resolve-session-for-ssr';
+import { createAuthSessionMiddleware } from './auth/session-middleware';
 import type { AuthConfig, AuthInstance } from './auth/types';
 import type { EntityOperations } from './entity/entity-operations';
 import { EntityRegistry } from './entity/entity-registry';
@@ -504,25 +502,7 @@ export function createServer(config: ServerConfig): AppBuilder | ServerInstance 
 
     // Auto-wire auth session middleware so entity/service handlers
     // receive ctx.userId, ctx.tenantId, ctx.roles from the JWT.
-    const authSessionMiddleware = createCoreMiddleware({
-      name: 'vertz-auth-session',
-      handler: async (ctx: Record<string, unknown>) => {
-        const raw = ctx.raw as { headers?: Headers } | undefined;
-        if (!raw?.headers) return {};
-
-        const result = await auth.api.getSession(raw.headers);
-        if (!result.ok || !result.data) return {};
-
-        return {
-          userId: result.data.user.id,
-          tenantId: result.data.payload.tenantId ?? null,
-          roles: [result.data.user.role],
-          user: result.data.user,
-          session: result.data,
-        };
-      },
-    });
-    app.middlewares([authSessionMiddleware]);
+    app.middlewares([createAuthSessionMiddleware(auth.api)]);
 
     // Guard: requestHandler only works with default /api prefix because
     // the auth handler hardcodes url.pathname.replace('/api/auth', '') internally.


### PR DESCRIPTION
## Summary

- Extracts the inline `vertz-auth-session` middleware from `create-server.ts` into a dedicated `createAuthSessionMiddleware()` function in `packages/server/src/auth/session-middleware.ts`
- Adds unit tests for the middleware in isolation (6 tests)
- Adds integration tests verifying `createServer()` with auth auto-wires `ctx.userId`, `ctx.tenantId`, and `ctx.roles` into entity handlers (4 tests)

## Public API Changes

No public API changes. The middleware was already being auto-wired internally — this PR extracts it to a proper module and adds test coverage.

## What was fixed

`createServer()` with auth config already had a workaround middleware that bridges JWT session data into entity handler context. This PR:

1. **Moves** the middleware from an inline definition in `create-server.ts` to `auth/session-middleware.ts` for proper separation of concerns and testability
2. **Tests** the four acceptance criteria from the issue:
   - Entity API returns 403 when no session is present
   - Entity API returns 200 when user is authenticated
   - Tenant-scoped entity filters by `tenantId` from JWT
   - Entity creation auto-sets `tenantId` from session

Fixes #1636

## Test plan

- [x] Unit tests for `createAuthSessionMiddleware` — tests handler with no headers, no session, valid session without tenant, valid session with tenant, admin role
- [x] Integration tests for auth-entity wiring — full end-to-end with SQLite DB, auth signup, tenant switching, and entity CRUD
- [x] Existing `server-instance` and `server-integration` tests still pass
- [x] TypeScript strict mode passes
- [x] Biome lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)