### PR TITLE
fix(ui-server): auto-restart dev server when bundler stale after new file (#1818)

### DIFF
--- a/.claude/rules/dev-server-debugging.md
+++ b/.claude/rules/dev-server-debugging.md
@@ -108,6 +108,20 @@ Log file is truncated on server start. Zero overhead when disabled.
 
 Useful for automated debugging and verifying server state without reading terminal output.
 
+## Stale Dev Bundler After Adding New Files
+
+**Symptom:** After creating a new page/component file and importing it from an existing file (e.g., adding a route), HMR fires and SSR refreshes, but the browser shows "Build failed / Could not load client bundle." Manual reload doesn't fix it.
+
+**Root cause:** Bun's persistent dev bundler doesn't reliably update its internal module graph when a new file is imported for the first time. The proactive `Bun.build()` check succeeds (one-shot, fresh context), but the dev bundler serves its reload stub because its module graph is stale.
+
+**Auto-recovery (since #1818 fix):** The dev server now self-fetches the bundle URL after the proactive build check passes. If the response is Bun's reload stub (`try{location.reload()}`), the server auto-restarts to get a fresh module graph.
+
+**Diagnostic:** Terminal log: `[Server] Dev bundler serving reload stub after successful build — restarting`
+
+**If auto-restart cap reached:** After 3 auto-restarts within 10s, the server stops auto-restarting. Terminal shows: `[Server] Dev bundler stale but auto-restart cap reached`. At this point, manually restart the dev server (`Ctrl+C` and re-run `bun run dev`).
+
+**Client-side fallback:** If the server-side detection misses the stale bundler (e.g., user navigates to the page after the watcher cycle completed), the BUILD_ERROR_LOADER requests a server restart via WebSocket. The browser shows "Restarting dev server... Dev bundler appears stale after adding new files."
+
 ## Quick Reference
 
 ### Key File Paths
@@ -139,6 +153,8 @@ Useful for automated debugging and verifying server state without reading termin
 | `[vertz-hmr] Hot updated: <moduleId>` | Fast Refresh re-mounted all instances of components in module |
 | `[vertz-hmr] Error re-mounting <Name>:` | Fast Refresh factory re-execution failed — old instance kept |
 | `[vertz-hmr] Signal count changed in <Name>` | Signal preservation skipped — component state was reset |
+| `[Server] Dev bundler serving reload stub after successful build — restarting` | Stale dev bundler detected — auto-restart triggered |
+| `[Server] Dev bundler stale but auto-restart cap reached` | Auto-restart skipped (3 restarts in 10s) — manual restart needed |
 
 ### Error Channel Categories
 

--- a/packages/ui-server/src/__tests__/bun-dev-server.test.ts
+++ b/packages/ui-server/src/__tests__/bun-dev-server.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
@@ -11,6 +11,7 @@ import {
   detectFaviconTag,
   formatTerminalRuntimeError,
   generateSSRPageHtml,
+  isReloadStub,
   isStaleGraphError,
   parseHMRAssets,
 } from '../bun-dev-server';
@@ -362,6 +363,26 @@ describe('buildScriptTag', () => {
     const tag = buildScriptTag(null, bootstrap, './src/app.tsx');
 
     expect(tag).not.toContain('bootstrap');
+  });
+
+  it('loader requests auto-restart via WS when no build errors but stub detected', () => {
+    const tag = buildScriptTag('/_bun/client/abc.js', null, './src/app.tsx');
+
+    expect(tag).toContain('_autoRestart');
+    expect(tag).toContain('_canAutoRestart');
+  });
+
+  it('loader shows restart message for stale bundler', () => {
+    const tag = buildScriptTag('/_bun/client/abc.js', null, './src/app.tsx');
+
+    expect(tag).toContain('Dev bundler appears stale');
+  });
+
+  it('loader keeps retry fallback when WS auto-restart unavailable', () => {
+    const tag = buildScriptTag('/_bun/client/abc.js', null, './src/app.tsx');
+
+    // Must still contain retry logic as fallback
+    expect(tag).toContain('__vertz_stub_retry');
   });
 });
 
@@ -1151,6 +1172,37 @@ describe('isStaleGraphError', () => {
 
   it('returns false for empty string', () => {
     expect(isStaleGraphError('')).toBe(false);
+  });
+});
+
+describe('isReloadStub', () => {
+  it('detects Bun reload stub', () => {
+    const stub =
+      'try{location.reload()}catch(_){}\naddEventListener("DOMContentLoaded",function(event){location.reload()})';
+    expect(isReloadStub(stub)).toBe(true);
+  });
+
+  it('rejects valid JS bundle content', () => {
+    expect(isReloadStub('import{signal}from"@vertz/ui";var app=function(){')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isReloadStub('')).toBe(false);
+  });
+
+  it('handles whitespace-prefixed stub', () => {
+    expect(isReloadStub('  try{location.reload()}catch(_){}')).toBe(true);
+  });
+
+  it('detects stub with only the try/catch line', () => {
+    expect(isReloadStub('try{location.reload()}catch(_){}')).toBe(true);
+  });
+});
+
+describe('stale bundler detection', () => {
+  it('source contains restart log message for stale dev bundler', () => {
+    const source = readFileSync(new URL('../bun-dev-server.ts', import.meta.url).pathname, 'utf8');
+    expect(source).toContain('Dev bundler serving reload stub after successful build');
   });
 });
 

--- a/packages/ui-server/src/bun-dev-server.ts
+++ b/packages/ui-server/src/bun-dev-server.ts
@@ -158,6 +158,16 @@ export function isStaleGraphError(message: string): boolean {
   return STALE_GRAPH_PATTERNS.some((pattern) => pattern.test(message));
 }
 
+/**
+ * Detect Bun's reload stub — the response served when the dev bundler
+ * fails to compile a client module. The stub is literally:
+ *   try{location.reload()}catch(_){}
+ *   addEventListener("DOMContentLoaded",function(event){location.reload()})
+ */
+export function isReloadStub(text: string): boolean {
+  return text.trimStart().startsWith('try{location.reload()}');
+}
+
 /** A resolved stack frame for terminal logging. */
 interface TerminalStackFrame {
   functionName: string | null;
@@ -727,9 +737,21 @@ const BUILD_ERROR_LOADER = [
   // was served, Bun is transitioning (hash not updated yet) → retry after delay.
   // Use sessionStorage counter to cap retries at 3 and avoid infinite loops.
   "if(j.errors&&j.errors.length>0){showOverlay('Build failed',formatErrors(j.errors),j)}",
+  // No build errors but reload stub detected → dev bundler is stale.
+  // Try auto-restart via WS first; fall back to retry loop if unavailable.
+  // Note: If the overlay runtime hasn't loaded yet (first page load), both
+  // V2._autoRestart and V._canAutoRestart are undefined, so we fall through
+  // to the retry loop. The server-side detection (stale bundler self-fetch)
+  // should catch and restart before the client reaches this fallback.
+  // The final showOverlay call passes restartable=true, but the fallback
+  // showOverlay function (line 725) ignores extra args — known degradation.
+  'else{var V2=window.__vertz_overlay;',
+  'if(V2&&V2._autoRestart&&V2._canAutoRestart&&V2._canAutoRestart()){',
+  "V2._autoRestart();sessionStorage.removeItem('__vertz_stub_retry');",
+  "showOverlay('Restarting dev server','<p style=\"margin:0;color:#666;font-size:12px\">Dev bundler appears stale after adding new files. Restarting...</p>')}",
   "else{var rk='__vertz_stub_retry',rc=+(sessionStorage.getItem(rk)||0);",
   'if(rc<3){sessionStorage.setItem(rk,String(rc+1));setTimeout(function(){location.reload()},2000)}',
-  "else{sessionStorage.removeItem(rk);showOverlay('Build failed','<p style=\"margin:0;color:#666;font-size:12px\">Could not load client bundle. Try reloading manually.</p>')}}",
+  "else{sessionStorage.removeItem(rk);showOverlay('Build failed','<p style=\"margin:0;color:#666;font-size:12px\">Could not load client bundle. Try restarting the dev server.</p>',null,null,true)}}}",
   '}).catch(function(){',
   "showOverlay('Build failed','<p style=\"margin:0;color:#666;font-size:12px\">Check your terminal for details.</p>')})}",
   "else{sessionStorage.removeItem('__vertz_stub_retry');var s=document.createElement('script');s.type='module';s.crossOrigin='';s.src=src;document.body.appendChild(s)}",
@@ -2066,6 +2088,33 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
                 if (stopped) return;
                 await discoverHMRAssets();
                 if (bundledScriptUrl !== prevUrl) break;
+              }
+              // Validate the dev bundler's actual output — if it's serving
+              // the reload stub despite the proactive Bun.build() succeeding,
+              // the dev bundler's module graph is stale (common when new files
+              // are imported for the first time). Auto-restart to get a fresh
+              // module graph.
+              if (bundledScriptUrl && server && !isRestarting) {
+                try {
+                  const bundleRes = await fetch(`http://${host}:${server.port}${bundledScriptUrl}`);
+                  const bundleText = await bundleRes.text();
+                  if (isReloadStub(bundleText)) {
+                    if (canAutoRestart()) {
+                      autoRestartTimestamps.push(Date.now());
+                      if (logRequests) {
+                        console.log(
+                          '[Server] Dev bundler serving reload stub after successful build — restarting',
+                        );
+                      }
+                      devServer.restart();
+                      return;
+                    } else if (logRequests) {
+                      console.log('[Server] Dev bundler stale but auto-restart cap reached');
+                    }
+                  }
+                } catch {
+                  // Self-fetch failed — server may be stopping, ignore
+                }
               }
               // Clear optimistically — if HMR fails, new errors will come in.
               // Don't set grace period: errors from this save cycle are


### PR DESCRIPTION
## Summary

Fixes #1818 — HMR fails with "Could not load client bundle" after adding a new page/route, requiring a full server restart.

**Root cause:** Bun's persistent dev bundler doesn't reliably update its internal module graph when a new file is imported for the first time. The proactive `Bun.build()` check passes (one-shot, fresh context) but the dev bundler serves its reload stub (`try{location.reload()}catch(_){}`). The BUILD_ERROR_LOADER retries 3× then gives up.

**Fix — two-pronged approach:**

- **Server-side detection:** After a successful proactive build check, self-fetch the bundle URL and verify it's not the reload stub. If stale, auto-restart the server (rate-limited to 3 within 10s via existing `canAutoRestart()`).
- **Client-side recovery:** Enhanced BUILD_ERROR_LOADER to request a server restart via WebSocket when the build check returns no errors but the reload stub persists, instead of blindly retrying with page reloads. Falls back to existing retry loop if WS unavailable.

## Public API Changes

- New exported function `isReloadStub(text: string): boolean` — detects Bun's reload stub content
- No breaking changes

## Test plan

- [x] 7 new unit tests (isReloadStub, stale bundler detection, BUILD_ERROR_LOADER enhancement)
- [x] All 1138 ui-server tests pass
- [x] Full CI (87 tasks green)
- [ ] Manual: start example app → create new page → add route → verify auto-restart and page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)