### PR TITLE
feat(server): multi-level tenancy (#1787)

### DIFF
--- a/packages/server/src/auth/__tests__/cloud/cached-wallet-store.test.ts
+++ b/packages/server/src/auth/__tests__/cloud/cached-wallet-store.test.ts
@@ -272,6 +272,42 @@ describe('Feature: CachedWalletStore', () => {
     });
   });
 
+  describe('Given a getBatchConsumption() call', () => {
+    describe('When the inner store succeeds', () => {
+      it('Then delegates to the inner store and returns the result', async () => {
+        inner.consumption = 10;
+        const cached = new CachedWalletStore(inner, { cacheTtlMs: 5000 });
+
+        const result = await cached.getBatchConsumption(
+          'tenant_abc',
+          ['prompt:create', 'task:create'],
+          periodStart,
+          periodEnd,
+        );
+
+        expect(result).toBeInstanceOf(Map);
+        expect(result.get('prompt:create')).toBe(10);
+        expect(result.get('task:create')).toBe(10);
+      });
+    });
+
+    describe('When the inner store fails', () => {
+      it('Then propagates the error (no cache fallback for batch)', async () => {
+        inner.shouldThrow = true;
+        const cached = new CachedWalletStore(inner, { cacheTtlMs: 5000 });
+
+        await expect(
+          cached.getBatchConsumption(
+            'tenant_abc',
+            ['prompt:create'],
+            periodStart,
+            periodEnd,
+          ),
+        ).rejects.toThrow('Cloud error');
+      });
+    });
+  });
+
   describe('Given default TTL', () => {
     it('Then uses 30 seconds', () => {
       const cached = new CachedWalletStore(inner);

--- a/packages/server/src/auth/__tests__/cloud/cloud-wallet-store.test.ts
+++ b/packages/server/src/auth/__tests__/cloud/cloud-wallet-store.test.ts
@@ -206,6 +206,67 @@ describe('Feature: CloudWalletStore', () => {
     });
   });
 
+  describe('Given a CloudWalletStore for getBatchConsumption', () => {
+    describe('When calling getBatchConsumption()', () => {
+      it('Then calls POST /api/v1/wallet/batch-check with correct payload', async () => {
+        const port = startMockServer();
+        mockResponse = {
+          status: 200,
+          body: { consumption: { 'prompt:create': 42, 'task:create': 7 } },
+        };
+
+        const store = new CloudWalletStore({
+          apiKey: 'vtz_live_test123',
+          baseUrl: `http://localhost:${port}`,
+        });
+
+        const periodStart = new Date('2026-03-01T00:00:00Z');
+        const periodEnd = new Date('2026-04-01T00:00:00Z');
+
+        const result = await store.getBatchConsumption(
+          'tenant_abc',
+          ['prompt:create', 'task:create'],
+          periodStart,
+          periodEnd,
+        );
+
+        expect(result).toBeInstanceOf(Map);
+        expect(result.get('prompt:create')).toBe(42);
+        expect(result.get('task:create')).toBe(7);
+        expect(lastRequest?.method).toBe('POST');
+        expect(lastRequest?.url).toBe('/api/v1/wallet/batch-check');
+        expect(lastRequest?.body).toEqual({
+          tenantId: 'tenant_abc',
+          limitKeys: ['prompt:create', 'task:create'],
+          periodStart: periodStart.toISOString(),
+          periodEnd: periodEnd.toISOString(),
+        });
+      });
+
+      it('Then returns an empty Map when no limit keys provided', async () => {
+        const port = startMockServer();
+        mockResponse = {
+          status: 200,
+          body: { consumption: {} },
+        };
+
+        const store = new CloudWalletStore({
+          apiKey: 'vtz_live_test123',
+          baseUrl: `http://localhost:${port}`,
+        });
+
+        const result = await store.getBatchConsumption(
+          'tenant_abc',
+          [],
+          new Date('2026-03-01'),
+          new Date('2026-04-01'),
+        );
+
+        expect(result.size).toBe(0);
+      });
+    });
+  });
+
   describe('Given the cloud API returns an error', () => {
     describe('When calling any wallet method', () => {
       it('Then throws an error with the response details', async () => {

--- a/packages/server/src/entity/__tests__/crud-pipeline-closure.test.ts
+++ b/packages/server/src/entity/__tests__/crud-pipeline-closure.test.ts
@@ -406,6 +406,43 @@ describe('Feature: Closure table auto-population', () => {
     });
   });
 
+  describe('Given closureStore.addResource throws for a root tenant entity', () => {
+    it('Then entity is still created successfully', async () => {
+      const def = entity('accounts', {
+        model: accountsModel,
+        access: { create: () => true },
+      });
+
+      const db = createStubDb();
+      db.create = mock(async (data: Record<string, unknown>) => ({
+        id: 'acct-fail',
+        name: 'Failing Account',
+        ...data,
+      }));
+
+      const failingClosureStore = new InMemoryClosureStore();
+      spyOn(failingClosureStore, 'addResource').mockRejectedValue(
+        new Error('DB connection lost'),
+      );
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+      const handlers = createCrudHandlers(def, db, {
+        closureStore: failingClosureStore,
+        tenantLevels,
+      });
+
+      const ctx = makeCtx({ tenantId: null });
+      const result = await handlers.create(ctx, { name: 'Failing Account' });
+
+      expect(result.ok).toBe(true);
+      expect(warnSpy).toHaveBeenCalled();
+      const warnMsg = warnSpy.mock.calls[0]![0] as string;
+      expect(warnMsg).toContain('Failed to populate closure table for root');
+
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('Given no closureStore provided (single-level backward compat)', () => {
     it('Then entity creation works without closure population', async () => {
       const def = entity('projects', {

--- a/packages/server/src/entity/__tests__/crud-pipeline-cross-level.test.ts
+++ b/packages/server/src/entity/__tests__/crud-pipeline-cross-level.test.ts
@@ -152,6 +152,35 @@ describe('Feature: Level-aware tenant filtering', () => {
     });
   });
 
+  describe('Given entity scoped to account, user scoped to project, but ancestor not found', () => {
+    it('Then list falls back to ctx.tenantId', async () => {
+      // Create a closure store where the project has NO account ancestor
+      const emptyClosureStore = new InMemoryClosureStore();
+      await emptyClosureStore.addResource('project', 'proj-orphan');
+      // No account ancestor added — getAncestors returns only self-reference
+
+      const def = entity('settings', {
+        model: settingsModel,
+        access: { list: () => true },
+      });
+
+      const db = createStubDb();
+      const handlers = createCrudHandlers(def, db, {
+        closureStore: emptyClosureStore,
+        tenantLevels,
+      });
+
+      const ctx = makeCtx({ tenantId: 'proj-orphan', tenantLevel: 'project' });
+      await handlers.list(ctx);
+
+      expect(db.list).toHaveBeenCalledTimes(1);
+      const listOpts = db.list.mock.calls[0]![0] as Record<string, unknown>;
+      const where = listOpts.where as Record<string, unknown>;
+      // Falls back to ctx.tenantId since no account ancestor found
+      expect(where.accountId).toBe('proj-orphan');
+    });
+  });
+
   describe('Given single-level tenancy (no tenantLevel in context)', () => {
     it('Then behavior is identical to pre-multi-level', async () => {
       const def = entity('settings', {


### PR DESCRIPTION
## Summary

Implements multi-level tenancy support for Vertz, enabling hierarchical tenant structures (e.g., Account → Project → Customer Tenant) with:

- **Closure table auto-population** — When tenant entities are created via CRUD pipeline, ancestor chains are automatically maintained in the closure store
- **Multi-level flag resolution** — `tenantLevel` field in JWT enables level-aware feature flag and plan resolution
- **Level-aware tenant filtering** — Cross-level queries automatically resolve ancestor IDs (e.g., a project-level user querying account-scoped entities)
- **Switch-tenant server resolution** — `/switch-tenant` endpoint auto-resolves `tenantLevel` from tenant ID when not provided by client
- **Cascaded wallet consumption** — `canAndConsume()` walks the ancestor chain to find the wallet owner; `getBatchConsumption()` returns all limit usage in one call
- **Documentation** — Mintlify guide covering setup, hierarchy definition, and cascaded billing

## Public API Changes

### `@vertz/server`
- `defineAccess()` — new `level` field on plan definitions; `tenantLevels` config for multi-level hierarchy
- `AccessContext` — `getBatchConsumption(entitlements, resource)` method added
- `WalletStore` interface — `getBatchConsumption()` method added (implemented by `InMemoryWalletStore`, `CloudWalletStore`, `CachedWalletStore`)
- `EntityContext` — `tenantLevel` field available for level-aware entity operations
- `createCrudHandlers()` — accepts `closureStore` and `tenantLevels` options for auto-population and cross-level filtering

### `@vertz/db`
- `TenantLevel` type exported for consumer use

## Phases

1. **Closure table auto-population + multi-level flag resolution** — `closureStore.addResource()` on entity create, `tenantLevel` in JWT for flag/plan lookup
2. **Level-aware tenant filtering + switch-tenant resolution** — Cross-level ancestor resolution in CRUD pipeline, server-side tenantLevel resolution
3. **Cascaded wallet consumption + getBatchConsumption** — Ancestor-chain wallet walk, batch consumption API
4. **Documentation** — Mintlify guide for multi-level tenancy setup

## Test plan

- [x] Closure table auto-population for 2-level and 3-level hierarchies
- [x] Root tenant creation (no parent) populates self-reference only
- [x] Non-tenant entities skip closure population
- [x] Closure store errors don't break entity creation (graceful degradation)
- [x] Cross-level filtering resolves ancestor IDs correctly
- [x] Same-level and single-level filtering unchanged (backward compat)
- [x] Ancestor-not-found fallback to ctx.tenantId
- [x] Switch-tenant auto-resolves tenantLevel from ID
- [x] Invalid tenantLevel returns 400
- [x] Cascaded canAndConsume walks ancestor chain
- [x] Cascaded unconsume with rollback on failure
- [x] getBatchConsumption returns all limit usage
- [x] CachedWalletStore.getBatchConsumption delegates to inner store
- [x] CloudWalletStore.getBatchConsumption calls correct API endpoint
- [x] Cloud failure modes (closed/open/cached) work with cascaded consumption

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)