### PR TITLE
chore(rules): remove Dagger refs and fix outdated rules

### DIFF
--- a/.claude/rules/bdd-acceptance-criteria.md
+++ b/.claude/rules/bdd-acceptance-criteria.md
@@ -187,7 +187,7 @@ BDD scenarios become the first tests the agent writes (red phase in TDD):
 
 A feature is done when:
 - [ ] All BDD scenarios pass
-- [ ] Quality gates green (`turbo run lint typecheck test`)
+- [ ] Quality gates green (`bun test && bun run typecheck && bun run lint`)
 - [ ] PR reviewed and merged
 - [ ] Developer Walkthrough passes
 
@@ -271,7 +271,5 @@ describe('Feature: Event emission', () => {
 
 ## Related Documents
 
-- [Task Assignment Checklist](./task-assignment-checklist.md) — Full spawning guide
-- [TDD Workflow](../vertz/.claude/rules/tdd.md) — Red→Green→Refactor process
-- [Design Docs](./design-docs.md) — Design doc requirements
-- [Definition of Done](../vertz/.claude/rules/definition-of-done.md) — Done criteria
+- [TDD Workflow](./tdd.md) — Red→Green→Refactor process
+- [Design & Planning](./design-and-planning.md) — Design doc requirements and definition of done

--- a/.claude/rules/design-and-planning.md
+++ b/.claude/rules/design-and-planning.md
@@ -32,7 +32,7 @@ Three sign-offs required before implementation:
 
 - Must use public package imports (`@vertz/server`, `@vertz/db`) — never relative
 - Walkthrough test written in Phase 1 as failing test (RED state)
-- Cross-package typecheck mandatory before merge: `bun run typecheck --filter @vertz/integration-tests`
+- Cross-package typecheck mandatory before merge: `bun run typecheck`
 - Types in public signatures → `dependencies` (not `devDependencies`)
 
 ## Definition of Done

--- a/.claude/rules/dev-server-debugging.md
+++ b/.claude/rules/dev-server-debugging.md
@@ -120,7 +120,8 @@ Useful for automated debugging and verifying server state without reading termin
 | Fast Refresh runtime | `packages/ui-server/src/bun-plugin/fast-refresh-runtime.ts` |
 | Fast Refresh codegen | `packages/ui-server/src/bun-plugin/fast-refresh-codegen.ts` |
 | DOM state preservation | `packages/ui-server/src/bun-plugin/fast-refresh-dom-state.ts` |
-| SSR render (two-pass) | `packages/ui-server/src/ssr-render.ts` |
+| SSR render (two-pass, production) | `packages/ui-server/src/ssr-render.ts` |
+| SSR render (single-pass, dev) | `packages/ui-server/src/ssr-single-pass.ts` |
 | Context + Provider | `packages/ui/src/component/context.ts` |
 | Source map resolver | `packages/ui-server/src/source-map-resolver.ts` |
 

--- a/.claude/rules/entity-access-rules.md
+++ b/.claude/rules/entity-access-rules.md
@@ -84,5 +84,4 @@ entity('system-template', {
 ## Key Files
 
 - Rule builders: `packages/server/src/auth/rules.ts`
-- Access redesign: `plans/access-redesign.md`
 - Entity types: `packages/server/src/entity/types.ts`

--- a/.claude/rules/local-phase-workflow.md
+++ b/.claude/rules/local-phase-workflow.md
@@ -38,16 +38,15 @@ feat/db-integration
 
 ### 3. Full CI Before Every Phase Merge
 
-Before a phase is considered "done" and the next phase starts, run the **full CI pipeline** via Dagger:
+Before a phase is considered "done" and the next phase starts, run the **full quality gates**:
 
 ```bash
-cd /app/vertz
-dagger call ci
+bun test && bun run typecheck && bun run lint
 ```
 
-This runs: lint → build → typecheck → test (with Postgres). It validates the **entire monorepo**, not just the changed package — because changes in one package can break dependents.
+This validates the **entire monorepo**, not just the changed package — because changes in one package can break dependents.
 
-**This is a hard gate.** If `dagger call ci` fails, the phase is not done. Fix the issue, re-run CI, and only then proceed to the next phase.
+**This is a hard gate.** If quality gates fail, the phase is not done. Fix the issue, re-run, and only then proceed to the next phase.
 
 ### 4. Local Phase Review
 
@@ -77,7 +76,7 @@ vertz/reviews/<feature-name>/
 
 ## CI Status
 
-- [x] `dagger call ci` passed at <commit-sha>
+- [x] Quality gates passed at <commit-sha>
 
 ## Review Checklist
 
@@ -102,7 +101,7 @@ vertz/reviews/<feature-name>/
 
 - Reviewer must be a **different bot** than the author
 - Reviewer adversarially looks for bugs, not rubber-stamps
-- If changes are requested, author fixes → re-runs `dagger call ci` → reviewer re-reviews
+- If changes are requested, author fixes → re-runs quality gates → reviewer re-reviews
 - Review file is updated with resolution
 
 ### 5. Final PR to GitHub
@@ -115,7 +114,7 @@ When all phases are complete:
 4. Push the feature branch to GitHub
 5. Open a single PR: `feat/<feature-name>` → `main`
 6. PR description includes:
-   - Public API Changes summary (mandatory per `pr-policies.md`)
+   - Public API Changes summary (mandatory)
    - Summary of all phases with links to local review files
    - E2E acceptance test status
 7. **Monitor GitHub CI** — use `gh pr checks` or `gh run list` to track CI status
@@ -149,7 +148,7 @@ Standard post-merge process:
 |--------|-------|
 | GitHub PR per phase | Local commits + local review markdown |
 | `gh-as.sh` for every PR | Only for final PR to main |
-| GitHub CI per phase | `dagger call ci` locally |
+| GitHub CI per phase | Local quality gates (`bun test && bun run typecheck && bun run lint`) |
 | Wait for GitHub API | Instant local operations |
 | Multiple branches per feature | One feature branch, phases as commit ranges |
 
@@ -157,7 +156,7 @@ Standard post-merge process:
 
 - **TDD is still mandatory.** Red → Green → Refactor for every behavior.
 - **Reviews are still mandatory.** Different bot reviews every phase.
-- **CI must pass.** Full Dagger CI, not just the changed package.
+- **CI must pass.** Full quality gates, not just the changed package.
 - **Human approves final merge to main.** This is the one GitHub PR.
 - **Design docs and retros are still required.** Process quality doesn't change.
 - **Git worktrees** are still used when multiple agents work in parallel.

--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -8,7 +8,7 @@ All framework development follows strict Test-Driven Development.
 2. **Green** — Write the MINIMAL code to make that one test pass. **Green means ALL of:**
    - Tests pass (`bun test`)
    - Typecheck passes (`bun run typecheck` on changed packages)
-   - Lint/format passes (`bunx biome check --write <files>`)
+   - Lint/format passes (`bunx biome check --fix <files>`)
    - If any of these fail, you are NOT green. Fix before proceeding.
 3. **Refactor** — Clean up while keeping all checks green
 4. **Repeat** — Go back to step 1 with the next behavior
@@ -56,9 +56,9 @@ After GREEN, run `bun run typecheck` — `@ts-expect-error` only verifies interf
 
 ## Code Coverage
 
-- **Target: 90%+ line coverage for every source file.** Run `bun test --coverage` to verify.
-- Before pushing, check that all changed source files meet the 90% threshold.
-- If a file drops below 90%, add tests for uncovered branches before merging.
+- **Target: 95%+ line coverage for every source file (aim for 100%).** Run `bun test --coverage` to verify.
+- Before pushing, check that all changed source files meet the 95% threshold.
+- If a file drops below 95%, add tests for uncovered branches before merging.
 - Coverage is measured per-file, not per-package — no file gets a free pass because the aggregate is high.
 
 ## Never Skip Quality Gates

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -16,19 +16,18 @@ For each phase:
 2. **Quality gates** — ALL must pass before review:
    - `bun test` (changed packages)
    - `bun run typecheck` (changed packages)
-   - `bunx biome check --write <changed-files>`
+   - `bunx biome check --fix <changed-files>`
 3. **Commit** — stage and commit all changes for the phase
-4. **Adversarial review** — spawn 4 review agents in parallel (ben, nora, ava, mike):
-   - Each agent reviews from their perspective (see `.claude/agents/` for personas)
+4. **Adversarial review** — spawn 1 review agent:
    - Reviews check: delivers what ticket asks, TDD compliance, no type gaps, no security issues, API matches design doc
-   - Reviews must be adversarial — actively look for mistakes, don't rubber-stamp
+   - Review must be adversarial — actively look for mistakes, don't rubber-stamp
 5. **Fix-review loop** — repeat until all blockers and should-fix items are resolved:
-   a. Fix ALL blocker and should-fix findings from the reviews
+   a. Fix ALL blocker and should-fix findings from the review
    b. Re-run quality gates (test + typecheck + lint)
    c. Commit the fixes
-   d. If any reviewer had blockers, re-run that reviewer's review on the new code
+   d. If the reviewer had blockers, re-run the review on the new code
    e. If re-review finds new blockers, go back to (a)
-   f. Loop exits when all 4 reviewers approve (no remaining blockers)
+   f. Loop exits when the reviewer approves (no remaining blockers)
 6. **Push** — push the branch to origin
 7. **Move to next phase** — no pause, no user prompt needed
 
@@ -70,7 +69,7 @@ For each phase:
 
 - Public API Changes summary (mandatory)
 - E2E acceptance test passing
-- Cross-package typecheck: `bun run typecheck --filter @vertz/integration-tests`
+- Cross-package typecheck: `bun run typecheck`
 - All issues marked done
 - **Docs updated** — if the PR introduces new APIs, changes existing behavior, or adds features, update `packages/docs/` (Mintlify). New APIs get new pages or sections; changed behavior gets existing pages updated; gotchas get noted.
 - Changeset added


### PR DESCRIPTION
## Summary

- Remove all Dagger references from `local-phase-workflow.md`, replacing with `bun test && bun run typecheck && bun run lint`
- Fix outdated/inconsistent content across 7 rules files: review agent count (4→1), coverage target (90%→95%+), turbo→bun commands, broken doc links, stale file references (`pr-policies.md`, `plans/access-redesign.md`), invalid `--filter` flag, biome `--write`→`--fix`, and SSR two-pass→single-pass update

## Test plan

- [x] Pre-push quality gates passed (all 87 tasks cached)
- [ ] Review each changed file for accuracy against current codebase state