### PR TITLE
fix(linear): label list overflow should scroll, not clip (#1715)

### DIFF
--- a/examples/linear/src/components/manage-labels-dialog.tsx
+++ b/examples/linear/src/components/manage-labels-dialog.tsx
@@ -7,7 +7,7 @@ import type { Label } from '../lib/types';
 import { formStyles, inputStyles, labelStyles } from '../styles/components';
 
 const styles = css({
-  list: ['flex', 'flex-col', 'gap:2', 'mb:4', 'max-h:80', 'overflow:hidden'],
+  list: ['flex', 'flex-col', 'gap:2', 'mb:4', 'max-h:80', 'overflow-y:auto'],
   item: ['flex', 'items:center', 'gap:2', 'px:3', 'py:2', 'rounded:md', 'bg:muted'],
   dot: ['w:3', 'h:3', 'rounded:full', 'shrink-0'],
   name: ['flex-1', 'text:sm', 'text:foreground'],


### PR DESCRIPTION
## Summary
- Changed `overflow:hidden` to `overflow-y:auto` on the label list in `manage-labels-dialog.tsx`
- Users can now scroll through a long label list instead of content being clipped

Closes #1715

## Public API Changes
None — example app only.

## Test plan
- [ ] Open manage-labels dialog with many labels and verify the list scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)