### PR TITLE
feat(dx): improve LLM discoverability with llms.txt and hello-world template

### DIFF
--- a/packages/create-vertz-app/bin/create-vertz-app.ts
+++ b/packages/create-vertz-app/bin/create-vertz-app.ts
@@ -13,10 +13,11 @@ program
   .description('Scaffold a new Vertz project')
   .version(pkg.version)
   .argument('[name]', 'Project name')
-  .action(async (name: string | undefined) => {
+  .option('--template <type>', 'Template to use (hello-world, todo-app)', 'todo-app')
+  .action(async (name: string | undefined, opts: { template?: string }) => {
     const { resolveOptions, scaffold } = await import('../dist/index.js');
     try {
-      const resolved = await resolveOptions({ projectName: name });
+      const resolved = await resolveOptions({ projectName: name, template: opts.template });
 
       console.log(`Creating Vertz app: ${resolved.projectName} (v${pkg.version})`);
 

--- a/packages/create-vertz-app/src/__tests__/prompts.test.ts
+++ b/packages/create-vertz-app/src/__tests__/prompts.test.ts
@@ -64,4 +64,27 @@ describe('prompts', () => {
       expect(result.projectName).toBe('my-app');
     });
   });
+
+  describe('template handling', () => {
+    it('defaults to todo-app when no template is provided', async () => {
+      const result = await resolveOptions({ projectName: 'my-app' });
+      expect(result.template).toBe('todo-app');
+    });
+
+    it('accepts hello-world template', async () => {
+      const result = await resolveOptions({ projectName: 'my-app', template: 'hello-world' });
+      expect(result.template).toBe('hello-world');
+    });
+
+    it('accepts todo-app template', async () => {
+      const result = await resolveOptions({ projectName: 'my-app', template: 'todo-app' });
+      expect(result.template).toBe('todo-app');
+    });
+
+    it('throws InvalidTemplateError for unknown template', async () => {
+      await expect(
+        resolveOptions({ projectName: 'my-app', template: 'nonexistent' }),
+      ).rejects.toThrow('Invalid template "nonexistent"');
+    });
+  });
 });

--- a/packages/create-vertz-app/src/__tests__/scaffold.test.ts
+++ b/packages/create-vertz-app/src/__tests__/scaffold.test.ts
@@ -11,7 +11,7 @@ describe('scaffold', () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vertz-scaffold-'));
   });
 
-  const defaultOptions: ScaffoldOptions = { projectName: 'test-app' };
+  const defaultOptions: ScaffoldOptions = { projectName: 'test-app', template: 'todo-app' };
 
   function projectPath(...segments: string[]): string {
     return path.join(tempDir, 'test-app', ...segments);
@@ -30,7 +30,7 @@ describe('scaffold', () => {
 
   describe('directory structure', () => {
     it('creates the project directory with the given name', async () => {
-      await scaffold(tempDir, { projectName: 'my-vertz-app' });
+      await scaffold(tempDir, { projectName: 'my-vertz-app', template: 'todo-app' });
 
       const stat = await fs.stat(path.join(tempDir, 'my-vertz-app'));
       expect(stat.isDirectory()).toBe(true);
@@ -87,9 +87,9 @@ describe('scaffold', () => {
     it('throws error if project directory already exists', async () => {
       await fs.mkdir(path.join(tempDir, 'existing-app'));
 
-      await expect(scaffold(tempDir, { projectName: 'existing-app' })).rejects.toThrow(
-        'already exists',
-      );
+      await expect(
+        scaffold(tempDir, { projectName: 'existing-app', template: 'todo-app' }),
+      ).rejects.toThrow('already exists');
     });
   });
 
@@ -97,7 +97,7 @@ describe('scaffold', () => {
 
   describe('config files', () => {
     it('generates package.json with project name', async () => {
-      await scaffold(tempDir, { projectName: 'my-awesome-app' });
+      await scaffold(tempDir, { projectName: 'my-awesome-app', template: 'todo-app' });
 
       const content = await fs.readFile(
         path.join(tempDir, 'my-awesome-app', 'package.json'),
@@ -326,7 +326,7 @@ describe('scaffold', () => {
 
   describe('LLM rules files', () => {
     it('generates CLAUDE.md with project name', async () => {
-      await scaffold(tempDir, { projectName: 'my-cool-app' });
+      await scaffold(tempDir, { projectName: 'my-cool-app', template: 'todo-app' });
 
       const content = await fs.readFile(path.join(tempDir, 'my-cool-app', 'CLAUDE.md'), 'utf-8');
       expect(content).toContain('# my-cool-app');
@@ -354,6 +354,169 @@ describe('scaffold', () => {
       expect(content).toContain('query(');
       expect(content).toContain("from 'vertz/ui'");
       expect(content).toContain('css(');
+    });
+  });
+
+  // ── Hello World template ────────────────────────────────
+
+  describe('hello-world template', () => {
+    const helloOptions: ScaffoldOptions = { projectName: 'test-app', template: 'hello-world' };
+
+    it('creates src/pages/ subdirectory', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const stat = await fs.stat(projectPath('src', 'pages'));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('creates src/styles/ subdirectory', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const stat = await fs.stat(projectPath('src', 'styles'));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('creates .claude/rules/ subdirectory', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const stat = await fs.stat(projectPath('.claude', 'rules'));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('creates public/ subdirectory', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const stat = await fs.stat(projectPath('public'));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('does NOT create src/api/ directory', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      expect(await exists(projectPath('src', 'api'))).toBe(false);
+    });
+
+    it('does NOT create .env file', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      expect(await exists(projectPath('.env'))).toBe(false);
+    });
+
+    it('does NOT create src/client.ts', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      expect(await exists(projectPath('src', 'client.ts'))).toBe(false);
+    });
+
+    it('package.json has no #generated imports', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('package.json'), 'utf-8');
+      const pkg = JSON.parse(content);
+      expect(pkg.imports).toBeUndefined();
+    });
+
+    it('package.json has no codegen script', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('package.json'), 'utf-8');
+      const pkg = JSON.parse(content);
+      expect(pkg.scripts.codegen).toBeUndefined();
+      expect(pkg.scripts.dev).toBe('vertz dev');
+      expect(pkg.scripts.build).toBe('vertz build');
+    });
+
+    it('package.json has no start script', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('package.json'), 'utf-8');
+      const pkg = JSON.parse(content);
+      expect(pkg.scripts.start).toBeUndefined();
+    });
+
+    it('vertz.config.ts has no entryFile', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('vertz.config.ts'), 'utf-8');
+      expect(content).not.toContain('entryFile');
+      expect(content).not.toContain('codegen');
+    });
+
+    it('home.tsx has a reactive counter with let', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('src', 'pages', 'home.tsx'), 'utf-8');
+      expect(content).toContain('let count = 0');
+      expect(content).toContain('count++');
+      expect(content).toContain('Hello, Vertz!');
+      expect(content).toContain('export function HomePage()');
+    });
+
+    it('app.tsx has ThemeProvider and HomePage', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('src', 'app.tsx'), 'utf-8');
+      expect(content).toContain('ThemeProvider');
+      expect(content).toContain('HomePage');
+      expect(content).toContain('export function App()');
+    });
+
+    it('CLAUDE.md describes UI-only project', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(projectPath('CLAUDE.md'), 'utf-8');
+      expect(content).toContain('# test-app');
+      expect(content).toContain('UI-only');
+      expect(content).toContain('Adding a Backend');
+    });
+
+    it('does NOT generate .claude/rules/api-development.md', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      expect(await exists(projectPath('.claude', 'rules', 'api-development.md'))).toBe(false);
+    });
+
+    it('generates .claude/rules/ui-development.md', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      const content = await fs.readFile(
+        projectPath('.claude', 'rules', 'ui-development.md'),
+        'utf-8',
+      );
+      expect(content).toContain('query(');
+      expect(content).toContain("from 'vertz/ui'");
+    });
+
+    it('reuses shared templates (tsconfig, bunfig, gitignore, theme, favicon)', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      // tsconfig
+      const tsconfig = JSON.parse(
+        await fs.readFile(projectPath('tsconfig.json'), 'utf-8'),
+      );
+      expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
+
+      // bunfig
+      const bunfig = await fs.readFile(projectPath('bunfig.toml'), 'utf-8');
+      expect(bunfig).toContain('[serve.static]');
+
+      // gitignore
+      const gitignore = await fs.readFile(projectPath('.gitignore'), 'utf-8');
+      expect(gitignore).toContain('node_modules');
+
+      // theme
+      const theme = await fs.readFile(projectPath('src', 'styles', 'theme.ts'), 'utf-8');
+      expect(theme).toContain('configureTheme');
+
+      // favicon
+      const favicon = await fs.readFile(projectPath('public', 'favicon.svg'), 'utf-8');
+      expect(favicon).toContain('viewBox');
+    });
+
+    it('throws error if project directory already exists', async () => {
+      await fs.mkdir(path.join(tempDir, 'test-app'));
+
+      await expect(scaffold(tempDir, helloOptions)).rejects.toThrow('already exists');
     });
   });
 });

--- a/packages/create-vertz-app/src/prompts.ts
+++ b/packages/create-vertz-app/src/prompts.ts
@@ -1,5 +1,8 @@
 import { createInterface } from 'node:readline';
-import type { CliOptions, ScaffoldOptions } from './types.js';
+import type { CliOptions, ScaffoldOptions, TemplateType } from './types.js';
+
+const VALID_TEMPLATES: TemplateType[] = ['hello-world', 'todo-app'];
+const DEFAULT_TEMPLATE: TemplateType = 'todo-app';
 
 /**
  * Error thrown in CI mode when project name is required but not provided
@@ -8,6 +11,18 @@ export class ProjectNameRequiredError extends Error {
   constructor() {
     super('Project name is required in CI mode. Use --name or pass as argument.');
     this.name = 'ProjectNameRequiredError';
+  }
+}
+
+/**
+ * Error thrown when an invalid template type is provided
+ */
+export class InvalidTemplateError extends Error {
+  constructor(template: string) {
+    super(
+      `Invalid template "${template}". Available templates: ${VALID_TEMPLATES.join(', ')}`,
+    );
+    this.name = 'InvalidTemplateError';
   }
 }
 
@@ -29,6 +44,17 @@ export async function promptForProjectName(): Promise<string> {
 }
 
 /**
+ * Validates and returns a template type
+ */
+function resolveTemplate(template?: string): TemplateType {
+  if (!template) return DEFAULT_TEMPLATE;
+  if (VALID_TEMPLATES.includes(template as TemplateType)) {
+    return template as TemplateType;
+  }
+  throw new InvalidTemplateError(template);
+}
+
+/**
  * Resolves CLI options into complete scaffold options
  * Handles both interactive and CI modes
  */
@@ -43,5 +69,7 @@ export async function resolveOptions(cliOptions: Partial<CliOptions>): Promise<S
     projectName = await promptForProjectName();
   }
 
-  return { projectName };
+  const template = resolveTemplate(cliOptions.template);
+
+  return { projectName, template };
 }

--- a/packages/create-vertz-app/src/scaffold.ts
+++ b/packages/create-vertz-app/src/scaffold.ts
@@ -14,6 +14,11 @@ import {
   envTemplate,
   faviconTemplate,
   gitignoreTemplate,
+  helloWorldAppTemplate,
+  helloWorldClaudeMdTemplate,
+  helloWorldHomePageTemplate,
+  helloWorldPackageJsonTemplate,
+  helloWorldVertzConfigTemplate,
   homePageTemplate,
   packageJsonTemplate,
   schemaTemplate,
@@ -42,7 +47,7 @@ export class DirectoryExistsError extends Error {
  * @param options - Scaffold options
  */
 export async function scaffold(parentDir: string, options: ScaffoldOptions): Promise<void> {
-  const { projectName } = options;
+  const { projectName, template } = options;
   const projectDir = path.join(parentDir, projectName);
 
   // Check if directory already exists
@@ -56,7 +61,58 @@ export async function scaffold(parentDir: string, options: ScaffoldOptions): Pro
     // Directory doesn't exist, which is what we want
   }
 
-  // Create project directory and subdirectories
+  if (template === 'hello-world') {
+    await scaffoldHelloWorld(projectDir, projectName);
+  } else {
+    await scaffoldTodoApp(projectDir, projectName);
+  }
+}
+
+/**
+ * Scaffolds the hello-world template — UI-only with a reactive counter
+ */
+async function scaffoldHelloWorld(projectDir: string, projectName: string): Promise<void> {
+  const srcDir = path.join(projectDir, 'src');
+  const pagesDir = path.join(srcDir, 'pages');
+  const stylesDir = path.join(srcDir, 'styles');
+  const claudeRulesDir = path.join(projectDir, '.claude', 'rules');
+  const publicDir = path.join(projectDir, 'public');
+
+  await Promise.all([
+    fs.mkdir(pagesDir, { recursive: true }),
+    fs.mkdir(stylesDir, { recursive: true }),
+    fs.mkdir(claudeRulesDir, { recursive: true }),
+    fs.mkdir(publicDir, { recursive: true }),
+  ]);
+
+  await Promise.all([
+    // Config files
+    writeFile(projectDir, 'package.json', helloWorldPackageJsonTemplate(projectName)),
+    writeFile(projectDir, 'tsconfig.json', tsconfigTemplate()),
+    writeFile(projectDir, 'vertz.config.ts', helloWorldVertzConfigTemplate()),
+    writeFile(projectDir, '.gitignore', gitignoreTemplate()),
+    writeFile(projectDir, 'bunfig.toml', bunfigTemplate()),
+    writeFile(projectDir, 'bun-plugin-shim.ts', bunPluginShimTemplate()),
+
+    // UI source files
+    writeFile(srcDir, 'app.tsx', helloWorldAppTemplate()),
+    writeFile(srcDir, 'entry-client.ts', entryClientTemplate()),
+    writeFile(pagesDir, 'home.tsx', helloWorldHomePageTemplate()),
+    writeFile(stylesDir, 'theme.ts', themeTemplate()),
+
+    // Static assets
+    writeFile(publicDir, 'favicon.svg', faviconTemplate()),
+
+    // LLM rules
+    writeFile(projectDir, 'CLAUDE.md', helloWorldClaudeMdTemplate(projectName)),
+    writeFile(claudeRulesDir, 'ui-development.md', uiDevelopmentRuleTemplate()),
+  ]);
+}
+
+/**
+ * Scaffolds the todo-app template — full-stack with DB, API, entities, and UI
+ */
+async function scaffoldTodoApp(projectDir: string, projectName: string): Promise<void> {
   const srcDir = path.join(projectDir, 'src');
   const apiDir = path.join(srcDir, 'api');
   const entitiesDir = path.join(apiDir, 'entities');
@@ -73,7 +129,6 @@ export async function scaffold(parentDir: string, options: ScaffoldOptions): Pro
     fs.mkdir(publicDir, { recursive: true }),
   ]);
 
-  // Write all files in parallel
   await Promise.all([
     // Config files
     writeFile(projectDir, 'package.json', packageJsonTemplate(projectName)),

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -1024,3 +1024,148 @@ export function HomePage() {
 }
 `;
 }
+
+// ── Hello World template functions ────────────────────────
+
+/**
+ * CLAUDE.md for hello-world template — UI-only project description
+ */
+export function helloWorldClaudeMdTemplate(projectName: string): string {
+  return `# ${projectName}
+
+A UI-only TypeScript application built with [Vertz](https://vertz.dev).
+
+## Stack
+
+- Runtime: Bun
+- Framework: Vertz (UI)
+- Language: TypeScript (strict mode)
+- Docs: https://docs.vertz.dev
+
+## Development
+
+\`\`\`bash
+bun install          # Install dependencies
+bun run dev          # Start dev server with HMR
+bun run build        # Production build
+\`\`\`
+
+## Adding a Backend
+
+To add API and database support, see https://docs.vertz.dev/guides/server/overview
+
+## Conventions
+
+- See \`.claude/rules/\` for UI development conventions
+- Refer to https://docs.vertz.dev for full framework documentation
+- The Vertz compiler handles all reactivity — never use \`.value\`, \`signal()\`, or \`computed()\` manually
+`;
+}
+
+/**
+ * Package.json for hello-world — no API deps, no #generated imports, no codegen
+ */
+export function helloWorldPackageJsonTemplate(projectName: string): string {
+  const pkg = {
+    name: projectName,
+    version: '0.1.0',
+    type: 'module',
+    license: 'MIT',
+    scripts: {
+      dev: 'vertz dev',
+      build: 'vertz build',
+    },
+    dependencies: {
+      vertz: '^0.2.0',
+      '@vertz/theme-shadcn': '^0.2.0',
+    },
+    devDependencies: {
+      '@vertz/cli': '^0.2.0',
+      '@vertz/ui-compiler': '^0.2.0',
+      'bun-types': '^1.0.0',
+      typescript: '^5.8.0',
+    },
+  };
+
+  return JSON.stringify(pkg, null, 2);
+}
+
+/**
+ * vertz.config.ts for hello-world — minimal, no server entry
+ */
+export function helloWorldVertzConfigTemplate(): string {
+  return `/** @type {import('@vertz/compiler').VertzConfig} */
+export default {};
+`;
+}
+
+/**
+ * src/app.tsx for hello-world — simple App with ThemeProvider
+ */
+export function helloWorldAppTemplate(): string {
+  return `import { css, getInjectedCSS, globalCss, ThemeProvider } from 'vertz/ui';
+import { HomePage } from './pages/home';
+import { appTheme, themeGlobals } from './styles/theme';
+
+const appGlobals = globalCss({
+  a: {
+    textDecoration: 'none',
+    color: 'inherit',
+  },
+});
+
+const styles = css({
+  shell: ['min-h:screen', 'bg:background', 'text:foreground'],
+});
+
+export { getInjectedCSS };
+export const theme = appTheme;
+export const globalStyles = [themeGlobals.css, appGlobals.css];
+
+export function App() {
+  return (
+    <div data-testid="app-root">
+      <ThemeProvider theme="light">
+        <div className={styles.shell}>
+          <HomePage />
+        </div>
+      </ThemeProvider>
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * src/pages/home.tsx for hello-world — reactive counter demonstrating
+ * the Vertz compiler's signal transformation (let → signal)
+ */
+export function helloWorldHomePageTemplate(): string {
+  return `import { css } from 'vertz/ui';
+import { Button } from '@vertz/ui/components';
+
+const styles = css({
+  container: ['flex', 'flex-col', 'items:center', 'justify:center', 'min-h:screen', 'gap:6'],
+  title: ['font:4xl', 'font:bold', 'text:foreground'],
+  subtitle: ['text:muted-foreground', 'text:lg'],
+  count: ['font:6xl', 'font:bold', 'text:primary'],
+  actions: ['flex', 'gap:3'],
+});
+
+export function HomePage() {
+  let count = 0;
+
+  return (
+    <div className={styles.container} data-testid="home-page">
+      <h1 className={styles.title}>Hello, Vertz!</h1>
+      <p className={styles.subtitle}>A reactive counter powered by the Vertz compiler</p>
+      <p className={styles.count}>{count}</p>
+      <div className={styles.actions}>
+        <Button intent="ghost" onClick={() => { count = 0; }}>Reset</Button>
+        <Button onClick={() => { count++; }}>Count is {count}</Button>
+      </div>
+    </div>
+  );
+}
+`;
+}

--- a/packages/create-vertz-app/src/types.ts
+++ b/packages/create-vertz-app/src/types.ts
@@ -1,9 +1,16 @@
 /**
+ * Available scaffold template types
+ */
+export type TemplateType = 'hello-world' | 'todo-app';
+
+/**
  * Options for the scaffold function
  */
 export interface ScaffoldOptions {
   /** Name of the project to create */
   projectName: string;
+  /** Template to scaffold (default: 'todo-app') */
+  template: TemplateType;
 }
 
 /**
@@ -12,4 +19,6 @@ export interface ScaffoldOptions {
 export interface CliOptions {
   /** Project name (positional argument or --name) */
   projectName?: string;
+  /** Template type */
+  template?: string;
 }

--- a/packages/mint-docs/docs.json
+++ b/packages/mint-docs/docs.json
@@ -202,5 +202,8 @@
       "source": "/manifesto"
     }
   ],
-  "theme": "mint"
+  "theme": "mint",
+  "llmsTxt": {
+    "enabled": true
+  }
 }

--- a/packages/mint-docs/guides/llm-quick-reference.mdx
+++ b/packages/mint-docs/guides/llm-quick-reference.mdx
@@ -5,6 +5,26 @@ description: 'Critical patterns for AI code generation — data fetching via typ
 
 This page summarizes the patterns that matter most when generating Vertz code. Reading this first prevents the most common class of mistakes.
 
+## Getting Started
+
+Scaffold a new project with one command:
+
+```bash
+# Full-stack app (database + API + UI)
+bunx @vertz/create-vertz-app@latest my-app
+
+# UI-only hello world (minimal starting point)
+bunx @vertz/create-vertz-app@latest my-app --template hello-world
+```
+
+Then install and run:
+
+```bash
+cd my-app
+bun install
+bun run dev
+```
+
 ## Data Fetching (UI)
 
 Vertz automatically generates a typed SDK at `.vertz/generated/client.ts` during development (`vertz dev`) and builds. Create a client wrapper, then pass SDK method calls to `query()` for reactive data. **Never pass raw entity name strings.**

--- a/packages/mint-docs/quickstart.mdx
+++ b/packages/mint-docs/quickstart.mdx
@@ -5,6 +5,13 @@ description: 'Get up and running with Vertz in under 5 minutes'
 
 Scaffold a full-stack task manager with a database, API, and UI — all typed end-to-end.
 
+<Tip>
+  Want a minimal starting point instead? Use `--template hello-world` for a UI-only counter app:
+  ```bash
+  bunx @vertz/create-vertz-app@latest my-app --template hello-world
+  ```
+</Tip>
+
 ## Create a new project
 
 <Steps>

--- a/sites/landing/public/sitemap.xml
+++ b/sites/landing/public/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://vertz.dev/llms.txt</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/sites/landing/src/__tests__/llms-txt.test.ts
+++ b/sites/landing/src/__tests__/llms-txt.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { LLMS_TXT } from '../llms-txt';
+
+describe('LLMS_TXT', () => {
+  it('starts with the Vertz title', () => {
+    expect(LLMS_TXT).toMatch(/^# Vertz/);
+  });
+
+  it('includes links to documentation', () => {
+    expect(LLMS_TXT).toContain('https://docs.vertz.dev/quickstart');
+    expect(LLMS_TXT).toContain('https://docs.vertz.dev/installation');
+    expect(LLMS_TXT).toContain('https://docs.vertz.dev/guides/llm-quick-reference');
+    expect(LLMS_TXT).toContain('https://docs.vertz.dev/llms-full.txt');
+  });
+
+  it('includes the scaffold command', () => {
+    expect(LLMS_TXT).toContain('bunx @vertz/create-vertz-app@latest');
+  });
+
+  it('includes both template options', () => {
+    expect(LLMS_TXT).toContain('--template todo-app');
+    expect(LLMS_TXT).toContain('--template hello-world');
+  });
+
+  it('includes key concepts', () => {
+    expect(LLMS_TXT).toContain('d.table()');
+    expect(LLMS_TXT).toContain('entity()');
+    expect(LLMS_TXT).toContain('vertz/ui');
+  });
+
+  it('includes source links', () => {
+    expect(LLMS_TXT).toContain('https://github.com/vertz-dev/vertz');
+  });
+});

--- a/sites/landing/src/llms-txt.ts
+++ b/sites/landing/src/llms-txt.ts
@@ -1,0 +1,53 @@
+/**
+ * llms.txt content for vertz.dev
+ *
+ * Serves as an LLM-friendly entry point that provides a concise overview
+ * of the Vertz framework and links to full documentation.
+ */
+export const LLMS_TXT = `# Vertz
+
+> Full-stack TypeScript framework where types flow from database to browser. Define your schema once — get a typed database layer, API, and compiled UI.
+
+## Docs
+
+- [Quickstart](https://docs.vertz.dev/quickstart)
+- [Installation](https://docs.vertz.dev/installation)
+- [LLM Quick Reference](https://docs.vertz.dev/guides/llm-quick-reference)
+- [Full Docs (LLM-optimized)](https://docs.vertz.dev/llms-full.txt)
+
+## Quick Start
+
+\`\`\`bash
+bunx @vertz/create-vertz-app@latest my-app
+cd my-app
+bun install
+bun run dev
+\`\`\`
+
+## Templates
+
+- \`--template todo-app\` (default): Full-stack app with database, API, entities, and UI
+- \`--template hello-world\`: UI-only counter app — minimal starting point
+
+## Key Concepts
+
+- **Schema**: \`d.table()\` and \`d.model()\` define your data shape (\`vertz/db\`)
+- **Entities**: \`entity()\` generates typed CRUD endpoints (\`vertz/server\`)
+- **UI**: Compiler-driven reactivity — \`let\` becomes signals, \`const\` becomes computed (\`vertz/ui\`)
+- **One dependency**: \`bun add vertz\` — meta-package includes all framework packages
+
+## Stack
+
+| Layer      | Package        | Purpose                              |
+|------------|----------------|--------------------------------------|
+| Schema     | vertz/schema   | Validation schemas (Zod-compatible)  |
+| Database   | vertz/db       | Type-safe tables, models, migrations |
+| Server     | vertz/server   | Entities, CRUD, auth, codegen        |
+| UI         | vertz/ui       | Compiled reactive UI with JSX        |
+| Theme      | @vertz/theme-shadcn | Shadcn-inspired component theme |
+
+## Source Code
+
+- [GitHub](https://github.com/vertz-dev/vertz)
+- [Documentation](https://docs.vertz.dev)
+`;

--- a/sites/landing/src/worker.ts
+++ b/sites/landing/src/worker.ts
@@ -11,6 +11,8 @@
  * 7. Security headers — nosniff, DENY frame, strict referrer
  */
 
+import { LLMS_TXT } from './llms-txt';
+
 // Minimal ambient declarations for Cloudflare Worker APIs.
 // The landing page tsconfig uses bun-types, which doesn't include these.
 // At runtime, wrangler provides the real implementations.
@@ -65,6 +67,17 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     const pathname = url.pathname;
+
+    // ── 0. LLM-friendly entry point ───────────────────────────
+    if (pathname === '/llms.txt') {
+      return new Response(LLMS_TXT, {
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Cache-Control': STATIC_CACHE,
+        },
+      });
+    }
+
     const isHTML = isHTMLRoute(pathname);
 
     // ── 1. Check Worker-level cache (Cache API) ─────────────────


### PR DESCRIPTION
## Summary

- **Landing page `llms.txt`**: Added `vertz.dev/llms.txt` endpoint in the Cloudflare Worker so AI agents can discover docs, scaffold commands, and key concepts without navigating a marketing site
- **Docs `llms.txt`**: Enabled Mintlify native `llmsTxt` in `docs.json` — auto-generates `docs.vertz.dev/llms.txt` and `docs.vertz.dev/llms-full.txt` from existing MDX pages
- **Hello-world template**: Added `--template hello-world` option to `create-vertz-app` — UI-only reactive counter (no API/DB). Default remains `todo-app` for backward compat
- **Docs updates**: Added Getting Started section to LLM Quick Reference and template tip to Quickstart

## Motivation

An ax-bench experiment showed that an LLM trying to build a Vertz hello world from scratch couldn't find the actual docs — `vertz.dev` is marketing-only and the docs site had no `llms.txt`. The scaffold also only offered a full todo app, which is overkill for a hello world.

## Public API Changes

- `ScaffoldOptions` now requires a `template` field (`'hello-world' | 'todo-app'`)
- CLI accepts `--template <type>` flag (default: `todo-app`)
- New endpoint: `GET vertz.dev/llms.txt` returns `text/plain`

## Test plan

- [x] 158 tests pass across `create-vertz-app` and landing page
- [x] `create-vertz-app` build clean (tsc)
- [x] Lint clean on all changed files
- [ ] Verify `docs.vertz.dev/llms.txt` works after Mintlify deploy
- [ ] Verify `vertz.dev/llms.txt` works after Cloudflare deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)