### PR TITLE
test(fetch): reach 100% code coverage

### DIFF
--- a/packages/fetch/src/descriptor.test.ts
+++ b/packages/fetch/src/descriptor.test.ts
@@ -235,6 +235,97 @@ describe('createMutationDescriptor', () => {
     expect(rollbackCalled).toHaveBeenCalledTimes(1);
     expect(handler.commit).not.toHaveBeenCalled();
   });
+
+  it('calls rollback and re-throws when fetch rejects without onRejected', async () => {
+    const fetchError = new Error('Connection refused');
+    const rollbackCalled = mock();
+    const fetchFn = mock().mockRejectedValue(fetchError);
+    const handler: OptimisticHandler = {
+      apply() {
+        return rollbackCalled;
+      },
+      commit: mock(),
+    };
+
+    const descriptor = createMutationDescriptor(
+      'POST',
+      '/todos',
+      fetchFn,
+      { entityType: 'todos', kind: 'create', body: { title: 'Test' } },
+      handler,
+    );
+
+    let caught: unknown;
+    try {
+      await descriptor;
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(fetchError);
+    expect(rollbackCalled).toHaveBeenCalledTimes(1);
+    expect(handler.commit).not.toHaveBeenCalled();
+  });
+
+  it('calls rollback and delegates to onRejected when fetch rejects with handler', async () => {
+    const fetchError = new Error('Connection refused');
+    const rollbackCalled = mock();
+    const fetchFn = mock().mockRejectedValue(fetchError);
+    const handler: OptimisticHandler = {
+      apply() {
+        return rollbackCalled;
+      },
+      commit: mock(),
+    };
+
+    const descriptor = createMutationDescriptor(
+      'POST',
+      '/todos',
+      fetchFn,
+      { entityType: 'todos', kind: 'create', body: { title: 'Test' } },
+      handler,
+    );
+
+    const result = await descriptor.then(
+      (r) => r,
+      (err) => ({ ok: false as const, caught: (err as Error).message }),
+    );
+
+    expect(result).toEqual({ ok: false, caught: 'Connection refused' });
+    expect(rollbackCalled).toHaveBeenCalledTimes(1);
+    expect(handler.commit).not.toHaveBeenCalled();
+  });
+
+  it('re-throws when fetch rejects and .then() called without onRejected', async () => {
+    const fetchError = new Error('Connection refused');
+    const rollbackCalled = mock();
+    const fetchFn = mock().mockRejectedValue(fetchError);
+    const handler: OptimisticHandler = {
+      apply() {
+        return rollbackCalled;
+      },
+      commit: mock(),
+    };
+
+    const descriptor = createMutationDescriptor(
+      'POST',
+      '/todos',
+      fetchFn,
+      { entityType: 'todos', kind: 'create', body: { title: 'Test' } },
+      handler,
+    );
+
+    let caught: unknown;
+    try {
+      await descriptor.then((r) => r);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(fetchError);
+    expect(rollbackCalled).toHaveBeenCalledTimes(1);
+    expect(handler.commit).not.toHaveBeenCalled();
+  });
 });
 
 describe('isMutationDescriptor', () => {

--- a/packages/fetch/src/vertzql.test.ts
+++ b/packages/fetch/src/vertzql.test.ts
@@ -166,6 +166,14 @@ describe('resolveVertzQL', () => {
     expect(result).toBe(query);
   });
 
+  it('preserves undefined values for non-VertzQL keys', () => {
+    const query = { status: 'active', filter: undefined };
+    const result = resolveVertzQL(query);
+
+    expect(result).toBe(query);
+    expect(result).toEqual({ status: 'active', filter: undefined });
+  });
+
   it('extracts select from query and encodes as q= param', () => {
     const query = { select: { id: true, name: true } };
     const result = resolveVertzQL(query);


### PR DESCRIPTION
## Summary

- Cover mutation descriptor rejection handler (lines 111-114 in `descriptor.ts`): test fetch Promise rejection with and without `onRejected` callback, including rollback behavior
- Cover `undefined` query key branch (lines 91-93 in `vertzql.ts`): test that top-level `undefined` values are preserved in `resolveVertzQL`
- All 4 source files now at **100% function and line coverage**

## Public API Changes

None — test-only changes.

Fixes #1796

## Test plan

- [x] `bun test packages/fetch --coverage` — 139 tests pass, 100% across all source files
- [x] `bun run typecheck` on fetch package — clean
- [x] `bunx biome check` — warnings only (pre-existing double-cast in test mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)