### PR TITLE
fix(db): remove deprecated d.entry() helper

### DIFF
--- a/.changeset/remove-d-entry.md
+++ b/.changeset/remove-d-entry.md
@@ -1,0 +1,5 @@
+---
+'@vertz/db': patch
+---
+
+Remove deprecated `d.entry()` helper — use `d.model()` instead

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -11,7 +11,6 @@ import type {
   VarcharMeta,
 } from './schema/column';
 import { createColumn, createSerialColumn } from './schema/column';
-import type { ModelEntry } from './schema/inference';
 import type { ModelDef, ValidateOneRelationFKs } from './schema/model';
 import { createModel } from './schema/model';
 import type { SchemaLike } from './schema/model-schemas';
@@ -89,12 +88,6 @@ export const d: {
     ): RelationDef<TTarget, 'many'>;
     many<TTarget extends TableDef<ColumnRecord>>(target: () => TTarget): ManyRelationDef<TTarget>;
   };
-  // biome-ignore lint/complexity/noBannedTypes: {} represents an empty relations record — the correct default for tables without relations
-  entry<TTable extends TableDef<ColumnRecord>>(table: TTable): ModelEntry<TTable, {}>;
-  entry<TTable extends TableDef<ColumnRecord>, TRelations extends Record<string, RelationDef>>(
-    table: TTable,
-    relations: TRelations,
-  ): ModelEntry<TTable, TRelations>;
   // biome-ignore lint/complexity/noBannedTypes: {} represents an empty relations record — the correct default for models without relations
   model<TTable extends TableDef<ColumnRecord>>(table: TTable): ModelDef<TTable, {}>;
   model<TTable extends TableDef<ColumnRecord>, TRelations extends Record<string, RelationDef>>(
@@ -181,10 +174,6 @@ export const d: {
       foreignKey?: Extract<keyof TTarget['_columns'], string>,
     ) => createManyRelation(target, foreignKey),
   },
-  entry: (table: TableDef<ColumnRecord>, relations: Record<string, RelationDef> = {}) => ({
-    table,
-    relations,
-  }),
   model: (table: TableDef<ColumnRecord>, relations: Record<string, RelationDef> = {}) =>
     createModel(table, relations),
 };

--- a/packages/db/src/schema/__tests__/registry.test-d.ts
+++ b/packages/db/src/schema/__tests__/registry.test-d.ts
@@ -30,65 +30,6 @@ const comments = d.table('comments', {
 });
 
 // ---------------------------------------------------------------------------
-// d.entry() type tests
-// ---------------------------------------------------------------------------
-
-describe('d.entry() types', () => {
-  it('returns ModelEntry with empty relations when called with table only', () => {
-    const entry = d.entry(users);
-
-    type _t1 = Expect<Extends<typeof entry, ModelEntry>>;
-    type _t2 = Expect<Equal<typeof entry.table, typeof users>>;
-    // biome-ignore lint/complexity/noBannedTypes: testing that the actual return type is {} (empty relations)
-    type _t3 = Expect<Equal<typeof entry.relations, {}>>;
-  });
-
-  it('returns ModelEntry with typed relations when called with table and relations', () => {
-    const postRelations = {
-      author: d.ref.one(() => users, 'authorId'),
-      comments: d.ref.many(() => comments, 'postId'),
-    };
-
-    const entry = d.entry(posts, postRelations);
-
-    type _t1 = Expect<Extends<typeof entry, ModelEntry>>;
-    type _t2 = Expect<Equal<typeof entry.table, typeof posts>>;
-    type _t3 = Expect<Equal<typeof entry.relations.author._type, 'one'>>;
-    type _t4 = Expect<Equal<typeof entry.relations.comments._type, 'many'>>;
-  });
-
-  it('entry result satisfies Record<string, ModelEntry>', () => {
-    const postRelations = {
-      author: d.ref.one(() => users, 'authorId'),
-    };
-
-    const models = {
-      users: d.entry(users),
-      posts: d.entry(posts, postRelations),
-    } satisfies Record<string, ModelEntry>;
-
-    type _t1 = Expect<Extends<typeof models.users, ModelEntry>>;
-    type _t2 = Expect<Extends<typeof models.posts, ModelEntry>>;
-  });
-
-  it('rejects non-table first argument', () => {
-    // @ts-expect-error -- first argument must be a TableDef
-    d.entry('not a table');
-
-    // @ts-expect-error -- first argument must be a TableDef
-    d.entry(42);
-  });
-
-  it('rejects non-relation-record second argument', () => {
-    // @ts-expect-error -- second argument must be a Record<string, RelationDef>
-    d.entry(users, 'not relations');
-
-    // @ts-expect-error -- second argument must be a Record<string, RelationDef>
-    d.entry(users, { bad: 42 });
-  });
-});
-
-// ---------------------------------------------------------------------------
 // createRegistry() type tests
 // ---------------------------------------------------------------------------
 

--- a/packages/db/src/schema/__tests__/registry.test.ts
+++ b/packages/db/src/schema/__tests__/registry.test.ts
@@ -27,33 +27,6 @@ const comments = d.table('comments', {
 });
 
 // ---------------------------------------------------------------------------
-// d.entry() helper
-// ---------------------------------------------------------------------------
-
-describe('d.entry()', () => {
-  it('returns { table, relations: {} } when called with table only', () => {
-    const entry = d.entry(users);
-
-    expect(entry.table).toBe(users);
-    expect(entry.relations).toEqual({});
-  });
-
-  it('returns { table, relations } when called with table and relations', () => {
-    const postRelations = {
-      author: d.ref.one(() => users, 'authorId'),
-      comments: d.ref.many(() => comments, 'postId'),
-    };
-
-    const entry = d.entry(posts, postRelations);
-
-    expect(entry.table).toBe(posts);
-    expect(entry.relations).toBe(postRelations);
-    expect(entry.relations.author._type).toBe('one');
-    expect(entry.relations.comments._type).toBe('many');
-  });
-});
-
-// ---------------------------------------------------------------------------
 // createRegistry()
 // ---------------------------------------------------------------------------
 

--- a/packages/integration-tests/src/__tests__/dts-type-preservation.test.ts
+++ b/packages/integration-tests/src/__tests__/dts-type-preservation.test.ts
@@ -229,12 +229,6 @@ describe('@vertz/db dist type preservation', () => {
     );
   });
 
-  // ---- d.entry() preserves generics ----
-
-  it('d.entry has generic parameters for table and relations', () => {
-    expect(dts).toMatch(/entry<\s*TTable\s+extends\s+TableDef/);
-  });
-
   // ---- d.ref.one / d.ref.many preserve generics ----
 
   it('d.ref.one returns RelationDef with target generic', () => {

--- a/plans/api-cheat-sheet-current.md
+++ b/plans/api-cheat-sheet-current.md
@@ -104,7 +104,7 @@ export const d: {
     many<TTarget>(target: () => TTarget, foreignKey?: string): ManyRelationDef
   }
   
-  entry<TTable>(table: TTable, relations?): TableEntry<TTable, TRelations>
+  model<TTable>(table: TTable, relations?): ModelDef<TTable, TRelations>
 }
 
 // CRUD queries
@@ -134,7 +134,7 @@ const tasks = d.table('tasks', {
 })
 
 // Relations
-const UserWithTasks = d.entry(users, {
+const UserWithTasks = d.model(users, {
   tasks: d.ref.many(() => tasks, 'userId'),
 })
 ```


### PR DESCRIPTION
## Summary

- Removes the deprecated `d.entry()` helper from `@vertz/db` — replaced by `d.model()` which includes derived schemas
- Removes associated runtime tests, type tests, and .d.ts preservation test
- Updates API cheat sheet to use `d.model()` instead of `d.entry()`
- `ModelEntry` type is **kept** — it's still used by `Database`, `createRegistry`, and `@vertz/server`

## Public API Changes

- **Removed:** `d.entry()` (use `d.model()` instead)
- No other API changes

## Test plan

- [x] All 1407 `@vertz/db` tests pass
- [x] Typecheck clean on `@vertz/db`, `@vertz/server`, `@vertz/integration-tests`
- [x] Lint clean
- [x] Full pre-push quality gates (87 tasks) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)