### PR TITLE
fix(ui): SSR hydration key mismatch causes data loss (#1859)

### DIFF
--- a/.changeset/fix-query-ssr-hydration-key.md
+++ b/.changeset/fix-query-ssr-hydration-key.md
@@ -1,0 +1,7 @@
+---
+'@vertz/ui': patch
+---
+
+Fix query() SSR hydration data loss and reactive re-fetch (#1859, #1861)
+
+Runtime: compute full dep-hash cache key during client hydration so it matches the SSR key format, fixing SSR data being discarded. Set idle=false in hydration resolve callback.

--- a/packages/ui/src/query/__tests__/query-ssr.test.ts
+++ b/packages/ui/src/query/__tests__/query-ssr.test.ts
@@ -264,10 +264,86 @@ describe('query() client-side SSR hydration', () => {
     expect(result.data.value).toBe('client-fetched');
   });
 
+  // Helper: compute the SSR key the same way query.ts does during SSR.
+  // During SSR, callThunkWithCapture() runs WITHOUT a subscriber, so the
+  // readValueCallback never fires and captured=[] → depHash=hashString("").
+  // The SSR key format is: `${baseKey}:${hashString("")}`.
+  function computeSSRKey(thunk: () => unknown): string {
+    const baseKey = `__q:${hashString(thunk.toString())}`;
+    // No subscriber → empty capture → dep hash from empty string
+    const depHash = hashString('');
+    return `${baseKey}:${depHash}`;
+  }
+
+  it('preserves SSR data during hydration for derived-key query (#1859)', async () => {
+    const page = signal(1);
+    const fetchFn = vi.fn(async () => ({ items: ['fetched'], total: 10 }));
+
+    const thunk = () => {
+      const currentPage = page.value;
+      return fetchFn(currentPage) as Promise<{ items: string[]; total: number }>;
+    };
+
+    // SSR stores data with the dep-hash key format.
+    const ssrKey = computeSSRKey(thunk);
+
+    (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
+      { key: ssrKey, data: { items: ['ssr-item'], total: 10 } },
+    ];
+
+    const result = query(thunk);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // SSR data must be preserved — no loading flash (#1859)
+    expect(result.data.value).toEqual({ items: ['ssr-item'], total: 10 });
+    expect(result.loading.value).toBe(false);
+
+    result.dispose();
+  });
+
+  it('preserves SSR data for descriptor-in-thunk during hydration (#1859)', async () => {
+    const page = signal(1);
+    const fetchFn = vi.fn().mockImplementation(async () => ({
+      ok: true as const,
+      data: { items: ['fetched'], total: 10 },
+    }));
+
+    const thunk = () => {
+      const currentPage = page.value;
+      const offset = (currentPage - 1) * 20;
+      return {
+        _tag: 'QueryDescriptor' as const,
+        _key: `GET:/brands?offset=${offset}`,
+        _fetch: () => fetchFn(offset),
+        // eslint-disable-next-line unicorn/no-thenable -- intentional PromiseLike mock
+        then(onFulfilled: any, onRejected: any) {
+          return this._fetch().then(onFulfilled, onRejected);
+        },
+      };
+    };
+
+    const ssrKey = computeSSRKey(thunk);
+
+    (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
+      { key: ssrKey, data: { items: ['ssr-brand'], total: 10 } },
+    ];
+
+    const result = query(thunk);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // SSR data preserved — no fetch triggered during hydration
+    expect(result.data.value).toEqual({ items: ['ssr-brand'], total: 10 });
+    expect(result.loading.value).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    result.dispose();
+  });
+
   it('re-fetches when reactive deps change after SSR hydration (#1861)', async () => {
     const page = signal(1);
 
-    // Build the thunk first so we can compute its baseKey for hydration.
     const fetchFn = vi.fn(async (offset: number) => {
       return { items: [`item-at-${offset}`], total: 100 };
     });
@@ -278,22 +354,17 @@ describe('query() client-side SSR hydration', () => {
       return fetchFn(offset) as Promise<{ items: string[]; total: number }>;
     };
 
-    // Compute the baseKey (hydration key) for this thunk.
-    // hydrateQueryFromSSR uses `customKey ?? baseKey` where
-    // baseKey = deriveKey(thunk) = `__q:${hashString(thunk.toString())}`.
-    const baseKey = `__q:${hashString(thunk.toString())}`;
+    const ssrKey = computeSSRKey(thunk);
 
-    // Simulate SSR data already buffered under the derived key.
     (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
-      { key: baseKey, data: { items: ['ssr-brand'], total: 100 } },
+      { key: ssrKey, data: { items: ['ssr-brand'], total: 100 } },
     ];
 
     const result = query(thunk);
 
-    // Wait for hydration to settle
     await new Promise((r) => setTimeout(r, 10));
 
-    // SSR data should be used — displayed data comes from SSR.
+    // SSR data hydrated
     expect(result.data.value).toEqual({ items: ['ssr-brand'], total: 100 });
 
     // Reset mock to track only the re-fetch from dep change
@@ -304,8 +375,6 @@ describe('query() client-side SSR hydration', () => {
 
     await new Promise((r) => setTimeout(r, 10));
 
-    // BUG: without fix, fetchFn is never called again because the effect
-    // never tracked page.value as a dependency (skipped thunk call on first run)
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn).toHaveBeenCalledWith(20);
     expect(result.data.value).toEqual({ items: ['item-at-20'], total: 100 });
@@ -321,7 +390,6 @@ describe('query() client-side SSR hydration', () => {
       data: { items: [`brand-at-${offset}`], total: 50 },
     }));
 
-    // Build the thunk first to compute the baseKey for hydration.
     const thunk = () => {
       const currentPage = page.value;
       const offset = (currentPage - 1) * 20;
@@ -336,19 +404,17 @@ describe('query() client-side SSR hydration', () => {
       };
     };
 
-    const baseKey = `__q:${hashString(thunk.toString())}`;
+    const ssrKey = computeSSRKey(thunk);
 
-    // SSR data buffered under the derived base key
     (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
-      { key: baseKey, data: { items: ['ssr-brand'], total: 50 } },
+      { key: ssrKey, data: { items: ['ssr-brand'], total: 50 } },
     ];
 
     const result = query(thunk);
 
-    // Wait for hydration to settle
     await new Promise((r) => setTimeout(r, 10));
 
-    // SSR data used — no fetch (descriptor thunk doesn't call _fetch during tracking)
+    // SSR data hydrated — no fetch
     expect(result.data.value).toEqual({ items: ['ssr-brand'], total: 50 });
     expect(fetchFn).not.toHaveBeenCalled();
 
@@ -357,9 +423,90 @@ describe('query() client-side SSR hydration', () => {
 
     await new Promise((r) => setTimeout(r, 10));
 
-    // BUG: without fix, fetchFn is never called because effect has no deps
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(result.data.value).toEqual({ items: ['brand-at-20'], total: 50 });
+
+    result.dispose();
+  });
+
+  it('full lifecycle: SSR hydrate → preserve data → dep change → re-fetch (#1859 + #1861)', async () => {
+    const page = signal(1);
+
+    const fetchFn = vi.fn(async (offset: number) => ({
+      items: [`item-at-${offset}`],
+      total: 100,
+    }));
+
+    const thunk = () => {
+      const currentPage = page.value;
+      const offset = (currentPage - 1) * 20;
+      return fetchFn(offset) as Promise<{ items: string[]; total: number }>;
+    };
+
+    const ssrKey = computeSSRKey(thunk);
+
+    (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
+      { key: ssrKey, data: { items: ['ssr-brand'], total: 100 } },
+    ];
+
+    const result = query(thunk);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Phase 1: SSR data preserved (no flash)
+    expect(result.data.value).toEqual({ items: ['ssr-brand'], total: 100 });
+    expect(result.loading.value).toBe(false);
+
+    fetchFn.mockClear();
+
+    // Phase 2: Change dep → re-fetch
+    page.value = 2;
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(20);
+    expect(result.data.value).toEqual({ items: ['item-at-20'], total: 100 });
+
+    fetchFn.mockClear();
+
+    // Phase 3: Change dep again → re-fetch again
+    page.value = 3;
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(40);
+    expect(result.data.value).toEqual({ items: ['item-at-40'], total: 100 });
+
+    result.dispose();
+  });
+
+  it('null-returning thunk during hydration falls through to normal effect path', async () => {
+    let ready = false;
+    const fetchFn = vi.fn(async () => 'data');
+    const thunk = () => (ready ? fetchFn() : null) as Promise<string> | null;
+
+    const ssrKey = computeSSRKey(thunk);
+
+    (globalThis as Record<string, unknown>).__VERTZ_SSR_DATA__ = [
+      { key: ssrKey, data: 'ssr-data-for-null-thunk' },
+    ];
+
+    const result = query(thunk);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Thunk returns null during init probe — SSR data key computed but the
+    // thunk's null causes the effect to skip on first run too.
+    // loading should be false because SSR hydration resolved.
+    expect(result.loading.value).toBe(false);
+
+    // Make thunk ready and trigger a re-fetch
+    ready = true;
+    result.refetch();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result.data.value).toBe('data');
 
     result.dispose();
   });

--- a/packages/ui/src/query/query.ts
+++ b/packages/ui/src/query/query.ts
@@ -441,9 +441,40 @@ export function query<T, E = unknown>(
 
   if (!isSSR() && initialData === undefined) {
     // Derive the cache key for hydration matching.
-    // For custom keys this is straightforward; for derived keys we need
-    // to call the thunk once to capture deps and compute the key.
-    const hydrationKey = customKey ?? baseKey;
+    // For custom keys this is straightforward. For derived keys, we must
+    // call the thunk to capture signal values and compute the dep hash —
+    // SSR stores data with the full dep-hash key (baseKey:depHash), so
+    // looking up just baseKey would never match. (#1859)
+    let hydrationKey: string;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SSR global
+    const hasSSRData = !!(globalThis as any).__VERTZ_SSR_DATA__;
+
+    if (customKey) {
+      hydrationKey = customKey;
+    } else if (hasSSRData) {
+      // Only probe the thunk for dep hash when SSR data exists — avoids
+      // an unnecessary thunk invocation on pure client-side navigations.
+      try {
+        const raw = callThunkWithCapture();
+        if (raw !== null) {
+          if (isQueryDescriptor<T, E>(raw)) {
+            // Descriptor: capture entity metadata but don't call _fetch()
+            if (raw._entity && !entityMeta) {
+              entityMeta = raw._entity;
+            }
+          } else {
+            // Promise thunk: suppress the eagerly-fired fetch
+            (raw as Promise<T>).catch(() => {});
+          }
+        }
+      } catch {
+        // Thunk error during hydration key derivation — effect will handle it
+      }
+      hydrationKey = getCacheKey();
+    } else {
+      hydrationKey = baseKey;
+    }
 
     // During nav prefetch, use persistent: true so the listener stays active
     // for SWR revalidation (fresh data arriving after a cache hit).
@@ -454,6 +485,7 @@ export function query<T, E = unknown>(
         normalizeToEntityStore(result as T);
         rawData.value = result as T;
         loading.value = false;
+        idle.value = false;
         cache.set(hydrationKey, result as T);
         ssrHydrated = true;
       },


### PR DESCRIPTION
## Summary

- **Root cause**: SSR stores query data with key `baseKey:depHash` (computed by `getCacheKey()` after `callThunkWithCapture()`). Client hydration was looking up just `baseKey` — these never match for derived-key queries, so SSR data was always discarded, causing a loading flash and double-fetch.
- **Fix**: When `__VERTZ_SSR_DATA__` exists, call `callThunkWithCapture()` during client init to compute the same dep-hash key that SSR used. Guarded behind `hasSSRData` to avoid unnecessary thunk calls on pure client navigations.
- **Also fixed**: `idle.value` not set to `false` in client-side SSR hydration resolve callback (parity with SSR resolve).
- **Previous fix PR #1877** had tests using wrong SSR key format (`baseKey` instead of `baseKey:depHash`), which masked the bug. Tests now use the real format.

## Public API Changes

None — bug fix only.

## Test plan

- [x] `query-ssr.test.ts`: preserves SSR data during hydration for derived-key query (#1859) — promise thunk
- [x] `query-ssr.test.ts`: preserves SSR data for descriptor-in-thunk during hydration (#1859)
- [x] `query-ssr.test.ts`: re-fetches when reactive deps change after SSR hydration (#1861) — with dep-hash SSR key
- [x] `query-ssr.test.ts`: re-fetches descriptor-in-thunk when reactive deps change (#1861)
- [x] `query-ssr.test.ts`: full lifecycle: SSR hydrate → preserve data → dep change → re-fetch (#1859 + #1861)
- [x] `query-ssr.test.ts`: null-returning thunk during hydration falls through to normal effect path
- [x] `query.test.ts`: no regressions (67 pass, 1 pre-existing polling failure)
- [x] Full quality gates: 90/90 turbo tasks passed

Fixes #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)