### PR TITLE
fix(ci): add concurrency group and job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
   # successful rebase+push.
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ---------------------------------------------------------------------------
   # Detect whether source files changed.
@@ -95,6 +99,7 @@ jobs:
   check:
     name: Lint, typecheck, test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.src == 'true'
 
@@ -121,6 +126,7 @@ jobs:
   coverage:
     name: Coverage report
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [changes, check]
     if: needs.changes.outputs.src == 'true'
 


### PR DESCRIPTION
## Summary

- Add `concurrency` group keyed by `github.ref` with `cancel-in-progress: true` — new pushes to the same branch automatically cancel in-progress CI runs instead of letting them run for hours
- Add `timeout-minutes: 15` to both `check` and `coverage` jobs — prevents stuck jobs from burning GitHub Actions minutes for up to 6 hours (the default)

## Root cause

CI runs were getting stuck for hours because:

1. **No concurrency group** — multiple pushes to the same PR branch spawned parallel CI runs. Old runs were never cancelled, so they'd run until GitHub's 6-hour default timeout
2. **No explicit timeout** — jobs relied on GitHub's 360-minute default, so a stuck `bun test` or `turbo` process would block for 6 hours before being killed

Example: run `23439863371` on `viniciusdacal/aot-ssr-design` ran for 3+ hours before being manually cancelled, while newer runs on the same branch had already completed successfully.

## Test plan

- [x] The CI workflow change is additive (only adds `concurrency` and `timeout-minutes`)
- [x] `timeout-minutes: 15` is generous — normal CI runs complete in ~1-2 minutes
- [x] `cancel-in-progress: true` only affects the same ref, so parallel PRs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)