### PR TITLE
fix(ui-compiler): extract CSS from @vertz-no-aot components for AOT manifest

### DIFF
--- a/packages/ui-compiler/src/__tests__/aot-compiler.test.ts
+++ b/packages/ui-compiler/src/__tests__/aot-compiler.test.ts
@@ -2156,5 +2156,29 @@ function Simple() {
 
       expect(result.css).toBeUndefined();
     });
+
+    it('extracts CSS from @vertz-no-aot components', () => {
+      const result = compileForSSRAot(
+        `
+// @vertz-no-aot
+import { css } from '@vertz/ui';
+
+const s = css({
+  root: ['p:4'],
+});
+
+export function Widget() {
+  return <div className={s.root}>Widget</div>;
+}
+        `.trim(),
+        { filename: 'src/widget.tsx' },
+      );
+
+      expect(result.components[0]!.tier).toBe('runtime-fallback');
+      expect(result.css).toBeDefined();
+      expect(Array.isArray(result.css)).toBe(true);
+      expect(result.css!.length).toBeGreaterThan(0);
+      expect(result.css!.some((r) => r.includes('padding'))).toBe(true);
+    });
   });
 });

--- a/packages/ui-compiler/src/compiler.ts
+++ b/packages/ui-compiler/src/compiler.ts
@@ -249,7 +249,18 @@ export function compileForSSRAot(
   const hasNoAotPragma = /\/\/\s*@vertz-no-aot/.test(source);
 
   if (hasNoAotPragma) {
-    // All components in this file are runtime-fallback
+    // All components in this file are runtime-fallback.
+    // Still extract CSS — runtime-fallback components still need their styles
+    // in the AOT manifest for non-Bun runtimes (#1989).
+    let noAotCss: string[] | undefined;
+    const noAotCssAnalyzer = new CSSAnalyzer();
+    const noAotCssCalls = noAotCssAnalyzer.analyze(sourceFile);
+    if (noAotCssCalls.length > 0) {
+      const noAotCssTransformer = new CSSTransformer();
+      const rules = noAotCssTransformer.extractCSS(sourceFile, noAotCssCalls, filename);
+      if (rules.length > 0) noAotCss = rules;
+    }
+
     return {
       code: source,
       map: s.generateMap({ source: filename, includeContent: true }),
@@ -260,6 +271,7 @@ export function compileForSSRAot(
         queryKeys: [],
       })),
       diagnostics: [],
+      css: noAotCss,
     };
   }
 

--- a/packages/ui-compiler/src/css-extraction/__tests__/css-extraction.test.ts
+++ b/packages/ui-compiler/src/css-extraction/__tests__/css-extraction.test.ts
@@ -278,13 +278,21 @@ const button = css({ root: ['m:2'] });`;
     expect(result.css).toContain(':hover');
   });
 
+  it('resolves grid-cols:N to repeat(N, minmax(0, 1fr))', () => {
+    const extractor = new CSSExtractor();
+    const source = `const s = css({ grid: ['grid-cols:5'] });`;
+    const result = extractor.extract(source, 'Grid.tsx');
+
+    expect(result.css).toContain('grid-template-columns: repeat(5, minmax(0, 1fr))');
+  });
+
   it('wraps @media at-rules around the class selector', () => {
     const extractor = new CSSExtractor();
     const source = `const s = css({ grid: ['gap:4', { '@media (min-width: 768px)': ['grid-cols:2'] }] });`;
     const result = extractor.extract(source, 'Grid.tsx');
 
     expect(result.css).toContain('@media (min-width: 768px)');
-    expect(result.css).toContain('grid-template-columns:');
+    expect(result.css).toContain('grid-template-columns: repeat(2, minmax(0, 1fr))');
     // The class selector must appear INSIDE the @media block
     expect(result.css).toMatch(/@media \(min-width: 768px\) \{\n\s+\._[a-f0-9]+ \{/);
   });

--- a/packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts
+++ b/packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts
@@ -550,4 +550,40 @@ describe('Feature: E2E AOT Pipeline', () => {
       });
     });
   });
+
+  describe('Given an AOT route with per-route CSS', () => {
+    describe('When the route is rendered via ssrRenderAot', () => {
+      it('Then the CSS is included in the render result', async () => {
+        writeFileSync(
+          join(serverDir, 'aot-manifest.json'),
+          JSON.stringify({
+            routes: {
+              '/styled': {
+                renderFn: '__ssr_StyledPage',
+                holes: [],
+                queryKeys: [],
+                css: ['._abc12345 { padding: 1rem; }', '._def67890 { color: red; }'],
+              },
+            },
+          }),
+        );
+        writeFileSync(
+          join(serverDir, 'aot-routes.js'),
+          `export function __ssr_StyledPage(data, ctx) { return '<div class="_abc12345">Styled</div>'; }`,
+        );
+
+        const { loadAotManifest } = await import('../aot-manifest-loader');
+        const aotManifest = await loadAotManifest(serverDir);
+        expect(aotManifest).not.toBeNull();
+
+        const { ssrRenderAot } = await import('../ssr-aot-pipeline');
+        const module = createMockModule();
+        const result = await ssrRenderAot(module, '/styled', { aotManifest: aotManifest! });
+
+        expect(result.html).toContain('Styled');
+        expect(result.css).toContain('padding: 1rem');
+        expect(result.css).toContain('color: red');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Fix missing CSS for `@vertz-no-aot` components**: Runtime-fallback components with `css()` calls now get their CSS rules extracted into the AOT manifest, fixing a gap where styles were missing on non-Bun runtimes (workerd, esbuild).
- **Fix per-route CSS e2e test format**: Updated the AOT e2e pipeline test to use `string[]` for route CSS, matching the upstream API introduced by #1988/#1989.
- **Add `grid-cols:N` CSS extraction test**: Verifies the extractor resolves `grid-cols:N` to `repeat(N, minmax(0, 1fr))`.

## Test plan

- [x] `@vertz-no-aot` components with `css()` calls produce CSS rule arrays in `compileForSSRAot()` output
- [x] AOT e2e pipeline test passes with `string[]` CSS format in manifest
- [x] CSS extraction tests pass for `grid-cols:N` shorthand
- [x] All 96 AOT compiler tests pass
- [x] All 49 AOT manifest + e2e pipeline tests pass
- [x] All 62 CSS extraction tests pass