### PR TITLE
fix(ui-server,cloudflare): wire AOT manifest into Node and Cloudflare handlers

### DIFF
--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -1,6 +1,6 @@
 import type { AppBuilder } from '@vertz/core';
 import { installFetchProxy, runWithScopedFetch } from '@vertz/ui-server/fetch-scope';
-import type { SSRModule } from '@vertz/ui-server/ssr';
+import type { AotManifest, SSRModule } from '@vertz/ui-server/ssr';
 import { injectNonce, lookupCache, storeCache, stripNonce } from './isr-cache.js';
 
 // ---------------------------------------------------------------------------
@@ -26,6 +26,12 @@ export interface SSRModuleConfig {
   title?: string;
   /** SSR query timeout in ms. Default: 5000 (generous for D1 cold starts). */
   ssrTimeout?: number;
+  /**
+   * AOT manifest with pre-compiled SSR render functions.
+   * On Cloudflare Workers (no filesystem), import the manifest at build time
+   * and pass it here.
+   */
+  aotManifest?: AotManifest;
 }
 
 /**
@@ -319,6 +325,7 @@ function createFullStackHandler(config: CloudflareHandlerConfig): CloudflareWork
         clientScript = '/assets/entry-client.js',
         title = 'Vertz App',
         ssrTimeout = 5000,
+        aotManifest,
       } = ssr;
       // Return a factory that creates an SSR handler with the per-request nonce
       ssrHandlerFactory = (nonce?: string) =>
@@ -327,6 +334,7 @@ function createFullStackHandler(config: CloudflareHandlerConfig): CloudflareWork
           template: generateHTMLTemplate(clientScript, title, nonce),
           ssrTimeout,
           nonce,
+          aotManifest,
         });
     } else {
       // Custom callback — wrap it in a factory that ignores the nonce

--- a/packages/ui-server/src/__tests__/node-handler.test.ts
+++ b/packages/ui-server/src/__tests__/node-handler.test.ts
@@ -304,7 +304,10 @@ describe('createNodeHandler', () => {
           },
         };
 
-        const handler = createNodeHandler({ module: moduleWithQuery, template });
+        const handler = createNodeHandler({
+          module: moduleWithQuery,
+          template,
+        });
         const result = await startServer(handler);
         server = result.server;
 
@@ -545,6 +548,84 @@ describe('createNodeHandler', () => {
     });
   });
 
+  describe('AOT manifest integration', () => {
+    describe('Given an AOT manifest with a matching route', () => {
+      describe('When a GET request arrives for that route', () => {
+        it('Then renders via AOT string concatenation', async () => {
+          const aotManifest = {
+            routes: {
+              '/projects/board': {
+                render: () => '<div class="board">AOT Board</div>',
+                holes: [],
+                queryKeys: [],
+              },
+            },
+          };
+
+          const handler = createNodeHandler({
+            module: simpleModule,
+            template,
+            aotManifest,
+          });
+          const result = await startServer(handler);
+          server = result.server;
+
+          const res = await fetch(`http://localhost:${result.port}/projects/board`);
+          expect(res.status).toBe(200);
+          const html = await res.text();
+          expect(html).toContain('AOT Board');
+        });
+      });
+    });
+
+    describe('Given an AOT manifest without a match for the requested route', () => {
+      describe('When a GET request arrives', () => {
+        it('Then falls back to ssrRenderSinglePass', async () => {
+          const aotManifest = {
+            routes: {
+              '/projects/board': {
+                render: () => '<div>AOT Board</div>',
+                holes: [],
+                queryKeys: [],
+              },
+            },
+          };
+
+          const handler = createNodeHandler({
+            module: simpleModule,
+            template,
+            aotManifest,
+          });
+          const result = await startServer(handler);
+          server = result.server;
+
+          const res = await fetch(`http://localhost:${result.port}/settings`);
+          const html = await res.text();
+          expect(html).toContain('Hello World');
+          expect(res.status).toBe(200);
+        });
+      });
+    });
+
+    describe('Given no AOT manifest', () => {
+      describe('When a GET request arrives', () => {
+        it('Then renders via ssrRenderSinglePass (backward compatible)', async () => {
+          const handler = createNodeHandler({
+            module: simpleModule,
+            template,
+          });
+          const result = await startServer(handler);
+          server = result.server;
+
+          const res = await fetch(`http://localhost:${result.port}/`);
+          const html = await res.text();
+          expect(html).toContain('Hello World');
+          expect(res.status).toBe(200);
+        });
+      });
+    });
+  });
+
   describe('Phase 3: SSE nav pre-fetch', () => {
     describe('Given a request with X-Vertz-Nav: 1 header', () => {
       describe('When queries are discovered for the URL', () => {
@@ -563,7 +644,10 @@ describe('createNodeHandler', () => {
             },
           };
 
-          const handler = createNodeHandler({ module: moduleWithQuery, template });
+          const handler = createNodeHandler({
+            module: moduleWithQuery,
+            template,
+          });
           const result = await startServer(handler);
           server = result.server;
 

--- a/packages/ui-server/src/node-handler.ts
+++ b/packages/ui-server/src/node-handler.ts
@@ -10,6 +10,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { SSRAuth } from '@vertz/ui/internals';
 import { escapeAttr } from './html-serializer';
+import { toPrefetchSession } from './ssr-access-evaluator';
+import { ssrRenderAot } from './ssr-aot-pipeline';
 import type { SSRHandlerOptions } from './ssr-handler';
 import {
   precomputeHandlerState,
@@ -36,6 +38,7 @@ export function createNodeHandler(
     sessionResolver,
     manifest,
     progressiveHTML,
+    aotManifest,
   } = options;
 
   const { template, linkHeader, modulepreloadTags, splitResult } = precomputeHandlerState(options);
@@ -95,12 +98,24 @@ export function createNodeHandler(
         }
 
         // Buffered path: render to string, write to res.end()
-        const result = await ssrRenderSinglePass(module, url, {
-          ssrTimeout,
-          fallbackMetrics,
-          ssrAuth,
-          manifest,
-        });
+        const prefetchSession = ssrAuth ? toPrefetchSession(ssrAuth) : undefined;
+
+        const result = aotManifest
+          ? await ssrRenderAot(module, url, {
+              aotManifest,
+              manifest,
+              ssrTimeout,
+              fallbackMetrics,
+              ssrAuth,
+              prefetchSession,
+            })
+          : await ssrRenderSinglePass(module, url, {
+              ssrTimeout,
+              fallbackMetrics,
+              ssrAuth,
+              manifest,
+              prefetchSession,
+            });
 
         // SSR redirect
         if (result.redirect) {

--- a/packages/ui-server/src/ssr/index.ts
+++ b/packages/ui-server/src/ssr/index.ts
@@ -15,8 +15,13 @@ export {
   prerenderRoutes,
   stripScriptsFromStaticHTML,
 } from '../prerender';
+export type { AotManifest } from '../ssr-aot-pipeline';
 export type { SSRHandlerOptions } from '../ssr-handler';
 export { createSSRHandler } from '../ssr-handler';
-export type { SSRDiscoverResult, SSRModule, SSRRenderResult } from '../ssr-render';
+export type {
+  SSRDiscoverResult,
+  SSRModule,
+  SSRRenderResult,
+} from '../ssr-render';
 export { ssrDiscoverQueries, ssrRenderToString } from '../ssr-render';
 export { injectIntoTemplate } from '../template-inject';


### PR DESCRIPTION
## Summary

- **Node handler**: Wire `aotManifest` through `createNodeHandler()` — AOT-first render path with fallback to `ssrRenderSinglePass()`
- **Cloudflare handler**: Add `aotManifest` to `SSRModuleConfig`, pass through to `createSSRHandler()` in `resolveSSR()`
- **Export `AotManifest` type** from `@vertz/ui-server/ssr` entrypoint so Cloudflare package can import it

Previously only `vertz start` (Bun) used AOT rendering. Node.js deployments (Express, Fastify) and Cloudflare Workers silently ignored the manifest.

## Test plan

- [x] 3 new AOT integration tests in `node-handler.test.ts` (AOT match, fallback, backward compat)
- [x] All 28 node-handler tests pass
- [x] Typecheck passes for both `ui-server` and `cloudflare` packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)