### PR TITLE
fix(ui): Link component accepts multiple children

### DIFF
--- a/packages/ui/src/router/__tests__/link.test.ts
+++ b/packages/ui/src/router/__tests__/link.test.ts
@@ -121,6 +121,37 @@ describe('Link component', () => {
     expect(el.textContent).toBe('Home');
   });
 
+  test('renders multiple Node children (icon + text pattern)', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    const icon = document.createElement('span');
+    icon.textContent = '🏠';
+    const text = document.createElement('span');
+    text.textContent = 'Home';
+
+    const el = Link({ children: () => [icon, text], href: '/' });
+
+    expect(el.tagName).toBe('A');
+    expect(el.querySelectorAll('span').length).toBe(2);
+    expect(el.textContent).toBe('🏠Home');
+  });
+
+  test('renders array of mixed string and Node children', () => {
+    const currentPath = signal('/');
+    const navigate = vi.fn();
+    const Link = createLink(currentPath, navigate);
+
+    const bold = document.createElement('strong');
+    bold.textContent = 'Store';
+
+    const el = Link({ children: () => [bold, 'front'], href: '/' });
+
+    expect(el.textContent).toBe('Storefront');
+    expect(el.querySelector('strong')).toBeTruthy();
+  });
+
   test('activeClass toggles reactively when currentPath changes', () => {
     const currentPath = signal('/');
     const navigate = vi.fn();
@@ -388,6 +419,18 @@ describe('Link (context-based)', () => {
   test('accepts thunked children', () => {
     const el = renderInRouter('/', () => Link({ children: () => 'About', href: '/about' }));
     expect(el.textContent).toBe('About');
+  });
+
+  test('renders multiple Node children', () => {
+    const icon = document.createElement('span');
+    icon.textContent = '📖';
+    const text = document.createElement('span');
+    text.textContent = 'About';
+
+    const el = renderInRouter('/', () => Link({ children: () => [icon, text], href: '/about' }));
+
+    expect(el.querySelectorAll('span').length).toBe(2);
+    expect(el.textContent).toBe('📖About');
   });
 
   test('blocks dangerous href schemes', () => {

--- a/packages/ui/src/router/link.ts
+++ b/packages/ui/src/router/link.ts
@@ -4,14 +4,15 @@
  * Creates `<a>` elements that intercept clicks for SPA navigation
  * and support active state styling.
  *
- * Uses __element/__on/__enterChildren/__exitChildren/__append/__staticText
+ * Uses __element/__on/__enterChildren/__exitChildren/__insert
  * so that during hydration it claims existing SSR anchor nodes instead
  * of creating new elements.
  */
 
+import type { ChildValue } from '../component/children';
 import { useContext } from '../component/context';
 import { __classList } from '../dom/attributes';
-import { __append, __element, __enterChildren, __exitChildren, __staticText } from '../dom/element';
+import { __element, __enterChildren, __exitChildren, __insert } from '../dom/element';
 import { __on } from '../dom/events';
 import { isBrowser } from '../env/is-browser';
 import type { ReadonlySignal } from '../runtime/signal-types';
@@ -45,8 +46,8 @@ function isSafeUrl(url: string): boolean {
 export interface LinkProps<T extends Record<string, RouteConfigLike> = RouteDefinitionMap> {
   /** The target URL path. */
   href: RoutePaths<T>;
-  /** Text or content for the link. Accepts string, Node, or a thunk returning either. */
-  children: string | Node | (() => string | Node);
+  /** Content for the link. Accepts string, Node, arrays, or thunks — same as JSX children. */
+  children: ChildValue;
   /** Class applied when the link's href matches the current path. */
   activeClass?: string;
   /** Static class name for the anchor element. */
@@ -110,19 +111,7 @@ export function createLink(
     __on(el, 'click', handleClick as EventListener);
 
     __enterChildren(el);
-    if (typeof children === 'function') {
-      // Compiler thunk may return a Text node (__staticText) or a raw string
-      const result = children();
-      if (typeof result === 'string') {
-        __append(el, __staticText(result));
-      } else {
-        __append(el, result as Node);
-      }
-    } else if (typeof children === 'string') {
-      __append(el, __staticText(children));
-    } else {
-      __append(el, children);
-    }
+    __insert(el, children);
     __exitChildren();
 
     // Reactive active state — re-evaluates whenever currentPath changes.
@@ -187,18 +176,7 @@ export function Link({
   __on(el, 'click', handleClick as EventListener);
 
   __enterChildren(el);
-  if (typeof children === 'function') {
-    const result = children();
-    if (typeof result === 'string') {
-      __append(el, __staticText(result));
-    } else {
-      __append(el, result as Node);
-    }
-  } else if (typeof children === 'string') {
-    __append(el, __staticText(children));
-  } else {
-    __append(el, children);
-  }
+  __insert(el, children);
   __exitChildren();
 
   if (activeClass) {


### PR DESCRIPTION
## Summary

- **Link children type** changed from `string | Node | (() => string | Node)` to `ChildValue` — now accepts strings, nodes, arrays, thunks, and nested combinations (same as all other JSX children)
- **Manual child handling** replaced with `__insert(el, children)` which recursively resolves thunks, arrays, and primitives (handles hydration correctly)
- Both `createLink` factory and context-based `Link` updated

## Public API Changes

- `LinkProps.children` type widened from `string | Node | (() => string | Node)` to `ChildValue` — non-breaking, existing usage still works

Fixes #1966

## Test plan

- [x] Multiple Node children (icon + text pattern) — factory Link
- [x] Mixed string and Node array children — factory Link
- [x] Multiple Node children — context-based Link
- [x] All 33 existing tests still pass (XSS, prefetch, activeClass, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)