### PR TITLE
fix(ci): exclude CHANGELOG.md from oxfmt format check

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,5 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "ignorePatterns": ["**/.vertz/**"]
+  "ignorePatterns": ["**/.vertz/**", "**/CHANGELOG.md"]
 }


### PR DESCRIPTION
## Summary

- Adds `**/CHANGELOG.md` to oxfmt's `ignorePatterns` in `.oxfmtrc.json`

## Problem

The `changesets/action` auto-generates CHANGELOG.md files on the `changeset-release/main` branch. These files don't conform to oxfmt formatting, causing the CI format check to fail every time a release is attempted.

Failed run: https://github.com/vertz-dev/vertz/actions/runs/23712166132

## Fix

Exclude CHANGELOG.md files from oxfmt since they're auto-generated and not hand-written code.

## Public API Changes

None.

## Test plan

- [x] `bunx oxfmt --check packages/` passes locally
- [x] Pre-push quality gates pass (lint, build, typecheck, test)
- [ ] CI passes on this PR
- [ ] Next release attempt on `changeset-release/main` passes format check

🤖 Generated with [Claude Code](https://claude.com/claude-code)