### PR TITLE
fix(fetch,server): keep where/orderBy/limit as flat query params (#1666)

### DIFF
--- a/.changeset/vertzql-encode-all-keys.md
+++ b/.changeset/vertzql-encode-all-keys.md
@@ -1,5 +1,0 @@
----
-'@vertz/fetch': patch
----
-
-Add unit tests for resolveVertzQL encoding where, orderBy, and limit into the q= parameter

--- a/.changeset/vertzql-flat-query-params.md
+++ b/.changeset/vertzql-flat-query-params.md
@@ -1,0 +1,6 @@
+---
+'@vertz/fetch': patch
+'@vertz/server': patch
+---
+
+Fix resolveVertzQL to keep where/orderBy/limit as flat query params instead of encoding them in the base64 q= parameter. Only select and include are encoded in q= (structural, not human-readable). Where is flattened to bracket notation (where[field]=value), orderBy to colon format (orderBy=field:dir), and limit stays as a raw number. Server parser updated to support comma-separated multi-field orderBy.

--- a/packages/fetch/src/vertzql.test.ts
+++ b/packages/fetch/src/vertzql.test.ts
@@ -41,177 +41,6 @@ describe('encodeVertzQL', () => {
   });
 });
 
-describe('resolveVertzQL', () => {
-  it('returns undefined when query is undefined', () => {
-    expect(resolveVertzQL(undefined)).toBeUndefined();
-  });
-
-  it('passes through query as-is when no VertzQL keys present', () => {
-    const query = { status: 'active', page: 1 };
-
-    expect(resolveVertzQL(query)).toEqual({ status: 'active', page: 1 });
-  });
-
-  it('extracts select from query and encodes as q= param', () => {
-    const query = { select: { id: true, name: true } };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.select).toBeUndefined();
-    expect(result?.q).toBeDefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      select: { id: true, name: true },
-    });
-  });
-
-  it('preserves other query params alongside q=', () => {
-    const query = { status: 'active', select: { id: true } };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.status).toBe('active');
-    expect(result?.select).toBeUndefined();
-    expect(result?.q).toBeDefined();
-  });
-
-  it('extracts include from query and encodes as q= param', () => {
-    const query = { include: { posts: true } };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.include).toBeUndefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      include: { posts: true },
-    });
-  });
-
-  it('combines select and include into single q= param', () => {
-    const query = {
-      select: { id: true, name: true },
-      include: { posts: true },
-    };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.select).toBeUndefined();
-    expect(result?.include).toBeUndefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      select: { id: true, name: true },
-      include: { posts: true },
-    });
-  });
-
-  it('extracts where from query and encodes inside q= param', () => {
-    const query = { where: { projectId: '123' } };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.where).toBeUndefined();
-    expect(result?.q).toBeDefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      where: { projectId: '123' },
-    });
-  });
-
-  it('extracts orderBy from query and encodes inside q= param', () => {
-    const query = { orderBy: { createdAt: 'desc' } };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.orderBy).toBeUndefined();
-    expect(result?.q).toBeDefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      orderBy: { createdAt: 'desc' },
-    });
-  });
-
-  it('extracts limit from query and encodes inside q= param', () => {
-    const query = { limit: 10 };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.limit).toBeUndefined();
-    expect(result?.q).toBeDefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      limit: 10,
-    });
-  });
-
-  it('combines all five VertzQL keys into single q= param', () => {
-    const query = {
-      select: { id: true, title: true },
-      include: { comments: true },
-      where: { status: 'active' },
-      orderBy: { createdAt: 'desc' },
-      limit: 25,
-      page: 2,
-    };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBeDefined();
-    expect(result?.select).toBeUndefined();
-    expect(result?.include).toBeUndefined();
-    expect(result?.where).toBeUndefined();
-    expect(result?.orderBy).toBeUndefined();
-    expect(result?.limit).toBeUndefined();
-    expect(result?.page).toBe(2);
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      select: { id: true, title: true },
-      include: { comments: true },
-      where: { status: 'active' },
-      orderBy: { createdAt: 'desc' },
-      limit: 25,
-    });
-  });
-
-  it('returns same reference when no VertzQL keys present (no-op)', () => {
-    const query = { status: 'active' };
-    const result = resolveVertzQL(query);
-
-    expect(result).toBe(query);
-  });
-
-  it('different selections produce different q= values (cache key differentiation)', () => {
-    const q1 = resolveVertzQL({ select: { id: true, name: true } });
-    const q2 = resolveVertzQL({ select: { id: true, email: true } });
-
-    expect(q1?.q).not.toBe(q2?.q);
-  });
-});
-
-describe('encodeVertzQL with top-level where/orderBy/limit (#1637)', () => {
-  it('encodes where as a top-level VertzQL key', () => {
-    const result = encodeVertzQL({ where: { projectId: '123' } });
-
-    expect(decodeBase64url(result)).toEqual({ where: { projectId: '123' } });
-  });
-
-  it('encodes orderBy as a top-level VertzQL key', () => {
-    const result = encodeVertzQL({ orderBy: { createdAt: 'desc' } });
-
-    expect(decodeBase64url(result)).toEqual({ orderBy: { createdAt: 'desc' } });
-  });
-
-  it('encodes limit as a top-level VertzQL key', () => {
-    const result = encodeVertzQL({ limit: 10 });
-
-    expect(decodeBase64url(result)).toEqual({ limit: 10 });
-  });
-
-  it('encodes all five VertzQL keys together', () => {
-    const params = {
-      select: { id: true, title: true },
-      include: { comments: true },
-      where: { status: 'active' },
-      orderBy: { createdAt: 'desc' },
-      limit: 25,
-    };
-    const result = encodeVertzQL(params);
-
-    expect(decodeBase64url(result)).toEqual(params);
-  });
-});
-
 describe('encodeVertzQL with where/orderBy/limit in include (#1130)', () => {
   it('encodes include with where, orderBy, and limit', () => {
     const result = encodeVertzQL({
@@ -282,35 +111,7 @@ describe('encodeVertzQL with where/orderBy/limit in include (#1130)', () => {
   });
 });
 
-describe('resolveVertzQL with nested include options (#1130)', () => {
-  it('extracts include with where/orderBy/limit into q= param', () => {
-    const query = {
-      include: {
-        comments: {
-          where: { status: 'published' },
-          orderBy: { createdAt: 'desc' },
-          limit: 10,
-        },
-      },
-    };
-    const result = resolveVertzQL(query);
-
-    expect(result?.include).toBeUndefined();
-    expect(result?.q).toBeDefined();
-    expect(decodeBase64url(result?.q as string)).toEqual({
-      include: {
-        comments: {
-          where: { status: 'published' },
-          orderBy: { createdAt: 'desc' },
-          limit: 10,
-        },
-      },
-    });
-  });
-});
-
 describe('encodeVertzQL round-trip with server decode logic', () => {
-  // Mirrors the server's parseVertzQL base64url decode logic
   function serverDecode(encoded: string): Record<string, unknown> {
     const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
     const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
@@ -341,39 +142,318 @@ describe('encodeVertzQL round-trip with server decode logic', () => {
     expect(decoded.select).toEqual({ id: true, name: true });
     expect(decoded.include).toEqual({ posts: true });
   });
+});
 
-  it('round-trips where filter (#1637)', () => {
-    const encoded = encodeVertzQL({ where: { projectId: '123' } });
-    const decoded = serverDecode(encoded);
+// ---------------------------------------------------------------------------
+// resolveVertzQL — only select/include go into q=, the rest stay as flat params
+// ---------------------------------------------------------------------------
 
-    expect(decoded.where).toEqual({ projectId: '123' });
+describe('resolveVertzQL', () => {
+  it('returns undefined when query is undefined', () => {
+    expect(resolveVertzQL(undefined)).toBeUndefined();
   });
 
-  it('round-trips orderBy (#1637)', () => {
-    const encoded = encodeVertzQL({ orderBy: { createdAt: 'desc' } });
-    const decoded = serverDecode(encoded);
+  it('passes through query as-is when no VertzQL keys present', () => {
+    const query = { status: 'active', page: 1 };
 
-    expect(decoded.orderBy).toEqual({ createdAt: 'desc' });
+    expect(resolveVertzQL(query)).toEqual({ status: 'active', page: 1 });
   });
 
-  it('round-trips limit (#1637)', () => {
-    const encoded = encodeVertzQL({ limit: 10 });
-    const decoded = serverDecode(encoded);
+  it('returns same reference when no VertzQL keys present (no-op)', () => {
+    const query = { status: 'active' };
+    const result = resolveVertzQL(query);
 
-    expect(decoded.limit).toBe(10);
+    expect(result).toBe(query);
   });
 
-  it('round-trips all five VertzQL keys (#1637)', () => {
-    const params = {
+  it('extracts select from query and encodes as q= param', () => {
+    const query = { select: { id: true, name: true } };
+    const result = resolveVertzQL(query);
+
+    expect(result).toBeDefined();
+    expect(result?.select).toBeUndefined();
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      select: { id: true, name: true },
+    });
+  });
+
+  it('extracts include from query and encodes as q= param', () => {
+    const query = { include: { posts: true } };
+    const result = resolveVertzQL(query);
+
+    expect(result).toBeDefined();
+    expect(result?.include).toBeUndefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      include: { posts: true },
+    });
+  });
+
+  it('combines select and include into single q= param', () => {
+    const query = {
+      select: { id: true, name: true },
+      include: { posts: true },
+    };
+    const result = resolveVertzQL(query);
+
+    expect(result?.select).toBeUndefined();
+    expect(result?.include).toBeUndefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      select: { id: true, name: true },
+      include: { posts: true },
+    });
+  });
+
+  it('extracts include with nested where/orderBy/limit into q= param', () => {
+    const query = {
+      include: {
+        comments: {
+          where: { status: 'published' },
+          orderBy: { createdAt: 'desc' },
+          limit: 10,
+        },
+      },
+    };
+    const result = resolveVertzQL(query);
+
+    expect(result?.include).toBeUndefined();
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      include: {
+        comments: {
+          where: { status: 'published' },
+          orderBy: { createdAt: 'desc' },
+          limit: 10,
+        },
+      },
+    });
+  });
+
+  it('preserves other query params alongside q=', () => {
+    const query = { status: 'active', select: { id: true } };
+    const result = resolveVertzQL(query);
+
+    expect(result?.status).toBe('active');
+    expect(result?.select).toBeUndefined();
+    expect(result?.q).toBeDefined();
+  });
+
+  it('different selections produce different q= values (cache key differentiation)', () => {
+    const q1 = resolveVertzQL({ select: { id: true, name: true } });
+    const q2 = resolveVertzQL({ select: { id: true, email: true } });
+
+    expect(q1?.q).not.toBe(q2?.q);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVertzQL — where flattened to bracket notation (NOT encoded in q)
+// ---------------------------------------------------------------------------
+
+describe('resolveVertzQL where flattening (#1666)', () => {
+  it('flattens simple where equality to bracket notation', () => {
+    const result = resolveVertzQL({ where: { projectId: '123' } });
+
+    expect(result?.q).toBeUndefined();
+    expect(result?.where).toBeUndefined();
+    expect(result?.['where[projectId]']).toBe('123');
+  });
+
+  it('flattens multiple where fields to separate bracket keys', () => {
+    const result = resolveVertzQL({ where: { status: 'active', projectId: '456' } });
+
+    expect(result?.q).toBeUndefined();
+    expect(result?.['where[status]']).toBe('active');
+    expect(result?.['where[projectId]']).toBe('456');
+  });
+
+  it('flattens where operator filters to nested bracket notation', () => {
+    const result = resolveVertzQL({ where: { age: { gt: 18 } } });
+
+    expect(result?.q).toBeUndefined();
+    expect(result?.['where[age][gt]']).toBe('18');
+  });
+
+  it('flattens where with multiple operators on same field', () => {
+    const result = resolveVertzQL({
+      where: { createdAt: { gte: '2024-01-01', lte: '2024-12-31' } },
+    });
+
+    expect(result?.['where[createdAt][gte]']).toBe('2024-01-01');
+    expect(result?.['where[createdAt][lte]']).toBe('2024-12-31');
+  });
+
+  it('flattens where with mix of equality and operator filters', () => {
+    const result = resolveVertzQL({
+      where: { status: 'active', priority: { gte: 3 } },
+    });
+
+    expect(result?.['where[status]']).toBe('active');
+    expect(result?.['where[priority][gte]']).toBe('3');
+  });
+
+  it('flattens where with numeric equality value', () => {
+    const result = resolveVertzQL({ where: { count: 42 } });
+
+    expect(result?.['where[count]']).toBe('42');
+  });
+
+  it('skips where fields with null values', () => {
+    const result = resolveVertzQL({ where: { deletedAt: null, status: 'active' } });
+
+    expect(result?.['where[deletedAt]']).toBeUndefined();
+    expect(result?.['where[status]']).toBe('active');
+  });
+
+  it('skips where fields with undefined values', () => {
+    const result = resolveVertzQL({ where: { name: undefined, status: 'active' } });
+
+    expect(result?.['where[name]']).toBeUndefined();
+    expect(result?.['where[status]']).toBe('active');
+  });
+
+  it('flattens where alongside q= for select/include', () => {
+    const result = resolveVertzQL({
+      select: { id: true, title: true },
+      where: { projectId: '123' },
+    });
+
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      select: { id: true, title: true },
+    });
+    expect(result?.['where[projectId]']).toBe('123');
+    expect(result?.where).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVertzQL — orderBy flattened to colon format (NOT encoded in q)
+// ---------------------------------------------------------------------------
+
+describe('resolveVertzQL orderBy flattening (#1666)', () => {
+  it('flattens single orderBy to colon format', () => {
+    const result = resolveVertzQL({ orderBy: { createdAt: 'desc' } });
+
+    expect(result?.q).toBeUndefined();
+    expect(result?.orderBy).toBe('createdAt:desc');
+  });
+
+  it('flattens orderBy asc direction', () => {
+    const result = resolveVertzQL({ orderBy: { name: 'asc' } });
+
+    expect(result?.orderBy).toBe('name:asc');
+  });
+
+  it('flattens multiple orderBy fields as comma-separated', () => {
+    const result = resolveVertzQL({ orderBy: { createdAt: 'desc', name: 'asc' } });
+
+    expect(result?.orderBy).toBe('createdAt:desc,name:asc');
+  });
+
+  it('flattens orderBy alongside q= for select/include', () => {
+    const result = resolveVertzQL({
+      include: { comments: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      include: { comments: true },
+    });
+    expect(result?.orderBy).toBe('createdAt:desc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVertzQL — limit stays as flat number (NOT encoded in q)
+// ---------------------------------------------------------------------------
+
+describe('resolveVertzQL limit flattening (#1666)', () => {
+  it('keeps limit as a flat number param', () => {
+    const result = resolveVertzQL({ limit: 10 });
+
+    expect(result?.q).toBeUndefined();
+    expect(result?.limit).toBe(10);
+  });
+
+  it('keeps limit alongside q= for select/include', () => {
+    const result = resolveVertzQL({
+      select: { id: true },
+      limit: 25,
+    });
+
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      select: { id: true },
+    });
+    expect(result?.limit).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVertzQL — combined scenarios
+// ---------------------------------------------------------------------------
+
+describe('resolveVertzQL combined flat params (#1666)', () => {
+  it('keeps where/orderBy/limit as flat params with select/include in q=', () => {
+    const query = {
       select: { id: true, title: true },
       include: { comments: true },
-      where: { status: 'active', projectId: '456' },
+      where: { status: 'active' },
+      orderBy: { createdAt: 'desc' },
+      limit: 25,
+      page: 2,
+    };
+    const result = resolveVertzQL(query);
+
+    // select and include are in q=
+    expect(result?.q).toBeDefined();
+    expect(decodeBase64url(result?.q as string)).toEqual({
+      select: { id: true, title: true },
+      include: { comments: true },
+    });
+
+    // where is flattened to bracket notation
+    expect(result?.['where[status]']).toBe('active');
+
+    // orderBy is flattened to colon format
+    expect(result?.orderBy).toBe('createdAt:desc');
+
+    // limit stays as number
+    expect(result?.limit).toBe(25);
+
+    // non-VertzQL params pass through
+    expect(result?.page).toBe(2);
+
+    // original keys removed
+    expect(result?.select).toBeUndefined();
+    expect(result?.include).toBeUndefined();
+    expect(result?.where).toBeUndefined();
+  });
+
+  it('works with only where/orderBy/limit (no q= generated)', () => {
+    const result = resolveVertzQL({
+      where: { projectId: '123' },
       orderBy: { createdAt: 'desc' },
       limit: 50,
-    };
-    const encoded = encodeVertzQL(params);
-    const decoded = serverDecode(encoded);
+    });
 
-    expect(decoded).toEqual(params);
+    expect(result?.q).toBeUndefined();
+    expect(result?.['where[projectId]']).toBe('123');
+    expect(result?.orderBy).toBe('createdAt:desc');
+    expect(result?.limit).toBe(50);
+  });
+
+  it('preserves non-VertzQL params alongside flattened params', () => {
+    const result = resolveVertzQL({
+      where: { status: 'active' },
+      page: 2,
+      cursor: 'abc',
+    });
+
+    expect(result?.['where[status]']).toBe('active');
+    expect(result?.page).toBe(2);
+    expect(result?.cursor).toBe('abc');
   });
 });

--- a/packages/fetch/src/vertzql.ts
+++ b/packages/fetch/src/vertzql.ts
@@ -27,13 +27,53 @@ export function encodeVertzQL(params: VertzQLParams): string {
   return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
-/** Keys that belong inside the encoded `q` parameter. */
-const VERTZQL_KEYS = new Set(['select', 'include', 'where', 'orderBy', 'limit']);
+/** Keys that belong inside the encoded `q` parameter (structural, not human-readable). */
+const ENCODED_KEYS = new Set(['select', 'include']);
 
 /**
- * Extracts VertzQL keys (`select`, `include`, `where`, `orderBy`, `limit`)
- * from a query object, encodes them as a base64url `q` parameter, and
- * returns the remaining keys alongside `q`.
+ * Flattens a `where` object into bracket-notation query keys.
+ *
+ * - `{ field: value }`          → `{ 'where[field]': String(value) }`
+ * - `{ field: { op: value } }`  → `{ 'where[field][op]': String(value) }`
+ */
+function flattenWhere(
+  where: Record<string, unknown>,
+  target: Record<string, unknown>,
+): void {
+  for (const [field, value] of Object.entries(where)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      for (const [op, opValue] of Object.entries(value as Record<string, unknown>)) {
+        if (opValue !== undefined && opValue !== null) {
+          target[`where[${field}][${op}]`] = String(opValue);
+        }
+      }
+    } else {
+      target[`where[${field}]`] = String(value);
+    }
+  }
+}
+
+/**
+ * Flattens an `orderBy` object into `field:dir` colon format.
+ *
+ * - `{ createdAt: 'desc' }` → `'createdAt:desc'`
+ */
+function flattenOrderBy(orderBy: Record<string, 'asc' | 'desc'>): string {
+  return Object.entries(orderBy)
+    .map(([field, dir]) => `${field}:${dir}`)
+    .join(',');
+}
+
+/**
+ * Extracts structural VertzQL keys (`select`, `include`) from a query object,
+ * encodes them as a base64url `q` parameter, and flattens `where`, `orderBy`,
+ * and `limit` into URL-native query parameter format.
+ *
+ * - `select` / `include` → encoded in `q` (complex nested structures)
+ * - `where`              → bracket notation: `where[field]=value`
+ * - `orderBy`            → colon format: `orderBy=field:dir`
+ * - `limit`              → flat number: `limit=N`
  *
  * Returns `undefined` if the input is `undefined`.
  * Returns the query unchanged if no VertzQL keys are present.
@@ -43,13 +83,27 @@ export function resolveVertzQL(
 ): Record<string, unknown> | undefined {
   if (!query) return undefined;
 
-  const vertzqlFields: Record<string, unknown> = {};
+  const encodedFields: Record<string, unknown> = {};
   const rest: Record<string, unknown> = {};
   let hasVertzQL = false;
 
   for (const key of Object.keys(query)) {
-    if (VERTZQL_KEYS.has(key) && query[key] !== undefined) {
-      vertzqlFields[key] = query[key];
+    if (query[key] === undefined) {
+      rest[key] = query[key];
+      continue;
+    }
+
+    if (ENCODED_KEYS.has(key)) {
+      encodedFields[key] = query[key];
+      hasVertzQL = true;
+    } else if (key === 'where') {
+      flattenWhere(query[key] as Record<string, unknown>, rest);
+      hasVertzQL = true;
+    } else if (key === 'orderBy') {
+      rest.orderBy = flattenOrderBy(query[key] as Record<string, 'asc' | 'desc'>);
+      hasVertzQL = true;
+    } else if (key === 'limit') {
+      rest.limit = query[key];
       hasVertzQL = true;
     } else {
       rest[key] = query[key];
@@ -58,6 +112,10 @@ export function resolveVertzQL(
 
   if (!hasVertzQL) return query;
 
-  const q = encodeVertzQL(vertzqlFields as VertzQLParams);
-  return { ...rest, q };
+  if (Object.keys(encodedFields).length > 0) {
+    const q = encodeVertzQL(encodedFields as VertzQLParams);
+    return { ...rest, q };
+  }
+
+  return rest;
 }

--- a/packages/server/src/entity/__tests__/vertzql-parser.test.ts
+++ b/packages/server/src/entity/__tests__/vertzql-parser.test.ts
@@ -1346,6 +1346,69 @@ describe('Feature: q= param extracts where/orderBy/limit/offset (#1243)', () => 
 });
 
 // ---------------------------------------------------------------------------
+// Client-produced pattern: flat where/orderBy/limit + q= with select/include
+// ---------------------------------------------------------------------------
+
+describe('Feature: flat params + q= with select/include (#1666)', () => {
+  describe('Given the full client pattern: where[]+orderBy+limit+q(select,include)', () => {
+    describe('When parseVertzQL is called', () => {
+      it('Then merges all sources into a single VertzQLOptions', () => {
+        const structural = {
+          select: { id: true, title: true },
+          include: { comments: true },
+        };
+        const q = btoa(JSON.stringify(structural));
+
+        const result = parseVertzQL({
+          'where[status]': 'active',
+          'where[priority][gte]': '3',
+          orderBy: 'createdAt:desc',
+          limit: '25',
+          q,
+        });
+
+        expect(result.select).toEqual({ id: true, title: true });
+        expect(result.include).toEqual({ comments: true });
+        expect(result.where).toEqual({
+          status: 'active',
+          priority: { gte: '3' },
+        });
+        expect(result.orderBy).toEqual({ createdAt: 'desc' });
+        expect(result.limit).toBe(25);
+      });
+    });
+  });
+
+  describe('Given comma-separated orderBy with multiple fields', () => {
+    describe('When parseVertzQL is called', () => {
+      it('Then parses all orderBy fields', () => {
+        const result = parseVertzQL({ orderBy: 'createdAt:desc,name:asc' });
+
+        expect(result.orderBy).toEqual({ createdAt: 'desc', name: 'asc' });
+      });
+    });
+  });
+
+  describe('Given flat params only (no q=)', () => {
+    describe('When parseVertzQL is called', () => {
+      it('Then parses where/orderBy/limit without q', () => {
+        const result = parseVertzQL({
+          'where[projectId]': '123',
+          orderBy: 'name:asc',
+          limit: '50',
+        });
+
+        expect(result.where).toEqual({ projectId: '123' });
+        expect(result.orderBy).toEqual({ name: 'asc' });
+        expect(result.limit).toBe(50);
+        expect(result.select).toBeUndefined();
+        expect(result.include).toBeUndefined();
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Security: q= parameter hardening
 // ---------------------------------------------------------------------------
 

--- a/packages/server/src/entity/vertzql-parser.ts
+++ b/packages/server/src/entity/vertzql-parser.ts
@@ -116,12 +116,15 @@ export function parseVertzQL(query: Record<string, string>): VertzQLOptions {
       continue;
     }
 
-    // orderBy=field:dir
+    // orderBy=field:dir or orderBy=field1:dir1,field2:dir2
     if (key === 'orderBy') {
-      const [field, dir] = value.split(':');
-      if (field) {
-        if (!result.orderBy) result.orderBy = {};
-        result.orderBy[field] = dir === 'desc' ? 'desc' : 'asc';
+      const entries = value.split(',');
+      for (const entry of entries) {
+        const [field, dir] = entry.split(':');
+        if (field) {
+          if (!result.orderBy) result.orderBy = {};
+          result.orderBy[field] = dir === 'desc' ? 'desc' : 'asc';
+        }
       }
       continue;
     }


### PR DESCRIPTION
## Summary

- **Reverts** the behavior where `resolveVertzQL` encoded all 5 VertzQL keys (`select`, `include`, `where`, `orderBy`, `limit`) into the base64 `q=` parameter
- **Now** only `select` and `include` are encoded in `q=` (complex nested structures not suited for flat URL params)
- `where` is flattened to bracket notation: `where[field]=value`, `where[field][op]=value`
- `orderBy` is flattened to colon format: `orderBy=field:dir` (comma-separated for multiple fields)
- `limit` stays as a flat number: `limit=N`
- Server parser updated to support comma-separated multi-field `orderBy`

## Public API Changes

- `resolveVertzQL` output shape changes: `where`/`orderBy`/`limit` are no longer inside the `q=` blob
- URL format changes from all-in-base64 to mixed flat+base64 (more human-readable)
- Server `parseVertzQL` now handles `orderBy=field1:dir1,field2:dir2`

## Test plan

- [x] Client tests: `where` flattened to bracket notation (simple, operators, mixed, null/undefined skipped)
- [x] Client tests: `orderBy` flattened to colon format (single and multi-field)
- [x] Client tests: `limit` stays as raw number
- [x] Client tests: combined scenarios (flat params + q= for select/include)
- [x] Server tests: comma-separated multi-field orderBy parsing
- [x] Server tests: full client pattern merge (flat where/orderBy/limit + q= with select/include)
- [x] Typecheck clean on @vertz/fetch and @vertz/server
- [x] All existing tests still pass (937 total across fetch, server entity, codegen)

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)