### PR TITLE
perf(db, schema): enable prepared statements and optimize parse path

### DIFF
--- a/packages/db/src/client/__tests__/postgres-driver.test.ts
+++ b/packages/db/src/client/__tests__/postgres-driver.test.ts
@@ -443,7 +443,7 @@ describe('PostgreSQL Driver', () => {
 
       // Result should be just the array of rows (without count)
       expect(result).toEqual(mockRows);
-      expect(mockUnsafe).toHaveBeenCalledWith('SELECT * FROM users', []);
+      expect(mockUnsafe).toHaveBeenCalledWith('SELECT * FROM users', [], { prepare: true });
     });
 
     it('passes params to queryFn', async () => {
@@ -457,13 +457,18 @@ describe('PostgreSQL Driver', () => {
 
       await driver.query('SELECT * FROM users WHERE id = $1', [1]);
 
-      expect(mockUnsafe).toHaveBeenCalledWith('SELECT * FROM users WHERE id = $1', [1]);
+      expect(mockUnsafe).toHaveBeenCalledWith('SELECT * FROM users WHERE id = $1', [1], {
+        prepare: true,
+      });
     });
 
-    it('coerces timestamp strings to Date objects', async () => {
+    it('passes through values without coercion (postgres.js handles types natively)', async () => {
       const { createPostgresDriver } = await import('../postgres-driver');
 
-      const mockRows = [{ id: 1, created: '2024-01-15T10:30:00.000Z' }];
+      // postgres.js returns Date objects natively for timestamp columns;
+      // the driver passes them through without additional coercion
+      const dateValue = new Date('2024-01-15T10:30:00.000Z');
+      const mockRows = [{ id: 1, created: dateValue }];
       const mockResult = Object.assign(mockRows, { count: 1 });
       mockUnsafe.mockResolvedValue(mockResult);
 
@@ -471,8 +476,7 @@ describe('PostgreSQL Driver', () => {
 
       const result = await driver.query<{ id: number; created: Date }>('SELECT * FROM users');
 
-      expect(result[0]?.created).toBeInstanceOf(Date);
-      expect(result[0]?.created.toISOString()).toBe('2024-01-15T10:30:00.000Z');
+      expect(result[0]?.created).toBe(dateValue);
     });
   });
 
@@ -489,7 +493,9 @@ describe('PostgreSQL Driver', () => {
       const result = await driver.execute('DELETE FROM users WHERE id = $1', [1]);
 
       expect(result).toEqual({ rowsAffected: 5 });
-      expect(mockUnsafe).toHaveBeenCalledWith('DELETE FROM users WHERE id = $1', [1]);
+      expect(mockUnsafe).toHaveBeenCalledWith('DELETE FROM users WHERE id = $1', [1], {
+        prepare: true,
+      });
     });
   });
 
@@ -567,14 +573,15 @@ describe('PostgreSQL Driver', () => {
       });
 
       expect(result).toEqual([{ id: 1, name: 'test' }]);
-      expect(txUnsafe).toHaveBeenCalledWith('SELECT * FROM users', []);
+      expect(txUnsafe).toHaveBeenCalledWith('SELECT * FROM users', [], { prepare: true });
 
       await driver.close();
     });
 
-    it('coerces timestamp values in transaction queries', async () => {
+    it('passes through values without coercion in transaction queries', async () => {
+      const dateValue = new Date('2024-01-15T10:30:00.000Z');
       const txUnsafe = mock().mockResolvedValue(
-        Object.assign([{ id: 1, created: '2024-01-15T10:30:00.000Z' }], { count: 1 }),
+        Object.assign([{ id: 1, created: dateValue }], { count: 1 }),
       );
 
       mock.module('postgres', () => ({
@@ -596,8 +603,7 @@ describe('PostgreSQL Driver', () => {
         return queryResult.rows[0]?.created;
       });
 
-      expect(result).toBeInstanceOf(Date);
-      expect((result as Date).toISOString()).toBe('2024-01-15T10:30:00.000Z');
+      expect(result).toBe(dateValue);
 
       await driver.close();
     });

--- a/packages/db/src/client/postgres-driver.ts
+++ b/packages/db/src/client/postgres-driver.ts
@@ -7,7 +7,6 @@
  * Handles:
  * - Connection pool creation from URL + PoolConfig
  * - QueryFn adapter (sql.unsafe with parameter binding)
- * - Proper Date handling (postgres returns strings for timestamps)
  * - Error mapping (postgres.js PostgresError → PgErrorInput shape)
  * - Connection close and health check
  */
@@ -116,28 +115,23 @@ export function createPostgresDriver(url: string, pool?: PoolConfig): PostgresDr
     max: pool?.max ?? 10,
     idle_timeout: pool?.idleTimeout !== undefined ? pool.idleTimeout / 1000 : 30,
     connect_timeout: pool?.connectionTimeout !== undefined ? pool.connectionTimeout / 1000 : 10,
-    // Disable automatic type fetching — we handle type conversion ourselves
-    // to ensure consistent behavior with PGlite tests
+    // Disable automatic type fetching — postgres.js handles standard types
+    // (timestamps → Date, etc.) natively via built-in OID parsers.
+    // fetch_types queries pg_type for custom/extension types on first connect,
+    // which is unnecessary overhead for standard schemas.
     fetch_types: false,
   });
 
   const queryFn: QueryFn = async <T>(sqlStr: string, params: readonly unknown[]) => {
     try {
       // biome-ignore lint/suspicious/noExplicitAny: postgres.js unsafe() expects any[] for dynamic params
-      const result = await sql.unsafe<Record<string, unknown>[]>(sqlStr, params as any[]);
-
-      // Map rows: convert timestamp strings to Date objects
-      const rows = result.map((row) => {
-        const mapped: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(row)) {
-          mapped[key] = coerceValue(value);
-        }
-        return mapped;
-      }) as readonly T[];
+      const result = await sql.unsafe<Record<string, unknown>[]>(sqlStr, params as any[], {
+        prepare: true,
+      });
 
       return {
-        rows,
-        rowCount: result.count ?? rows.length,
+        rows: result as unknown as readonly T[],
+        rowCount: result.count ?? result.length,
       } as ExecutorResult<T>;
     } catch (error: unknown) {
       adaptPostgresError(error);
@@ -162,17 +156,12 @@ export function createPostgresDriver(url: string, pool?: PoolConfig): PostgresDr
         const txQueryFn: QueryFn = async <R>(sqlStr: string, params: readonly unknown[]) => {
           try {
             // biome-ignore lint/suspicious/noExplicitAny: postgres.js unsafe() expects any[] for dynamic params
-            const result = await txSql.unsafe<Record<string, unknown>[]>(sqlStr, params as any[]);
-            const rows = result.map((row) => {
-              const mapped: Record<string, unknown> = {};
-              for (const [key, value] of Object.entries(row)) {
-                mapped[key] = coerceValue(value);
-              }
-              return mapped;
-            }) as readonly R[];
+            const result = await txSql.unsafe<Record<string, unknown>[]>(sqlStr, params as any[], {
+              prepare: true,
+            });
             return {
-              rows,
-              rowCount: result.count ?? rows.length,
+              rows: result as unknown as readonly R[],
+              rowCount: result.count ?? result.length,
             } as ExecutorResult<R>;
           } catch (error: unknown) {
             adaptPostgresError(error);
@@ -204,50 +193,3 @@ export function createPostgresDriver(url: string, pool?: PoolConfig): PostgresDr
   };
 }
 
-// ---------------------------------------------------------------------------
-// Value coercion
-// ---------------------------------------------------------------------------
-
-/**
- * Coerce values returned from PostgreSQL to appropriate JS types.
- *
- * postgres.js returns most types correctly, but when fetch_types is disabled,
- * timestamp values may come as strings. This function ensures:
- * - ISO 8601 timestamp strings → Date objects
- * - Everything else passes through unchanged
- *
- * **⚠️ False-positive risk:** This heuristic coerces ANY string matching the
- * ISO 8601 timestamp pattern (e.g., `"2024-01-15T10:30:00Z"`) into a `Date`,
- * even if the column is a plain `text` type. If you store timestamp-like
- * strings in text columns, they will be silently converted to Date objects.
- *
- * A future iteration may add column-type-aware coercion to eliminate this
- * risk by inspecting the PG column OID or schema metadata.
- */
-function coerceValue(value: unknown): unknown {
-  if (typeof value === 'string' && isTimestampString(value)) {
-    const date = new Date(value);
-    if (!Number.isNaN(date.getTime())) {
-      return date;
-    }
-  }
-  return value;
-}
-
-/**
- * Check if a string looks like an ISO 8601 timestamp from PostgreSQL.
- *
- * Matches patterns like:
- * - "2024-01-15T10:30:00.000Z"
- * - "2024-01-15 10:30:00+00"
- * - "2024-01-15 10:30:00.123456+00:00"
- *
- * **Note:** This is a heuristic check using regex. Any string column value
- * matching this pattern will be coerced to a Date object, which may produce
- * false positives for text columns containing timestamp-formatted strings.
- * See {@link coerceValue} for details on the false-positive risk.
- */
-function isTimestampString(value: string): boolean {
-  // Must start with a date pattern YYYY-MM-DD and contain time separator
-  return /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(value);
-}

--- a/packages/schema/src/core/parse-context.ts
+++ b/packages/schema/src/core/parse-context.ts
@@ -1,18 +1,23 @@
 import type { ValidationIssue } from './errors';
 
 export class ParseContext {
-  readonly issues: ValidationIssue[] = [];
+  private _issues: ValidationIssue[] | null = null;
   private _path: (string | number)[] = [];
 
+  get issues(): ValidationIssue[] {
+    return this._issues ?? [];
+  }
+
   addIssue(issue: Omit<ValidationIssue, 'path'> & { path?: (string | number)[] }): void {
-    this.issues.push({
+    if (this._issues === null) this._issues = [];
+    this._issues.push({
       ...issue,
       path: issue.path ?? [...this._path],
     });
   }
 
   hasIssues(): boolean {
-    return this.issues.length > 0;
+    return this._issues !== null && this._issues.length > 0;
   }
 
   pushPath(segment: string | number): void {

--- a/packages/schema/src/schemas/object.ts
+++ b/packages/schema/src/schemas/object.ts
@@ -20,12 +20,14 @@ function receivedType(value: unknown): string {
 
 export class ObjectSchema<S extends Shape = Shape> extends Schema<InferShape<S>> {
   private readonly _shape: S;
+  private readonly _shapeKeys: Set<string>;
   private _unknownKeys: UnknownKeyMode = 'strip';
   private _catchall: SchemaAny | undefined;
 
   constructor(shape: S) {
     super();
     this._shape = shape;
+    this._shapeKeys = new Set(Object.keys(shape));
   }
 
   get shape(): S {
@@ -46,7 +48,7 @@ export class ObjectSchema<S extends Shape = Shape> extends Schema<InferShape<S>>
     }
     const obj = value as Record<string, unknown>;
     const result: Record<string, unknown> = {};
-    const shapeKeys = new Set(Object.keys(this._shape));
+    const shapeKeys = this._shapeKeys;
 
     for (const key of shapeKeys) {
       const schema = this._shape[key];
@@ -63,24 +65,26 @@ export class ObjectSchema<S extends Shape = Shape> extends Schema<InferShape<S>>
       ctx.popPath();
     }
 
-    const unknownKeys = Object.keys(obj).filter((k) => !shapeKeys.has(k));
-    if (unknownKeys.length > 0) {
-      if (this._catchall) {
-        for (const key of unknownKeys) {
-          if (key === '__proto__') continue;
-          ctx.pushPath(key);
-          result[key] = this._catchall._runPipeline(obj[key], ctx);
-          ctx.popPath();
-        }
-      } else if (this._unknownKeys === 'strict') {
-        ctx.addIssue({
-          code: ErrorCode.UnrecognizedKeys,
-          message: `Unrecognized key(s) in object: ${unknownKeys.map((k) => `"${k}"`).join(', ')}`,
-        });
-      } else if (this._unknownKeys === 'passthrough') {
-        for (const key of unknownKeys) {
-          if (key === '__proto__') continue;
-          result[key] = obj[key];
+    if (this._unknownKeys !== 'strip' || this._catchall) {
+      const unknownKeys = Object.keys(obj).filter((k) => !shapeKeys.has(k));
+      if (unknownKeys.length > 0) {
+        if (this._catchall) {
+          for (const key of unknownKeys) {
+            if (key === '__proto__') continue;
+            ctx.pushPath(key);
+            result[key] = this._catchall._runPipeline(obj[key], ctx);
+            ctx.popPath();
+          }
+        } else if (this._unknownKeys === 'strict') {
+          ctx.addIssue({
+            code: ErrorCode.UnrecognizedKeys,
+            message: `Unrecognized key(s) in object: ${unknownKeys.map((k) => `"${k}"`).join(', ')}`,
+          });
+        } else if (this._unknownKeys === 'passthrough') {
+          for (const key of unknownKeys) {
+            if (key === '__proto__') continue;
+            result[key] = obj[key];
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Enable `{ prepare: true }` on `sql.unsafe()` in `@vertz/db` postgres driver — enables server-side prepared statement caching, reducing per-query overhead by ~60% (0.57ms → 0.24ms/op)
- Remove manual `coerceValue` timestamp coercion — postgres.js handles type conversion natively via built-in OID parsers
- Optimize `@vertz/schema` parse hot path: memoize shape keys Set, lazy issues array, skip unknown key filtering in strip mode (the default)

## Benchmark Results (rinha-de-backend URL shortener challenge)

| # | Participant | RPS | p95 Latency |
|---|---|---|---|
| **1** | **Vertz (Bun)** | **2443** | **54.5ms** |
| 2 | Go | 1528 | 78.7ms |
| 3 | Python | 504 | 114ms |
| 4 | Ruby | 243 | 298ms |

Vertz beats Go by 60% on throughput and 31% on latency.

## What changed

### `@vertz/db` postgres driver
- `sql.unsafe()` now passes `{ prepare: true }` — postgres.js caches query plans server-side, avoiding parse+plan on every call
- Removed `coerceValue()` / `isTimestampString()` — these ran a regex on every column of every row to convert timestamp strings to Dates. With `fetch_types: false`, postgres.js still handles standard type conversion natively. The regex coercion was unnecessary overhead with false-positive risk (text columns containing timestamp-like strings would be silently converted)

### `@vertz/schema` parse context + object schema
- `ParseContext.issues` is now lazily allocated — the empty `[]` array was allocated on every successful parse (the 99% case), wasted
- `ObjectSchema._shapeKeys` Set is memoized in the constructor instead of recreated per `.parse()` call
- Unknown key filtering is skipped entirely in `strip` mode (the default) — previously computed the list of unknown keys then threw it away

## Test plan

- [x] All 37 postgres driver tests pass (updated to expect `{ prepare: true }`)
- [x] All 371 schema tests pass
- [x] Full monorepo CI: 87/87 tasks pass (lint + typecheck + test + build)
- [x] Benchmarked: 39/39 correctness tests pass, 2443 rps throughput

## Related

- #1748 — Explore automatic server-side cache layer for `@vertz/db` queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)