### PR TITLE
fix(runtime): implement Drop for SmartDebouncer #2084

### DIFF
--- a/native/vertz-runtime/src/watcher/file_watcher.rs
+++ b/native/vertz-runtime/src/watcher/file_watcher.rs
@@ -648,6 +648,14 @@ mod tests {
         assert!(!debouncer.has_pending());
         assert!(!debouncer.is_ready());
         assert_eq!(debouncer.pending_count(), 0);
+
+        // Verify reuse after cancel works
+        debouncer.add(FileChange {
+            kind: FileChangeKind::Create,
+            path: PathBuf::from("/src/NewFile.tsx"),
+        });
+        assert!(debouncer.has_pending());
+        assert_eq!(debouncer.pending_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `cancel()` method to `SmartDebouncer` that clears pending events and resets timestamps
- Implement `Drop` trait delegating to `cancel()`, ensuring no stale pending state survives the debouncer's lifetime
- Add tests for cancel behavior, post-cancel reuse, and drop-with-pending safety

Closes #2084

## Public API Changes

- **Addition:** `SmartDebouncer::cancel(&mut self)` — public method to discard pending changes without dropping the debouncer

## Review

Adversarial review approved (see `reviews/fix-debouncer-drop/phase-01-drop-impl.md`). Pre-existing parity gap in `Debouncer` tracked as #2089.

## Test plan

- [x] `test_smart_debouncer_cancel_clears_pending` — cancel clears state + debouncer reusable after cancel
- [x] `test_smart_debouncer_drop_with_pending_does_not_panic` — drop with pending events is safe
- [x] All 26 `file_watcher` tests pass
- [x] Full Rust test suite passes (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-targets`)
- [x] Format clean (`cargo fmt --all --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)