### PR TITLE
fix(ui): SSR hydration key mismatch with useSearchParams (#1925)

### DIFF
--- a/packages/ui/src/router/__tests__/search-params.test.ts
+++ b/packages/ui/src/router/__tests__/search-params.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
-import { domEffect } from '../../runtime/signal';
+import { computed, domEffect } from '../../runtime/signal';
+import { setReadValueCallback } from '../../runtime/tracking';
 import { createTestSSRContext, disableTestSSR, enableTestSSR } from '../../ssr/test-ssr-helpers';
 import type { SearchParamSchema } from '../define-routes';
 import { defineRoutes } from '../define-routes';
@@ -457,5 +458,118 @@ describe('SSR reactive search params safety', () => {
     });
 
     expect(Object.keys(sp!).sort()).toEqual(['page', 'q']);
+  });
+
+  test('SSR proxy triggers readValueCallback inside computed (#1925)', () => {
+    enableTestSSR(createTestSSRContext('/brands?page=2'));
+    const schema: SearchParamSchema<{ page: number }> = {
+      parse(data: unknown) {
+        const raw = data as Record<string, string>;
+        return {
+          ok: true as const,
+          data: { page: Number(raw.page ?? '1') },
+        };
+      },
+    };
+    const routes = defineRoutes({
+      '/brands': {
+        component: () => document.createElement('div'),
+        searchParams: schema,
+      },
+    });
+    const router = createRouter(routes);
+
+    let sp: ReturnType<typeof useSearchParams> | undefined;
+    RouterContext.Provider(router, () => {
+      sp = useSearchParams();
+    });
+
+    // Simulate callThunkWithCapture() reading search params through a
+    // computed (the compiler wraps derived expressions in computed).
+    // Inside a computed, getSubscriber() returns the computed itself,
+    // which gates the readValueCallback invocation in SignalImpl.value.
+    // The SSR proxy must match this behavior.
+    const captured: unknown[] = [];
+    const prevCb = setReadValueCallback((v) => captured.push(v));
+
+    // Create a computed that reads search params — mirrors what the
+    // compiler does with `const offset = (params.page - 1) * 20`
+    const offset = computed(() => ((sp!.page as number) - 1) * 20);
+
+    try {
+      // Trigger computed evaluation (simulates thunk reading `offset`)
+      const _val = offset.value;
+      expect(_val).toBe(20); // page=2 → offset=20
+    } finally {
+      setReadValueCallback(prevCb);
+    }
+
+    // Client signal reads invoke callback with the full object value.
+    // SSR must do the same so dep hashes match during hydration.
+    expect(captured.length).toBe(1);
+    expect(captured[0]).toEqual({ page: 2 });
+  });
+
+  test('SSR and client dep hash match for search-params-derived computed (#1925)', () => {
+    const PAGE_SIZE = 20;
+    const schema: SearchParamSchema<{ page: number }> = {
+      parse(data: unknown) {
+        const raw = data as Record<string, string>;
+        return {
+          ok: true as const,
+          data: { page: Number(raw.page ?? '1') },
+        };
+      },
+    };
+    const routes = defineRoutes({
+      '/brands': {
+        component: () => document.createElement('div'),
+        searchParams: schema,
+      },
+    });
+
+    // ── SSR side ──
+    enableTestSSR(createTestSSRContext('/brands?page=2'));
+    const ssrRouter = createRouter(routes);
+
+    let ssrSp: ReturnType<typeof useSearchParams> | undefined;
+    RouterContext.Provider(ssrRouter, () => {
+      ssrSp = useSearchParams();
+    });
+
+    // Compute dep hash as callThunkWithCapture() would during SSR
+    const ssrCaptured: unknown[] = [];
+    const prevCb1 = setReadValueCallback((v) => ssrCaptured.push(v));
+    const ssrOffset = computed(() => ((ssrSp!.page as number) - 1) * PAGE_SIZE);
+    try {
+      ssrOffset.value;
+    } finally {
+      setReadValueCallback(prevCb1);
+    }
+
+    disableTestSSR();
+
+    // ── Client side ──
+    // Pass initialUrl to avoid window.location dependency
+    const clientRouter = createRouter(routes, '/brands?page=2');
+
+    let clientSp: ReturnType<typeof useSearchParams> | undefined;
+    RouterContext.Provider(clientRouter, () => {
+      clientSp = useSearchParams();
+    });
+
+    const clientCaptured: unknown[] = [];
+    const prevCb2 = setReadValueCallback((v) => clientCaptured.push(v));
+    const clientOffset = computed(() => ((clientSp!.page as number) - 1) * PAGE_SIZE);
+    try {
+      clientOffset.value;
+    } finally {
+      setReadValueCallback(prevCb2);
+    }
+
+    // Core assertion: SSR and client captured the same values
+    // → dep hashes match → hydration key match → no content wipe
+    expect(ssrCaptured.length).toBe(clientCaptured.length);
+    expect(JSON.stringify(ssrCaptured)).toBe(JSON.stringify(clientCaptured));
   });
 });

--- a/packages/ui/src/router/navigate.ts
+++ b/packages/ui/src/router/navigate.ts
@@ -9,6 +9,7 @@ import { isBrowser } from '../env/is-browser';
 import { batch } from '../runtime/scheduler';
 import { signal } from '../runtime/signal';
 import type { Signal } from '../runtime/signal-types';
+import { getReadValueCallback, getSubscriber } from '../runtime/tracking';
 import { getSSRContext } from '../ssr/ssr-render-context';
 import type {
   CompiledRoute,
@@ -294,11 +295,23 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
         }
         if (typeof key === 'symbol') return undefined;
         const ctx = getSSRContext();
-        if (ctx) {
-          const m = matchRoute(routes, ctx.url);
-          return m?.search?.[key];
+        const search = ctx
+          ? (matchRoute(routes, ctx.url)?.search ?? {})
+          : (fallbackMatch?.search ?? {});
+
+        // Invoke read-value callback so callThunkWithCapture() captures
+        // search params values during SSR — matching client-side signal
+        // behavior where rawSearchParamsSignal.value triggers the callback.
+        // Gated behind getSubscriber() to mirror SignalImpl.value exactly:
+        // the callback only fires inside a tracking context (e.g., inside
+        // a computed evaluation), not for bare reads. (#1925)
+        const sub = getSubscriber();
+        if (sub) {
+          const cb = getReadValueCallback();
+          if (cb) cb(search);
         }
-        return fallbackMatch?.search?.[key];
+
+        return search[key];
       },
       set() {
         if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary

- SSR reactive search params Proxy now invokes `readValueCallback` inside tracking contexts, matching `SignalImpl.value` behavior
- Fixes hydration key mismatch that caused SSR content to be wiped when `query()` args derived from `useSearchParams()`
- Gated behind `getSubscriber()` check — only fires inside computed evaluations (where the compiler places derived expressions), not bare reads

## Root Cause

The SSR search params Proxy (`navigate.ts:283-347`) read from `matchRoute()` directly, bypassing the signal system. During `callThunkWithCapture()`, `setReadValueCallback` captures signal values to compute a dep hash for cache keys. On SSR, search params reads weren't captured → different dep hash → `hydrateQueryFromSSR()` couldn't find SSR data → content wiped permanently.

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/router/navigate.ts` | SSR Proxy `get` trap invokes `getReadValueCallback()` when `getSubscriber()` is truthy |
| `packages/ui/src/router/__tests__/search-params.test.ts` | 2 tests: callback fires in SSR computed, SSR/client dep hash match |

## Test plan

- [x] `SSR proxy triggers readValueCallback inside computed (#1925)` — verifies callback fires during SSR computed evaluation
- [x] `SSR and client dep hash match for search-params-derived computed (#1925)` — proves SSR and client capture identical values
- [x] All 26 search-params tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)