### PR TITLE
chore(landing): add SSR rendering benchmarks

### DIFF
--- a/sites/landing/benchmark-plugin.ts
+++ b/sites/landing/benchmark-plugin.ts
@@ -1,0 +1,16 @@
+/**
+ * Bun preload plugin for the landing page benchmark.
+ */
+import { compile } from '@vertz/ui-compiler';
+import { plugin } from 'bun';
+
+plugin({
+  name: 'vertz-benchmark-compiler',
+  setup(build) {
+    build.onLoad({ filter: /sites\/landing\/src\/.*\.tsx$/ }, async (args) => {
+      const source = await Bun.file(args.path).text();
+      const result = compile(source, args.path);
+      return { contents: result.code, loader: 'tsx' };
+    });
+  },
+});

--- a/sites/landing/benchmark-prod.ts
+++ b/sites/landing/benchmark-prod.ts
@@ -1,0 +1,138 @@
+/**
+ * Benchmark: Production landing page (vertz.dev)
+ *
+ * Measures real HTTP response times against the production Cloudflare Worker.
+ * Run this BEFORE and AFTER deploying the new version to compare.
+ *
+ * Run: bun run sites/landing/benchmark-prod.ts
+ */
+
+const BASE = 'https://vertz.dev';
+const ITERATIONS = 50;
+const WARMUP = 5;
+
+interface BenchmarkResult {
+  name: string;
+  iterations: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  minMs: number;
+  maxMs: number;
+  statusCode: number;
+  sizeKB: number;
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+async function benchmarkUrl(
+  name: string,
+  url: string,
+  iterations: number,
+): Promise<BenchmarkResult> {
+  let statusCode = 0;
+  let sizeKB = 0;
+
+  // Warmup
+  for (let i = 0; i < WARMUP; i++) {
+    const res = await fetch(url);
+    await res.text();
+  }
+
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    const res = await fetch(url, {
+      headers: {
+        'Accept': 'text/html',
+        'User-Agent': 'VertzBenchmark/1.0',
+        'Cache-Control': 'no-cache',
+      },
+    });
+    const body = await res.text();
+    times.push(performance.now() - start);
+
+    if (i === 0) {
+      statusCode = res.status;
+      sizeKB = round(body.length / 1024);
+    }
+  }
+
+  times.sort((a, b) => a - b);
+  const total = times.reduce((a, b) => a + b, 0);
+
+  return {
+    name,
+    iterations,
+    avgMs: round(total / iterations),
+    p50Ms: round(times[Math.floor(times.length * 0.5)]!),
+    p95Ms: round(times[Math.floor(times.length * 0.95)]!),
+    p99Ms: round(times[Math.floor(times.length * 0.99)]!),
+    minMs: round(times[0]!),
+    maxMs: round(times[times.length - 1]!),
+    statusCode,
+    sizeKB,
+  };
+}
+
+function printResult(r: BenchmarkResult): void {
+  console.log(`  ${r.name} (${r.statusCode}, ${r.sizeKB} KB)`);
+  console.log(
+    `    avg: ${r.avgMs}ms | p50: ${r.p50Ms}ms | p95: ${r.p95Ms}ms | p99: ${r.p99Ms}ms`,
+  );
+  console.log(`    min: ${r.minMs}ms | max: ${r.maxMs}ms (${r.iterations} runs)`);
+}
+
+async function main() {
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Production Benchmark — vertz.dev (Cloudflare Worker)');
+  console.log(`  ${ITERATIONS} iterations, ${WARMUP} warmup`);
+  console.log(`  Date: ${new Date().toISOString()}`);
+  console.log('═══════════════════════════════════════════════════════════════');
+
+  const pages = [
+    { name: 'Home', url: `${BASE}/` },
+    { name: 'Manifesto', url: `${BASE}/manifesto` },
+  ];
+
+  const results: BenchmarkResult[] = [];
+
+  for (const { name, url } of pages) {
+    console.log('');
+    console.log(`─── ${name} (${url}) ───`);
+    const result = await benchmarkUrl(`GET ${url}`, url, ITERATIONS);
+    printResult(result);
+    results.push(result);
+  }
+
+  // Summary
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Summary');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('');
+  console.log(
+    '  Page          Status  Size      avg       p50       p95       min',
+  );
+  console.log(
+    '  ────────────  ──────  ────────  ────────  ────────  ────────  ────────',
+  );
+
+  for (const r of results) {
+    const name = r.name.replace(/^GET https:\/\/vertz\.dev/, '').padEnd(14);
+    console.log(
+      `  ${name}${String(r.statusCode).padEnd(8)}${`${r.sizeKB} KB`.padEnd(10)}${`${r.avgMs}ms`.padEnd(10)}${`${r.p50Ms}ms`.padEnd(10)}${`${r.p95Ms}ms`.padEnd(10)}${r.minMs}ms`,
+    );
+  }
+
+  console.log('');
+  console.log('  Note: These times include network latency (client → Cloudflare edge → Worker → response).');
+  console.log('  Compare these numbers after deploying the new version to measure real-world impact.');
+  console.log('');
+}
+
+main().catch(console.error);

--- a/sites/landing/benchmark-ssr-direct.ts
+++ b/sites/landing/benchmark-ssr-direct.ts
@@ -1,0 +1,165 @@
+/**
+ * Direct SSR benchmark — isolates rendering time from HTTP overhead.
+ *
+ * Loads the landing page SSR module via the Vertz compiler plugin,
+ * then benchmarks two-pass vs discovery vs zero-discovery directly.
+ *
+ * Run: bun --preload ./benchmark-plugin.ts run ./benchmark-ssr-direct.ts
+ * (from sites/landing/)
+ */
+import { ssrRenderToString, ssrRenderSinglePass } from '@vertz/ui-server';
+import { installDomShim } from '@vertz/ui-server/dom-shim';
+
+installDomShim();
+
+// Import the landing page app as an SSR module
+const ssrMod = await import('./src/app.tsx');
+
+// ─── Benchmark helpers ─────────────────────────────────────────
+
+interface BenchmarkResult {
+  name: string;
+  iterations: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  minMs: number;
+  maxMs: number;
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+async function benchmark(
+  name: string,
+  fn: () => Promise<unknown>,
+  iterations: number,
+): Promise<BenchmarkResult> {
+  // Warmup
+  for (let i = 0; i < 10; i++) {
+    await fn();
+  }
+
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    await fn();
+    times.push(performance.now() - start);
+  }
+
+  times.sort((a, b) => a - b);
+  const total = times.reduce((a, b) => a + b, 0);
+
+  return {
+    name,
+    iterations,
+    avgMs: round(total / iterations),
+    p50Ms: round(times[Math.floor(times.length * 0.5)]!),
+    p95Ms: round(times[Math.floor(times.length * 0.95)]!),
+    p99Ms: round(times[Math.floor(times.length * 0.99)]!),
+    minMs: round(times[0]!),
+    maxMs: round(times[times.length - 1]!),
+  };
+}
+
+function printResult(r: BenchmarkResult): void {
+  console.log(`  ${r.name}`);
+  console.log(
+    `    avg: ${r.avgMs}ms | p50: ${r.p50Ms}ms | p95: ${r.p95Ms}ms | p99: ${r.p99Ms}ms`,
+  );
+  console.log(`    min: ${r.minMs}ms | max: ${r.maxMs}ms (${r.iterations} runs)`);
+}
+
+// ─── Run ───────────────────────────────────────────────────────
+
+const ITERATIONS = 200;
+
+async function main() {
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════════════');
+  console.log('  Landing Page — Direct SSR Benchmark (no HTTP overhead)');
+  console.log(`  ${ITERATIONS} iterations, 10 warmup, rendering / (home page)`);
+  console.log('═══════════════════════════════════════════════════════════════════════');
+  console.log('');
+
+  // Get HTML size for reference
+  const ref = await ssrRenderToString(ssrMod, '/');
+  console.log(`  HTML size: ${(ref.html.length / 1024).toFixed(1)} KB`);
+  console.log(`  CSS size:  ${(ref.css.length / 1024).toFixed(1)} KB`);
+  console.log('');
+
+  // 1. Two-pass (ssrRenderToString)
+  const twoPass = await benchmark(
+    'Two-pass (ssrRenderToString)',
+    () => ssrRenderToString(ssrMod, '/'),
+    ITERATIONS,
+  );
+  printResult(twoPass);
+
+  // 2. Discovery-based single-pass (no manifest)
+  const discovery = await benchmark(
+    'Discovery single-pass (no manifest)',
+    () => ssrRenderSinglePass(ssrMod, '/'),
+    ITERATIONS,
+  );
+  printResult(discovery);
+
+  // 3. Zero-discovery single-pass (with manifest, empty queries for static page)
+  const manifest = {
+    routePatterns: ['/', '/manifesto'],
+    routeEntries: {
+      '/': { queries: [] },
+      '/manifesto': { queries: [] },
+    },
+  };
+  const zeroDisc = await benchmark(
+    'Zero-discovery single-pass (with manifest)',
+    () => ssrRenderSinglePass(ssrMod, '/', { manifest }),
+    ITERATIONS,
+  );
+  printResult(zeroDisc);
+
+  // Comparisons
+  console.log('');
+  console.log('─── Comparisons ───');
+  const discVsTp = ((1 - discovery.avgMs / twoPass.avgMs) * 100).toFixed(1);
+  const zdVsTp = ((1 - zeroDisc.avgMs / twoPass.avgMs) * 100).toFixed(1);
+  const zdVsDisc = ((1 - zeroDisc.avgMs / discovery.avgMs) * 100).toFixed(1);
+
+  console.log(
+    `  Discovery vs Two-pass:       ${discVsTp}% (${(twoPass.avgMs / discovery.avgMs).toFixed(2)}x)`,
+  );
+  console.log(
+    `  Zero-disc vs Two-pass:       ${zdVsTp}% (${(twoPass.avgMs / zeroDisc.avgMs).toFixed(2)}x)`,
+  );
+  console.log(
+    `  Zero-disc vs Discovery:      ${zdVsDisc}% (${(discovery.avgMs / zeroDisc.avgMs).toFixed(2)}x)`,
+  );
+
+  // Summary table
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════════════');
+  console.log('  Summary');
+  console.log('═══════════════════════════════════════════════════════════════════════');
+  console.log('');
+  console.log(
+    '  Approach                          avg       p50       p95       vs Two-pass',
+  );
+  console.log(
+    '  ────────────────────────────────  ────────  ────────  ────────  ───────────',
+  );
+  console.log(
+    `  Two-pass                          ${`${twoPass.avgMs}ms`.padEnd(10)}${`${twoPass.p50Ms}ms`.padEnd(10)}${`${twoPass.p95Ms}ms`.padEnd(10)}baseline`,
+  );
+  console.log(
+    `  Discovery single-pass             ${`${discovery.avgMs}ms`.padEnd(10)}${`${discovery.p50Ms}ms`.padEnd(10)}${`${discovery.p95Ms}ms`.padEnd(10)}${discVsTp}%`,
+  );
+  console.log(
+    `  Zero-discovery single-pass        ${`${zeroDisc.avgMs}ms`.padEnd(10)}${`${zeroDisc.p50Ms}ms`.padEnd(10)}${`${zeroDisc.p95Ms}ms`.padEnd(10)}${zdVsTp}%`,
+  );
+  console.log('');
+}
+
+main().catch(console.error);

--- a/sites/landing/benchmark-ssr.ts
+++ b/sites/landing/benchmark-ssr.ts
@@ -1,0 +1,121 @@
+/**
+ * Benchmark: Landing page SSR — Two-pass vs Discovery vs Zero-discovery
+ *
+ * Measures real HTTP response times against the running dev server,
+ * then compares the three rendering paths.
+ *
+ * Run: bun run sites/landing/benchmark-ssr.ts
+ * (requires dev server running on port 4000)
+ */
+
+const PORT = Number(process.env.PORT) || 4000;
+const BASE = `http://localhost:${PORT}`;
+const ITERATIONS = 100;
+const WARMUP = 10;
+
+interface BenchmarkResult {
+  name: string;
+  iterations: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  minMs: number;
+  maxMs: number;
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+async function benchmarkUrl(name: string, url: string, iterations: number): Promise<BenchmarkResult> {
+  // Warmup
+  for (let i = 0; i < WARMUP; i++) {
+    await fetch(url);
+  }
+
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    const res = await fetch(url);
+    await res.text(); // consume body
+    times.push(performance.now() - start);
+  }
+
+  times.sort((a, b) => a - b);
+  const total = times.reduce((a, b) => a + b, 0);
+
+  return {
+    name,
+    iterations,
+    avgMs: round(total / iterations),
+    p50Ms: round(times[Math.floor(times.length * 0.5)]!),
+    p95Ms: round(times[Math.floor(times.length * 0.95)]!),
+    p99Ms: round(times[Math.floor(times.length * 0.99)]!),
+    minMs: round(times[0]!),
+    maxMs: round(times[times.length - 1]!),
+  };
+}
+
+function printResult(r: BenchmarkResult): void {
+  console.log(`  ${r.name}`);
+  console.log(`    avg: ${r.avgMs}ms | p50: ${r.p50Ms}ms | p95: ${r.p95Ms}ms | p99: ${r.p99Ms}ms`);
+  console.log(`    min: ${r.minMs}ms | max: ${r.maxMs}ms (${r.iterations} runs)`);
+}
+
+async function main() {
+  // Verify server is running
+  try {
+    await fetch(BASE);
+  } catch {
+    console.error(`Dev server not running at ${BASE}. Start it with: cd sites/landing && bun run dev`);
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Landing Page SSR Benchmark (HTTP, end-to-end)');
+  console.log(`  ${ITERATIONS} iterations, ${WARMUP} warmup, server at ${BASE}`);
+  console.log('═══════════════════════════════════════════════════════════════');
+
+  // Benchmark the home page
+  console.log('');
+  console.log('─── Home Page (/) ───');
+  const home = await benchmarkUrl('GET /', BASE + '/', ITERATIONS);
+  printResult(home);
+
+  // Benchmark the manifesto page
+  console.log('');
+  console.log('─── Manifesto Page (/manifesto) ───');
+  const manifesto = await benchmarkUrl('GET /manifesto', BASE + '/manifesto', ITERATIONS);
+  printResult(manifesto);
+
+  // Get response size for context
+  const homeRes = await fetch(BASE + '/');
+  const homeHtml = await homeRes.text();
+  const manifestoRes = await fetch(BASE + '/manifesto');
+  const manifestoHtml = await manifestoRes.text();
+
+  console.log('');
+  console.log('─── Response Sizes ───');
+  console.log(`  Home:      ${(homeHtml.length / 1024).toFixed(1)} KB`);
+  console.log(`  Manifesto: ${(manifestoHtml.length / 1024).toFixed(1)} KB`);
+
+  // Summary
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Summary');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('');
+  console.log('  Page          avg       p50       p95       Size');
+  console.log('  ────────────  ────────  ────────  ────────  ────────');
+  console.log(`  Home          ${home.avgMs}ms`.padEnd(24) + `${home.p50Ms}ms`.padEnd(10) + `${home.p95Ms}ms`.padEnd(10) + `${(homeHtml.length / 1024).toFixed(1)} KB`);
+  console.log(`  Manifesto     ${manifesto.avgMs}ms`.padEnd(24) + `${manifesto.p50Ms}ms`.padEnd(10) + `${manifesto.p95Ms}ms`.padEnd(10) + `${(manifestoHtml.length / 1024).toFixed(1)} KB`);
+  console.log('');
+  console.log('  Note: The landing page has NO data queries — it is fully static.');
+  console.log('  The zero-discovery optimization targets pages with query() calls.');
+  console.log('  These numbers represent the baseline SSR cost (component tree + HTML serialization).');
+  console.log('');
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- Add benchmark scripts for measuring SSR rendering performance across different approaches
- Used to validate the zero-discovery SSR optimization (#1741)

### Benchmark Scripts

| Script | Purpose | How to run |
|---|---|---|
| `benchmark-ssr-direct.ts` | Direct SSR function comparison (two-pass vs discovery vs zero-discovery) against real landing page components | `cd sites/landing && bun -r ./benchmark-plugin.ts ./benchmark-ssr-direct.ts` |
| `benchmark-prod.ts` | Production HTTP benchmark against vertz.dev for before/after deploy comparison | `bun run sites/landing/benchmark-prod.ts` |
| `benchmark-ssr.ts` | HTTP benchmark against local dev server | `bun run sites/landing/benchmark-ssr.ts` (requires dev server on port 4000) |

### Benchmark Results (Landing Page — 39.7 KB HTML)

| Approach | avg | p50 | p95 | vs Two-pass |
|---|---|---|---|---|
| Two-pass | 2.627ms | 2.018ms | 5.58ms | baseline |
| Discovery single-pass | 2.145ms | 1.921ms | 3.92ms | **18.3% faster** |
| Zero-discovery | 2.224ms | 1.959ms | 4.15ms | **15.3% faster** |

Note: Landing page is fully static (no queries). Zero-discovery shows larger gains (1.4-1.8x) on data-driven pages with `query()` calls.

## Test plan

- [x] `benchmark-ssr-direct.ts` runs successfully with compiler preload
- [x] `benchmark-prod.ts` runs against live vertz.dev
- [x] `benchmark-ssr.ts` runs against local dev server
- [x] Quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)