### PR TITLE
feat(docs): CodeGroup tab rendering from child code block titles

### DIFF
--- a/packages/docs/src/__tests__/mdx-components.test.ts
+++ b/packages/docs/src/__tests__/mdx-components.test.ts
@@ -146,7 +146,7 @@ const x = 1;
 </CodeGroup>
 `;
       const html = await compileMdxToHtml(source);
-      const panelMatches = html.match(/<div data-code-group-panel[^>]*>/g) ?? [];
+      const panelMatches = html.match(/<div role="tabpanel" data-code-group-panel[^>]*>/g) ?? [];
       expect(panelMatches.length).toBe(2);
       // First panel visible, second hidden
       expect(panelMatches[0]).not.toContain('display:none');

--- a/packages/docs/src/components/code-group.ts
+++ b/packages/docs/src/components/code-group.ts
@@ -103,7 +103,7 @@ export function CodeGroup(props: Record<string, unknown>): string {
       const selected = i === 0;
       const borderColor = selected ? 'var(--docs-primary,#2563eb)' : 'transparent';
       const textColor = selected ? 'var(--docs-primary,#2563eb)' : 'var(--docs-muted,#6b7280)';
-      return `<button role="tab" aria-selected="${selected}" data-code-group-tab onclick="${escapeHtml(tabClickHandler(i))}" style="padding:8px 16px;font-size:13px;font-family:monospace;background:none;border:none;border-bottom:2px solid ${borderColor};color:${textColor};cursor:pointer">${escapeHtml(title)}</button>`;
+      return `<button type="button" role="tab" aria-selected="${selected}" data-code-group-tab onclick="${escapeHtml(tabClickHandler(i))}" style="padding:8px 16px;font-size:13px;font-family:monospace;background:none;border:none;border-bottom:2px solid ${borderColor};color:${textColor};cursor:pointer">${escapeHtml(title)}</button>`;
     })
     .join('');
 
@@ -114,7 +114,7 @@ export function CodeGroup(props: Record<string, unknown>): string {
     .map((block, i) => {
       const cleaned = stripBlockChrome(block);
       const style = i === 0 ? '' : ' style="display:none"';
-      return `<div data-code-group-panel${style}>${cleaned}</div>`;
+      return `<div role="tabpanel" data-code-group-panel${style}>${cleaned}</div>`;
     })
     .join('');
 


### PR DESCRIPTION
## Summary

- CodeGroup component now parses child code blocks and renders a tab bar with titles extracted from `data-code-title` elements
- First tab is active by default; clicking a tab shows only that code block
- Inline JS handles tab switching — no client-side framework runtime needed
- Proper ARIA: `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `type="button"`
- Falls back to language class name or "Code" when no title is present
- Strips per-block chrome (title bar, border, margin) when inside CodeGroup

## Public API Changes

None — internal docs-framework component, not a public API.

## Test plan

- [x] Tab headers rendered from child code block titles
- [x] First tab active by default (`aria-selected="true"`)
- [x] Second+ panels hidden by default (`display:none`)
- [x] Tab bar has `role="tablist"`
- [x] Inline JS onclick handlers present for switching
- [x] Fallback to language class when no title
- [x] Fallback to "Code" when no title and no language
- [x] Falls back to wrapper div when no code blocks found
- [x] Title bars stripped from panels (shown in tab bar instead)
- [x] LLM markdown conversion preserves all code blocks
- [x] 100% line and branch coverage on `code-group.ts`

Closes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)