### PR TITLE
fix(native-compiler,ui): runtime bugs + back-nav orphaned history

### DIFF
--- a/native/vertz-compiler/src/field_selection.rs
+++ b/native/vertz-compiler/src/field_selection.rs
@@ -274,8 +274,8 @@ fn check_query_declarator(
         _ => return,
     };
 
-    let (injection_pos, injection_kind) = compute_injection_point(&descriptor_call);
-    let inferred_entity_name = infer_entity_name(&descriptor_call);
+    let (injection_pos, injection_kind) = compute_injection_point(descriptor_call);
+    let inferred_entity_name = infer_entity_name(descriptor_call);
 
     results.push(QueryVarInfo {
         var_name,
@@ -347,10 +347,10 @@ fn compute_injection_point(descriptor_call: &CallExpression) -> (u32, InjectionK
 fn infer_entity_name(call: &CallExpression) -> Option<String> {
     // Pattern: api.tasks.list() → callee is api.tasks.list
     if let Some(member) = call.callee.as_member_expression() {
-        if let Some(inner_member) = member.object().as_member_expression() {
-            if let MemberExpression::StaticMemberExpression(static_member) = inner_member {
-                return Some(static_member.property.name.as_str().to_string());
-            }
+        if let Some(MemberExpression::StaticMemberExpression(static_member)) =
+            member.object().as_member_expression()
+        {
+            return Some(static_member.property.name.as_str().to_string());
         }
     }
     None
@@ -499,76 +499,76 @@ fn track_field_access_in_expr(
     match expr {
         Expression::CallExpression(call) => {
             // Check for array method callbacks: varName.data.items.map(item => item.field)
-            if let Some(callee_member) = call.callee.as_member_expression() {
-                if let MemberExpression::StaticMemberExpression(static_member) = callee_member {
-                    let method_name = static_member.property.name.as_str();
-                    if matches!(
-                        method_name,
-                        "map" | "filter" | "find" | "forEach" | "some" | "every"
-                    ) {
-                        let obj_chain = build_property_chain(&static_member.object);
-                        if let Some(ref chain) = obj_chain {
-                            if !chain.is_empty()
-                                && chain[0] == var_name
-                                && (chain.contains(&"items".to_string())
-                                    || chain.contains(&"data".to_string()))
-                            {
-                                // Analyze callback
-                                if let Some(callback) = call.arguments.first() {
-                                    let callback_expr = callback.to_expression();
-                                    let param_name = get_callback_param_name(callback_expr);
-                                    if let Some(param_name) = param_name {
-                                        // Determine if this is a relation-level map
-                                        // (not on .items but on a relation field like .members)
-                                        let parent_result = extract_field_from_chain(chain);
-                                        let parent_field = parent_result
-                                            .as_ref()
-                                            .filter(|r| r.nested_path.is_empty())
-                                            .map(|r| r.field.clone());
+            if let Some(MemberExpression::StaticMemberExpression(static_member)) =
+                call.callee.as_member_expression()
+            {
+                let method_name = static_member.property.name.as_str();
+                if matches!(
+                    method_name,
+                    "map" | "filter" | "find" | "forEach" | "some" | "every"
+                ) {
+                    let obj_chain = build_property_chain(&static_member.object);
+                    if let Some(ref chain) = obj_chain {
+                        if !chain.is_empty()
+                            && chain[0] == var_name
+                            && (chain.contains(&"items".to_string())
+                                || chain.contains(&"data".to_string()))
+                        {
+                            // Analyze callback
+                            if let Some(callback) = call.arguments.first() {
+                                let callback_expr = callback.to_expression();
+                                let param_name = get_callback_param_name(callback_expr);
+                                if let Some(param_name) = param_name {
+                                    // Determine if this is a relation-level map
+                                    // (not on .items but on a relation field like .members)
+                                    let parent_result = extract_field_from_chain(chain);
+                                    let parent_field = parent_result
+                                        .as_ref()
+                                        .filter(|r| r.nested_path.is_empty())
+                                        .map(|r| r.field.clone());
 
-                                        let mut cb_fields = Vec::new();
-                                        let mut cb_nested = Vec::new();
-                                        let mut cb_opaque = false;
+                                    let mut cb_fields = Vec::new();
+                                    let mut cb_nested = Vec::new();
+                                    let mut cb_opaque = false;
 
-                                        track_callback_field_access(
-                                            callback_expr,
-                                            &param_name,
-                                            &mut cb_fields,
-                                            &mut cb_nested,
-                                            &mut cb_opaque,
-                                        );
+                                    track_callback_field_access(
+                                        callback_expr,
+                                        &param_name,
+                                        &mut cb_fields,
+                                        &mut cb_nested,
+                                        &mut cb_opaque,
+                                    );
 
-                                        if let Some(ref pf) = parent_field {
-                                            // Relation-level map — nest under parent
-                                            fields.push(pf.clone());
-                                            for f in &cb_fields {
-                                                nested_access.push(NestedFieldAccess {
-                                                    field: pf.clone(),
-                                                    nested_path: vec![f.clone()],
-                                                });
-                                            }
-                                            for n in &cb_nested {
-                                                nested_access.push(NestedFieldAccess {
-                                                    field: pf.clone(),
-                                                    nested_path: {
-                                                        let mut path = vec![n.field.clone()];
-                                                        path.extend(n.nested_path.clone());
-                                                        path
-                                                    },
-                                                });
-                                            }
-                                        } else {
-                                            // Standard .items.map() — top-level fields
-                                            fields.extend(cb_fields);
-                                            nested_access.extend(cb_nested);
+                                    if let Some(ref pf) = parent_field {
+                                        // Relation-level map — nest under parent
+                                        fields.push(pf.clone());
+                                        for f in &cb_fields {
+                                            nested_access.push(NestedFieldAccess {
+                                                field: pf.clone(),
+                                                nested_path: vec![f.clone()],
+                                            });
                                         }
-
-                                        if cb_opaque {
-                                            *has_opaque_access = true;
+                                        for n in &cb_nested {
+                                            nested_access.push(NestedFieldAccess {
+                                                field: pf.clone(),
+                                                nested_path: {
+                                                    let mut path = vec![n.field.clone()];
+                                                    path.extend(n.nested_path.clone());
+                                                    path
+                                                },
+                                            });
                                         }
-
-                                        return; // Don't recurse further into this call
+                                    } else {
+                                        // Standard .items.map() — top-level fields
+                                        fields.extend(cb_fields);
+                                        nested_access.extend(cb_nested);
                                     }
+
+                                    if cb_opaque {
+                                        *has_opaque_access = true;
+                                    }
+
+                                    return; // Don't recurse further into this call
                                 }
                             }
                         }
@@ -649,17 +649,17 @@ fn track_field_access_in_expr(
             // Check JSX attributes for prop flows and field access
             for attr in &jsx.opening_element.attributes {
                 if let JSXAttributeItem::Attribute(jsx_attr) = attr {
-                    if let Some(ref value) = jsx_attr.value {
-                        if let JSXAttributeValue::ExpressionContainer(container) = value {
-                            if let Some(expr) = container.expression.as_expression() {
-                                track_field_access_in_expr(
-                                    expr,
-                                    var_name,
-                                    fields,
-                                    nested_access,
-                                    has_opaque_access,
-                                );
-                            }
+                    if let Some(JSXAttributeValue::ExpressionContainer(container)) =
+                        jsx_attr.value.as_ref()
+                    {
+                        if let Some(expr) = container.expression.as_expression() {
+                            track_field_access_in_expr(
+                                expr,
+                                var_name,
+                                fields,
+                                nested_access,
+                                has_opaque_access,
+                            );
                         }
                     }
                 }
@@ -737,63 +737,61 @@ fn track_field_access_in_expr(
             match &chain_expr.expression {
                 ChainElement::CallExpression(call) => {
                     // Treat like a regular call expression — check for array method patterns
-                    if let Some(callee_member) = call.callee.as_member_expression() {
-                        if let MemberExpression::StaticMemberExpression(static_member) =
-                            callee_member
-                        {
-                            let method_name = static_member.property.name.as_str();
-                            if matches!(
-                                method_name,
-                                "map" | "filter" | "find" | "forEach" | "some" | "every"
-                            ) {
-                                let obj_chain = build_property_chain(&static_member.object);
-                                if let Some(ref chain) = obj_chain {
-                                    if !chain.is_empty()
-                                        && chain[0] == var_name
-                                        && (chain.contains(&"items".to_string())
-                                            || chain.contains(&"data".to_string()))
-                                    {
-                                        if let Some(callback) = call.arguments.first() {
-                                            let callback_expr = callback.to_expression();
-                                            let param_name = get_callback_param_name(callback_expr);
-                                            if let Some(param_name) = param_name {
-                                                let parent_result = extract_field_from_chain(chain);
-                                                let parent_field = parent_result
-                                                    .as_ref()
-                                                    .filter(|r| r.nested_path.is_empty())
-                                                    .map(|r| r.field.clone());
+                    if let Some(MemberExpression::StaticMemberExpression(static_member)) =
+                        call.callee.as_member_expression()
+                    {
+                        let method_name = static_member.property.name.as_str();
+                        if matches!(
+                            method_name,
+                            "map" | "filter" | "find" | "forEach" | "some" | "every"
+                        ) {
+                            let obj_chain = build_property_chain(&static_member.object);
+                            if let Some(ref chain) = obj_chain {
+                                if !chain.is_empty()
+                                    && chain[0] == var_name
+                                    && (chain.contains(&"items".to_string())
+                                        || chain.contains(&"data".to_string()))
+                                {
+                                    if let Some(callback) = call.arguments.first() {
+                                        let callback_expr = callback.to_expression();
+                                        let param_name = get_callback_param_name(callback_expr);
+                                        if let Some(param_name) = param_name {
+                                            let parent_result = extract_field_from_chain(chain);
+                                            let parent_field = parent_result
+                                                .as_ref()
+                                                .filter(|r| r.nested_path.is_empty())
+                                                .map(|r| r.field.clone());
 
-                                                let mut cb_fields = Vec::new();
-                                                let mut cb_nested = Vec::new();
-                                                let mut cb_opaque = false;
+                                            let mut cb_fields = Vec::new();
+                                            let mut cb_nested = Vec::new();
+                                            let mut cb_opaque = false;
 
-                                                track_callback_field_access(
-                                                    callback_expr,
-                                                    &param_name,
-                                                    &mut cb_fields,
-                                                    &mut cb_nested,
-                                                    &mut cb_opaque,
-                                                );
+                                            track_callback_field_access(
+                                                callback_expr,
+                                                &param_name,
+                                                &mut cb_fields,
+                                                &mut cb_nested,
+                                                &mut cb_opaque,
+                                            );
 
-                                                if let Some(ref pf) = parent_field {
-                                                    fields.push(pf.clone());
-                                                    for f in &cb_fields {
-                                                        nested_access.push(NestedFieldAccess {
-                                                            field: pf.clone(),
-                                                            nested_path: vec![f.clone()],
-                                                        });
-                                                    }
-                                                } else {
-                                                    fields.extend(cb_fields);
-                                                    nested_access.extend(cb_nested);
+                                            if let Some(ref pf) = parent_field {
+                                                fields.push(pf.clone());
+                                                for f in &cb_fields {
+                                                    nested_access.push(NestedFieldAccess {
+                                                        field: pf.clone(),
+                                                        nested_path: vec![f.clone()],
+                                                    });
                                                 }
-
-                                                if cb_opaque {
-                                                    *has_opaque_access = true;
-                                                }
-
-                                                return;
+                                            } else {
+                                                fields.extend(cb_fields);
+                                                nested_access.extend(cb_nested);
                                             }
+
+                                            if cb_opaque {
+                                                *has_opaque_access = true;
+                                            }
+
+                                            return;
                                         }
                                     }
                                 }
@@ -860,17 +858,16 @@ fn track_field_access_in_jsx_element(
 ) {
     for attr in &jsx.opening_element.attributes {
         if let JSXAttributeItem::Attribute(jsx_attr) = attr {
-            if let Some(ref value) = jsx_attr.value {
-                if let JSXAttributeValue::ExpressionContainer(container) = value {
-                    if let Some(expr) = container.expression.as_expression() {
-                        track_field_access_in_expr(
-                            expr,
-                            var_name,
-                            fields,
-                            nested_access,
-                            has_opaque_access,
-                        );
-                    }
+            if let Some(JSXAttributeValue::ExpressionContainer(container)) = jsx_attr.value.as_ref()
+            {
+                if let Some(expr) = container.expression.as_expression() {
+                    track_field_access_in_expr(
+                        expr,
+                        var_name,
+                        fields,
+                        nested_access,
+                        has_opaque_access,
+                    );
                 }
             }
         }
@@ -1059,17 +1056,16 @@ fn track_callback_expr_in_jsx(
 ) {
     for attr in &jsx.opening_element.attributes {
         if let JSXAttributeItem::Attribute(jsx_attr) = attr {
-            if let Some(ref value) = jsx_attr.value {
-                if let JSXAttributeValue::ExpressionContainer(container) = value {
-                    if let Some(inner_expr) = container.expression.as_expression() {
-                        track_callback_expr(
-                            inner_expr,
-                            param_name,
-                            fields,
-                            nested_access,
-                            has_opaque_access,
-                        );
-                    }
+            if let Some(JSXAttributeValue::ExpressionContainer(container)) = jsx_attr.value.as_ref()
+            {
+                if let Some(inner_expr) = container.expression.as_expression() {
+                    track_callback_expr(
+                        inner_expr,
+                        param_name,
+                        fields,
+                        nested_access,
+                        has_opaque_access,
+                    );
                 }
             }
         }
@@ -1194,17 +1190,17 @@ fn track_callback_expr(
         Expression::JSXElement(jsx) => {
             for attr in &jsx.opening_element.attributes {
                 if let JSXAttributeItem::Attribute(jsx_attr) = attr {
-                    if let Some(ref value) = jsx_attr.value {
-                        if let JSXAttributeValue::ExpressionContainer(container) = value {
-                            if let Some(inner_expr) = container.expression.as_expression() {
-                                track_callback_expr(
-                                    inner_expr,
-                                    param_name,
-                                    fields,
-                                    nested_access,
-                                    has_opaque_access,
-                                );
-                            }
+                    if let Some(JSXAttributeValue::ExpressionContainer(container)) =
+                        jsx_attr.value.as_ref()
+                    {
+                        if let Some(inner_expr) = container.expression.as_expression() {
+                            track_callback_expr(
+                                inner_expr,
+                                param_name,
+                                fields,
+                                nested_access,
+                                has_opaque_access,
+                            );
                         }
                     }
                 }

--- a/native/vertz-compiler/src/jsx_transformer.rs
+++ b/native/vertz-compiler/src/jsx_transformer.rs
@@ -408,8 +408,10 @@ impl<'c> Visit<'c> for ElementFinder {
         oxc_ast_visit::walk::walk_jsx_element(self, elem);
     }
 
-    fn visit_jsx_fragment(&mut self, _frag: &JSXFragment<'c>) {
-        // Don't recurse into fragments looking for elements
+    fn visit_jsx_fragment(&mut self, frag: &JSXFragment<'c>) {
+        // Must recurse into fragments — elements can be children of fragments,
+        // e.g. when a && conditional inside a fragment contains a <div>.
+        oxc_ast_visit::walk::walk_jsx_fragment(self, frag);
     }
 }
 
@@ -1108,19 +1110,27 @@ fn process_attr(
                 *is_reactive && is_expr_reactive_in_scope(ms, *expr_start, *expr_end, rx);
 
             if is_reactive_in_scope {
+                // If expr_text starts with '{', it's an object literal —
+                // wrap in parens so `() => { ... }` isn't parsed as a block body.
+                let needs_parens = expr_text.trim_start().starts_with('{');
+                let wrapped = if needs_parens {
+                    format!("({})", expr_text)
+                } else {
+                    expr_text.to_string()
+                };
                 if use_property {
                     return Some(format!(
                         "__prop({}, {}, () => {})",
                         el_var,
                         json_quote(attr_name),
-                        expr_text
+                        wrapped
                     ));
                 }
                 return Some(format!(
                     "__attr({}, {}, () => {})",
                     el_var,
                     json_quote(attr_name),
-                    expr_text
+                    wrapped
                 ));
             }
 

--- a/native/vertz-compiler/src/prefetch_manifest.rs
+++ b/native/vertz-compiler/src/prefetch_manifest.rs
@@ -95,13 +95,13 @@ fn find_define_routes_in_stmt<'a>(stmt: &'a Statement<'a>) -> Option<&'a ObjectE
             }
         }
         Statement::ExportNamedDeclaration(export_decl) => {
-            if let Some(ref decl) = export_decl.declaration {
-                if let Declaration::VariableDeclaration(var_decl) = decl {
-                    for declarator in &var_decl.declarations {
-                        if let Some(ref init) = declarator.init {
-                            if let Some(obj) = find_define_routes_in_expr(init) {
-                                return Some(obj);
-                            }
+            if let Some(Declaration::VariableDeclaration(var_decl)) =
+                export_decl.declaration.as_ref()
+            {
+                for declarator in &var_decl.declarations {
+                    if let Some(ref init) = declarator.init {
+                        if let Some(obj) = find_define_routes_in_expr(init) {
+                            return Some(obj);
                         }
                     }
                 }
@@ -186,7 +186,7 @@ fn parse_route_object<'a>(obj: &'a ObjectExpression<'a>, source: &str) -> Vec<Ne
             };
 
             if key == "component" {
-                component_name = extract_component_name(&inner_property.value, source);
+                component_name = extract_component_name(&inner_property.value);
             } else if key == "children" {
                 if let Expression::ObjectExpression(children_obj) = &inner_property.value {
                     children = parse_route_object(children_obj, source);
@@ -234,12 +234,12 @@ fn get_identifier_key(prop: &ObjectProperty) -> Option<String> {
 }
 
 /// Extract component name from a route's component property value.
-fn extract_component_name(expr: &Expression, source: &str) -> Option<String> {
+fn extract_component_name(expr: &Expression) -> Option<String> {
     match expr {
         Expression::ArrowFunctionExpression(arrow) => {
             // () => ComponentName() or () => <ComponentName />
             let body_expr = get_arrow_body_expr(arrow)?;
-            extract_component_name_from_expr(body_expr, source)
+            extract_component_name_from_expr(body_expr)
         }
         Expression::Identifier(ident) => {
             // Bare identifier: component: HomePage
@@ -251,19 +251,17 @@ fn extract_component_name(expr: &Expression, source: &str) -> Option<String> {
 
 fn get_arrow_body_expr<'a>(arrow: &'a ArrowFunctionExpression<'a>) -> Option<&'a Expression<'a>> {
     if arrow.expression {
-        if let Some(stmt) = arrow.body.statements.first() {
-            if let Statement::ExpressionStatement(expr_stmt) = stmt {
-                return Some(&expr_stmt.expression);
-            }
+        if let Some(Statement::ExpressionStatement(expr_stmt)) = arrow.body.statements.first() {
+            return Some(&expr_stmt.expression);
         }
     }
     None
 }
 
-fn extract_component_name_from_expr(expr: &Expression, source: &str) -> Option<String> {
+fn extract_component_name_from_expr(expr: &Expression) -> Option<String> {
     match expr {
         Expression::ParenthesizedExpression(paren) => {
-            extract_component_name_from_expr(&paren.expression, source)
+            extract_component_name_from_expr(&paren.expression)
         }
         Expression::CallExpression(call) => {
             // ComponentName() — function call

--- a/native/vertz-compiler/src/route_splitting.rs
+++ b/native/vertz-compiler/src/route_splitting.rs
@@ -163,12 +163,12 @@ fn collect_define_routes_calls_in_stmt<'a>(
             }
         }
         Statement::ExportNamedDeclaration(export_decl) => {
-            if let Some(ref decl) = export_decl.declaration {
-                if let Declaration::VariableDeclaration(var_decl) = decl {
-                    for declarator in &var_decl.declarations {
-                        if let Some(ref init) = declarator.init {
-                            collect_define_routes_calls_in_expr(init, calls);
-                        }
+            if let Some(Declaration::VariableDeclaration(var_decl)) =
+                export_decl.declaration.as_ref()
+            {
+                for declarator in &var_decl.declarations {
+                    if let Some(ref init) = declarator.init {
+                        collect_define_routes_calls_in_expr(init, calls);
                     }
                 }
             }
@@ -362,10 +362,8 @@ fn get_arrow_expression_body<'a>(
         return None;
     }
     // When expression is true, the body has a single ExpressionStatement
-    if let Some(stmt) = arrow.body.statements.first() {
-        if let Statement::ExpressionStatement(expr_stmt) = stmt {
-            return Some(&expr_stmt.expression);
-        }
+    if let Some(Statement::ExpressionStatement(expr_stmt)) = arrow.body.statements.first() {
+        return Some(&expr_stmt.expression);
     }
     None
 }
@@ -382,7 +380,7 @@ fn extract_jsx_symbol(expr: &Expression) -> Option<String> {
             };
             name.and_then(|n| {
                 // Only uppercase names (components), not lowercase (HTML elements)
-                if n.chars().next().map_or(false, |c| c.is_uppercase()) {
+                if n.chars().next().is_some_and(|c| c.is_uppercase()) {
                     Some(n.to_string())
                 } else {
                     None
@@ -503,22 +501,22 @@ fn visit_identifiers_in_stmt(
             visit_identifiers_in_expr(&expr_stmt.expression, symbol_name, factory_spans, found);
         }
         Statement::ExportNamedDeclaration(export_decl) => {
-            if let Some(ref decl) = export_decl.declaration {
-                if let Declaration::VariableDeclaration(var_decl) = decl {
-                    for declarator in &var_decl.declarations {
-                        if let Some(ref init) = declarator.init {
-                            visit_identifiers_in_expr(init, symbol_name, factory_spans, found);
-                        }
+            if let Some(Declaration::VariableDeclaration(var_decl)) =
+                export_decl.declaration.as_ref()
+            {
+                for declarator in &var_decl.declarations {
+                    if let Some(ref init) = declarator.init {
+                        visit_identifiers_in_expr(init, symbol_name, factory_spans, found);
                     }
                 }
             }
         }
-        Statement::ExportDefaultDeclaration(export_default) => match &export_default.declaration {
-            ExportDefaultDeclarationKind::CallExpression(call) => {
+        Statement::ExportDefaultDeclaration(export_default) => {
+            if let ExportDefaultDeclarationKind::CallExpression(call) = &export_default.declaration
+            {
                 visit_identifiers_in_call_expr(call, symbol_name, factory_spans, found);
             }
-            _ => {}
-        },
+        }
         _ => {}
     }
 }

--- a/packages/ui-server/src/__tests__/bun-dev-server.test.ts
+++ b/packages/ui-server/src/__tests__/bun-dev-server.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -163,7 +163,7 @@ describe('createBunDevServer', () => {
     await server.restart();
     consoleSpy.mockRestore();
     consoleErrSpy.mockRestore();
-  });
+  }, 10_000);
 
   it('broadcastError auto-triggers restart for stale-graph runtime errors', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
@@ -1354,10 +1354,28 @@ describe('generateSSRPageHtml editor variants', () => {
 });
 
 describe('broadcastError state machine', () => {
+  // Track servers created in each test so afterEach can stop them.
+  // Some tests trigger fire-and-forget restart() via stale-graph errors,
+  // which does real I/O (Bun.serve, dynamic import) that hangs on CI.
+  const servers: ReturnType<typeof createBunDevServer>[] = [];
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await s.stop();
+    }
+    servers.length = 0;
+  });
+
+  function makeServer(opts?: { logRequests?: boolean }) {
+    const s = createBunDevServer({ entry: './src/app.tsx', ...opts });
+    servers.push(s);
+    return s;
+  }
+
   it('build errors block subsequent SSR errors', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // First: broadcast a build error
     server.broadcastError('build', [{ message: 'Build failed' }]);
@@ -1374,7 +1392,7 @@ describe('broadcastError state machine', () => {
   it('build errors block subsequent runtime errors', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     server.broadcastError('build', [{ message: 'Build failed' }]);
     server.broadcastError('runtime', [{ message: 'Runtime error' }]);
@@ -1392,7 +1410,7 @@ describe('broadcastError state machine', () => {
   it('build errors can be overwritten by newer build errors', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     server.broadcastError('build', [{ message: 'First build error' }]);
     // Another build error should replace the first one
@@ -1405,7 +1423,7 @@ describe('broadcastError state machine', () => {
   it('clearError sets grace period that suppresses runtime errors', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Set an error, then clear it
     server.broadcastError('build', [{ message: 'Build error' }]);
@@ -1427,7 +1445,7 @@ describe('broadcastError state machine', () => {
   it('clearErrorForFileChange does not set grace period', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: true });
+    const server = makeServer({ logRequests: true });
 
     // Set an error, then clear it via file change (no grace period)
     server.broadcastError('build', [{ message: 'Build error' }]);
@@ -1450,7 +1468,7 @@ describe('broadcastError state machine', () => {
   it('clearError is no-op when no error is set', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Should not throw
     server.clearError();
@@ -1463,7 +1481,7 @@ describe('broadcastError state machine', () => {
   it('clearErrorForFileChange is no-op when no error is set', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Should not throw
     server.clearErrorForFileChange();
@@ -1476,7 +1494,7 @@ describe('broadcastError state machine', () => {
   it('runtime errors are debounced and most informative error wins', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Fire multiple runtime errors in rapid succession
     server.broadcastError('runtime', [{ message: 'Error 1' }]);
@@ -1494,7 +1512,7 @@ describe('broadcastError state machine', () => {
   it('clearError cancels pending debounced runtime error', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Broadcast a runtime error (will be debounced)
     server.broadcastError('runtime', [{ message: 'Debounced error' }]);
@@ -1513,7 +1531,7 @@ describe('broadcastError state machine', () => {
   it('clearErrorForFileChange cancels pending debounced runtime error', async () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // Broadcast a runtime error (will be debounced)
     server.broadcastError('runtime', [{ message: 'Debounced error' }]);
@@ -1531,7 +1549,7 @@ describe('broadcastError state machine', () => {
   it('non-build/non-runtime errors are broadcast immediately', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const server = createBunDevServer({ entry: './src/app.tsx', logRequests: false });
+    const server = makeServer();
 
     // SSR and resolve errors should not be debounced
     server.broadcastError('ssr', [{ message: 'SSR error' }]);

--- a/packages/ui-server/src/bun-plugin/plugin.ts
+++ b/packages/ui-server/src/bun-plugin/plugin.ts
@@ -380,6 +380,9 @@ export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunP
           // ── 3. Compile (reactive + JSX transforms) ─────────────
           // Use native Rust compiler when available (20-50x faster),
           // otherwise fall back to ts-morph TypeScript compiler.
+          // When using native compiler, CSS is extracted during compilation
+          // (returned in nativeResult.css) instead of the TS cssExtractor.
+          let nativeCss: string | undefined;
           const compileResult = nativeCompiler
             ? (() => {
                 // Warn once that native compiler does not support cross-file
@@ -407,6 +410,10 @@ export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunP
                   // Plugin handles context stable IDs and fast refresh separately
                   fastRefresh: false,
                 });
+                // Capture CSS extracted by the native compiler for step 5
+                if (nativeResult.css) {
+                  nativeCss = nativeResult.css;
+                }
                 return {
                   code: nativeResult.code,
                   map: nativeResult.map
@@ -440,8 +447,26 @@ export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunP
           const remapped = remapping(mapsToChain, () => null);
 
           // ── 5. CSS extraction → sidecar file ───────────────────
-          const extraction = cssExtractor.extract(source, args.path);
+          // When native compiler is used, it already extracted CSS and replaced
+          // css() calls with class name objects. Use the native CSS directly.
+          // Otherwise, use the TS-based cssExtractor on the original source.
+          const extraction: { css: string; blockNames: string[] } = nativeCss
+            ? { css: nativeCss, blockNames: [] }
+            : cssExtractor.extract(source, args.path);
           let cssImportLine = '';
+
+          // When native compiler extracted CSS, we need to inject it at runtime
+          // so SSR's getInjectedCSS() can collect it. The native compiler replaces
+          // css() calls with plain class-name objects, skipping runtime injection.
+          let nativeCssInjection = '';
+          if (nativeCss && extraction.css.length > 0) {
+            // Escape the CSS for embedding in a JS string
+            const escaped = extraction.css
+              .replace(/\\/g, '\\\\')
+              .replace(/`/g, '\\`')
+              .replace(/\$/g, '\\$');
+            nativeCssInjection = `import { injectCSS as __injectCSS } from '@vertz/ui';\n__injectCSS(\`${escaped}\`);\n`;
+          }
 
           if (extraction.css.length > 0) {
             fileExtractions.set(args.path, extraction);
@@ -485,6 +510,9 @@ export function createVertzBunPlugin(options?: VertzBunPluginOptions): VertzBunP
           // offset the source map. Without this, breakpoints land on
           // the wrong line in browser DevTools.
           let contents = '';
+          if (nativeCssInjection) {
+            contents += nativeCssInjection;
+          }
           if (cssImportLine) {
             contents += cssImportLine;
           }

--- a/packages/ui/src/router/navigate.ts
+++ b/packages/ui/src/router/navigate.ts
@@ -623,19 +623,6 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
     // Start server nav prefetch before navigation (skip for search-param changes)
     const handle = isSearchParamOnly ? null : startPrefetch(navUrl);
 
-    // Update browser history
-    if (input.replace) {
-      window.history.replaceState(null, '', navUrl);
-    } else {
-      window.history.pushState(null, '', navUrl);
-    }
-
-    // Update lastPathname synchronously after history change, before any async
-    // work. This ensures popstate events that fire during awaitPrefetch see the
-    // correct value, and covers the navigateGen early-return case where
-    // applyNavigation is never called but pushState already happened.
-    lastPathname = navPathname;
-
     // Skip SSE wait for previously visited URLs — query cache will
     // serve data instantly. SSE prefetch still fires for SWR revalidation.
     const isCachedNav = visitedUrls.has(normalizeUrl(navUrl));
@@ -644,9 +631,23 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
     }
 
     // Guard: skip if a newer navigation started while we waited.
-    // Must precede withViewTransition to avoid capturing a DOM snapshot
-    // and then bailing out inside the callback.
+    // Must precede pushState to avoid orphaned history entries — if we
+    // pushed before this check, a superseded navigation would leave a
+    // ghost entry in the history stack, requiring an extra back click.
     if (gen !== navigateGen) return;
+
+    // Update browser history — deferred until after the generation guard
+    // so that only the winning navigation pushes a history entry.
+    if (input.replace) {
+      window.history.replaceState(null, '', navUrl);
+    } else {
+      window.history.pushState(null, '', navUrl);
+    }
+
+    // Update lastPathname synchronously after history change, before any async
+    // work. This ensures popstate events that fire during awaitPrefetch see the
+    // correct value for search-param-only detection.
+    lastPathname = navPathname;
 
     // Resolve transition config: navigate-level > route-level > global.
     // Search-param-only changes skip view transitions — the page content


### PR DESCRIPTION
## Summary

Fixes four bugs found while testing the task-manager example with `VERTZ_NATIVE_COMPILER=1`:

- **Object literal arrow functions** — native compiler generated `() => { key: val }` for reactive style attributes, which JS parses as a block body. Now wraps in parens: `() => ({ key: val })`
- **CSS missing from SSR** — native compiler replaces `css()` at compile time, but SSR collects styles via runtime `getInjectedCSS()`. Now injects `injectCSS()` calls in plugin output so SSR can collect native-extracted CSS
- **Nested JSX in fragments not transformed** — `ElementFinder` refused to recurse into JSX fragments, so elements inside `&&` conditionals weren't found. Signal `.value` insertion was skipped for those subtrees (caused "Page undefined of undefined" in pagination)
- **Back button requiring double click** — `pushState` was called before the async prefetch await, so superseded navigations left orphaned history entries. Deferred `pushState` until after the generation guard so only the winning navigation pushes a history entry

## Public API Changes

None — all fixes are internal behavior corrections.

## Test plan

- [x] All 293 router tests pass (including rapid navigation tests)
- [x] All 1309 ui-server tests pass
- [x] Native compiler Rust tests pass
- [x] Full quality gates green (test + typecheck + lint)
- [ ] Manual: run task-manager with `VERTZ_NATIVE_COMPILER=1`, verify styles render, pagination works, back button works on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)