### PR TITLE
fix(ci): fix @vertz/site build and task-manager workflow

### DIFF
--- a/.github/workflows/preview-task-manager.yml
+++ b/.github/workflows/preview-task-manager.yml
@@ -27,19 +27,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '22'
-          cache: 'bun'
+          bun-version: 1.3.9
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build Task Manager
-        run: |
-          bun run build --filter=@vertz-examples/task-manager
-        working-directory: examples/task-manager
+        run: bunx turbo run build --filter=@vertz-examples/task-manager
 
       - name: Deploy to Cloudflare Workers (Preview)
         uses: cloudflare/wrangler-action@v3
@@ -56,17 +53,17 @@ jobs:
           script: |
             const previewUrl = 'https://pr-${{ github.event.pull_request.number }}-task-manager.viniciusldacal.workers.dev';
             const commentBody = `🚀 **Preview Deployment Ready**\n\nThe task manager has been deployed to: ${previewUrl}\n\n- This preview will be available for the duration of this PR\n- Production deployment to follow`;
-            
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
-            const existingComment = comments.find(comment => 
+
+            const existingComment = comments.find(comment =>
               comment.body.includes('Preview Deployment Ready')
             );
-            
+
             if (existingComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -94,19 +91,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '22'
-          cache: 'bun'
+          bun-version: 1.3.9
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build Task Manager
-        run: |
-          bun run build --filter=@vertz-examples/task-manager
-        working-directory: examples/task-manager
+        run: bunx turbo run build --filter=@vertz-examples/task-manager
 
       - name: Deploy to Cloudflare Workers (Production)
         uses: cloudflare/wrangler-action@v3

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Vertz documentation site — built with @vertz/docs",
   "scripts": {
-    "dev": "vertz docs dev",
-    "build": "vertz docs build",
-    "check": "vertz docs check"
+    "dev": "bun node_modules/@vertz/cli/dist/vertz.js docs dev",
+    "build": "bun node_modules/@vertz/cli/dist/vertz.js docs build",
+    "check": "bun node_modules/@vertz/cli/dist/vertz.js docs check"
   },
   "dependencies": {
     "@vertz/cli": "workspace:^",


### PR DESCRIPTION
## Summary

Fixes two CI failures on `main`:

- **`@vertz/site` build (Release workflow):** The build script used bare `vertz docs build`, but the `vertz` binary isn't in PATH on CI runners (exit code 127). Changed to use explicit `bun node_modules/@vertz/cli/dist/vertz.js docs build`, matching the pattern used by `@vertz/landing` and `@vertz/component-docs`.

- **`preview-task-manager.yml` (Task Manager CI):** Used `actions/setup-node` with `cache: 'bun'` which isn't supported — causing immediate workflow failure. Replaced with `oven-sh/setup-bun@v2`. Also fixed the build command to run `bunx turbo run build --filter=...` from the monorepo root instead of a broken `bun run build --filter=...` from a subdirectory.

## Public API Changes

None.

## Test plan

- [ ] Release workflow builds `@vertz/site` successfully
- [ ] Task Manager CI workflow no longer fails at the workflow file level
- [ ] Existing CI pipeline unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)