### PR TITLE
fix(ci): exclude native compiler from release build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "changeset:publish": "bun run build && bash scripts/publish.sh",
     "postinstall": "if [ \"$(git rev-parse --git-dir 2>/dev/null)\" = \"$(git rev-parse --git-common-dir 2>/dev/null)\" ]; then lefthook install || true; fi",
     "test:tree-shaking": "bun test tests/tree-shaking/tree-shaking.test.ts",
-    "build": "turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel'"
+    "build": "turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' --filter='!@vertz/native-compiler' --filter='!@vertz-benchmarks/*'"
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.3.0",


### PR DESCRIPTION
## Summary

- Adds `--filter='!@vertz/native-compiler'` to the root `build` script, matching what all `ci:*` scripts already have
- Also excludes `@vertz-benchmarks/*` for consistency

## Problem

The release workflow (`release.yml`) runs `bun run build`, which uses the root `build` script. This script was missing the native compiler exclusion filter that all CI scripts had.

On `ubuntu-latest` runners (which have Rust/Cargo pre-installed), this caused:
1. `which cargo` succeeds → `cargo build --release` starts
2. Full Rust workspace compilation in release mode (10-20+ minutes)
3. `cp ...dylib` fails on Linux (produces `.so`, not `.dylib`)
4. Falls through to echo — wasting CI time for nothing

The native compiler is `private: true`, not published to NPM, and has its own dedicated CI workflow (`native-compiler.yml`). There is no reason to build it during the JS release pipeline.

## Public API Changes

None — CI-only change.

## Test plan

- [x] Pre-push hooks pass (lint, quality gates, trojan-source)
- [ ] Verify next release pipeline completes without attempting Rust compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)