### PR TITLE
fix(db): add hnsw index type, fix timestamp defaults and casing in codegen

### DIFF
--- a/packages/db/src/migration/__tests__/codegen.test.ts
+++ b/packages/db/src/migration/__tests__/codegen.test.ts
@@ -555,6 +555,30 @@ describe('generateSchemaCode — SQLite type mapping', () => {
 // ---------------------------------------------------------------------------
 
 describe('generateSchemaCode — column name casing', () => {
+  it('preserves leading underscores in column names', () => {
+    const snapshot = makeSnapshot({
+      internals: {
+        columns: {
+          id: { type: 'uuid', nullable: false, primary: true, unique: false, udtName: 'uuid' },
+          _private_field: {
+            type: 'text',
+            nullable: false,
+            primary: false,
+            unique: false,
+            udtName: 'text',
+          },
+        },
+        indexes: [],
+        foreignKeys: [],
+        _metadata: {},
+      },
+    });
+
+    const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
+    expect(file.content).toContain('_privateField: d.text()');
+    expect(file.content).not.toContain('PrivateField');
+  });
+
   it('converts snake_case column names to camelCase keys', () => {
     const snapshot = makeSnapshot({
       users: {
@@ -652,6 +676,31 @@ describe('generateSchemaCode — indexes', () => {
 
     const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
     expect(file.content).toContain("d.index('slug', { name: 'idx_posts_slug', unique: true })");
+  });
+
+  it('generates index with hnsw type', () => {
+    const snapshot = makeSnapshot({
+      documents: {
+        columns: {
+          id: { type: 'uuid', nullable: false, primary: true, unique: false, udtName: 'uuid' },
+          embedding: {
+            type: 'text',
+            nullable: false,
+            primary: false,
+            unique: false,
+            udtName: 'text',
+          },
+        },
+        indexes: [{ columns: ['embedding'], name: 'idx_documents_embedding', type: 'hnsw' }],
+        foreignKeys: [],
+        _metadata: {},
+      },
+    });
+
+    const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
+    expect(file.content).toContain(
+      "d.index('embedding', { name: 'idx_documents_embedding', type: 'hnsw' })",
+    );
   });
 
   it('generates multi-column indexes with camelCased columns', () => {
@@ -1411,6 +1460,88 @@ describe('generateSchemaCode — index WHERE clause escaping', () => {
 
     const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
     expect(file.content).toContain("where: 'status = \\'active\\''");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timestamp concrete date defaults
+// ---------------------------------------------------------------------------
+
+describe('generateSchemaCode — timestamp concrete date defaults', () => {
+  it('generates .default(new Date(...)) for timestamp columns with concrete date defaults', () => {
+    const snapshot = makeSnapshot({
+      events: {
+        columns: {
+          id: { type: 'uuid', nullable: false, primary: true, unique: false, udtName: 'uuid' },
+          startsAt: {
+            type: 'timestamp with time zone',
+            nullable: false,
+            primary: false,
+            unique: false,
+            default: "'2024-01-15 00:00:00+00'::timestamp with time zone",
+            udtName: 'timestamptz',
+          },
+        },
+        indexes: [],
+        foreignKeys: [],
+        _metadata: {},
+      },
+    });
+
+    const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
+    expect(file.content).toContain(
+      "startsAt: d.timestamp().default(new Date('2024-01-15 00:00:00+00'))",
+    );
+  });
+
+  it('generates .default(new Date(...)) for timestamp without time zone with concrete defaults', () => {
+    const snapshot = makeSnapshot({
+      logs: {
+        columns: {
+          id: { type: 'uuid', nullable: false, primary: true, unique: false, udtName: 'uuid' },
+          loggedAt: {
+            type: 'timestamp without time zone',
+            nullable: false,
+            primary: false,
+            unique: false,
+            default: "'2024-06-01 12:00:00'",
+            udtName: 'timestamp',
+          },
+        },
+        indexes: [],
+        foreignKeys: [],
+        _metadata: {},
+      },
+    });
+
+    const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
+    expect(file.content).toContain(
+      "loggedAt: d.timestamp().default(new Date('2024-06-01 12:00:00'))",
+    );
+  });
+
+  it('keeps .default(string) for date columns with concrete string defaults', () => {
+    const snapshot = makeSnapshot({
+      events: {
+        columns: {
+          id: { type: 'uuid', nullable: false, primary: true, unique: false, udtName: 'uuid' },
+          eventDate: {
+            type: 'date',
+            nullable: false,
+            primary: false,
+            unique: false,
+            default: "'2024-01-15'::date",
+            udtName: 'date',
+          },
+        },
+        indexes: [],
+        foreignKeys: [],
+        _metadata: {},
+      },
+    });
+
+    const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
+    expect(file.content).toContain("eventDate: d.date().default('2024-01-15')");
   });
 });
 

--- a/packages/db/src/migration/__tests__/validate-indexes.test.ts
+++ b/packages/db/src/migration/__tests__/validate-indexes.test.ts
@@ -29,6 +29,7 @@ describe('validateIndexes', () => {
       { columns: ['title'], type: 'hash' },
       { columns: ['title'], type: 'gist' },
       { columns: ['title'], type: 'brin' },
+      { columns: ['title'], type: 'hnsw' },
     ]);
     expect(validateIndexes(tables, 'postgres')).toEqual([]);
   });
@@ -50,6 +51,14 @@ describe('validateIndexes', () => {
     ]);
     const warnings = validateIndexes(tables, 'sqlite');
     expect(warnings).toHaveLength(3);
+  });
+
+  it('warns when using hnsw index type on sqlite', () => {
+    const tables = makeTable([{ columns: ['title'], type: 'hnsw' }]);
+    const warnings = validateIndexes(tables, 'sqlite');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('hnsw');
+    expect(warnings[0]).toContain('sqlite');
   });
 
   it('allows btree on both dialects without warning', () => {

--- a/packages/db/src/migration/codegen.ts
+++ b/packages/db/src/migration/codegen.ts
@@ -1,3 +1,4 @@
+import { snakeToCamel } from '../sql/casing';
 import type { ColumnSnapshot, ForeignKeySnapshot, SchemaSnapshot, TableSnapshot } from './snapshot';
 
 // ---------------------------------------------------------------------------
@@ -70,9 +71,9 @@ function generatePerTableFiles(snapshot: SchemaSnapshot, ordered: string[]): Gen
     const table = snapshot.tables[tableName];
     if (!table) continue;
 
-    const varBase = toCamelCase(tableName);
+    const varBase = snakeToCamel(tableName);
     const tableVar = `${varBase}Table`;
-    const fileName = toCamelCase(tableName);
+    const fileName = snakeToCamel(tableName);
 
     const lines: string[] = ["import { d } from '@vertz/db';"];
 
@@ -84,8 +85,8 @@ function generatePerTableFiles(snapshot: SchemaSnapshot, ordered: string[]): Gen
       }
     }
     for (const target of fkTargets) {
-      const targetVar = `${toCamelCase(target)}Table`;
-      const targetFile = toCamelCase(target);
+      const targetVar = `${snakeToCamel(target)}Table`;
+      const targetFile = snakeToCamel(target);
       lines.push(`import { ${targetVar} } from './${targetFile}';`);
     }
 
@@ -104,7 +105,7 @@ function generatePerTableFiles(snapshot: SchemaSnapshot, ordered: string[]): Gen
   // Barrel index.ts
   const indexLines: string[] = [];
   for (const tableName of ordered) {
-    const fileName = toCamelCase(tableName);
+    const fileName = snakeToCamel(tableName);
     const exports = exportMap.get(fileName);
     if (exports) {
       indexLines.push(`export { ${exports.join(', ')} } from './${fileName}';`);
@@ -125,7 +126,7 @@ function generateTableCode(
   snapshot: SchemaSnapshot,
   ordered: string[],
 ): string[] {
-  const varBase = toCamelCase(tableName);
+  const varBase = snakeToCamel(tableName);
   const tableVar = `${varBase}Table`;
   const lines: string[] = [];
 
@@ -137,7 +138,7 @@ function generateTableCode(
   lines.push(`export const ${tableVar} = d.table('${tableName}', {`);
 
   for (const [colName, col] of Object.entries(table.columns)) {
-    const camelName = toCamelCase(colName);
+    const camelName = snakeToCamel(colName);
     const { code, comment } = generateColumnCode(col, isCompositePK, snapshot);
     const commentStr = comment ? ` ${comment}` : '';
     lines.push(`  ${camelName}: ${code},${commentStr}`);
@@ -148,7 +149,7 @@ function generateTableCode(
   if (isCompositePK || hasIndexes) {
     lines.push('}, {');
     if (isCompositePK) {
-      const camelPKs = pkCols.map((c) => `'${toCamelCase(c)}'`);
+      const camelPKs = pkCols.map((c) => `'${snakeToCamel(c)}'`);
       lines.push(`  primaryKey: [${camelPKs.join(', ')}],`);
     }
     if (hasIndexes) {
@@ -170,7 +171,7 @@ function generateTableCode(
     lines.push('');
     lines.push(`export const ${modelVar} = d.model(${tableVar}, {`);
     for (const rel of relations) {
-      const targetTableVar = `${toCamelCase(rel.targetTable)}Table`;
+      const targetTableVar = `${snakeToCamel(rel.targetTable)}Table`;
       lines.push(`  ${rel.name}: d.ref.one(() => ${targetTableVar}, '${rel.fkCamel}'),`);
     }
     lines.push('});');
@@ -347,7 +348,12 @@ function formatDefault(defaultValue: string, colType: string): string | null {
   // String defaults (quoted)
   const stringMatch = defaultValue.match(/^'([^']*)'(::.*)?$/);
   if (stringMatch?.[1] != null) {
-    return `'${stringMatch[1]}'`;
+    const extracted = stringMatch[1];
+    // Timestamp columns need new Date() wrapping — d.timestamp() expects Date | 'now'
+    if (isTimestampType(colType)) {
+      return `new Date('${extracted}')`;
+    }
+    return `'${extracted}'`;
   }
 
   // Skip complex expressions (function calls, casts, etc.)
@@ -365,7 +371,7 @@ function generateIndexCode(idx: {
   type?: string;
   where?: string;
 }): string {
-  const camelCols = idx.columns.map((c) => toCamelCase(c));
+  const camelCols = idx.columns.map((c) => snakeToCamel(c));
   const cols =
     camelCols.length === 1 ? `'${camelCols[0]}'` : `[${camelCols.map((c) => `'${c}'`).join(', ')}]`;
 
@@ -399,12 +405,12 @@ function inferRelations(
   const usedNames = new Set<string>();
 
   for (const fk of foreignKeys) {
-    const fkCamel = toCamelCase(fk.column);
+    const fkCamel = snakeToCamel(fk.column);
     let name = stripFkSuffix(fkCamel);
 
     // Collision detection
     if (usedNames.has(name)) {
-      name = `${toCamelCase(fk.targetTable)}By${capitalize(fkCamel)}`;
+      name = `${snakeToCamel(fk.targetTable)}By${capitalize(fkCamel)}`;
     }
     usedNames.add(name);
 
@@ -496,8 +502,8 @@ function topologicalSort(tables: Record<string, TableSnapshot>): string[] {
 // Utilities
 // ---------------------------------------------------------------------------
 
-function toCamelCase(str: string): string {
-  return str.replace(/_([a-zA-Z0-9])/g, (_, c: string) => c.toUpperCase());
+function isTimestampType(colType: string): boolean {
+  return colType === 'timestamp with time zone' || colType === 'timestamp without time zone';
 }
 
 function capitalize(str: string): string {

--- a/packages/db/src/migration/validate-indexes.ts
+++ b/packages/db/src/migration/validate-indexes.ts
@@ -1,7 +1,13 @@
 import type { IndexType } from '../schema/table';
 import type { TableSnapshot } from './snapshot';
 
-const POSTGRES_ONLY_INDEX_TYPES: ReadonlySet<IndexType> = new Set(['hash', 'gin', 'gist', 'brin']);
+const POSTGRES_ONLY_INDEX_TYPES: ReadonlySet<IndexType> = new Set([
+  'hash',
+  'gin',
+  'gist',
+  'brin',
+  'hnsw',
+]);
 
 /**
  * Validate index definitions against a target dialect.

--- a/packages/db/src/schema/table.ts
+++ b/packages/db/src/schema/table.ts
@@ -5,7 +5,7 @@ import type { RelationDef } from './relation';
 // Index Definition
 // ---------------------------------------------------------------------------
 
-export type IndexType = 'btree' | 'hash' | 'gin' | 'gist' | 'brin';
+export type IndexType = 'btree' | 'hash' | 'gin' | 'gist' | 'brin' | 'hnsw';
 
 export interface IndexDef {
   readonly columns: readonly string[];


### PR DESCRIPTION
## Summary

- Add `'hnsw'` to `IndexType` union and `POSTGRES_ONLY_INDEX_TYPES` set for pgvector support
- Fix codegen to emit `new Date('...')` for timestamp columns with concrete date defaults instead of raw strings (which caused type errors since `d.timestamp().default()` expects `Date | 'now'`)
- Replace local `toCamelCase` in codegen with `snakeToCamel` from the casing module, fixing leading underscore handling (`_private_field` → `_privateField` instead of incorrect `PrivateField`)

Related: #1810 (full pgvector support tracked separately)

## Test plan

- [x] `bun test packages/db` — all 1469 tests pass
- [x] Timestamp concrete date default generates `new Date('...')` for `timestamp with time zone` and `timestamp without time zone`
- [x] Date columns still generate plain string defaults
- [x] HNSW index type generates correctly in codegen and warns on SQLite
- [x] Leading underscores preserved in column name casing
- [x] Typecheck clean (no new errors)
- [x] Lint clean