### PR TITLE
perf(auth): use getBatchConsumption in computeAccessSet (#1831)

### DIFF
--- a/packages/server/src/auth/__tests__/access-set-batch-consumption.test.ts
+++ b/packages/server/src/auth/__tests__/access-set-batch-consumption.test.ts
@@ -1,0 +1,731 @@
+/**
+ * Tests for batch consumption optimization in computeAccessSet (#1831)
+ *
+ * Verifies that computeAccessSet uses getBatchConsumption instead of
+ * individual getConsumption calls, grouped by billing period.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { computeAccessSet } from '../access-set';
+import { calculateBillingPeriod } from '../billing-period';
+import { InMemoryClosureStore } from '../closure-store';
+import { defineAccess } from '../define-access';
+import { InMemoryRoleAssignmentStore } from '../role-assignment-store';
+import { InMemorySubscriptionStore } from '../subscription-store';
+import { InMemoryWalletStore } from '../wallet-store';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createStores() {
+  const roleStore = new InMemoryRoleAssignmentStore();
+  const closureStore = new InMemoryClosureStore();
+  const subscriptionStore = new InMemorySubscriptionStore();
+  const walletStore = new InMemoryWalletStore();
+  return { roleStore, closureStore, subscriptionStore, walletStore };
+}
+
+// ============================================================================
+// Single-level batch consumption
+// ============================================================================
+
+describe('Feature: single-level batch consumption in computeAccessSet (#1831)', () => {
+  const singleLimitDef = defineAccess({
+    entities: {
+      organization: { roles: ['owner', 'admin'] },
+    },
+    entitlements: {
+      'organization:create-project': { roles: ['admin', 'owner'] },
+      'organization:view': { roles: ['admin', 'owner'] },
+    },
+    plans: {
+      pro: {
+        group: 'main',
+        features: ['organization:create-project', 'organization:view'],
+        limits: {
+          projects: { max: 10, gates: 'organization:create-project', per: 'month' },
+        },
+      },
+    },
+  });
+
+  describe('Given a plan with one limited entitlement and partial consumption', () => {
+    describe('When computeAccessSet is called with walletStore', () => {
+      it('Then includes correct limit meta (consumed/remaining)', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        const { periodStart, periodEnd } = calculateBillingPeriod(startedAt, 'month');
+        await walletStore.consume('tenant', 'org-1', 'projects', periodStart, periodEnd, 10, 3);
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: singleLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(result.entitlements['organization:create-project'].allowed).toBe(true);
+        expect(result.entitlements['organization:create-project'].meta?.limit).toEqual({
+          key: 'projects',
+          max: 10,
+          consumed: 3,
+          remaining: 7,
+        });
+      });
+
+      it('Then calls getBatchConsumption instead of getConsumption', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        let batchCalls = 0;
+        let individualCalls = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        const originalIndividual = walletStore.getConsumption.bind(walletStore);
+
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCalls++;
+          return originalBatch(...args);
+        };
+        walletStore.getConsumption = (...args: Parameters<typeof walletStore.getConsumption>) => {
+          individualCalls++;
+          return originalIndividual(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: singleLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(batchCalls).toBe(1);
+        expect(individualCalls).toBe(0);
+      });
+    });
+  });
+
+  // Multi-limit plan for batch tests
+  const multiLimitDef = defineAccess({
+    entities: {
+      organization: { roles: ['owner', 'admin'] },
+    },
+    entitlements: {
+      'organization:create-project': { roles: ['admin', 'owner'] },
+      'organization:create-team': { roles: ['admin', 'owner'] },
+      'organization:view': { roles: ['admin', 'owner'] },
+    },
+    plans: {
+      pro: {
+        group: 'main',
+        features: ['organization:create-project', 'organization:create-team', 'organization:view'],
+        limits: {
+          projects: { max: 10, gates: 'organization:create-project', per: 'month' },
+          teams: { max: 5, gates: 'organization:create-team', per: 'month' },
+        },
+      },
+    },
+  });
+
+  describe('Given a plan with multiple limited entitlements (same period)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then fetches all consumption in one batch call', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        let batchCallCount = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCallCount++;
+          return originalBatch(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: multiLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(batchCallCount).toBe(1);
+      });
+
+      it('Then enriches each entitlement with its respective consumed value', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        const { periodStart, periodEnd } = calculateBillingPeriod(startedAt, 'month');
+        await walletStore.consume('tenant', 'org-1', 'projects', periodStart, periodEnd, 10, 3);
+        await walletStore.consume('tenant', 'org-1', 'teams', periodStart, periodEnd, 5, 2);
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: multiLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(result.entitlements['organization:create-project'].meta?.limit).toEqual({
+          key: 'projects',
+          max: 10,
+          consumed: 3,
+          remaining: 7,
+        });
+        expect(result.entitlements['organization:create-team'].meta?.limit).toEqual({
+          key: 'teams',
+          max: 5,
+          consumed: 2,
+          remaining: 3,
+        });
+      });
+    });
+  });
+
+  // Mixed-period plan
+  const mixedPeriodDef = defineAccess({
+    entities: {
+      organization: { roles: ['owner', 'admin'] },
+    },
+    entitlements: {
+      'organization:create-project': { roles: ['admin', 'owner'] },
+      'organization:api-call': { roles: ['admin', 'owner'] },
+      'organization:view': { roles: ['admin', 'owner'] },
+    },
+    plans: {
+      pro: {
+        group: 'main',
+        features: ['organization:create-project', 'organization:api-call', 'organization:view'],
+        limits: {
+          projects: { max: 10, gates: 'organization:create-project', per: 'month' },
+          'api-calls': { max: 1000, gates: 'organization:api-call', per: 'day' },
+        },
+      },
+    },
+  });
+
+  describe('Given a plan with limits using different billing periods', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then groups by period and calls getBatchConsumption per group', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        let batchCallCount = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCallCount++;
+          return originalBatch(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: mixedPeriodDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        // 'month' and 'day' produce different periods → 2 batch calls
+        expect(batchCallCount).toBe(2);
+      });
+
+      it('Then enriches each entitlement with correct consumed value for its period', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        const monthPeriod = calculateBillingPeriod(startedAt, 'month');
+        const dayPeriod = calculateBillingPeriod(startedAt, 'day');
+        await walletStore.consume(
+          'tenant', 'org-1', 'projects',
+          monthPeriod.periodStart, monthPeriod.periodEnd, 10, 4,
+        );
+        await walletStore.consume(
+          'tenant', 'org-1', 'api-calls',
+          dayPeriod.periodStart, dayPeriod.periodEnd, 1000, 150,
+        );
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: mixedPeriodDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(result.entitlements['organization:create-project'].meta?.limit).toEqual({
+          key: 'projects',
+          max: 10,
+          consumed: 4,
+          remaining: 6,
+        });
+        expect(result.entitlements['organization:api-call'].meta?.limit).toEqual({
+          key: 'api-calls',
+          max: 1000,
+          consumed: 150,
+          remaining: 850,
+        });
+      });
+    });
+  });
+
+  // Lifetime + monthly mix
+  const lifetimeMixDef = defineAccess({
+    entities: {
+      organization: { roles: ['owner', 'admin'] },
+    },
+    entitlements: {
+      'organization:create-project': { roles: ['admin', 'owner'] },
+      'organization:storage-upload': { roles: ['admin', 'owner'] },
+      'organization:view': { roles: ['admin', 'owner'] },
+    },
+    plans: {
+      pro: {
+        group: 'main',
+        features: ['organization:create-project', 'organization:storage-upload', 'organization:view'],
+        limits: {
+          projects: { max: 10, gates: 'organization:create-project', per: 'month' },
+          storage: { max: 50, gates: 'organization:storage-upload' }, // no per = lifetime
+        },
+      },
+    },
+  });
+
+  describe('Given a plan with a lifetime limit (no per) and a monthly limit', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then issues separate batch calls for lifetime and monthly periods', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        let batchCallCount = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCallCount++;
+          return originalBatch(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: lifetimeMixDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        // lifetime period != monthly period → 2 batch calls
+        expect(batchCallCount).toBe(2);
+      });
+    });
+  });
+
+  describe('Given limit reached (consumed >= max)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then denies with limit_reached reason', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('tenant', 'org-1', 'pro', startedAt);
+
+        const { periodStart, periodEnd } = calculateBillingPeriod(startedAt, 'month');
+        await walletStore.consume('tenant', 'org-1', 'projects', periodStart, periodEnd, 10, 10);
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: singleLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(result.entitlements['organization:create-project'].allowed).toBe(false);
+        expect(result.entitlements['organization:create-project'].reasons).toContain('limit_reached');
+        expect(result.entitlements['organization:create-project'].meta?.limit?.remaining).toBe(0);
+      });
+    });
+  });
+
+  // Unlimited plan
+  const unlimitedDef = defineAccess({
+    entities: {
+      organization: { roles: ['owner', 'admin'] },
+    },
+    entitlements: {
+      'organization:create-project': { roles: ['admin', 'owner'] },
+      'organization:view': { roles: ['admin', 'owner'] },
+    },
+    plans: {
+      enterprise: {
+        group: 'main',
+        features: ['organization:create-project', 'organization:view'],
+        limits: {
+          projects: { max: -1, gates: 'organization:create-project', per: 'month' },
+        },
+      },
+    },
+  });
+
+  describe('Given unlimited entitlement (max = -1)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then skips wallet call and sets consumed=0, remaining=-1', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        await subscriptionStore.assign('tenant', 'org-1', 'enterprise');
+
+        let batchCallCount = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCallCount++;
+          return originalBatch(...args);
+        };
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: unlimitedDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(batchCallCount).toBe(0);
+        expect(result.entitlements['organization:create-project'].meta?.limit).toEqual({
+          key: 'projects',
+          max: -1,
+          consumed: 0,
+          remaining: -1,
+        });
+      });
+    });
+  });
+
+  describe('Given no limited entitlements', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then does not call getBatchConsumption', async () => {
+        const noLimitDef = defineAccess({
+          entities: {
+            organization: { roles: ['owner', 'admin'] },
+          },
+          entitlements: {
+            'organization:view': { roles: ['admin', 'owner'] },
+          },
+          plans: {
+            free: {
+              group: 'main',
+              features: ['organization:view'],
+            },
+          },
+        });
+
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('organization', 'org-1');
+        await roleStore.assign('user-1', 'organization', 'org-1', 'admin');
+        await subscriptionStore.assign('tenant', 'org-1', 'free');
+
+        let batchCallCount = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCallCount++;
+          return originalBatch(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: noLimitDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'org-1',
+        });
+
+        expect(batchCallCount).toBe(0);
+      });
+    });
+  });
+});
+
+// ============================================================================
+// Multi-level batch consumption
+// ============================================================================
+
+describe('Feature: multi-level batch consumption in computeAccessSet (#1831)', () => {
+  const multiLevelDef = defineAccess({
+    entities: {
+      account: { roles: ['owner', 'admin'] },
+      project: {
+        roles: ['admin', 'editor'],
+        inherits: {
+          'account:owner': 'admin',
+          'account:admin': 'editor',
+        },
+      },
+    },
+    entitlements: {
+      'account:create-project': { roles: ['owner', 'admin'] },
+      'account:api-call': { roles: ['owner', 'admin'] },
+      'project:view': { roles: ['admin', 'editor'] },
+    },
+    plans: {
+      pro: {
+        level: 'project',
+        group: 'project-plans',
+        features: ['account:create-project', 'account:api-call'],
+        limits: {
+          projects: { max: 10, gates: 'account:create-project', per: 'month' },
+          'api-calls': { max: 500, gates: 'account:api-call', per: 'month' },
+        },
+      },
+    },
+    defaultPlans: {
+      project: 'pro',
+    },
+  });
+
+  function mockAncestorResolver(
+    ancestors: Record<string, { type: string; id: string; depth: number }[]>,
+  ) {
+    return async (_level: string, id: string) => ancestors[id] ?? [];
+  }
+
+  describe('Given multi-level setup with limited entitlements at deepest level', () => {
+    describe('When computeAccessSet is called with ancestorResolver', () => {
+      it('Then uses getBatchConsumption for deepest level limits', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('account', 'acct-1');
+        await closureStore.addResource('project', 'proj-1', {
+          parentType: 'account',
+          parentId: 'acct-1',
+        });
+        await roleStore.assign('user-1', 'account', 'acct-1', 'owner');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('project', 'proj-1', 'pro', startedAt);
+
+        let batchCalls = 0;
+        let individualCalls = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        const originalIndividual = walletStore.getConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCalls++;
+          return originalBatch(...args);
+        };
+        walletStore.getConsumption = (...args: Parameters<typeof walletStore.getConsumption>) => {
+          individualCalls++;
+          return originalIndividual(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: multiLevelDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'proj-1',
+          tenantLevel: 'project',
+          ancestorResolver: mockAncestorResolver({
+            'proj-1': [{ type: 'account', id: 'acct-1', depth: 1 }],
+          }),
+        });
+
+        expect(batchCalls).toBe(1);
+        expect(individualCalls).toBe(0);
+      });
+
+      it('Then enriches limit meta correctly', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('account', 'acct-1');
+        await closureStore.addResource('project', 'proj-1', {
+          parentType: 'account',
+          parentId: 'acct-1',
+        });
+        await roleStore.assign('user-1', 'account', 'acct-1', 'owner');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('project', 'proj-1', 'pro', startedAt);
+
+        const { periodStart, periodEnd } = calculateBillingPeriod(startedAt, 'month');
+        await walletStore.consume('project', 'proj-1', 'projects', periodStart, periodEnd, 10, 4);
+        await walletStore.consume('project', 'proj-1', 'api-calls', periodStart, periodEnd, 500, 120);
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: multiLevelDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'proj-1',
+          tenantLevel: 'project',
+          ancestorResolver: mockAncestorResolver({
+            'proj-1': [{ type: 'account', id: 'acct-1', depth: 1 }],
+          }),
+        });
+
+        expect(result.entitlements['account:create-project'].meta?.limit).toEqual({
+          key: 'projects',
+          max: 10,
+          consumed: 4,
+          remaining: 6,
+        });
+        expect(result.entitlements['account:api-call'].meta?.limit).toEqual({
+          key: 'api-calls',
+          max: 500,
+          consumed: 120,
+          remaining: 380,
+        });
+      });
+    });
+  });
+
+  describe('Given multi-level with limit reached', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then denies with limit_reached reason', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('account', 'acct-1');
+        await closureStore.addResource('project', 'proj-1', {
+          parentType: 'account',
+          parentId: 'acct-1',
+        });
+        await roleStore.assign('user-1', 'account', 'acct-1', 'owner');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('project', 'proj-1', 'pro', startedAt);
+
+        const { periodStart, periodEnd } = calculateBillingPeriod(startedAt, 'month');
+        await walletStore.consume('project', 'proj-1', 'projects', periodStart, periodEnd, 10, 10);
+
+        const result = await computeAccessSet({
+          userId: 'user-1',
+          accessDef: multiLevelDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'proj-1',
+          tenantLevel: 'project',
+          ancestorResolver: mockAncestorResolver({
+            'proj-1': [{ type: 'account', id: 'acct-1', depth: 1 }],
+          }),
+        });
+
+        expect(result.entitlements['account:create-project'].allowed).toBe(false);
+        expect(result.entitlements['account:create-project'].reasons).toContain('limit_reached');
+        expect(result.entitlements['account:create-project'].meta?.limit?.remaining).toBe(0);
+      });
+    });
+  });
+
+  // Mixed-period multi-level
+  const mixedPeriodMultiDef = defineAccess({
+    entities: {
+      account: { roles: ['owner', 'admin'] },
+      project: {
+        roles: ['admin', 'editor'],
+        inherits: {
+          'account:owner': 'admin',
+          'account:admin': 'editor',
+        },
+      },
+    },
+    entitlements: {
+      'account:create-project': { roles: ['owner', 'admin'] },
+      'account:api-call': { roles: ['owner', 'admin'] },
+      'project:view': { roles: ['admin', 'editor'] },
+    },
+    plans: {
+      pro: {
+        level: 'project',
+        group: 'project-plans',
+        features: ['account:create-project', 'account:api-call'],
+        limits: {
+          projects: { max: 10, gates: 'account:create-project', per: 'month' },
+          'api-calls': { max: 1000, gates: 'account:api-call', per: 'day' },
+        },
+      },
+    },
+    defaultPlans: {
+      project: 'pro',
+    },
+  });
+
+  describe('Given multi-level with limits using different periods', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then groups by period and uses batch consumption per group', async () => {
+        const { roleStore, closureStore, subscriptionStore, walletStore } = createStores();
+        await closureStore.addResource('account', 'acct-1');
+        await closureStore.addResource('project', 'proj-1', {
+          parentType: 'account',
+          parentId: 'acct-1',
+        });
+        await roleStore.assign('user-1', 'account', 'acct-1', 'owner');
+        const startedAt = new Date('2026-01-01T00:00:00Z');
+        await subscriptionStore.assign('project', 'proj-1', 'pro', startedAt);
+
+        let batchCalls = 0;
+        const originalBatch = walletStore.getBatchConsumption.bind(walletStore);
+        walletStore.getBatchConsumption = (...args: Parameters<typeof walletStore.getBatchConsumption>) => {
+          batchCalls++;
+          return originalBatch(...args);
+        };
+
+        await computeAccessSet({
+          userId: 'user-1',
+          accessDef: mixedPeriodMultiDef,
+          roleStore,
+          closureStore,
+          subscriptionStore,
+          walletStore,
+          tenantId: 'proj-1',
+          tenantLevel: 'project',
+          ancestorResolver: mockAncestorResolver({
+            'proj-1': [{ type: 'account', id: 'acct-1', depth: 1 }],
+          }),
+        });
+
+        // 'month' and 'day' → 2 batch calls
+        expect(batchCalls).toBe(2);
+      });
+    });
+  });
+});

--- a/packages/server/src/auth/access-set.ts
+++ b/packages/server/src/auth/access-set.ts
@@ -350,6 +350,10 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
           // When no subscription exists (default-plan tenant), use epoch as period anchor
           const periodAnchor = deepestSub?.startedAt ?? new Date(0);
           const deepestAddOns = await subscriptionStore.getAddOns?.(config.tenantLevel!, tenantId);
+
+          // Collect pending limits for batch consumption
+          const pendingLimits: PendingLimit[] = [];
+
           for (const name of Object.keys(accessDef.entitlements)) {
             const limitKeys = accessDef._entitlementToLimitKeys[name];
             if (!limitKeys?.length) continue;
@@ -388,40 +392,23 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
                     periodStart: periodAnchor,
                     periodEnd: new Date('9999-12-31T23:59:59Z'),
                   };
-              const consumed = await walletStore.getConsumption(
-                config.tenantLevel!,
-                tenantId,
+              pendingLimits.push({
+                entitlementName: name,
                 limitKey,
-                period.periodStart,
-                period.periodEnd,
-              );
-              const remaining = Math.max(0, effectiveMax - consumed);
-              const entry = entitlements[name];
-
-              if (consumed >= effectiveMax) {
-                const reasons: DenialReason[] = [...entry.reasons];
-                if (!reasons.includes('limit_reached')) reasons.push('limit_reached');
-                entitlements[name] = {
-                  ...entry,
-                  allowed: false,
-                  reasons,
-                  reason: reasons[0],
-                  meta: {
-                    ...entry.meta,
-                    limit: { key: limitKey, max: effectiveMax, consumed, remaining },
-                  },
-                };
-              } else {
-                entitlements[name] = {
-                  ...entry,
-                  meta: {
-                    ...entry.meta,
-                    limit: { key: limitKey, max: effectiveMax, consumed, remaining },
-                  },
-                };
-              }
+                effectiveMax,
+                periodStart: period.periodStart,
+                periodEnd: period.periodEnd,
+              });
             }
           }
+
+          await enrichLimitsFromBatch(
+            pendingLimits,
+            entitlements,
+            walletStore,
+            config.tenantLevel!,
+            tenantId,
+          );
         }
       }
     } else {
@@ -450,6 +437,8 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
               }
             }
 
+            const pendingLimits: PendingLimit[] = [];
+
             for (const name of Object.keys(accessDef.entitlements)) {
               // Plan check: if entitlement is plan-gated, verify effective features include it
               if (accessDef._planGatedEntitlements.has(name) && !effectiveFeatures.has(name)) {
@@ -470,15 +459,12 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
                 };
               }
 
-              // Wallet check: add limit info if entitlement has limits
+              // Wallet check: collect limit info for batch fetch
               const limitKeys = accessDef._entitlementToLimitKeys[name];
               if (walletStore && limitKeys?.length) {
-                // Use the first limit key for display in access set
-                // (multi-limit detail is for real-time checks, not JWT snapshots)
                 const limitKey = limitKeys[0];
                 const limitDef = planDef.limits?.[limitKey];
                 if (limitDef) {
-                  // Compute effective max (base + add-ons + overrides)
                   let effectiveMax = limitDef.max;
                   if (addOns) {
                     for (const addOnId of addOns) {
@@ -494,7 +480,6 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
                   if (override) effectiveMax = Math.max(effectiveMax, override.max);
 
                   if (effectiveMax === -1) {
-                    // Unlimited — no wallet check needed, but report in meta
                     const entry = entitlements[name];
                     entitlements[name] = {
                       ...entry,
@@ -510,41 +495,26 @@ export async function computeAccessSet(config: ComputeAccessSetConfig): Promise<
                           periodStart: subscription.startedAt,
                           periodEnd: new Date('9999-12-31T23:59:59Z'),
                         };
-                    const consumed = await walletStore.getConsumption(
-                      resourceType,
-                      tenantId,
+                    pendingLimits.push({
+                      entitlementName: name,
                       limitKey,
-                      period.periodStart,
-                      period.periodEnd,
-                    );
-                    const remaining = Math.max(0, effectiveMax - consumed);
-                    const entry = entitlements[name];
-
-                    if (consumed >= effectiveMax) {
-                      const reasons: DenialReason[] = [...entry.reasons];
-                      if (!reasons.includes('limit_reached')) reasons.push('limit_reached');
-                      entitlements[name] = {
-                        ...entry,
-                        allowed: false,
-                        reasons,
-                        reason: reasons[0],
-                        meta: {
-                          ...entry.meta,
-                          limit: { key: limitKey, max: effectiveMax, consumed, remaining },
-                        },
-                      };
-                    } else {
-                      entitlements[name] = {
-                        ...entry,
-                        meta: {
-                          ...entry.meta,
-                          limit: { key: limitKey, max: effectiveMax, consumed, remaining },
-                        },
-                      };
-                    }
+                      effectiveMax,
+                      periodStart: period.periodStart,
+                      periodEnd: period.periodEnd,
+                    });
                   }
                 }
               }
+            }
+
+            if (walletStore) {
+              await enrichLimitsFromBatch(
+                pendingLimits,
+                entitlements,
+                walletStore,
+                resourceType,
+                tenantId,
+              );
             }
           }
         }
@@ -672,4 +642,81 @@ function addRole(map: Map<string, Set<string>>, resourceType: string, role: stri
     map.set(resourceType, roles);
   }
   roles.add(role);
+}
+
+interface PendingLimit {
+  entitlementName: string;
+  limitKey: string;
+  effectiveMax: number;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+/**
+ * Batch-fetch consumption for pending limits grouped by billing period,
+ * then enrich entitlements with consumed/remaining metadata.
+ */
+async function enrichLimitsFromBatch(
+  pendingLimits: PendingLimit[],
+  entitlements: Record<string, AccessCheckData>,
+  walletStore: WalletStore,
+  resourceType: string,
+  resourceId: string,
+): Promise<void> {
+  if (pendingLimits.length === 0) return;
+
+  // Group by period
+  const byPeriod = new Map<
+    string,
+    { periodStart: Date; periodEnd: Date; entries: PendingLimit[] }
+  >();
+  for (const p of pendingLimits) {
+    const periodKey = `${p.periodStart.getTime()}:${p.periodEnd.getTime()}`;
+    let group = byPeriod.get(periodKey);
+    if (!group) {
+      group = { periodStart: p.periodStart, periodEnd: p.periodEnd, entries: [] };
+      byPeriod.set(periodKey, group);
+    }
+    group.entries.push(p);
+  }
+
+  for (const group of byPeriod.values()) {
+    const keys = group.entries.map((e) => e.limitKey);
+    const consumptionMap = await walletStore.getBatchConsumption(
+      resourceType,
+      resourceId,
+      keys,
+      group.periodStart,
+      group.periodEnd,
+    );
+
+    for (const pending of group.entries) {
+      const consumed = consumptionMap.get(pending.limitKey) ?? 0;
+      const remaining = Math.max(0, pending.effectiveMax - consumed);
+      const entry = entitlements[pending.entitlementName];
+
+      if (consumed >= pending.effectiveMax) {
+        const reasons: DenialReason[] = [...entry.reasons];
+        if (!reasons.includes('limit_reached')) reasons.push('limit_reached');
+        entitlements[pending.entitlementName] = {
+          ...entry,
+          allowed: false,
+          reasons,
+          reason: reasons[0],
+          meta: {
+            ...entry.meta,
+            limit: { key: pending.limitKey, max: pending.effectiveMax, consumed, remaining },
+          },
+        };
+      } else {
+        entitlements[pending.entitlementName] = {
+          ...entry,
+          meta: {
+            ...entry.meta,
+            limit: { key: pending.limitKey, max: pending.effectiveMax, consumed, remaining },
+          },
+        };
+      }
+    }
+  }
 }

--- a/plans/batch-consumption-access-set.md
+++ b/plans/batch-consumption-access-set.md
@@ -1,0 +1,249 @@
+# perf(auth): Use getBatchConsumption in computeAccessSet
+
+**Issue:** #1831
+**Status:** Approved (DX, Product, Technical — 2026-03-27)
+**Author:** viniciusdacal
+
+## Context
+
+`computeAccessSet()` enriches entitlements with wallet consumption data for JWT embedding.
+Currently it calls `walletStore.getConsumption()` individually per limit key — O(N) round-trips
+where N = number of limited entitlements. The `WalletStore` interface already has
+`getBatchConsumption()` which resolves multiple keys in one call — O(1) round-trip.
+
+For CloudWalletStore, each `getConsumption()` is an HTTP POST to `/api/v1/wallet/check`.
+Batching into one `/api/v1/wallet/batch-check` call reduces network latency proportionally.
+
+**Period constraint:** `getBatchConsumption` takes a single `(periodStart, periodEnd)` pair
+for all keys. Since each `LimitDef` can have a different `per` value (`'month'`, `'day'`,
+`'year'`, or omitted for lifetime), limit keys within the same plan may produce different
+billing periods. The implementation must **group keys by their computed period** and issue
+one batch call per distinct period group — O(P) where P = number of distinct periods
+(typically 1-2, much less than N).
+
+## API Surface
+
+No public API changes. `getBatchConsumption` already exists on the `WalletStore` interface
+and is implemented in all three stores:
+- `InMemoryWalletStore` — iterates keys internally
+- `CloudWalletStore` — single POST to `/api/v1/wallet/batch-check`
+- `CachedWalletStore` — delegates to inner store
+
+The change is internal to `computeAccessSet()`.
+
+### Before (O(N) calls)
+
+```ts
+for (const name of Object.keys(accessDef.entitlements)) {
+  const limitKeys = accessDef._entitlementToLimitKeys[name];
+  if (!limitKeys?.length) continue;
+  const limitKey = limitKeys[0];
+  // ... compute effectiveMax, period ...
+  const consumed = await walletStore.getConsumption(
+    resourceType, tenantId, limitKey, period.periodStart, period.periodEnd,
+  );
+  // ... enrich entitlement with consumed/remaining ...
+}
+```
+
+### After (O(P) calls, P = distinct periods)
+
+```ts
+// Step 1: Collect all limit keys that need consumption data
+interface PendingLimit {
+  entitlementName: string;
+  limitKey: string;
+  effectiveMax: number;
+  periodStart: Date;
+  periodEnd: Date;
+}
+const pendingLimits: PendingLimit[] = [];
+
+for (const name of Object.keys(accessDef.entitlements)) {
+  const limitKeys = accessDef._entitlementToLimitKeys[name];
+  if (!limitKeys?.length) continue;
+  const limitKey = limitKeys[0];
+  // ... compute effectiveMax, period per limitDef.per ...
+  if (effectiveMax === -1) {
+    // unlimited — enrich immediately, no wallet call needed
+  } else {
+    pendingLimits.push({ entitlementName: name, limitKey, effectiveMax, periodStart, periodEnd });
+  }
+}
+
+// Step 2: Group by period and batch fetch
+if (pendingLimits.length > 0) {
+  const byPeriod = new Map<string, { periodStart: Date; periodEnd: Date; entries: PendingLimit[] }>();
+  for (const p of pendingLimits) {
+    const periodKey = `${p.periodStart.getTime()}:${p.periodEnd.getTime()}`;
+    let group = byPeriod.get(periodKey);
+    if (!group) {
+      group = { periodStart: p.periodStart, periodEnd: p.periodEnd, entries: [] };
+      byPeriod.set(periodKey, group);
+    }
+    group.entries.push(p);
+  }
+
+  for (const group of byPeriod.values()) {
+    const keys = group.entries.map((e) => e.limitKey);
+    const consumptionMap = await walletStore.getBatchConsumption(
+      resourceType, tenantId, keys, group.periodStart, group.periodEnd,
+    );
+
+    // Step 3: Enrich entitlements using batch results
+    for (const entry of group.entries) {
+      const consumed = consumptionMap.get(entry.limitKey) ?? 0;
+      // ... same enrichment logic as before ...
+    }
+  }
+}
+```
+
+## Manifesto Alignment
+
+- **Performance by default** — reduces wallet round-trips from O(N) to O(P) where P = distinct periods (typically 1)
+- **No new API surface** — uses existing `getBatchConsumption` method
+- **Internal refactor** — no breaking changes, no new concepts for developers
+
+## Non-Goals
+
+- Extending `getBatchConsumption` to accept per-key periods (would change WalletStore interface)
+- Batching across ancestor levels in multi-level mode (each level has its own tenant/resourceType)
+- Changing `canAndConsume()` in AccessContext (that performs atomic consume, not advisory reads)
+- Scoped limits (`scope` field on `LimitDef`) — not currently handled in `computeAccessSet`, pre-existing limitation
+
+## Unknowns
+
+None identified. `getBatchConsumption` is already implemented and tested in all stores.
+
+## Type Flow Map
+
+No generic type parameters involved. All types are concrete (`string`, `number`, `Date`, `Map<string, number>`).
+
+## E2E Acceptance Test
+
+```ts
+describe('Feature: computeAccessSet uses batch consumption', () => {
+  describe('Given a plan with multiple limited entitlements (same period)', () => {
+    describe('When computing access set', () => {
+      it('Then calls getBatchConsumption once instead of getConsumption per key', () => {
+        // Spy on walletStore.getBatchConsumption — called once
+        // Spy on walletStore.getConsumption — never called
+        // Entitlement meta has correct consumed/remaining values
+      });
+    });
+  });
+
+  describe('Given a plan with limits using different billing periods', () => {
+    describe('When computing access set', () => {
+      it('Then groups keys by period and calls getBatchConsumption per group', () => {
+        // e.g., one limit per: 'month', one per: 'day'
+        // getBatchConsumption called twice (once per period group)
+        // Each entitlement enriched with correct consumed value for its period
+      });
+    });
+  });
+
+  describe('Given a plan with a lifetime limit (no per) and a monthly limit', () => {
+    describe('When computing access set', () => {
+      it('Then handles the lifetime period separately from monthly', () => {
+        // lifetime period = (startedAt, 9999-12-31)
+        // monthly period = calculateBillingPeriod(startedAt, 'month')
+        // Two batch calls, each with correct period
+      });
+    });
+  });
+
+  describe('Given multi-level mode with wallet store', () => {
+    describe('When computing access set for deepest level', () => {
+      it('Then uses batch consumption for the deepest level limits', () => {
+        // Same enrichment semantics, but via batch call
+      });
+    });
+  });
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Refactor single-level path to use batch consumption
+
+**Scope:** Refactor the single-level wallet enrichment in `computeAccessSet()` (lines 471-545) to collect limit keys, group by period, then batch-fetch.
+
+**Acceptance criteria:**
+```ts
+describe('Feature: single-level batch consumption in computeAccessSet', () => {
+  describe('Given a plan with one limited entitlement and partial consumption', () => {
+    describe('When computeAccessSet is called with walletStore', () => {
+      it('Then includes correct limit meta (consumed/remaining)', () => {});
+      it('Then calls getBatchConsumption instead of getConsumption', () => {});
+    });
+  });
+
+  describe('Given a plan with multiple limited entitlements (same period)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then fetches all consumption in one batch call', () => {});
+      it('Then enriches each entitlement with its respective consumed value', () => {});
+    });
+  });
+
+  describe('Given a plan with limits using different billing periods', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then groups by period and calls getBatchConsumption per group', () => {});
+      it('Then enriches each entitlement with correct consumed value for its period', () => {});
+    });
+  });
+
+  describe('Given a plan with a lifetime limit (no per) and a monthly limit', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then issues separate batch calls for lifetime and monthly periods', () => {});
+    });
+  });
+
+  describe('Given limit reached (consumed >= max)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then denies with limit_reached reason', () => {});
+    });
+  });
+
+  describe('Given unlimited entitlement (max = -1)', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then skips wallet call and sets consumed=0, remaining=-1', () => {});
+    });
+  });
+
+  describe('Given no limited entitlements', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then does not call getBatchConsumption', () => {});
+    });
+  });
+});
+```
+
+### Phase 2: Refactor multi-level path to use batch consumption
+
+**Scope:** Refactor the multi-level wallet enrichment (lines 346-424) to use the same collect-group-batch pattern.
+
+**Acceptance criteria:**
+```ts
+describe('Feature: multi-level batch consumption in computeAccessSet', () => {
+  describe('Given multi-level setup with limited entitlements at deepest level', () => {
+    describe('When computeAccessSet is called with ancestorResolver', () => {
+      it('Then uses getBatchConsumption for deepest level limits', () => {});
+      it('Then enriches limit meta correctly', () => {});
+    });
+  });
+
+  describe('Given multi-level with limit reached', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then denies with limit_reached reason', () => {});
+    });
+  });
+
+  describe('Given multi-level with limits using different periods', () => {
+    describe('When computeAccessSet is called', () => {
+      it('Then groups by period and uses batch consumption per group', () => {});
+    });
+  });
+});
+```


### PR DESCRIPTION
## Summary

- Refactors `computeAccessSet()` to use `WalletStore.getBatchConsumption()` instead of individual `getConsumption()` calls per limit key
- Keys are grouped by billing period and fetched in one batch call per distinct period — O(P) instead of O(N), where P = distinct periods (typically 1-2)
- Both single-level and multi-level paths are refactored
- Shared enrichment logic extracted into `enrichLimitsFromBatch()` helper

## Public API Changes

None. This is a purely internal optimization. The `WalletStore` interface, `computeAccessSet` signature, and `AccessSet` return type are all unchanged.

## Phase Summary

### Phase 1: Single-level batch consumption
- Refactored single-level wallet enrichment to collect pending limits, group by period, batch-fetch
- Covers: same-period batching, mixed-period grouping (month vs day), lifetime limits (no `per`), unlimited skip, limit-reached denial, no-limit passthrough

### Phase 2: Multi-level batch consumption
- Refactored multi-level wallet enrichment with the same collect-group-batch pattern
- Covers: multi-level batch calls, limit-reached, mixed-period grouping

### Refactor: Extract `enrichLimitsFromBatch` helper
- Deduplicated the batch fetch + enrichment logic shared between single-level and multi-level paths

## Review

- Design doc reviewed by 3 agents (DX, Product, Technical) — all approved
- Critical finding caught during review: different limit keys can have different billing periods (`per: 'month'` vs `per: 'day'` vs lifetime). Design doc updated to group by period before batch-fetching.
- Adversarial code review: approved, no blockers

## Test plan

- [x] 14 new tests covering all acceptance criteria (single-level + multi-level)
- [x] All 1284 existing auth tests pass (0 regressions)
- [x] Typecheck clean
- [x] Lint clean

Fixes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)