### PR TITLE
fix(linear): use framework Dialog primitives instead of custom markup

### DIFF
--- a/examples/linear/src/components/create-issue-dialog.tsx
+++ b/examples/linear/src/components/create-issue-dialog.tsx
@@ -1,13 +1,13 @@
 import type { DialogHandle } from '@vertz/ui';
 import { form } from '@vertz/ui';
-import { Button } from '@vertz/ui/components';
+import { Button, Dialog } from '@vertz/ui/components';
 import { api } from '../api/client';
 import { PRIORITIES } from '../lib/issue-config';
-import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
+import { formStyles, inputStyles, labelStyles } from '../styles/components';
 
 interface CreateIssueDialogProps {
   projectId: string;
-  dialog: DialogHandle<boolean>;
+  dialog: DialogHandle<void>;
 }
 
 export function CreateIssueDialog({ projectId, dialog }: CreateIssueDialogProps) {
@@ -19,31 +19,21 @@ export function CreateIssueDialog({ projectId, dialog }: CreateIssueDialogProps)
       status: 'backlog',
       priority: 'none',
     },
-    onSuccess: () => dialog.close(true),
+    onSuccess: () => dialog.close(),
   });
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: dialog overlay backdrop
-    <div
-      className={dialogStyles.overlay}
-      data-state="open"
-      role="presentation"
-      onClick={(e: MouseEvent) => {
-        if (e.target === e.currentTarget) dialog.close(false);
-      }}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === 'Escape') dialog.close(false);
-      }}
-    >
-      <div
-        className={dialogStyles.panel}
-        role="dialog"
-        aria-modal="true"
-        aria-label="New Issue"
-        data-state="open"
-      >
-        <h3 className={dialogStyles.title}>New Issue</h3>
-        <form action={createForm.action} method={createForm.method} onSubmit={createForm.onSubmit}>
+    <>
+      <Dialog.Header>
+        <Dialog.Title>New Issue</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
+        <form
+          id="create-issue-form"
+          action={createForm.action}
+          method={createForm.method}
+          onSubmit={createForm.onSubmit}
+        >
           <input type="hidden" name="projectId" value={projectId} />
 
           <div className={formStyles.field}>
@@ -86,17 +76,20 @@ export function CreateIssueDialog({ projectId, dialog }: CreateIssueDialogProps)
               ))}
             </select>
           </div>
-
-          <footer className={dialogStyles.footer}>
-            <Button intent="outline" size="sm" onClick={() => dialog.close(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" intent="primary" size="sm" disabled={createForm.submitting.value}>
-              {createForm.submitting ? 'Creating...' : 'Create Issue'}
-            </Button>
-          </footer>
         </form>
-      </div>
-    </div>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Cancel>Cancel</Dialog.Cancel>
+        <Button
+          type="submit"
+          form="create-issue-form"
+          intent="primary"
+          size="sm"
+          disabled={createForm.submitting.value}
+        >
+          {createForm.submitting ? 'Creating...' : 'Create Issue'}
+        </Button>
+      </Dialog.Footer>
+    </>
   );
 }

--- a/examples/linear/src/components/create-project-dialog.tsx
+++ b/examples/linear/src/components/create-project-dialog.tsx
@@ -1,10 +1,10 @@
 import { s } from '@vertz/schema';
 import type { DialogHandle } from '@vertz/ui';
 import { form } from '@vertz/ui';
-import { Button } from '@vertz/ui/components';
+import { Button, Dialog } from '@vertz/ui/components';
 import { createProjectsInputSchema } from '#generated/schemas';
 import { api } from '../api/client';
-import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
+import { formStyles, inputStyles, labelStyles } from '../styles/components';
 
 const createProjectSchema = createProjectsInputSchema.extend({
   key: s
@@ -15,38 +15,28 @@ const createProjectSchema = createProjectsInputSchema.extend({
 });
 
 interface CreateProjectDialogProps {
-  dialog: DialogHandle<boolean>;
+  dialog: DialogHandle<void>;
 }
 
 export function CreateProjectDialog({ dialog }: CreateProjectDialogProps) {
   const createForm = form(api.projects.create, {
     schema: createProjectSchema,
     initial: { name: '', key: '', description: '' },
-    onSuccess: () => dialog.close(true),
+    onSuccess: () => dialog.close(),
   });
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: dialog overlay backdrop
-    <div
-      className={dialogStyles.overlay}
-      data-state="open"
-      role="presentation"
-      onClick={(e: MouseEvent) => {
-        if (e.target === e.currentTarget) dialog.close(false);
-      }}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === 'Escape') dialog.close(false);
-      }}
-    >
-      <div
-        className={dialogStyles.panel}
-        role="dialog"
-        aria-modal="true"
-        aria-label="New Project"
-        data-state="open"
-      >
-        <h3 className={dialogStyles.title}>New Project</h3>
-        <form action={createForm.action} method={createForm.method} onSubmit={createForm.onSubmit}>
+    <>
+      <Dialog.Header>
+        <Dialog.Title>New Project</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
+        <form
+          id="create-project-form"
+          action={createForm.action}
+          method={createForm.method}
+          onSubmit={createForm.onSubmit}
+        >
           <div className={formStyles.field}>
             <label className={labelStyles.base} htmlFor="project-name">
               Name
@@ -91,17 +81,20 @@ export function CreateProjectDialog({ dialog }: CreateProjectDialogProps) {
               style={{ minHeight: '5rem', resize: 'vertical' }}
             />
           </div>
-
-          <footer className={dialogStyles.footer}>
-            <Button intent="outline" size="sm" onClick={() => dialog.close(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" intent="primary" size="sm" disabled={createForm.submitting.value}>
-              {createForm.submitting ? 'Creating...' : 'Create Project'}
-            </Button>
-          </footer>
         </form>
-      </div>
-    </div>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Cancel>Cancel</Dialog.Cancel>
+        <Button
+          type="submit"
+          form="create-project-form"
+          intent="primary"
+          size="sm"
+          disabled={createForm.submitting.value}
+        >
+          {createForm.submitting ? 'Creating...' : 'Create Project'}
+        </Button>
+      </Dialog.Footer>
+    </>
   );
 }

--- a/examples/linear/src/components/edit-issue-dialog.tsx
+++ b/examples/linear/src/components/edit-issue-dialog.tsx
@@ -1,11 +1,11 @@
 import type { DialogHandle } from '@vertz/ui';
 import { css } from '@vertz/ui';
-import { Button } from '@vertz/ui/components';
+import { Button, Dialog } from '@vertz/ui/components';
 import { api } from '../api/client';
 import { editIssueSchema } from '../lib/edit-issue-schema';
 import { PRIORITIES, STATUSES } from '../lib/issue-config';
 import type { Issue } from '../lib/types';
-import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
+import { formStyles, inputStyles, labelStyles } from '../styles/components';
 
 const styles = css({
   formError: ['text:sm', 'text:destructive', 'mb:4'],
@@ -13,7 +13,7 @@ const styles = css({
 
 interface EditIssueDialogProps {
   issue: Issue;
-  dialog: DialogHandle<boolean>;
+  dialog: DialogHandle<void>;
 }
 
 export function EditIssueDialog({ issue, dialog }: EditIssueDialogProps) {
@@ -52,31 +52,16 @@ export function EditIssueDialog({ issue, dialog }: EditIssueDialogProps) {
       return;
     }
 
-    dialog.close(true);
+    dialog.close();
   };
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: dialog overlay backdrop
-    <div
-      className={dialogStyles.overlay}
-      data-state="open"
-      role="presentation"
-      onClick={(e: MouseEvent) => {
-        if (e.target === e.currentTarget) dialog.close(false);
-      }}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === 'Escape') dialog.close(false);
-      }}
-    >
-      <div
-        className={dialogStyles.panel}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Edit Issue"
-        data-state="open"
-      >
-        <h3 className={dialogStyles.title}>Edit Issue</h3>
-        <form onSubmit={handleSubmit}>
+    <>
+      <Dialog.Header>
+        <Dialog.Title>Edit Issue</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
+        <form id="edit-issue-form" onSubmit={handleSubmit}>
           {formError && <div className={styles.formError}>{formError}</div>}
 
           <div className={formStyles.field}>
@@ -143,17 +128,20 @@ export function EditIssueDialog({ issue, dialog }: EditIssueDialogProps) {
               ))}
             </select>
           </div>
-
-          <footer className={dialogStyles.footer}>
-            <Button intent="outline" size="sm" onClick={() => dialog.close(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" intent="primary" size="sm" disabled={submitting}>
-              {submitting ? 'Saving...' : 'Save Changes'}
-            </Button>
-          </footer>
         </form>
-      </div>
-    </div>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Cancel>Cancel</Dialog.Cancel>
+        <Button
+          type="submit"
+          form="edit-issue-form"
+          intent="primary"
+          size="sm"
+          disabled={submitting}
+        >
+          {submitting ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </Dialog.Footer>
+    </>
   );
 }

--- a/examples/linear/src/components/manage-labels-dialog.tsx
+++ b/examples/linear/src/components/manage-labels-dialog.tsx
@@ -1,10 +1,10 @@
 import type { DialogHandle } from '@vertz/ui';
-import { css, form, query } from '@vertz/ui';
-import { Button } from '@vertz/ui/components';
+import { css, form, query, useDialogStack } from '@vertz/ui';
+import { Button, Dialog } from '@vertz/ui/components';
 import { api } from '../api/client';
 import { LABEL_COLORS } from '../lib/issue-config';
 import type { Label } from '../lib/types';
-import { dialogStyles, formStyles, inputStyles, labelStyles } from '../styles/components';
+import { formStyles, inputStyles, labelStyles } from '../styles/components';
 
 const styles = css({
   list: ['flex', 'flex-col', 'gap:2', 'mb:4', 'max-h:80', 'overflow:hidden'],
@@ -38,11 +38,12 @@ const styles = css({
 
 interface ManageLabelsDialogProps {
   projectId: string;
-  dialog: DialogHandle<boolean>;
+  dialog: DialogHandle<void>;
 }
 
 export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProps) {
   const labelsQuery = query(api.labels.list({ where: { projectId } }));
+  const dialogs = useDialogStack();
 
   let editingLabel: Label | null = null;
   let isCreating = false;
@@ -63,8 +64,17 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
     selectedColor = LABEL_COLORS[0].value;
   };
 
-  const handleDelete = async (labelId: string) => {
-    await api.labels.delete(labelId);
+  const handleDelete = async (label: Label) => {
+    const confirmed = await dialogs.confirm({
+      title: `Delete "${label.name}"?`,
+      description: 'This label will be removed from all issues. This action cannot be undone.',
+      confirm: 'Delete',
+      cancel: 'Cancel',
+      intent: 'danger',
+    });
+    if (confirmed) {
+      await api.labels.delete(label.id);
+    }
   };
 
   const startEdit = (label: Label) => {
@@ -78,37 +88,22 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
     isCreating = true;
   };
 
-  const handleUpdate = async () => {
+  const handleUpdate = async (e: SubmitEvent) => {
+    e.preventDefault();
     if (!editingLabel) return;
-    const nameInput = document.querySelector<HTMLInputElement>('#label-name');
-    const name = nameInput?.value?.trim();
+    const formData = new FormData(e.target as HTMLFormElement);
+    const name = (formData.get('name') as string)?.trim();
     if (!name) return;
     await api.labels.update(editingLabel.id, { name, color: selectedColor });
     resetForm();
   };
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: dialog overlay backdrop
-    <div
-      className={dialogStyles.overlay}
-      data-state="open"
-      role="presentation"
-      onClick={(e: MouseEvent) => {
-        if (e.target === e.currentTarget) dialog.close(true);
-      }}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === 'Escape') dialog.close(true);
-      }}
-    >
-      <div
-        className={dialogStyles.panel}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Manage Labels"
-        data-state="open"
-      >
-        <h3 className={dialogStyles.title}>Manage Labels</h3>
-
+    <>
+      <Dialog.Header>
+        <Dialog.Title>Manage Labels</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
         <div className={styles.list}>
           {labelsQuery.data?.items.length === 0 && !labelsQuery.loading && (
             <div className={styles.empty}>No labels yet. Create one below.</div>
@@ -121,7 +116,7 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
                 <Button intent="ghost" size="sm" onClick={() => startEdit(label as Label)}>
                   Edit
                 </Button>
-                <Button intent="ghost" size="sm" onClick={() => handleDelete(label.id)}>
+                <Button intent="ghost" size="sm" onClick={() => handleDelete(label as Label)}>
                   Delete
                 </Button>
               </div>
@@ -129,7 +124,7 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
           ))}
         </div>
 
-        {isCreating && !editingLabel && (
+        {isCreating && !editingLabel ? (
           <form
             action={createForm.action}
             method={createForm.method}
@@ -166,7 +161,7 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
                 />
               ))}
             </div>
-            <div className={dialogStyles.footer}>
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
               <Button intent="outline" size="sm" onClick={resetForm}>
                 Cancel
               </Button>
@@ -180,10 +175,10 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
               </Button>
             </div>
           </form>
-        )}
+        ) : null}
 
-        {isCreating && editingLabel && (
-          <div className={styles.formContainer}>
+        {isCreating && editingLabel ? (
+          <form onSubmit={handleUpdate} className={styles.formContainer}>
             <div className={formStyles.field}>
               <label className={labelStyles.base} htmlFor="label-name">
                 Name
@@ -191,6 +186,7 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
               <input
                 className={inputStyles.base}
                 id="label-name"
+                name="name"
                 placeholder="Label name"
                 value={editingLabel.name}
               />
@@ -209,28 +205,27 @@ export function ManageLabelsDialog({ projectId, dialog }: ManageLabelsDialogProp
                 />
               ))}
             </div>
-            <div className={dialogStyles.footer}>
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
               <Button intent="outline" size="sm" onClick={resetForm}>
                 Cancel
               </Button>
-              <Button intent="primary" size="sm" onClick={handleUpdate}>
+              <Button type="submit" intent="primary" size="sm">
                 Update
               </Button>
             </div>
-          </div>
-        )}
-
-        <footer className={dialogStyles.footer}>
-          {!isCreating && (
-            <Button intent="outline" size="sm" onClick={startCreate}>
-              New Label
-            </Button>
-          )}
-          <Button intent="primary" size="sm" onClick={() => dialog.close(true)}>
-            Done
+          </form>
+        ) : null}
+      </Dialog.Body>
+      <Dialog.Footer>
+        {!isCreating ? (
+          <Button intent="outline" size="sm" onClick={startCreate}>
+            New Label
           </Button>
-        </footer>
-      </div>
-    </div>
+        ) : null}
+        <Button intent="primary" size="sm" onClick={() => dialog.close()}>
+          Done
+        </Button>
+      </Dialog.Footer>
+    </>
   );
 }

--- a/examples/linear/src/styles/components.ts
+++ b/examples/linear/src/styles/components.ts
@@ -14,8 +14,6 @@ export const cardStyles = themeStyles.card;
 export const inputStyles = themeStyles.input;
 export const labelStyles = themeStyles.label;
 export const formGroupStyles = themeStyles.formGroup;
-export const dialogStyles = themeStyles.dialog;
-
 // ── Form styles (app-specific extensions) ───────────────────
 
 export const formStyles = css({


### PR DESCRIPTION
## Summary

Fixes #1664

- Refactored all 4 Linear clone dialog components to use `Dialog.Header`, `Dialog.Title`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.Cancel` from `@vertz/ui/components` instead of custom overlay/panel markup with manual event handlers
- Added delete confirmation via `dialogs.confirm()` in manage-labels dialog (stacked dialog pattern)
- Fixed imperative `document.querySelector` usage in label edit handler — now uses `<form>` with `FormData`
- Removed unused `dialogStyles` export from `components.ts`

## Changes

| File | What changed |
|------|-------------|
| `create-issue-dialog.tsx` | Framework Dialog sub-components, `DialogHandle<void>`, form linked via `form` attribute |
| `create-project-dialog.tsx` | Same pattern |
| `edit-issue-dialog.tsx` | Same pattern |
| `manage-labels-dialog.tsx` | Same + `dialogs.confirm()` for delete, `<form>` for edit handler |
| `styles/components.ts` | Removed dead `dialogStyles` export |

## Public API Changes

None — example app only.

## Pre-existing issues found during review

- #1714 — `EditIssueDialog` is defined but never used
- #1715 — Label list `overflow:hidden` should be `overflow-y:auto`

## Test plan

- [ ] Existing E2E test `create issue appears in list` still passes (selectors `#issue-title` and button `Create Issue` preserved)
- [ ] Dialogs center in viewport via native `<dialog>` positioning
- [ ] Backdrop click and ESC dismiss work via framework
- [ ] Form submission works within Dialog.Body (via HTML5 `form` attribute)
- [ ] Delete label shows confirmation dialog before proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)