### PR TITLE
chore(icons): exclude generated files from coverage reporting

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,4 +3,4 @@ peer = true
 
 [test]
 timeout = 120000
-coveragePathIgnorePatterns = ["**/__tests__/**", "**/generated-*.ts"]
+coveragePathIgnorePatterns = ["**/__tests__/**"]


### PR DESCRIPTION
## Summary

- Add `coveragePathIgnorePatterns` to `packages/icons/bunfig.toml` to exclude `generated-icons.ts` (auto-generated, ~48k lines) and `scripts/` (build-time codegen) from coverage reports
- Coverage now only shows meaningful source files: `render-icon.ts` at 100%

## Public API Changes

None — configuration only.

## Review

- Adversarial review in `reviews/exclude-generated-coverage/phase-01-config.md`
- SHOULD-FIX found: root-level `**/generated-*.ts` pattern was overly broad for a single-package problem — reverted, keeping pattern scoped to icons package only (follows monorepo convention)

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)