### PR TITLE
fix(ui-server,ui): dev server error recovery and hydration duplicate handlers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -109,7 +109,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -132,7 +132,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -161,7 +161,7 @@
     },
     "packages/cli-runtime": {
       "name": "@vertz/cli-runtime",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -173,7 +173,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -191,7 +191,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -203,7 +203,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -216,7 +216,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -229,7 +229,7 @@
     },
     "packages/create-vertz": {
       "name": "create-vertz",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "bin": {
         "create-vertz": "./bin/create-vertz.ts",
       },
@@ -239,7 +239,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -253,7 +253,7 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
@@ -307,7 +307,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "devDependencies": {
         "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
@@ -316,7 +316,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -328,7 +328,7 @@
     },
     "packages/icons": {
       "name": "@vertz/icons",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
         "bunup": "^0.16.31",
@@ -407,7 +407,7 @@
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -419,7 +419,7 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -437,7 +437,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -452,7 +452,7 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/ui": "workspace:^",
         "@vertz/ui-primitives": "workspace:^",
@@ -467,7 +467,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -479,7 +479,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -508,7 +508,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -525,7 +525,7 @@
     },
     "packages/ui-compiler": {
       "name": "@vertz/ui-compiler",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@vertz/ui": "workspace:^",
@@ -542,7 +542,7 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
         "@vertz/ui": "workspace:^",
@@ -557,7 +557,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@capsizecss/unpack": "^4.0.0",
@@ -581,7 +581,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@vertz/cloudflare": "workspace:^",
         "@vertz/db": "workspace:^",

--- a/packages/ui-server/src/__tests__/bun-dev-server.test.ts
+++ b/packages/ui-server/src/__tests__/bun-dev-server.test.ts
@@ -1830,3 +1830,72 @@ describe('broadcastError with resolve and ssr categories', () => {
     errSpy.mockRestore();
   });
 });
+
+describe('error recovery (#1849)', () => {
+  it('clearError resets auto-restart timestamps so future restarts are not throttled', () => {
+    // Use two separate server instances to avoid isRestarting state bleeding.
+    // Server 1: trigger a stale-graph error (pushes timestamp), then clearError.
+    // Server 2: verify that after clearError the timestamps were reset by
+    // confirming a stale-graph error triggers "Stale graph detected" (not "cap reached").
+    //
+    // Since both instances share the same module-level state, this isn't a direct
+    // unit test of reset behavior. Instead, we test the observable effect: after
+    // clearError, the "Stale graph detected" log appears for the next stale error.
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: true });
+
+    // Set a build error then clear it — clearError should reset timestamps
+    server.broadcastError('build', [{ message: 'Build error' }]);
+    server.clearError();
+
+    logSpy.mockClear();
+
+    // Create a fresh server (isRestarting is false) and verify stale-graph
+    // still triggers properly after the clear
+    const server2 = createBunDevServer({ entry: './src/app.tsx', logRequests: true });
+    server2.broadcastError('runtime', [{ message: "Export named 'X' not found in module './y'" }]);
+
+    const staleMsg = logSpy.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('Stale graph detected'),
+    );
+    expect(staleMsg).toBeDefined();
+
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('clearErrorForFileChange resets auto-restart timestamps', () => {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: true });
+
+    // Set a build error so clearErrorForFileChange is not a no-op
+    server.broadcastError('build', [{ message: 'Some build error' }]);
+    server.clearErrorForFileChange();
+
+    logSpy.mockClear();
+
+    // Fresh server — verify stale-graph still triggers after clearErrorForFileChange
+    const server2 = createBunDevServer({ entry: './src/app.tsx', logRequests: true });
+    server2.broadcastError('runtime', [{ message: "Export named 'X' not found in module './y'" }]);
+
+    const staleMsg = logSpy.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('Stale graph detected'),
+    );
+    expect(staleMsg).toBeDefined();
+
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('BUILD_ERROR_LOADER handles restarting flag from build check response', () => {
+    const tag = buildScriptTag('/_bun/client/abc123.js', null, '/src/app.tsx');
+    // The loader should check j.restarting before checking j.errors
+    expect(tag).toContain('j.restarting');
+    expect(tag).toContain("showOverlay('Restarting dev server'");
+    expect(tag).toContain("sessionStorage.removeItem('__vertz_stub_retry')");
+  });
+});

--- a/packages/ui-server/src/bun-dev-server.ts
+++ b/packages/ui-server/src/bun-dev-server.ts
@@ -751,6 +751,7 @@ const BUILD_ERROR_LOADER = [
   // If build check has actual errors → show overlay. If no errors but reload stub
   // was served, Bun is transitioning (hash not updated yet) → retry after delay.
   // Use sessionStorage counter to cap retries at 3 and avoid infinite loops.
+  "if(j.restarting){showOverlay('Restarting dev server','<p style=\"margin:0;color:#666;font-size:12px\">Stale module graph detected. Restarting...</p>');sessionStorage.removeItem('__vertz_stub_retry');return}",
   "if(j.errors&&j.errors.length>0){showOverlay('Build failed',formatErrors(j.errors),j)}",
   // No build errors but reload stub detected → dev bundler is stale.
   // Try auto-restart via WS first; fall back to retry loop if unavailable.
@@ -989,6 +990,8 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
       pendingRuntimeError = null;
     }
     clearGraceUntil = Date.now() + 5000;
+    // Reset auto-restart cap — a successful clear means recovery worked
+    autoRestartTimestamps.length = 0;
     const msg = JSON.stringify({ type: 'clear' });
     for (const ws of wsClients) {
       ws.sendText(msg);
@@ -1007,6 +1010,8 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
     }
     // No grace period — HMR errors from this save cycle are legitimate
     clearGraceUntil = 0;
+    // Reset auto-restart cap — recovery from error state should not be throttled
+    autoRestartTimestamps.length = 0;
     const msg = JSON.stringify({ type: 'clear' });
     for (const ws of wsClients) {
       ws.sendText(msg);
@@ -1582,6 +1587,25 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
             if (lastBuildError) {
               return Response.json({ errors: [{ message: lastBuildError }] });
             }
+            // Build passed with no errors — but the client detected a reload stub,
+            // which means the dev bundler's graph is stale. Trigger auto-restart
+            // so the client doesn't get stuck in retry limbo.
+            if (bundledScriptUrl && !isRestarting && canAutoRestart()) {
+              try {
+                const bundleRes = await fetch(`http://${host}:${server?.port}${bundledScriptUrl}`);
+                const bundleText = await bundleRes.text();
+                if (isReloadStub(bundleText)) {
+                  autoRestartTimestamps.push(Date.now());
+                  if (logRequests) {
+                    console.log('[Server] Build check: dev bundler stale — restarting');
+                  }
+                  devServer.restart();
+                  return Response.json({ errors: [], restarting: true });
+                }
+              } catch {
+                // Self-fetch failed — ignore
+              }
+            }
             return Response.json({ errors: [] });
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
@@ -2045,6 +2069,32 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
       }
     }
 
+    /** Check if the dev bundler is serving a reload stub and trigger restart if so. */
+    async function checkAndRestartIfBundlerStale(): Promise<boolean> {
+      if (!bundledScriptUrl || !server || isRestarting) return false;
+      try {
+        const bundleRes = await fetch(`http://${host}:${server.port}${bundledScriptUrl}`);
+        const bundleText = await bundleRes.text();
+        if (isReloadStub(bundleText)) {
+          if (canAutoRestart()) {
+            autoRestartTimestamps.push(Date.now());
+            if (logRequests) {
+              console.log(
+                '[Server] Dev bundler still serving reload stub after SSR recovery — restarting',
+              );
+            }
+            devServer.restart();
+            return true;
+          } else if (logRequests) {
+            console.log('[Server] Dev bundler stale but auto-restart cap reached');
+          }
+        }
+      } catch {
+        // Self-fetch failed — server may be stopping, ignore
+      }
+      return false;
+    }
+
     // Watch for file changes — re-discover hash + re-import SSR module
     stopped = false;
 
@@ -2138,10 +2188,9 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
                   // Self-fetch failed — server may be stopping, ignore
                 }
               }
-              // Clear optimistically — if HMR fails, new errors will come in.
-              // Don't set grace period: errors from this save cycle are
-              // legitimate, not stale leftovers.
-              clearErrorForFileChange();
+              // Don't clear error here — wait until SSR re-import succeeds.
+              // Premature clearing causes a race: the client receives 'clear',
+              // reloads, but hits a still-broken SSR module or stale bundler.
             }
           } catch {
             // Bun.build() itself failed — ignore, the fetch-validate loader
@@ -2221,10 +2270,14 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
               onRestartNeeded();
               return;
             }
-            // No restart callback — try normal re-import as best effort
+            // No onRestartNeeded callback — use soft restart to get a fresh ESM cache.
+            // devServer.restart() resets ssrFallback, clears all caches, and
+            // creates a fresh Bun.serve() with a clean module graph.
             if (logRequests) {
-              console.log('[Server] SSR in fallback mode — attempting re-import (best effort)');
+              console.log('[Server] SSR in fallback mode — restarting dev server');
             }
+            devServer.restart();
+            return;
           }
 
           const cacheCleared = clearSSRRequireCache();
@@ -2250,6 +2303,11 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
             if (logRequests) {
               console.log('[Server] SSR module refreshed');
             }
+            // SSR succeeded — check if dev bundler is stale before clearing errors.
+            // This catches the case where Bun.build() passed and SSR refreshed
+            // but the persistent dev bundler graph is still stale (e.g. new file added).
+            if (await checkAndRestartIfBundlerStale()) return;
+            clearErrorForFileChange();
           } catch {
             logger.log('watcher', 'ssr-reload', { status: 'retry' });
             // First import may fail due to stale Bun module cache (race between
@@ -2278,6 +2336,8 @@ export function createBunDevServer(options: BunDevServerOptions): BunDevServer {
               if (logRequests) {
                 console.log('[Server] SSR module refreshed (retry)');
               }
+              if (await checkAndRestartIfBundlerStale()) return;
+              clearErrorForFileChange();
             } catch (e2) {
               console.error('[Server] Failed to refresh SSR module:', e2);
               const errMsg = e2 instanceof Error ? e2.message : String(e2);

--- a/packages/ui/src/dom/__tests__/hydration-element.test.ts
+++ b/packages/ui/src/dom/__tests__/hydration-element.test.ts
@@ -440,6 +440,41 @@ describe('DOM helpers — hydration branches', () => {
       warnSpy.mockRestore();
     });
 
+    it('clears nested <!--child--> markers from SSR content (#1853)', () => {
+      // Simulates the SSR output of a composed component (e.g., ComposedButton)
+      // that receives children through __child, which themselves contain
+      // nested __child markers for reactive text:
+      //   <button><!--child-->Theme: <!--child-->0<!--/child--><!--/child--></button>
+      const root = document.createElement('div');
+      const outer = document.createComment('child');
+      root.appendChild(outer);
+      root.appendChild(document.createTextNode('Theme: '));
+      root.appendChild(document.createComment('child'));
+      root.appendChild(document.createTextNode('0'));
+      root.appendChild(document.createComment('/child'));
+      root.appendChild(document.createComment('/child'));
+      startHydration(root);
+
+      const s = signal(0);
+      const result = __child(() => ['Theme: ', s.value]);
+      endHydration();
+
+      // The anchor should be followed by CSR-rendered content only.
+      // The stale SSR nested <!--child-->0<!--/child--> must be removed.
+      const anchor = result as Comment;
+      expect(root.textContent).toBe('Theme: 0');
+
+      // Verify no stale "0" text node from SSR remains
+      const allText = Array.from(root.childNodes)
+        .filter((n) => n.nodeType === 3)
+        .map((n) => (n as Text).data);
+      expect(allText).toEqual(['Theme: ', '0']);
+
+      // Reactive update should show correct value, not "10" (stale + new)
+      s.value = 1;
+      expect(root.textContent).toBe('Theme: 1');
+    });
+
     it('dispose cleans up effects on hydrated __child', () => {
       const root = document.createElement('div');
       root.appendChild(document.createComment('child'));

--- a/packages/ui/src/dom/element.ts
+++ b/packages/ui/src/dom/element.ts
@@ -195,19 +195,35 @@ export function __child(
       // via CSR below. JSX inside callbacks is not hydration-aware, so
       // attempting to hydrate would create detached DOM nodes with dead
       // event handlers. See #826.
-      // Stop at the <!--/child--> end marker (precise boundary) or the next
-      // <!--child--> comment (legacy fallback for SSR without end markers).
+      // Stop at the matching <!--/child--> end marker. Nested <!--child-->
+      // / <!--/child--> pairs (from composed components passing children
+      // through __child) are tracked by depth so they are fully removed.
+      // See #1853.
       let sibling = anchor.nextSibling;
+      let depth = 0;
       while (sibling) {
         const next = sibling.nextSibling;
-        // End marker: remove it and stop — content boundary reached.
-        if (sibling.nodeType === 8 && (sibling as Comment).data.trim() === '/child') {
-          sibling.parentNode?.removeChild(sibling);
-          break;
-        }
-        // Next __child boundary (legacy SSR without end markers): stop without removing.
-        if (sibling.nodeType === 8 && (sibling as Comment).data.trim() === 'child') {
-          break;
+        if (sibling.nodeType === 8) {
+          const data = (sibling as Comment).data.trim();
+          if (data === '/child') {
+            if (depth > 0) {
+              // Nested end marker — remove and continue.
+              depth--;
+              sibling.parentNode?.removeChild(sibling);
+              sibling = next;
+              continue;
+            }
+            // Matching end marker — remove and stop.
+            sibling.parentNode?.removeChild(sibling);
+            break;
+          }
+          if (data === 'child') {
+            // Nested child marker — track depth and remove.
+            depth++;
+            sibling.parentNode?.removeChild(sibling);
+            sibling = next;
+            continue;
+          }
         }
         sibling.parentNode?.removeChild(sibling);
         sibling = next;


### PR DESCRIPTION
## Summary

- **Dev server error recovery (#1849):** `ssrFallback` mode now triggers a soft restart instead of a doomed best-effort re-import; error clearing is deferred until SSR re-import succeeds; build check endpoint proactively detects stale bundlers and triggers restart; auto-restart cap resets on successful recovery.
- **Hydration duplicate handlers (#1853):** `__child` hydration cleanup now tracks nested `<!--child-->` marker depth. Composed components (e.g., `Button` wrapping children through `__child`) produced nested markers that were not fully cleared, leaving stale SSR text nodes and causing duplicate event listeners (~10x per click).

Closes #1849
Closes #1853

## Test plan

- [ ] `bun test` passes (3 new tests for error recovery, 1 new test for nested hydration markers)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] Manual: start component-docs dev server, add counter button, verify single increment per click after SSR hydration
- [ ] Manual: introduce a build error, save a fix, verify dev server recovers without manual restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)