### PR TITLE
test(schema): reach 100% code coverage

### DIFF
--- a/packages/schema/src/__tests__/index.test.ts
+++ b/packages/schema/src/__tests__/index.test.ts
@@ -1,17 +1,65 @@
 import { describe, expect, it } from 'bun:test';
-import { ParseError, SchemaRegistry, s, schema } from '..';
+import {
+  CustomSchema,
+  DiscriminatedUnionSchema,
+  FileSchema,
+  InstanceOfSchema,
+  IntersectionSchema,
+  LazySchema,
+  MapSchema,
+  NanSchema,
+  ParseError,
+  RecordSchema,
+  SchemaRegistry,
+  SetSchema,
+  s,
+  schema,
+  TupleSchema,
+  UnionSchema,
+} from '..';
 import { ArraySchema } from '../schemas/array';
 import { BigIntSchema } from '../schemas/bigint';
 import { BooleanSchema } from '../schemas/boolean';
-import { CoercedStringSchema } from '../schemas/coerced';
+import {
+  CoercedBigIntSchema,
+  CoercedBooleanSchema,
+  CoercedDateSchema,
+  CoercedNumberSchema,
+  CoercedStringSchema,
+} from '../schemas/coerced';
 import { DateSchema } from '../schemas/date';
 import { EnumSchema } from '../schemas/enum';
-import { EmailSchema } from '../schemas/formats/email';
-import { IsoDateSchema } from '../schemas/formats/iso';
+import {
+  Base64Schema,
+  CuidSchema,
+  EmailSchema,
+  HexSchema,
+  HostnameSchema,
+  Ipv4Schema,
+  Ipv6Schema,
+  IsoDateSchema,
+  IsoDatetimeSchema,
+  IsoDurationSchema,
+  IsoTimeSchema,
+  JwtSchema,
+  NanoidSchema,
+  UlidSchema,
+  UrlSchema,
+  UuidSchema,
+} from '../schemas/formats';
 import { LiteralSchema } from '../schemas/literal';
 import { NumberSchema } from '../schemas/number';
 import { ObjectSchema } from '../schemas/object';
+import {
+  AnySchema,
+  NeverSchema,
+  NullSchema,
+  UndefinedSchema,
+  UnknownSchema,
+  VoidSchema,
+} from '../schemas/special';
 import { StringSchema } from '../schemas/string';
+import { SymbolSchema } from '../schemas/symbol';
 
 describe('Factory Object', () => {
   it('s.string() returns StringSchema', () => {
@@ -22,14 +70,66 @@ describe('Factory Object', () => {
     expect(s.number()).toBeInstanceOf(NumberSchema);
   });
 
-  it('all factory methods return correct schema types', () => {
+  it('primitive factory methods return correct types', () => {
     expect(s.boolean()).toBeInstanceOf(BooleanSchema);
     expect(s.bigint()).toBeInstanceOf(BigIntSchema);
     expect(s.date()).toBeInstanceOf(DateSchema);
+    expect(s.symbol()).toBeInstanceOf(SymbolSchema);
+    expect(s.nan()).toBeInstanceOf(NanSchema);
+  });
+
+  it('special factory methods return correct types', () => {
+    expect(s.any()).toBeInstanceOf(AnySchema);
+    expect(s.unknown()).toBeInstanceOf(UnknownSchema);
+    expect(s.null()).toBeInstanceOf(NullSchema);
+    expect(s.undefined()).toBeInstanceOf(UndefinedSchema);
+    expect(s.void()).toBeInstanceOf(VoidSchema);
+    expect(s.never()).toBeInstanceOf(NeverSchema);
+  });
+
+  it('composite factory methods return correct types', () => {
     expect(s.object({ name: s.string() })).toBeInstanceOf(ObjectSchema);
     expect(s.array(s.string())).toBeInstanceOf(ArraySchema);
     expect(s.enum(['a', 'b'])).toBeInstanceOf(EnumSchema);
     expect(s.literal('hello')).toBeInstanceOf(LiteralSchema);
+    expect(s.record(s.number())).toBeInstanceOf(RecordSchema);
+    expect(s.set(s.string())).toBeInstanceOf(SetSchema);
+    expect(s.file()).toBeInstanceOf(FileSchema);
+    expect(s.custom<number>((v) => typeof v === 'number')).toBeInstanceOf(CustomSchema);
+    expect(s.instanceof(Date)).toBeInstanceOf(InstanceOfSchema);
+    expect(s.lazy(() => s.string())).toBeInstanceOf(LazySchema);
+  });
+
+  it('s.tuple() returns TupleSchema', () => {
+    const t = s.tuple([s.string(), s.number()]);
+    expect(t).toBeInstanceOf(TupleSchema);
+    expect(t.parse(['hello', 42]).data).toEqual(['hello', 42]);
+  });
+
+  it('s.union() returns UnionSchema', () => {
+    const u = s.union([s.string(), s.number()]);
+    expect(u).toBeInstanceOf(UnionSchema);
+    expect(u.parse('hello').data).toBe('hello');
+  });
+
+  it('s.discriminatedUnion() returns DiscriminatedUnionSchema', () => {
+    const du = s.discriminatedUnion('type', [
+      s.object({ type: s.literal('a'), value: s.string() }),
+      s.object({ type: s.literal('b'), count: s.number() }),
+    ]);
+    expect(du).toBeInstanceOf(DiscriminatedUnionSchema);
+  });
+
+  it('s.intersection() returns IntersectionSchema', () => {
+    const ix = s.intersection(s.object({ a: s.string() }), s.object({ b: s.number() }));
+    expect(ix).toBeInstanceOf(IntersectionSchema);
+  });
+
+  it('s.map() returns MapSchema', () => {
+    const m = s.map(s.string(), s.number());
+    expect(m).toBeInstanceOf(MapSchema);
+    const input = new Map([['a', 1]]);
+    expect(m.parse(input).data).toEqual(input);
   });
 
   it('s.int() returns NumberSchema with .int() applied', () => {
@@ -39,18 +139,41 @@ describe('Factory Object', () => {
     expect(intSchema.parse(42).data).toBe(42);
   });
 
-  it('s.coerce.string() returns CoercedStringSchema', () => {
-    const coerced = s.coerce.string();
-    expect(coerced).toBeInstanceOf(CoercedStringSchema);
-    expect(coerced.parse(42).data).toBe('42');
-  });
-
-  it('s.email() returns EmailSchema', () => {
+  it('format factory methods return correct types', () => {
     expect(s.email()).toBeInstanceOf(EmailSchema);
+    expect(s.uuid()).toBeInstanceOf(UuidSchema);
+    expect(s.url()).toBeInstanceOf(UrlSchema);
+    expect(s.hostname()).toBeInstanceOf(HostnameSchema);
+    expect(s.ipv4()).toBeInstanceOf(Ipv4Schema);
+    expect(s.ipv6()).toBeInstanceOf(Ipv6Schema);
+    expect(s.base64()).toBeInstanceOf(Base64Schema);
+    expect(s.hex()).toBeInstanceOf(HexSchema);
+    expect(s.jwt()).toBeInstanceOf(JwtSchema);
+    expect(s.cuid()).toBeInstanceOf(CuidSchema);
+    expect(s.ulid()).toBeInstanceOf(UlidSchema);
+    expect(s.nanoid()).toBeInstanceOf(NanoidSchema);
   });
 
-  it('s.iso.date() returns IsoDateSchema', () => {
+  it('s.iso.* factory methods return correct types', () => {
     expect(s.iso.date()).toBeInstanceOf(IsoDateSchema);
+    expect(s.iso.time()).toBeInstanceOf(IsoTimeSchema);
+    expect(s.iso.datetime()).toBeInstanceOf(IsoDatetimeSchema);
+    expect(s.iso.duration()).toBeInstanceOf(IsoDurationSchema);
+  });
+
+  it('s.fromDbEnum() creates EnumSchema from column metadata', () => {
+    const col = { _meta: { enumValues: ['active', 'inactive'] as const } };
+    const e = s.fromDbEnum(col);
+    expect(e).toBeInstanceOf(EnumSchema);
+    expect(e.parse('active').data).toBe('active');
+  });
+
+  it('s.coerce.* factory methods return correct types', () => {
+    expect(s.coerce.string()).toBeInstanceOf(CoercedStringSchema);
+    expect(s.coerce.number()).toBeInstanceOf(CoercedNumberSchema);
+    expect(s.coerce.boolean()).toBeInstanceOf(CoercedBooleanSchema);
+    expect(s.coerce.bigint()).toBeInstanceOf(CoercedBigIntSchema);
+    expect(s.coerce.date()).toBeInstanceOf(CoercedDateSchema);
   });
 
   it('schema and s are the same object', () => {

--- a/packages/schema/src/core/__tests__/wrappers.test.ts
+++ b/packages/schema/src/core/__tests__/wrappers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { NumberSchema } from '../../schemas/number';
 import { StringSchema } from '../../schemas/string';
 import { DefaultSchema, NullableSchema, OptionalSchema } from '../schema';
+import { SchemaType } from '../types';
 
 describe('OptionalSchema', () => {
   it('accepts undefined and returns undefined', () => {
@@ -20,6 +22,22 @@ describe('OptionalSchema', () => {
     const inner = new StringSchema();
     const schema = new OptionalSchema(inner);
     expect(schema.unwrap()).toBe(inner);
+  });
+
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().optional();
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema().optional().describe('opt field');
+    expect(schema.metadata.description).toBe('opt field');
+    expect(schema.parse(undefined).data).toBeUndefined();
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().optional();
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
   });
 });
 
@@ -41,6 +59,31 @@ describe('NullableSchema', () => {
     const inner = new StringSchema();
     const schema = new NullableSchema(inner);
     expect(schema.toJSONSchema()).toEqual({ type: ['string', 'null'] });
+  });
+
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().nullable();
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema().nullable().describe('nullable field');
+    expect(schema.metadata.description).toBe('nullable field');
+    expect(schema.parse(null).data).toBeNull();
+  });
+
+  it('unwrap() returns the inner schema', () => {
+    const inner = new StringSchema();
+    const schema = new NullableSchema(inner);
+    expect(schema.unwrap()).toBe(inner);
+  });
+
+  it('toJSONSchema() uses anyOf when inner type is not a simple string type', () => {
+    const inner = new StringSchema().nullable();
+    // NullableSchema wrapping NullableSchema — inner type is array, not string
+    const schema = new NullableSchema(inner);
+    const json = schema.toJSONSchema();
+    expect(json.anyOf).toBeDefined();
   });
 });
 
@@ -71,6 +114,152 @@ describe('DefaultSchema', () => {
     const inner = new StringSchema();
     const schema = new DefaultSchema(inner, 'fallback');
     expect(schema.toJSONSchema()).toEqual({ type: 'string', default: 'fallback' });
+  });
+
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().default('hi');
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema().default('hi').describe('with default');
+    expect(schema.metadata.description).toBe('with default');
+    expect(schema.parse(undefined).data).toBe('hi');
+  });
+});
+
+describe('RefinedSchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().refine((v) => v.length > 0);
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().refine((v) => v.length > 0);
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata and refinement', () => {
+    const schema = new StringSchema()
+      .refine((v) => v.length > 0, 'must be non-empty')
+      .describe('refined');
+    expect(schema.metadata.description).toBe('refined');
+    expect(schema.parse('').ok).toBe(false);
+    expect(schema.parse('hello').data).toBe('hello');
+  });
+});
+
+describe('SuperRefinedSchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().superRefine(() => {});
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().superRefine(() => {});
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata and refinement', () => {
+    const schema = new StringSchema()
+      .superRefine((val, ctx) => {
+        if (val.length === 0) ctx.addIssue({ code: 'custom', message: 'empty' });
+      })
+      .describe('super-refined');
+    expect(schema.metadata.description).toBe('super-refined');
+    expect(schema.parse('').ok).toBe(false);
+  });
+});
+
+describe('TransformSchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().transform((v) => v.length);
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().transform((v) => v.length);
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata and transform', () => {
+    const schema = new StringSchema().transform((v) => v.length).describe('length transform');
+    expect(schema.metadata.description).toBe('length transform');
+    expect(schema.parse('hello').data).toBe(5);
+  });
+});
+
+describe('PipeSchema', () => {
+  it('_schemaType() returns second schema type', () => {
+    const schema = new StringSchema().pipe(new NumberSchema());
+    expect(schema.metadata.type).toBe(SchemaType.Number);
+  });
+
+  it('toJSONSchema() delegates to first schema', () => {
+    const schema = new StringSchema().pipe(new NumberSchema());
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema()
+      .transform((v) => Number(v))
+      .pipe(new NumberSchema())
+      .describe('piped');
+    expect(schema.metadata.description).toBe('piped');
+  });
+});
+
+describe('CatchSchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().catch('fallback');
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().catch('fallback');
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata and fallback', () => {
+    const schema = new StringSchema().catch('fallback').describe('with catch');
+    expect(schema.metadata.description).toBe('with catch');
+    // Invalid input returns fallback
+    expect(schema.parse(42).data).toBe('fallback');
+  });
+});
+
+describe('BrandedSchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().brand<'Email'>();
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().brand<'Email'>();
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema().brand<'Email'>().describe('branded');
+    expect(schema.metadata.description).toBe('branded');
+    expect(schema.parse('test').data).toBe('test');
+  });
+});
+
+describe('ReadonlySchema', () => {
+  it('_schemaType() delegates to inner schema', () => {
+    const schema = new StringSchema().readonly();
+    expect(schema.metadata.type).toBe(SchemaType.String);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = new StringSchema().readonly();
+    expect(schema.toJSONSchema()).toEqual({ type: 'string' });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new StringSchema().readonly().describe('readonly');
+    expect(schema.metadata.description).toBe('readonly');
   });
 });
 

--- a/packages/schema/src/schemas/__tests__/array.test.ts
+++ b/packages/schema/src/schemas/__tests__/array.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { ArraySchema } from '../array';
 import { NumberSchema } from '../number';
 import { StringSchema } from '../string';
@@ -75,5 +76,19 @@ describe('ArraySchema', () => {
       minItems: 1,
       maxItems: 10,
     });
+  });
+
+  it('.length() toJSONSchema uses minItems and maxItems with same value', () => {
+    const schema = new ArraySchema(new NumberSchema()).length(5);
+    expect(schema.toJSONSchema()).toEqual({
+      type: 'array',
+      items: { type: 'number' },
+      minItems: 5,
+      maxItems: 5,
+    });
+  });
+
+  it('metadata.type returns SchemaType.Array', () => {
+    expect(new ArraySchema(new StringSchema()).metadata.type).toBe(SchemaType.Array);
   });
 });

--- a/packages/schema/src/schemas/__tests__/bigint.test.ts
+++ b/packages/schema/src/schemas/__tests__/bigint.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { BigIntSchema } from '../bigint';
 
 describe('BigIntSchema', () => {
@@ -17,5 +18,15 @@ describe('BigIntSchema', () => {
     }
 
     expect(schema.toJSONSchema()).toEqual({ type: 'integer', format: 'int64' });
+  });
+
+  it('metadata.type returns SchemaType.BigInt', () => {
+    expect(new BigIntSchema().metadata.type).toBe(SchemaType.BigInt);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new BigIntSchema().describe('bigint field');
+    expect(schema.metadata.description).toBe('bigint field');
+    expect(schema.parse(1n).data).toBe(1n);
   });
 });

--- a/packages/schema/src/schemas/__tests__/boolean.test.ts
+++ b/packages/schema/src/schemas/__tests__/boolean.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { BooleanSchema } from '../boolean';
 
 describe('BooleanSchema', () => {
@@ -15,5 +16,15 @@ describe('BooleanSchema', () => {
         expect(result.error).toBeInstanceOf(ParseError);
       }
     }
+  });
+
+  it('metadata.type returns SchemaType.Boolean', () => {
+    expect(new BooleanSchema().metadata.type).toBe(SchemaType.Boolean);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new BooleanSchema().describe('bool field');
+    expect(schema.metadata.description).toBe('bool field');
+    expect(schema.parse(true).data).toBe(true);
   });
 });

--- a/packages/schema/src/schemas/__tests__/coerced.test.ts
+++ b/packages/schema/src/schemas/__tests__/coerced.test.ts
@@ -123,3 +123,35 @@ describe('coerced schemas inherit constraint methods', () => {
     expect(new CoercedDateSchema().toJSONSchema()).toEqual({ type: 'string', format: 'date-time' });
   });
 });
+
+describe('coerced schema _clone() preserves metadata', () => {
+  it('CoercedStringSchema._clone() preserves description', () => {
+    const schema = new CoercedStringSchema().describe('coerced str');
+    expect(schema.metadata.description).toBe('coerced str');
+    expect(schema.parse(42).data).toBe('42');
+  });
+
+  it('CoercedNumberSchema._clone() preserves description', () => {
+    const schema = new CoercedNumberSchema().describe('coerced num');
+    expect(schema.metadata.description).toBe('coerced num');
+    expect(schema.parse('42').data).toBe(42);
+  });
+
+  it('CoercedBooleanSchema._clone() preserves description', () => {
+    const schema = new CoercedBooleanSchema().describe('coerced bool');
+    expect(schema.metadata.description).toBe('coerced bool');
+    expect(schema.parse(1).data).toBe(true);
+  });
+
+  it('CoercedBigIntSchema._clone() preserves description', () => {
+    const schema = new CoercedBigIntSchema().describe('coerced bigint');
+    expect(schema.metadata.description).toBe('coerced bigint');
+    expect(schema.parse('42').data).toBe(42n);
+  });
+
+  it('CoercedDateSchema._clone() preserves description', () => {
+    const schema = new CoercedDateSchema().describe('coerced date');
+    expect(schema.metadata.description).toBe('coerced date');
+    expect(schema.parse('2024-01-01').data).toBeInstanceOf(Date);
+  });
+});

--- a/packages/schema/src/schemas/__tests__/custom.test.ts
+++ b/packages/schema/src/schemas/__tests__/custom.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { CustomSchema } from '../custom';
 
 describe('CustomSchema', () => {
@@ -17,5 +18,22 @@ describe('CustomSchema', () => {
     if (!result.ok) {
       expect(result.error.issues[0].message).toBe('Must be positive');
     }
+  });
+
+  it('metadata.type returns SchemaType.Custom', () => {
+    const schema = new CustomSchema<number>((v) => typeof v === 'number');
+    expect(schema.metadata.type).toBe(SchemaType.Custom);
+  });
+
+  it('toJSONSchema() returns empty object', () => {
+    const schema = new CustomSchema<number>((v) => typeof v === 'number');
+    expect(schema.toJSONSchema()).toEqual({});
+  });
+
+  it('_clone() preserves metadata and check function', () => {
+    const schema = new CustomSchema<number>((v) => typeof v === 'number').describe('custom num');
+    expect(schema.metadata.description).toBe('custom num');
+    expect(schema.parse(42).data).toBe(42);
+    expect(schema.safeParse('nope').ok).toBe(false);
   });
 });

--- a/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
+++ b/packages/schema/src/schemas/__tests__/discriminated-union.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { DiscriminatedUnionSchema } from '../discriminated-union';
 import { LiteralSchema } from '../literal';
 import { NumberSchema } from '../number';
@@ -67,5 +68,21 @@ describe('DiscriminatedUnionSchema', () => {
     if (!result.ok) {
       expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
     }
+  });
+
+  it('metadata.type returns SchemaType.DiscriminatedUnion', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]);
+    expect(schema.metadata.type).toBe(SchemaType.DiscriminatedUnion);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new DiscriminatedUnionSchema('type', [catSchema, dogSchema]).describe(
+      'animal union',
+    );
+    expect(schema.metadata.description).toBe('animal union');
+    expect(schema.parse({ type: 'cat', meow: 'loud' }).data).toEqual({
+      type: 'cat',
+      meow: 'loud',
+    });
   });
 });

--- a/packages/schema/src/schemas/__tests__/enum.test.ts
+++ b/packages/schema/src/schemas/__tests__/enum.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { EnumSchema } from '../enum';
 
 describe('EnumSchema', () => {
@@ -47,5 +48,15 @@ describe('EnumSchema', () => {
         expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidEnumValue);
       }
     }
+  });
+
+  it('metadata.type returns SchemaType.Enum', () => {
+    expect(new EnumSchema(['a', 'b']).metadata.type).toBe(SchemaType.Enum);
+  });
+
+  it('_clone() preserves metadata and values', () => {
+    const schema = new EnumSchema(['red', 'green', 'blue']).describe('color enum');
+    expect(schema.metadata.description).toBe('color enum');
+    expect(schema.parse('red').data).toBe('red');
   });
 });

--- a/packages/schema/src/schemas/__tests__/file.test.ts
+++ b/packages/schema/src/schemas/__tests__/file.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { FileSchema } from '../file';
 
 describe('FileSchema', () => {
@@ -13,5 +14,21 @@ describe('FileSchema', () => {
     expect(schema.safeParse('hello').ok).toBe(false);
     expect(schema.safeParse(42).ok).toBe(false);
     expect(schema.safeParse({}).ok).toBe(false);
+  });
+
+  it('metadata.type returns SchemaType.File', () => {
+    expect(new FileSchema().metadata.type).toBe(SchemaType.File);
+  });
+
+  it('toJSONSchema() returns content media type', () => {
+    expect(new FileSchema().toJSONSchema()).toEqual({
+      type: 'string',
+      contentMediaType: 'application/octet-stream',
+    });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new FileSchema().describe('file upload');
+    expect(schema.metadata.description).toBe('file upload');
   });
 });

--- a/packages/schema/src/schemas/__tests__/instanceof.test.ts
+++ b/packages/schema/src/schemas/__tests__/instanceof.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { InstanceOfSchema } from '../instanceof';
 
 describe('InstanceOfSchema', () => {
@@ -19,5 +20,19 @@ describe('InstanceOfSchema', () => {
     class Dog extends Animal {}
     const schema = new InstanceOfSchema(Animal);
     expect(schema.parse(new Dog()).data).toBeInstanceOf(Animal);
+  });
+
+  it('metadata.type returns SchemaType.InstanceOf', () => {
+    expect(new InstanceOfSchema(Date).metadata.type).toBe(SchemaType.InstanceOf);
+  });
+
+  it('toJSONSchema() returns empty object', () => {
+    expect(new InstanceOfSchema(Date).toJSONSchema()).toEqual({});
+  });
+
+  it('_clone() preserves metadata and class reference', () => {
+    const schema = new InstanceOfSchema(Date).describe('date instance');
+    expect(schema.metadata.description).toBe('date instance');
+    expect(schema.parse(new Date()).data).toBeInstanceOf(Date);
   });
 });

--- a/packages/schema/src/schemas/__tests__/intersection.test.ts
+++ b/packages/schema/src/schemas/__tests__/intersection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { IntersectionSchema } from '../intersection';
 import { NumberSchema } from '../number';
 import { ObjectSchema } from '../object';
@@ -34,5 +35,19 @@ describe('IntersectionSchema', () => {
         { type: 'object', properties: { age: { type: 'number' } }, required: ['age'] },
       ],
     });
+  });
+
+  it('metadata.type returns SchemaType.Intersection', () => {
+    const left = new ObjectSchema({ name: new StringSchema() });
+    const right = new ObjectSchema({ age: new NumberSchema() });
+    expect(new IntersectionSchema(left, right).metadata.type).toBe(SchemaType.Intersection);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const left = new ObjectSchema({ name: new StringSchema() });
+    const right = new ObjectSchema({ age: new NumberSchema() });
+    const schema = new IntersectionSchema(left, right).describe('name+age');
+    expect(schema.metadata.description).toBe('name+age');
+    expect(schema.parse({ name: 'Alice', age: 30 }).data).toEqual({ name: 'Alice', age: 30 });
   });
 });

--- a/packages/schema/src/schemas/__tests__/lazy.test.ts
+++ b/packages/schema/src/schemas/__tests__/lazy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { NullableSchema } from '../../core/schema';
+import { SchemaType } from '../../core/types';
 import { LazySchema } from '../lazy';
 import { ObjectSchema } from '../object';
 import { StringSchema } from '../string';
@@ -88,5 +89,16 @@ describe('LazySchema', () => {
     if (!result.ok) {
       expect(result.error.issues[0].path).toEqual(['children', 'value']);
     }
+  });
+
+  it('metadata.type returns SchemaType.Lazy', () => {
+    const schema = new LazySchema(() => new StringSchema());
+    expect(schema.metadata.type).toBe(SchemaType.Lazy);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new LazySchema(() => new StringSchema()).describe('lazy string');
+    expect(schema.metadata.description).toBe('lazy string');
+    expect(schema.parse('hello').data).toBe('hello');
   });
 });

--- a/packages/schema/src/schemas/__tests__/literal.test.ts
+++ b/packages/schema/src/schemas/__tests__/literal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { LiteralSchema } from '../literal';
 
 describe('LiteralSchema', () => {
@@ -28,5 +29,15 @@ describe('LiteralSchema', () => {
     expect(new LiteralSchema(42).toJSONSchema()).toEqual({ const: 42 });
     expect(new LiteralSchema(true).toJSONSchema()).toEqual({ const: true });
     expect(new LiteralSchema(null).toJSONSchema()).toEqual({ const: null });
+  });
+
+  it('metadata.type returns SchemaType.Literal', () => {
+    expect(new LiteralSchema('hello').metadata.type).toBe(SchemaType.Literal);
+  });
+
+  it('_clone() preserves metadata and value', () => {
+    const schema = new LiteralSchema('hello').describe('greeting');
+    expect(schema.metadata.description).toBe('greeting');
+    expect(schema.parse('hello').data).toBe('hello');
   });
 });

--- a/packages/schema/src/schemas/__tests__/map.test.ts
+++ b/packages/schema/src/schemas/__tests__/map.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { MapSchema } from '../map';
 import { NumberSchema } from '../number';
 import { StringSchema } from '../string';
@@ -39,5 +40,18 @@ describe('MapSchema', () => {
         items: false,
       },
     });
+  });
+
+  it('metadata.type returns SchemaType.Map', () => {
+    expect(new MapSchema(new StringSchema(), new NumberSchema()).metadata.type).toBe(
+      SchemaType.Map,
+    );
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new MapSchema(new StringSchema(), new NumberSchema()).describe('str-num map');
+    expect(schema.metadata.description).toBe('str-num map');
+    const input = new Map([['a', 1]]);
+    expect(schema.parse(input).data).toEqual(input);
   });
 });

--- a/packages/schema/src/schemas/__tests__/nan.test.ts
+++ b/packages/schema/src/schemas/__tests__/nan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { NanSchema } from '../nan';
 
 describe('NanSchema', () => {
@@ -19,5 +20,15 @@ describe('NanSchema', () => {
   it('.toJSONSchema() returns { not: {} } since NaN is not representable in JSON Schema', () => {
     const schema = new NanSchema();
     expect(schema.toJSONSchema()).toEqual({ not: {} });
+  });
+
+  it('metadata.type returns SchemaType.NaN', () => {
+    expect(new NanSchema().metadata.type).toBe(SchemaType.NaN);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new NanSchema().describe('nan field');
+    expect(schema.metadata.description).toBe('nan field');
+    expect(Number.isNaN(schema.parse(NaN).data)).toBe(true);
   });
 });

--- a/packages/schema/src/schemas/__tests__/object.test.ts
+++ b/packages/schema/src/schemas/__tests__/object.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { ErrorCode, ParseError } from '../../core/errors';
 import { SchemaRegistry } from '../../core/registry';
+import { SchemaType } from '../../core/types';
 import { NumberSchema } from '../number';
 import { ObjectSchema } from '../object';
 import { StringSchema } from '../string';
@@ -275,6 +276,10 @@ describe('ObjectSchema', () => {
     if (!result.ok) {
       expect(result.error.issues[0]?.path).toEqual(['user', 'address', 'city']);
     }
+  });
+
+  it('metadata.type returns SchemaType.Object', () => {
+    expect(new ObjectSchema({ name: new StringSchema() }).metadata.type).toBe(SchemaType.Object);
   });
 
   it('named schemas in shape produce $ref in JSON Schema', () => {

--- a/packages/schema/src/schemas/__tests__/record.test.ts
+++ b/packages/schema/src/schemas/__tests__/record.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { NumberSchema } from '../number';
 import { RecordSchema } from '../record';
 import { StringSchema } from '../string';
@@ -60,5 +61,23 @@ describe('RecordSchema', () => {
       type: 'object',
       additionalProperties: { type: 'number' },
     });
+  });
+
+  it('metadata.type returns SchemaType.Record', () => {
+    expect(new RecordSchema(new NumberSchema()).metadata.type).toBe(SchemaType.Record);
+  });
+
+  it('_clone() preserves value-only record metadata', () => {
+    const schema = new RecordSchema(new NumberSchema()).describe('value-only');
+    expect(schema.metadata.description).toBe('value-only');
+    expect(schema.parse({ a: 1 }).data).toEqual({ a: 1 });
+  });
+
+  it('_clone() preserves key+value record metadata', () => {
+    const schema = new RecordSchema(new StringSchema().min(2), new NumberSchema()).describe(
+      'key-value',
+    );
+    expect(schema.metadata.description).toBe('key-value');
+    expect(schema.parse({ ab: 1 }).data).toEqual({ ab: 1 });
   });
 });

--- a/packages/schema/src/schemas/__tests__/set.test.ts
+++ b/packages/schema/src/schemas/__tests__/set.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { SetSchema } from '../set';
 import { StringSchema } from '../string';
 
@@ -55,5 +56,9 @@ describe('SetSchema', () => {
       minItems: 3,
       maxItems: 3,
     });
+  });
+
+  it('metadata.type returns SchemaType.Set', () => {
+    expect(new SetSchema(new StringSchema()).metadata.type).toBe(SchemaType.Set);
   });
 });

--- a/packages/schema/src/schemas/__tests__/special.test.ts
+++ b/packages/schema/src/schemas/__tests__/special.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import {
   AnySchema,
   NeverSchema,
@@ -66,5 +67,23 @@ describe('Special schemas', () => {
         expect(result.error).toBeInstanceOf(ParseError);
       }
     }
+  });
+
+  it('metadata.type returns correct SchemaType for each special schema', () => {
+    expect(new AnySchema().metadata.type).toBe(SchemaType.Any);
+    expect(new UnknownSchema().metadata.type).toBe(SchemaType.Unknown);
+    expect(new NullSchema().metadata.type).toBe(SchemaType.Null);
+    expect(new UndefinedSchema().metadata.type).toBe(SchemaType.Undefined);
+    expect(new VoidSchema().metadata.type).toBe(SchemaType.Void);
+    expect(new NeverSchema().metadata.type).toBe(SchemaType.Never);
+  });
+
+  it('_clone() preserves metadata for each special schema', () => {
+    expect(new AnySchema().describe('any desc').metadata.description).toBe('any desc');
+    expect(new UnknownSchema().describe('unknown desc').metadata.description).toBe('unknown desc');
+    expect(new NullSchema().describe('null desc').metadata.description).toBe('null desc');
+    expect(new UndefinedSchema().describe('undef desc').metadata.description).toBe('undef desc');
+    expect(new VoidSchema().describe('void desc').metadata.description).toBe('void desc');
+    expect(new NeverSchema().describe('never desc').metadata.description).toBe('never desc');
   });
 });

--- a/packages/schema/src/schemas/__tests__/symbol.test.ts
+++ b/packages/schema/src/schemas/__tests__/symbol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ParseError } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { SymbolSchema } from '../symbol';
 
 describe('SymbolSchema', () => {
@@ -21,5 +22,16 @@ describe('SymbolSchema', () => {
   it('.toJSONSchema() returns { not: {} } since Symbol is not representable in JSON Schema', () => {
     const schema = new SymbolSchema();
     expect(schema.toJSONSchema()).toEqual({ not: {} });
+  });
+
+  it('metadata.type returns SchemaType.Symbol', () => {
+    expect(new SymbolSchema().metadata.type).toBe(SchemaType.Symbol);
+  });
+
+  it('_clone() preserves metadata', () => {
+    const sym = Symbol('test');
+    const schema = new SymbolSchema().describe('sym field');
+    expect(schema.metadata.description).toBe('sym field');
+    expect(schema.parse(sym).data).toBe(sym);
   });
 });

--- a/packages/schema/src/schemas/__tests__/tuple.test.ts
+++ b/packages/schema/src/schemas/__tests__/tuple.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { BooleanSchema } from '../boolean';
 import { NumberSchema } from '../number';
 import { StringSchema } from '../string';
@@ -60,6 +61,21 @@ describe('TupleSchema', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.issues[0]?.code).toBe(ErrorCode.InvalidType);
+    }
+  });
+
+  it('metadata.type returns SchemaType.Tuple', () => {
+    expect(new TupleSchema([new StringSchema()]).metadata.type).toBe(SchemaType.Tuple);
+  });
+
+  it('.rest() rejects too few elements', () => {
+    const schema = new TupleSchema([new StringSchema(), new NumberSchema()]).rest(
+      new BooleanSchema(),
+    );
+    const result = schema.safeParse(['only-one']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toContain('at least 2');
     }
   });
 });

--- a/packages/schema/src/schemas/__tests__/union.test.ts
+++ b/packages/schema/src/schemas/__tests__/union.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { ErrorCode } from '../../core/errors';
+import { SchemaType } from '../../core/types';
 import { NumberSchema } from '../number';
 import { StringSchema } from '../string';
 import { UnionSchema } from '../union';
@@ -29,5 +30,16 @@ describe('UnionSchema', () => {
     expect(schema.toJSONSchema()).toEqual({
       anyOf: [{ type: 'string' }, { type: 'number' }],
     });
+  });
+
+  it('metadata.type returns SchemaType.Union', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]);
+    expect(schema.metadata.type).toBe(SchemaType.Union);
+  });
+
+  it('_clone() preserves metadata and options', () => {
+    const schema = new UnionSchema([new StringSchema(), new NumberSchema()]).describe('str or num');
+    expect(schema.metadata.description).toBe('str or num');
+    expect(schema.parse('hello').data).toBe('hello');
   });
 });

--- a/packages/schema/src/schemas/formats/__tests__/cuid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/cuid.test.ts
@@ -12,4 +12,8 @@ describe('CuidSchema', () => {
     expect(schema.safeParse('not-a-cuid').ok).toBe(false);
     expect(schema.safeParse('xjld2cyuq0000t3rmniod1foy').ok).toBe(false); // wrong prefix
   });
+
+  it('toJSONSchema returns base string type (no extra format)', () => {
+    expect(new CuidSchema().toJSONSchema()).toEqual({ type: 'string' });
+  });
 });

--- a/packages/schema/src/schemas/formats/__tests__/hex.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/hex.test.ts
@@ -13,4 +13,17 @@ describe('HexSchema', () => {
     expect(schema.safeParse('xyz').ok).toBe(false);
     expect(schema.safeParse('0x1234').ok).toBe(false);
   });
+
+  it('toJSONSchema includes pattern', () => {
+    expect(new HexSchema().toJSONSchema()).toEqual({
+      type: 'string',
+      pattern: '^[0-9a-fA-F]+$',
+    });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = new HexSchema().describe('hex value');
+    expect(schema.metadata.description).toBe('hex value');
+    expect(schema.parse('ff').data).toBe('ff');
+  });
 });

--- a/packages/schema/src/schemas/formats/__tests__/jwt.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/jwt.test.ts
@@ -15,4 +15,8 @@ describe('JwtSchema', () => {
     expect(schema.safeParse('only-one-part').ok).toBe(false);
     expect(schema.safeParse('two.parts').ok).toBe(false);
   });
+
+  it('toJSONSchema returns base string type (no extra format)', () => {
+    expect(new JwtSchema().toJSONSchema()).toEqual({ type: 'string' });
+  });
 });

--- a/packages/schema/src/schemas/formats/__tests__/nanoid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/nanoid.test.ts
@@ -12,4 +12,8 @@ describe('NanoidSchema', () => {
     expect(schema.safeParse('too-short').ok).toBe(false);
     expect(schema.safeParse('V1StGXR8_Z5jdHi6B-myT!').ok).toBe(false); // invalid char
   });
+
+  it('toJSONSchema returns base string type (no extra format)', () => {
+    expect(new NanoidSchema().toJSONSchema()).toEqual({ type: 'string' });
+  });
 });

--- a/packages/schema/src/schemas/formats/__tests__/ulid.test.ts
+++ b/packages/schema/src/schemas/formats/__tests__/ulid.test.ts
@@ -12,4 +12,8 @@ describe('UlidSchema', () => {
     expect(schema.safeParse('not-a-ulid').ok).toBe(false);
     expect(schema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FA').ok).toBe(false); // too short
   });
+
+  it('toJSONSchema returns base string type (no extra format)', () => {
+    expect(new UlidSchema().toJSONSchema()).toEqual({ type: 'string' });
+  });
 });

--- a/packages/schema/src/transforms/__tests__/preprocess.test.ts
+++ b/packages/schema/src/transforms/__tests__/preprocess.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { SchemaType } from '../../core/types';
 import { NumberSchema } from '../../schemas/number';
 import { preprocess } from '../preprocess';
 
@@ -20,5 +21,21 @@ describe('preprocess()', () => {
     }, new NumberSchema());
     const result = schema.safeParse('hello');
     expect(result.ok).toBe(false);
+  });
+
+  it('metadata.type delegates to inner schema', () => {
+    const schema = preprocess((val) => Number(val), new NumberSchema());
+    expect(schema.metadata.type).toBe(SchemaType.Number);
+  });
+
+  it('toJSONSchema() delegates to inner schema', () => {
+    const schema = preprocess((val) => Number(val), new NumberSchema());
+    expect(schema.toJSONSchema()).toEqual({ type: 'number' });
+  });
+
+  it('_clone() preserves metadata', () => {
+    const schema = preprocess((val) => Number(val), new NumberSchema()).describe('preprocessed');
+    expect(schema.metadata.description).toBe('preprocessed');
+    expect(schema.parse('42').data).toBe(42);
   });
 });


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for `packages/schema` targeting **100% line coverage** across all source files
- Cover all uncovered `_schemaType()`, `_toJSONSchema()`, and `_clone()` methods across schema classes
- Exercise all factory methods in the `s` object (`index.ts`)

## What Changed

**Wrapper schema coverage** (`schema.ts`):
- Added `_schemaType()` / `_toJSONSchema()` / `_clone()` tests for: OptionalSchema, NullableSchema, DefaultSchema, RefinedSchema, SuperRefinedSchema, TransformSchema, PipeSchema, CatchSchema, BrandedSchema, ReadonlySchema

**Concrete schema coverage**:
- Added `metadata.type` + `_clone()` tests for: BigInt, Boolean, Symbol, NaN, File, Custom, InstanceOf, Lazy, Literal, Union, Intersection, DiscriminatedUnion, Enum, Map, Record, Array, Set, Tuple, Object
- Added `toJSONSchema()` tests for: File, Custom, InstanceOf, Hex, Cuid, JWT, Nanoid, Ulid

**Factory object coverage** (`index.ts`):
- Added tests for all remaining factory methods: `s.symbol()`, `s.nan()`, `s.any()`, `s.unknown()`, `s.null()`, `s.undefined()`, `s.void()`, `s.never()`, `s.tuple()`, `s.union()`, `s.discriminatedUnion()`, `s.intersection()`, `s.record()`, `s.set()`, `s.file()`, `s.custom()`, `s.instanceof()`, `s.lazy()`, `s.map()`, all format factories, `s.fromDbEnum()`, all `s.coerce.*` factories, `s.iso.*`

**Other coverage**:
- Array `.length()` JSON schema test
- Tuple `.rest()` too-few-elements validation
- Coerced schema `_clone()` for all 5 coerced types
- NullableSchema `anyOf` branch (non-string inner type)

## Coverage Results

| Metric | Before | After |
|--------|--------|-------|
| `schema.ts` lines | 90.15% | **100%** |
| `index.ts` lines | 97.04% | **100%** |
| `json-schema.ts` lines | 100% | **100%** |
| All source files line coverage | Mixed | **100%** |

## Test plan

- [x] `bun test packages/schema` — 465 tests pass (94 new)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — clean (only pre-existing warnings)

Fixes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)