### PR TITLE
test(db): 100% coverage for rls-differ

### DIFF
--- a/packages/db/src/migration/__tests__/rls-differ.test.ts
+++ b/packages/db/src/migration/__tests__/rls-differ.test.ts
@@ -51,7 +51,7 @@ describe('Feature: RLS policy diffing', () => {
         const changes = diffRlsPolicies(previous, current);
         const policyAdded = changes.find((c) => c.type === 'policy_added' && c.table === 'tasks');
         expect(policyAdded).toBeDefined();
-        expect(policyAdded!.policy).toEqual({
+        expect(policyAdded?.policy).toEqual({
           name: 'tasks_tenant_isolation',
           for: 'ALL',
           using: "tenant_id = current_setting('app.tenant_id')::UUID",
@@ -116,8 +116,8 @@ describe('Feature: RLS policy diffing', () => {
         const changes = diffRlsPolicies(previous, current);
         const removed = changes.find((c) => c.type === 'policy_removed');
         expect(removed).toBeDefined();
-        expect(removed!.table).toBe('tasks');
-        expect(removed!.policy!.name).toBe('tasks_tenant_isolation');
+        expect(removed?.table).toBe('tasks');
+        expect(removed?.policy?.name).toBe('tasks_tenant_isolation');
       });
     });
   });
@@ -159,9 +159,9 @@ describe('Feature: RLS policy diffing', () => {
         const changes = diffRlsPolicies(previous, current);
         const changed = changes.find((c) => c.type === 'policy_changed');
         expect(changed).toBeDefined();
-        expect(changed!.table).toBe('tasks');
-        expect(changed!.policy!.using).toContain('AND active = true');
-        expect(changed!.oldPolicy!.using).not.toContain('AND active = true');
+        expect(changed?.table).toBe('tasks');
+        expect(changed?.policy?.using).toContain('AND active = true');
+        expect(changed?.oldPolicy?.using).not.toContain('AND active = true');
       });
     });
   });
@@ -249,6 +249,63 @@ describe('Feature: RLS policy diffing', () => {
         expect(changed).toBeDefined();
         expect(changed?.policy?.for).toBe('ALL');
         expect(changed?.oldPolicy?.for).toBe('SELECT');
+      });
+    });
+  });
+
+  describe('Given RLS disabled in current (table entry present with rlsEnabled: false)', () => {
+    describe('When diffRlsPolicies() is called', () => {
+      it('Then returns policy_removed changes followed by rls_disabled', () => {
+        const previous: RlsSnapshot = {
+          version: 1,
+          tables: {
+            tasks: {
+              rlsEnabled: true,
+              policies: [
+                {
+                  name: 'tasks_tenant_isolation',
+                  for: 'ALL',
+                  using: "tenant_id = current_setting('app.tenant_id')::UUID",
+                },
+                {
+                  name: 'tasks_owner_policy',
+                  for: 'UPDATE',
+                  using: "created_by = current_setting('app.user_id')::UUID",
+                  withCheck: "created_by = current_setting('app.user_id')::UUID",
+                },
+              ],
+            },
+          },
+        };
+        const current: RlsSnapshot = {
+          version: 1,
+          tables: {
+            tasks: {
+              rlsEnabled: false,
+              policies: [],
+            },
+          },
+        };
+
+        const changes = diffRlsPolicies(previous, current);
+
+        const removedPolicies = changes.filter(
+          (c) => c.type === 'policy_removed' && c.table === 'tasks',
+        );
+        expect(removedPolicies).toHaveLength(2);
+        expect(removedPolicies[0]?.policy?.name).toBe('tasks_tenant_isolation');
+        expect(removedPolicies[1]?.policy?.name).toBe('tasks_owner_policy');
+        expect(removedPolicies[1]?.policy?.withCheck).toBe(
+          "created_by = current_setting('app.user_id')::UUID",
+        );
+
+        const disabled = changes.find((c) => c.type === 'rls_disabled' && c.table === 'tasks');
+        expect(disabled).toBeDefined();
+
+        // rls_disabled should come after policy_removed
+        const disabledIdx = disabled ? changes.indexOf(disabled) : -1;
+        const lastRemovedIdx = removedPolicies[1] ? changes.indexOf(removedPolicies[1]) : -1;
+        expect(disabledIdx).toBeGreaterThan(lastRemovedIdx);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Adds test for the `rlsEnabled: false` branch in `rls-differ.ts` (lines 39-52 were uncovered)
- Fixes all non-null assertion biome warnings → optional chaining
- Coverage: `rls-differ.ts` 86% → 100%

Follow-up to #1763 — this commit was made after the PR was merged.

## Test plan

- [x] `bun test packages/db/src/migration/__tests__/rls-differ.test.ts --coverage` → 100%
- [x] All 9 tests pass
- [x] Zero biome warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)