### PR TITLE
docs(testing): add createTestClient() to LLM quick reference

### DIFF
--- a/packages/mint-docs/guides/llm-quick-reference.mdx
+++ b/packages/mint-docs/guides/llm-quick-reference.mdx
@@ -207,7 +207,7 @@ const result = await tasks.get('some-id');
 if (result.ok) {
   result.body.title; // typed to $response
 } else {
-  result.body.message; // ErrorBody { error, message, statusCode }
+  result.body.message; // ErrorBody { error, message, statusCode, details? }
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add a **Testing (Server)** section to `packages/mint-docs/guides/llm-quick-reference.mdx` showing `createTestClient()` patterns
- The LLM quick reference had zero mention of server testing — LLMs reading it couldn't discover the typed test client API
- Covers: entity proxy, service proxy, `TestResponse` discriminated union, `withHeaders()` for auth, and a warning block against raw `server.handler()` usage

## Public API Changes

None — docs only.

## Context

`createTestClient()` was implemented in PR #1785 (v0.2.29) and fully documented in `testing-server.mdx`. However, the LLM quick reference page (the first thing LLMs read) didn't mention testing at all, which is why #1917 was filed.

Closes #1917

## Test plan

- [ ] Verify the docs render correctly on Mintlify (`bun run --filter @vertz/mint-docs dev`)
- [ ] Verify code examples match the actual `createTestClient()` API in `@vertz/testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)