### PR TITLE
test(cli-runtime): reach 95%+ code coverage (#1799)

### DIFF
--- a/packages/cli-runtime/src/__tests__/auth.test.ts
+++ b/packages/cli-runtime/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
-import type { ConfigStore, TokenResponse } from '../auth';
+import type { ConfigStore, DeviceCodeResponse, TokenResponse } from '../auth';
 import { AuthError, createAuthManager } from '../auth';
 
 function createMockStore(data: Record<string, string> = {}): ConfigStore {
@@ -90,6 +90,23 @@ describe('createAuthManager', () => {
     });
   });
 
+  describe('default config store', () => {
+    it('uses default no-op store when none is provided', async () => {
+      const auth = createAuthManager({ configDir: '/tmp/test' });
+
+      const credentials = await auth.loadCredentials();
+      expect(credentials).toEqual({});
+
+      // setApiKey writes then reads — default store read always returns null
+      await auth.setApiKey('key');
+      const key = await auth.getApiKey();
+      expect(key).toBeUndefined();
+
+      // clearCredentials calls remove — should not throw
+      await auth.clearCredentials();
+    });
+  });
+
   describe('device code flow', () => {
     it('initiates device code flow with correct parameters', async () => {
       const store = createMockStore();
@@ -128,6 +145,59 @@ describe('createAuthManager', () => {
           scope: 'read write',
         },
       });
+    });
+
+    it('initiates device code flow without scopes', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      const mockClient = {
+        request: mock().mockResolvedValue({
+          ok: true,
+          data: {
+            data: {
+              device_code: 'device-123',
+              user_code: 'ABCD-1234',
+              verification_uri: 'https://example.com/verify',
+              expires_in: 300,
+              interval: 5,
+            } satisfies DeviceCodeResponse,
+            status: 200,
+            headers: new Headers(),
+          },
+        }),
+      };
+
+      await auth.initiateDeviceCodeFlow(
+        mockClient as never,
+        'https://example.com/device/code',
+        'client-id',
+      );
+
+      expect(mockClient.request).toHaveBeenCalledWith('POST', 'https://example.com/device/code', {
+        body: { client_id: 'client-id' },
+      });
+    });
+
+    it('throws when device code flow request fails', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      const error = new Error('Request failed');
+      const mockClient = {
+        request: mock().mockResolvedValue({
+          ok: false,
+          error,
+        }),
+      };
+
+      await expect(
+        auth.initiateDeviceCodeFlow(
+          mockClient as never,
+          'https://example.com/device/code',
+          'client-id',
+        ),
+      ).rejects.toThrow('Request failed');
     });
   });
 
@@ -259,6 +329,128 @@ describe('createAuthManager', () => {
 
       expect(result.access_token).toBe('polled-token');
       expect(callCount).toBe(3);
+    });
+
+    it('increases interval on slow_down error', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      // Override setTimeout to resolve instantly so slow_down +5s doesn't block
+      const origSetTimeout = globalThis.setTimeout;
+      globalThis.setTimeout = ((fn: () => void) => origSetTimeout(fn, 0)) as never;
+
+      let callCount = 0;
+      const mockClient = {
+        request: mock().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              ok: false,
+              error: { body: { error: 'slow_down' } },
+            };
+          }
+          return {
+            ok: true,
+            data: {
+              data: {
+                access_token: 'token-after-slowdown',
+                token_type: 'Bearer',
+                expires_in: 3600,
+              },
+              status: 200,
+              headers: new Headers(),
+            },
+          };
+        }),
+      };
+
+      try {
+        const result = await auth.pollForToken(
+          mockClient as never,
+          'https://example.com/token',
+          'device-code',
+          'client-id',
+          0.01,
+          10,
+        );
+
+        expect(result.access_token).toBe('token-after-slowdown');
+        expect(callCount).toBe(2);
+      } finally {
+        globalThis.setTimeout = origSetTimeout;
+      }
+    });
+
+    it('throws on unknown poll error', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      const unknownError = { body: { error: 'access_denied' } };
+      const mockClient = {
+        request: mock().mockResolvedValue({
+          ok: false,
+          error: unknownError,
+        }),
+      };
+
+      await expect(
+        auth.pollForToken(
+          mockClient as never,
+          'https://example.com/token',
+          'device-code',
+          'client-id',
+          0.01,
+          10,
+        ),
+      ).rejects.toBe(unknownError);
+    });
+
+    it('returns false from error checks when error has no body', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      const errorWithoutBody = { message: 'no body' };
+      const mockClient = {
+        request: mock().mockResolvedValue({
+          ok: false,
+          error: errorWithoutBody,
+        }),
+      };
+
+      await expect(
+        auth.pollForToken(
+          mockClient as never,
+          'https://example.com/token',
+          'device-code',
+          'client-id',
+          0.01,
+          10,
+        ),
+      ).rejects.toBe(errorWithoutBody);
+    });
+
+    it('returns false from error checks when body has no error field', async () => {
+      const store = createMockStore();
+      const auth = createAuthManager({ configDir: '/tmp/test' }, store);
+
+      const errorWithBadBody = { body: { status: 500 } };
+      const mockClient = {
+        request: mock().mockResolvedValue({
+          ok: false,
+          error: errorWithBadBody,
+        }),
+      };
+
+      await expect(
+        auth.pollForToken(
+          mockClient as never,
+          'https://example.com/token',
+          'device-code',
+          'client-id',
+          0.01,
+          10,
+        ),
+      ).rejects.toBe(errorWithBadBody);
     });
 
     it('throws AuthError when device code expires', async () => {

--- a/packages/cli-runtime/src/__tests__/cli.test.ts
+++ b/packages/cli-runtime/src/__tests__/cli.test.ts
@@ -218,3 +218,44 @@ describe('command execution', () => {
     expect(errors[0]).toContain('Error:');
   });
 });
+
+describe('default output functions', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('uses console.log when no output option provided', async () => {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    const config: CLIConfig = {
+      name: 'testapp',
+      version: '1.0.0',
+      commands: testManifest,
+    };
+
+    const cli = createCLI(config);
+    await cli.run(['--version']);
+
+    expect(logSpy).toHaveBeenCalledWith('testapp v1.0.0');
+    logSpy.mockRestore();
+  });
+
+  it('uses console.error when no errorOutput option provided', async () => {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    const config: CLIConfig = {
+      name: 'testapp',
+      version: '1.0.0',
+      commands: testManifest,
+    };
+
+    const cli = createCLI(config);
+    await cli.run(['nonexistent']);
+
+    expect(errorSpy).toHaveBeenCalledWith('Unknown namespace: nonexistent');
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/cli-runtime/src/__tests__/output.test.ts
+++ b/packages/cli-runtime/src/__tests__/output.test.ts
@@ -79,4 +79,34 @@ describe('formatOutput', () => {
     expect(formatOutput('hello', 'human')).toBe('hello');
     expect(formatOutput(42, 'human')).toBe('42');
   });
+
+  it('returns string for null/undefined in table format', () => {
+    expect(formatOutput(null, 'table')).toBe('null');
+    expect(formatOutput(undefined, 'table')).toBe('undefined');
+  });
+
+  it('returns string for table with non-object rows (no columns)', () => {
+    const result = formatOutput([42, 'hello'], 'table');
+    // Non-object rows produce no keys, so columns.length === 0 → String(data)
+    expect(result).toBe('42,hello');
+  });
+
+  it('renders non-object rows in table as string fallback', () => {
+    // Mix of objects and primitives: objects contribute columns, primitives hit String(row)
+    const data = [{ name: 'Alice' }, 'raw-value'];
+    const result = formatOutput(data, 'table');
+    expect(result).toContain('Alice');
+    expect(result).toContain('raw-value');
+  });
+
+  it('formats human-readable array of primitives with index prefix', () => {
+    const data = [42, 'hello'];
+    const result = formatOutput(data, 'human');
+    expect(result).toContain('[1] 42');
+    expect(result).toContain('[2] hello');
+  });
+
+  it('returns string for undefined in human format', () => {
+    expect(formatOutput(undefined, 'human')).toBe('undefined');
+  });
 });

--- a/packages/cli-runtime/src/__tests__/resolver.test.ts
+++ b/packages/cli-runtime/src/__tests__/resolver.test.ts
@@ -219,4 +219,122 @@ describe('resolveParameters', () => {
       CliRuntimeError,
     );
   });
+
+  it('default adapter select returns first choice when choices are provided', async () => {
+    const definition: CommandDefinition = {
+      method: 'POST',
+      path: '/users',
+      description: 'Create user',
+      body: {
+        role: { type: 'string', required: true, enum: ['admin', 'user'] },
+      },
+    };
+
+    // Use default prompt adapter — select should return first choice
+    const result = await resolveParameters(definition, {}, {}, createMockContext());
+    expect(result.role).toBe('admin');
+  });
+
+  it('default adapter select returns first choice via resolver', async () => {
+    const definition: CommandDefinition = {
+      method: 'GET',
+      path: '/users/:id',
+      description: 'Get user',
+      params: {
+        id: { type: 'string', required: true },
+      },
+    };
+
+    const resolver: ParameterResolver = {
+      param: 'id',
+      fetchOptions: mock().mockResolvedValue([
+        { label: 'Alice', value: 'user-1' },
+        { label: 'Bob', value: 'user-2' },
+      ]),
+      prompt: 'Select a user',
+    };
+
+    // Use default prompt adapter — should return first choice
+    const result = await resolveParameters(definition, {}, { id: resolver }, createMockContext());
+    expect(result.id).toBe('user-1');
+  });
+
+  it('passes through non-string flag values without coercion', async () => {
+    const definition: CommandDefinition = {
+      method: 'GET',
+      path: '/users',
+      description: 'List users',
+      query: {
+        verbose: { type: 'boolean', required: false },
+      },
+    };
+
+    // Pass a boolean value (not a string) — coerceValue should return it as-is
+    const flags: Record<string, string | boolean> = { verbose: true };
+    const result = await resolveParameters(definition, flags, {}, createMockContext());
+
+    expect(result.verbose).toBe(true);
+  });
+
+  it('coerces integer type the same as number', async () => {
+    const definition: CommandDefinition = {
+      method: 'GET',
+      path: '/users',
+      description: 'List users',
+      query: {
+        count: { type: 'integer', required: false },
+      },
+    };
+
+    const result = await resolveParameters(definition, { count: '5' }, {}, createMockContext());
+    expect(result.count).toBe(5);
+  });
+
+  it('uses fallback message when field has no description', async () => {
+    const definition: CommandDefinition = {
+      method: 'POST',
+      path: '/users',
+      description: 'Create user',
+      body: {
+        name: { type: 'string', required: true },
+      },
+    };
+
+    const promptAdapter = createMockPromptAdapter({
+      text: mock().mockResolvedValue('Alice'),
+    });
+
+    const result = await resolveParameters(definition, {}, {}, createMockContext(), promptAdapter);
+
+    expect(result.name).toBe('Alice');
+    expect(promptAdapter.text).toHaveBeenCalledWith({
+      message: 'Enter name',
+    });
+  });
+
+  it('uses fallback message for enum select when field has no description', async () => {
+    const definition: CommandDefinition = {
+      method: 'POST',
+      path: '/users',
+      description: 'Create user',
+      body: {
+        role: { type: 'string', required: true, enum: ['admin', 'user'] },
+      },
+    };
+
+    const promptAdapter = createMockPromptAdapter({
+      select: mock().mockResolvedValue('admin'),
+    });
+
+    const result = await resolveParameters(definition, {}, {}, createMockContext(), promptAdapter);
+
+    expect(result.role).toBe('admin');
+    expect(promptAdapter.select).toHaveBeenCalledWith({
+      message: 'Select role',
+      choices: [
+        { label: 'admin', value: 'admin' },
+        { label: 'user', value: 'user' },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add 20 new tests covering previously uncovered branches across `auth.ts`, `cli.ts`, `output.ts`, and `resolver.ts`
- All `cli-runtime` source files now at **95%+ line coverage**

## Coverage Results

| File | Before | After |
|---|---|---|
| `auth.ts` | 82.99% | **100%** |
| `cli.ts` | 97.14% | **98.11%** |
| `output.ts` | 92.41% | **100%** |
| `resolver.ts` | 86.36% | **96.55%** |

## Public API Changes

None — test-only changes.

## Notes

- `cli.ts` line 140 (`writeError('An unexpected error occurred')`) remains uncovered — the non-Error throw branch is unreachable through `FetchClient` which always wraps errors as `Error` instances
- `resolver.ts` lines 21-22 are dead code in the default prompt adapter's select function (falsy first choice in a non-empty array)

## Test plan

- [x] All 93 cli-runtime tests pass
- [x] Typecheck passes
- [x] Lint/format clean
- [x] Pre-push quality gates (90/90 tasks cached/passing)

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)