### PR TITLE
test(cloudflare): reach 95%+ code coverage

### DIFF
--- a/packages/cloudflare/tests/handler.test.ts
+++ b/packages/cloudflare/tests/handler.test.ts
@@ -535,6 +535,72 @@ describe('createHandler (config object)', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // SSR fetch interceptor
+  // ---------------------------------------------------------------------------
+
+  describe('Feature: SSR fetch interceptor routes local API calls through app handler', () => {
+    describe('Given an SSR callback that calls fetch() with a relative API URL', () => {
+      it('Then intercepts the fetch and routes it to the app handler', async () => {
+        const apiHandler = mock().mockResolvedValue(
+          new Response('{"items":["a","b"]}', {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+
+        const ssrCallback = async (_request: Request) => {
+          // During SSR, fetch data from the API using a relative URL
+          const apiResponse = await fetch('/api/data');
+          const data = await apiResponse.text();
+          return new Response(`<html>${data}</html>`, {
+            headers: { 'Content-Type': 'text/html' },
+          });
+        };
+
+        const worker = createHandler({
+          app: () => mockApp(apiHandler),
+          basePath: '/api',
+          ssr: ssrCallback,
+        });
+
+        const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+        expect(apiHandler).toHaveBeenCalledTimes(1);
+        const calledRequest = apiHandler.mock.calls[0][0] as Request;
+        expect(new URL(calledRequest.url).pathname).toBe('/api/data');
+        const text = await response.text();
+        expect(text).toContain('{"items":["a","b"]}');
+      });
+    });
+
+    describe('Given an SSR callback that calls fetch() with an absolute same-origin API URL', () => {
+      it('Then intercepts the fetch and routes it to the app handler', async () => {
+        const apiHandler = mock().mockResolvedValue(new Response('abs-ok'));
+
+        const ssrCallback = async (request: Request) => {
+          const origin = new URL(request.url).origin;
+          const apiResponse = await fetch(`${origin}/api/items`);
+          const data = await apiResponse.text();
+          return new Response(`<html>${data}</html>`, {
+            headers: { 'Content-Type': 'text/html' },
+          });
+        };
+
+        const worker = createHandler({
+          app: () => mockApp(apiHandler),
+          basePath: '/api',
+          ssr: ssrCallback,
+        });
+
+        const response = await worker.fetch(new Request('https://example.com/'), mockEnv, mockCtx);
+
+        expect(apiHandler).toHaveBeenCalledTimes(1);
+        const text = await response.text();
+        expect(text).toContain('abs-ok');
+      });
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cloudflare/tests/image-optimizer.test.ts
+++ b/packages/cloudflare/tests/image-optimizer.test.ts
@@ -368,5 +368,64 @@ describe('Feature: Edge image optimizer', () => {
         expect(fetchInit.redirect).toBe('manual');
       });
     });
+
+    describe('When request is missing width and height parameters', () => {
+      it('Then returns 400 with missing w/h error', async () => {
+        const response = await handler(makeRequest({ url: 'https://cdn.example.com/photo.jpg' }));
+
+        expect(response.status).toBe(400);
+        const body = (await response.json()) as { error: string };
+        expect(body.error).toContain('"w" and "h"');
+      });
+    });
+
+    describe('When request has an unparseable URL', () => {
+      it('Then returns 400 with invalid url error', async () => {
+        const response = await handler(makeRequest({ url: 'not-a-valid-url', w: '400', h: '300' }));
+
+        expect(response.status).toBe(400);
+        const body = (await response.json()) as { error: string };
+        expect(body.error).toContain('Invalid "url"');
+      });
+    });
+
+    describe('When fetch throws a timeout error', () => {
+      it('Then returns 504 with timeout error', async () => {
+        globalThis.fetch = mock(() => {
+          const err = new DOMException('The operation was aborted', 'TimeoutError');
+          return Promise.reject(err);
+        });
+
+        const response = await handler(
+          makeRequest({
+            url: 'https://cdn.example.com/photo.jpg',
+            w: '400',
+            h: '300',
+          }),
+        );
+
+        expect(response.status).toBe(504);
+        const body = (await response.json()) as { error: string };
+        expect(body.error).toContain('timed out');
+      });
+    });
+
+    describe('When fetch throws a non-timeout error', () => {
+      it('Then returns 502 with fetch failure error', async () => {
+        globalThis.fetch = mock(() => Promise.reject(new Error('Network error')));
+
+        const response = await handler(
+          makeRequest({
+            url: 'https://cdn.example.com/photo.jpg',
+            w: '400',
+            h: '300',
+          }),
+        );
+
+        expect(response.status).toBe(502);
+        const body = (await response.json()) as { error: string };
+        expect(body.error).toContain('Failed to fetch');
+      });
+    });
   });
 });

--- a/packages/cloudflare/tests/tpr-routes.test.ts
+++ b/packages/cloudflare/tests/tpr-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { classifyRoutes } from '../src/tpr-routes.js';
 
 describe('classifyRoutes', () => {
@@ -82,5 +82,45 @@ describe('classifyRoutes', () => {
 
     expect(result.static).toEqual([]);
     expect(result.dynamic).toEqual(['/contact']);
+  });
+
+  it('joins child pattern "/" or "" to non-root parent as parent itself', () => {
+    // Exercises joinPatterns where child is '/' or '' and parent is non-root
+    const routes = [
+      {
+        pattern: '/admin',
+        component: () => null,
+        prerender: true,
+        children: [
+          { pattern: '/', component: () => null, prerender: true },
+          { pattern: '', component: () => null, prerender: true },
+        ],
+      },
+    ];
+
+    const result = classifyRoutes(routes);
+
+    // /admin itself + both children resolve to /admin
+    expect(result.static).toEqual(['/admin', '/admin', '/admin']);
+  });
+
+  it('joins child pattern to non-root parent with slash normalization', () => {
+    // Exercises joinPatterns where parent is non-root and child is a real segment
+    const routes = [
+      {
+        pattern: '/admin',
+        component: () => null,
+        prerender: true,
+        children: [
+          { pattern: 'settings', component: () => null, prerender: true },
+          { pattern: '/users', component: () => null, prerender: true },
+        ],
+      },
+    ];
+
+    const result = classifyRoutes(routes);
+
+    // /admin itself + /admin/settings + /admin/users
+    expect(result.static).toEqual(['/admin', '/admin/settings', '/admin/users']);
   });
 });


### PR DESCRIPTION
## Summary

- **handler.ts** — added tests for SSR fetch interceptor (lines 346-357): relative API URL interception and absolute same-origin API URL interception during SSR rendering
- **image-optimizer.ts** — added tests for missing/invalid w/h params, unparseable URL, fetch timeout (DOMException/TimeoutError), and generic fetch error (lines 79, 86, 133-136)
- **tpr-routes.ts** — added tests for `joinPatterns` with non-root parent: child `/` or `""` returning parent, and child segments with/without leading slash (lines 76-79)

## Coverage Results

| File | Before | After |
|---|---|---|
| `handler.ts` | 94.71% | 99.56% |
| `image-optimizer.ts` | 92.78% | 98.97% |
| `tpr-routes.ts` | 86.21% | 100% |

All files now exceed the 95% line coverage target.

## Public API Changes

None — test-only changes.

Fixes #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)