### PR TITLE
test(errors): reach 100% code coverage

### DIFF
--- a/packages/errors/src/tests/domain/auth.test.ts
+++ b/packages/errors/src/tests/domain/auth.test.ts
@@ -8,6 +8,8 @@ import {
   createRateLimitedError,
   createSessionExpiredError,
   createSessionNotFoundError,
+  createTokenExpiredError,
+  createTokenInvalidError,
   createUserExistsError,
   isAuthValidationError,
   isInvalidCredentialsError,
@@ -16,6 +18,8 @@ import {
   isRateLimitedError,
   isSessionExpiredError,
   isSessionNotFoundError,
+  isTokenExpiredError,
+  isTokenInvalidError,
   isUserExistsError,
 } from '../../domain/auth';
 
@@ -187,6 +191,52 @@ describe('domain/auth', () => {
     });
   });
 
+  describe('TokenExpiredError', () => {
+    it('creates with default message', () => {
+      const error = createTokenExpiredError();
+      expect(error.code).toBe('TOKEN_EXPIRED');
+      expect(error.message).toBe('Token has expired');
+    });
+
+    it('creates with custom message', () => {
+      const error = createTokenExpiredError('Verification token expired');
+      expect(error.message).toBe('Verification token expired');
+    });
+
+    it('type guard returns true for TokenExpiredError', () => {
+      const error = createTokenExpiredError();
+      expect(isTokenExpiredError(error)).toBe(true);
+    });
+
+    it('type guard returns false for other errors', () => {
+      expect(isTokenExpiredError(createInvalidCredentialsError())).toBe(false);
+      expect(isTokenExpiredError(createSessionExpiredError())).toBe(false);
+    });
+  });
+
+  describe('TokenInvalidError', () => {
+    it('creates with default message', () => {
+      const error = createTokenInvalidError();
+      expect(error.code).toBe('TOKEN_INVALID');
+      expect(error.message).toBe('Invalid token');
+    });
+
+    it('creates with custom message', () => {
+      const error = createTokenInvalidError('Reset token not found');
+      expect(error.message).toBe('Reset token not found');
+    });
+
+    it('type guard returns true for TokenInvalidError', () => {
+      const error = createTokenInvalidError();
+      expect(isTokenInvalidError(error)).toBe(true);
+    });
+
+    it('type guard returns false for other errors', () => {
+      expect(isTokenInvalidError(createInvalidCredentialsError())).toBe(false);
+      expect(isTokenInvalidError(createTokenExpiredError())).toBe(false);
+    });
+  });
+
   describe('AuthError union', () => {
     it('accepts all auth error types', () => {
       const errors: AuthError[] = [
@@ -198,9 +248,11 @@ describe('domain/auth', () => {
         createRateLimitedError(),
         createAuthValidationError('Invalid email', 'email'),
         createOAuthError('OAuth failed'),
+        createTokenExpiredError(),
+        createTokenInvalidError(),
       ];
 
-      expect(errors.length).toBe(8);
+      expect(errors.length).toBe(10);
       expect(errors.every((e) => 'code' in e)).toBe(true);
     });
   });

--- a/packages/errors/src/tests/match-error.test.ts
+++ b/packages/errors/src/tests/match-error.test.ts
@@ -251,6 +251,27 @@ describe('matchError', () => {
     });
   });
 
+  describe('exhaustive check throws for unhandled error codes', () => {
+    it('throws for an unknown entity error code', () => {
+      // Force an unrecognized code past the type system to exercise the
+      // runtime exhaustiveness guard (lines 138-139).
+      const fakeError = { code: 'UnknownCode', name: 'EntityUnknown', message: 'bad' };
+      expect(() =>
+        matchError(fakeError as unknown as EntityErrorType, {
+          BadRequest: () => 'bad-request',
+          Unauthorized: () => 'unauthorized',
+          Forbidden: () => 'forbidden',
+          NotFound: () => 'not-found',
+          MethodNotAllowed: () => 'method-not-allowed',
+          Conflict: () => 'conflict',
+          ValidationError: () => 'validation',
+          InternalError: () => 'internal',
+          ServiceUnavailable: () => 'unavailable',
+        }),
+      ).toThrow('Unhandled error code: UnknownCode');
+    });
+  });
+
   describe('TypeScript exhaustiveness checking', () => {
     // This test should compile only if all error types are handled
     // If you add a new error type but don't handle it, TypeScript should error


### PR DESCRIPTION
## Summary

- Add tests for `createTokenExpiredError`, `isTokenExpiredError`, `createTokenInvalidError`, `isTokenInvalidError` in `auth.ts` (lines 431-465)
- Add test for the exhaustive check branch in `matchError()` (lines 138-139 — throws on unhandled error code)
- Update `AuthError` union test to include `TokenExpiredError` and `TokenInvalidError`

## Coverage

All source files in `packages/errors` now have **100% function and line coverage**.

| File | Before | After |
|---|---|---|
| `src/domain/auth.ts` | 85.71% fn / 92.70% line | 100% / 100% |
| `src/match-error.ts` | 50% fn / 96% line | 100% / 100% |

## Test plan

- [x] `bun test --coverage packages/errors/` — 267 tests pass, 100% across all files
- [x] `bun run typecheck` (errors package) — clean
- [x] `bunx biome check` on changed files — clean

> **Note:** Pre-push hook fails due to pre-existing `@vertz/cli` test failures unrelated to this change (CI on `main` is also red).

Fixes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>