### PR TITLE
fix(ui-primitives): guard double done() in onItemExit (#1737)

### DIFF
--- a/packages/ui-primitives/src/list/__tests__/list-animation-hooks.test.tsx
+++ b/packages/ui-primitives/src/list/__tests__/list-animation-hooks.test.tsx
@@ -124,6 +124,43 @@ describe('ComposedList animation hooks behavior', () => {
         el.dispatchEvent(new Event('transitionend'));
         expect(calls).toEqual(['done']);
       });
+
+      it('Then done() is called exactly once even when both transitionend and timeout fire', async () => {
+        const hooks = captureAnimationHooks({ duration: 50 });
+        const el = document.createElement('li');
+        let callCount = 0;
+
+        hooks?.onItemExit(el, 'key-1', () => {
+          callCount++;
+        });
+
+        // Simulate transitionend fires first
+        el.dispatchEvent(new Event('transitionend'));
+        expect(callCount).toBe(1);
+
+        // Wait for the safety timeout to fire (duration + 50 = 100ms)
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        // done() must NOT have been called a second time
+        expect(callCount).toBe(1);
+      });
+
+      it('Then done() is called exactly once via timeout when transitionend never fires', async () => {
+        const hooks = captureAnimationHooks({ duration: 50 });
+        const el = document.createElement('li');
+        let callCount = 0;
+
+        hooks?.onItemExit(el, 'key-1', () => {
+          callCount++;
+        });
+
+        // Don't dispatch transitionend — let the safety timeout handle it
+        expect(callCount).toBe(0);
+
+        // Wait for safety timeout (duration 50 + 50 = 100ms)
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(callCount).toBe(1);
+      });
     });
   });
 

--- a/packages/ui-primitives/src/list/list-composed.tsx
+++ b/packages/ui-primitives/src/list/list-composed.tsx
@@ -238,10 +238,21 @@ function createAnimationHooks(animate: boolean | AnimateConfig): ListAnimationHo
           el.style.paddingBottom = '0';
           el.style.opacity = '0';
 
-          el.addEventListener('transitionend', () => done(), { once: true });
+          // Guard against double done() calls — transitionend and safety timeout
+          // can both fire, but done() must only be called once.
+          let exitDone = false;
+          let safetyTimer: ReturnType<typeof setTimeout>;
+          const safeDone = () => {
+            if (exitDone) return;
+            exitDone = true;
+            clearTimeout(safetyTimer);
+            done();
+          };
+
+          el.addEventListener('transitionend', safeDone, { once: true });
 
           // Safety timeout in case transitionend doesn't fire
-          setTimeout(() => done(), duration + 50);
+          safetyTimer = setTimeout(safeDone, duration + 50);
         } else {
           done();
         }


### PR DESCRIPTION
## Summary

- Fixes double `done()` call in `onItemExit` animation handler where both `transitionend` and the safety `setTimeout` could invoke `done()`
- Adds a `safeDone` guard wrapper with `exitDone` flag so `done()` is called exactly once
- Clears the safety timer via `clearTimeout` when `transitionend` fires first, preventing stale timer/closure references

Closes #1737

## Public API Changes

None. Internal implementation fix only.

## Test plan

- [x] Test: `done()` called exactly once when `transitionend` fires before timeout
- [x] Test: `done()` called exactly once via timeout when `transitionend` never fires
- [x] All 63 list tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)