### PR TITLE
feat(cli): add --experimental-runtime flag to vertz dev (#2052)

### DIFF
--- a/native/vertz-runtime/src/cli.rs
+++ b/native/vertz-runtime/src/cli.rs
@@ -54,6 +54,10 @@ pub struct DevArgs {
     #[arg(long, default_value = "localhost")]
     pub host: String,
 
+    /// Open browser after server starts
+    #[arg(long)]
+    pub open: bool,
+
     /// Directory to serve static files from
     #[arg(long, default_value = "public")]
     pub public_dir: PathBuf,

--- a/native/vertz-runtime/src/config.rs
+++ b/native/vertz-runtime/src/config.rs
@@ -19,6 +19,8 @@ pub struct ServerConfig {
     pub tsconfig_path: Option<PathBuf>,
     /// Explicit type checker binary path (default: None — auto-detect tsgo/tsc).
     pub typecheck_binary: Option<PathBuf>,
+    /// Whether to open the browser after the server starts.
+    pub open_browser: bool,
     /// Optional server entry file (e.g., "src/server.ts") for API route delegation.
     /// When present, a persistent V8 isolate is created to handle /api/* requests.
     pub server_entry: Option<PathBuf>,
@@ -41,6 +43,7 @@ impl ServerConfig {
             enable_typecheck: true,
             tsconfig_path: None,
             typecheck_binary: None,
+            open_browser: false,
             server_entry,
         }
     }
@@ -61,6 +64,7 @@ impl ServerConfig {
             enable_typecheck: true,
             tsconfig_path: None,
             typecheck_binary: None,
+            open_browser: false,
             server_entry,
         }
     }

--- a/native/vertz-runtime/src/main.rs
+++ b/native/vertz-runtime/src/main.rs
@@ -16,6 +16,7 @@ async fn main() {
         Command::Dev(args) => {
             let mut config = ServerConfig::new(args.port, args.host, args.public_dir);
             config.enable_typecheck = !args.no_typecheck;
+            config.open_browser = args.open;
             config.tsconfig_path = args.tsconfig;
             config.typecheck_binary = args.typecheck_binary;
 

--- a/packages/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/__tests__/dev.test.ts
@@ -830,9 +830,9 @@ describe('devAction --experimental-runtime', () => {
       kill: vi.fn(),
       pid: 12345,
     };
-    launchSpy = vi
-      .spyOn(launcherMod, 'launchRuntime')
-      .mockReturnValue(mockChild as never) as Mock<(...args: unknown[]) => unknown>;
+    launchSpy = vi.spyOn(launcherMod, 'launchRuntime').mockReturnValue(mockChild as never) as Mock<
+      (...args: unknown[]) => unknown
+    >;
 
     const { devAction } = await import('../dev');
     const result = await devAction({ experimentalRuntime: true, port: 4000, host: '0.0.0.0' });
@@ -842,6 +842,7 @@ describe('devAction --experimental-runtime', () => {
       port: 4000,
       host: '0.0.0.0',
       typecheck: true,
+      open: false,
     });
   });
 
@@ -859,9 +860,9 @@ describe('devAction --experimental-runtime', () => {
       kill: vi.fn(),
       pid: 12345,
     };
-    launchSpy = vi
-      .spyOn(launcherMod, 'launchRuntime')
-      .mockReturnValue(mockChild as never) as Mock<(...args: unknown[]) => unknown>;
+    launchSpy = vi.spyOn(launcherMod, 'launchRuntime').mockReturnValue(mockChild as never) as Mock<
+      (...args: unknown[]) => unknown
+    >;
 
     const pipelineMod = await import('../../pipeline');
     const orchestratorSpy = vi

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -56,7 +56,7 @@ export async function devAction(options: DevCommandOptions = {}): Promise<Result
 
   // Experimental: use Rust runtime instead of Bun dev server
   if (experimentalRuntime) {
-    return startExperimentalRuntime(projectRoot, { port, host, typecheck });
+    return startExperimentalRuntime(projectRoot, { port, host, typecheck, open });
   }
 
   // Detect app type from file conventions
@@ -220,9 +220,20 @@ function startExperimentalRuntime(
   process.on('SIGTERM', shutdown);
   process.on('SIGHUP', shutdown);
 
-  // Wait for the child to exit — this is a promise that resolves
-  // when the Rust process terminates (Ctrl+C, crash, etc.)
+  // Handle spawn errors (e.g., binary not executable)
+  child.on('error', (error) => {
+    console.error(`Failed to start Rust runtime: ${error.message}`);
+    process.removeListener('SIGINT', shutdown);
+    process.removeListener('SIGTERM', shutdown);
+    process.removeListener('SIGHUP', shutdown);
+    process.exit(1);
+  });
+
+  // Clean up signal handlers and exit when the child terminates
   child.on('exit', (code) => {
+    process.removeListener('SIGINT', shutdown);
+    process.removeListener('SIGTERM', shutdown);
+    process.removeListener('SIGHUP', shutdown);
     process.exit(code ?? 0);
   });
 

--- a/packages/cli/src/runtime/__tests__/launcher.test.ts
+++ b/packages/cli/src/runtime/__tests__/launcher.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { findRuntimeBinary, type RuntimeLaunchOptions, buildRuntimeArgs } from '../launcher';
+import {
+  findRuntimeBinary,
+  launchRuntime,
+  type RuntimeLaunchOptions,
+  buildRuntimeArgs,
+} from '../launcher';
 
 describe('findRuntimeBinary', () => {
   let tmpDir: string;
@@ -115,11 +120,62 @@ describe('buildRuntimeArgs', () => {
     expect(args).not.toContain('--no-typecheck');
   });
 
+  it('includes --open when open is true', () => {
+    const opts: RuntimeLaunchOptions = {
+      port: 3000,
+      host: 'localhost',
+      open: true,
+    };
+
+    const args = buildRuntimeArgs(opts);
+
+    expect(args).toContain('--open');
+  });
+
+  it('does not include --open when open is false or undefined', () => {
+    const args1 = buildRuntimeArgs({ open: false });
+    const args2 = buildRuntimeArgs({});
+
+    expect(args1).not.toContain('--open');
+    expect(args2).not.toContain('--open');
+  });
+
   it('uses default port 3000 and host localhost', () => {
     const opts: RuntimeLaunchOptions = {};
 
     const args = buildRuntimeArgs(opts);
 
     expect(args).toEqual(['dev', '--port', '3000', '--host', 'localhost']);
+  });
+});
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 12345 })),
+}));
+
+describe('launchRuntime', () => {
+  it('spawns the binary with correct args and stdio inherit', async () => {
+    const { spawn } = await import('node:child_process');
+
+    const child = launchRuntime('/usr/bin/vertz-runtime', { port: 8080, host: '0.0.0.0' });
+
+    expect(spawn).toHaveBeenCalledWith(
+      '/usr/bin/vertz-runtime',
+      ['dev', '--port', '8080', '--host', '0.0.0.0'],
+      { stdio: 'inherit', env: process.env },
+    );
+    expect(child).toBeDefined();
+  });
+
+  it('passes --open and --no-typecheck flags through to spawn', async () => {
+    const { spawn } = await import('node:child_process');
+
+    launchRuntime('/usr/bin/vertz-runtime', { open: true, typecheck: false });
+
+    expect(spawn).toHaveBeenCalledWith(
+      '/usr/bin/vertz-runtime',
+      ['dev', '--port', '3000', '--host', 'localhost', '--no-typecheck', '--open'],
+      { stdio: 'inherit', env: process.env },
+    );
   });
 });

--- a/packages/cli/src/runtime/launcher.ts
+++ b/packages/cli/src/runtime/launcher.ts
@@ -6,6 +6,7 @@ export interface RuntimeLaunchOptions {
   port?: number;
   host?: string;
   typecheck?: boolean;
+  open?: boolean;
 }
 
 /**
@@ -43,6 +44,10 @@ export function buildRuntimeArgs(opts: RuntimeLaunchOptions): string[] {
 
   if (opts.typecheck === false) {
     args.push('--no-typecheck');
+  }
+
+  if (opts.open) {
+    args.push('--open');
   }
 
   return args;


### PR DESCRIPTION
## Summary

- Adds `--experimental-runtime` flag to `vertz dev` that spawns the Rust runtime binary instead of the Bun dev server
- New `packages/cli/src/runtime/launcher.ts` module handles binary discovery (`VERTZ_RUNTIME_BINARY` env → release → debug), CLI arg building, and subprocess spawning
- Forwards `--port`, `--host`, `--no-typecheck`, and `--open` flags to the Rust binary
- Proper process lifecycle management: signal forwarding (SIGINT/SIGTERM/SIGHUP), signal handler cleanup on exit, spawn error handling
- Rust side: adds `--open` flag to `DevArgs` and `open_browser` to `ServerConfig`

## Public API Changes

- **New CLI flag:** `vertz dev --experimental-runtime` — spawns the Rust dev server instead of the Bun pipeline
- **New env var:** `VERTZ_RUNTIME_BINARY` — override path for the runtime binary

## Test Plan

- [x] `findRuntimeBinary`: 5 tests — debug path, release preferred, not found, env override, env nonexistent
- [x] `buildRuntimeArgs`: 6 tests — basic args, --no-typecheck, --open, defaults
- [x] `launchRuntime`: 2 tests — correct spawn args + stdio, flag forwarding
- [x] `devAction --experimental-runtime`: 3 tests — binary not found error, spawn on found, Bun pipeline not started
- [x] `registerDevCommand`: flag registration verified
- [x] Rust: 1321 tests pass, clippy clean, fmt clean

## Review

Adversarial review completed in `reviews/experimental-runtime-flag/phase-01-cli-integration.md`:
- B1 (--open not forwarded) → Fixed
- B2 (launchRuntime untested) → Fixed, 2 tests added
- S3 (signal handler leak) → Fixed, handlers removed on exit/error
- S4 (no error handler) → Fixed, child.on('error') added

Closes #2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)