### PR TITLE
chore: exclude __tests__/ from code coverage

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,3 +3,4 @@ peer = true
 
 [test]
 timeout = 120000
+coveragePathIgnorePatterns = ["**/__tests__/**"]

--- a/packages/cli-runtime/bunfig.toml
+++ b/packages/cli-runtime/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-coveragePathIgnorePatterns = ["**/errors/dist/**", "**/fetch/dist/**"]
+coveragePathIgnorePatterns = ["**/errors/dist/**", "**/fetch/dist/**", "**/__tests__/**"]

--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -9,4 +9,5 @@ coveragePathIgnorePatterns = [
   "**/tui/dist/**",
   "**/ui/dist/**",
   "**/server/dist/**",
+  "**/__tests__/**",
 ]

--- a/packages/db/bunfig.toml
+++ b/packages/db/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-coveragePathIgnorePatterns = ["**/errors/dist/**", "**/schema/dist/**", "**/schema/src/**"]
+coveragePathIgnorePatterns = ["**/errors/dist/**", "**/schema/dist/**", "**/schema/src/**", "**/__tests__/**"]

--- a/packages/fetch/bunfig.toml
+++ b/packages/fetch/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-coveragePathIgnorePatterns = ["**/errors/dist/**"]
+coveragePathIgnorePatterns = ["**/errors/dist/**", "**/__tests__/**"]

--- a/packages/server/bunfig.toml
+++ b/packages/server/bunfig.toml
@@ -1,3 +1,3 @@
 [test]
-coveragePathIgnorePatterns = ["**/core/dist/**", "**/db/dist/**", "**/errors/dist/**", "**/schema/dist/**"]
+coveragePathIgnorePatterns = ["**/core/dist/**", "**/db/dist/**", "**/errors/dist/**", "**/schema/dist/**", "**/__tests__/**"]
 timeout = 120000

--- a/packages/testing/bunfig.toml
+++ b/packages/testing/bunfig.toml
@@ -4,4 +4,5 @@ coveragePathIgnorePatterns = [
   "**/errors/dist/**",
   "**/schema/dist/**",
   "**/server/dist/**",
+  "**/__tests__/**",
 ]

--- a/packages/ui-compiler/bunfig.toml
+++ b/packages/ui-compiler/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-coveragePathIgnorePatterns = ["**/ui/dist/**"]
+coveragePathIgnorePatterns = ["**/ui/dist/**", "**/__tests__/**"]

--- a/packages/ui-primitives/bunfig.toml
+++ b/packages/ui-primitives/bunfig.toml
@@ -1,3 +1,3 @@
 [test]
 preload = ["./happydom.ts", "./test-compiler-plugin.ts"]
-coveragePathIgnorePatterns = ["**/ui/dist/**"]
+coveragePathIgnorePatterns = ["**/ui/dist/**", "**/__tests__/**"]

--- a/packages/ui-server/bunfig.toml
+++ b/packages/ui-server/bunfig.toml
@@ -6,4 +6,5 @@ coveragePathIgnorePatterns = [
   "**/server/dist/**",
   "**/ui/dist/**",
   "**/ui/src/**",
+  "**/__tests__/**",
 ]


### PR DESCRIPTION
## Summary

- Test helper files inside `__tests__/` directories (e.g. `test-keys.ts`) were being counted in code coverage reports, inflating or skewing coverage numbers
- Added `**/__tests__/**` to `coveragePathIgnorePatterns` in the root `bunfig.toml` and in every package that overrides the pattern (9 packages)

## Affected packages

`cli-runtime`, `cli`, `db`, `fetch`, `server`, `testing`, `ui-compiler`, `ui-primitives`, `ui-server` + root config

## Test plan

- [x] Server tests pass (1983/1983)
- [x] Config-only change — no source code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)