### PR TITLE
fix(runtime): SmartDebouncer max-wait cap for batch phase #2086

### DIFF
--- a/native/vertz-runtime/src/watcher/file_watcher.rs
+++ b/native/vertz-runtime/src/watcher/file_watcher.rs
@@ -628,8 +628,8 @@ mod tests {
 
     #[test]
     fn test_smart_debouncer_multi_file_waits_for_batch() {
-        // Use a long batch debounce so it's definitely not ready
-        let mut debouncer = SmartDebouncer::with_timings(0, 1000);
+        // Use a long batch debounce and long max_wait so it's definitely not ready
+        let mut debouncer = SmartDebouncer::with_timings(0, 1000).with_max_wait(2000);
         debouncer.add(FileChange {
             kind: FileChangeKind::Modify,
             path: PathBuf::from("/src/app.tsx"),
@@ -726,6 +726,25 @@ mod tests {
         assert!(
             debouncer.is_ready(),
             "Rapid continuous events should still fire within max_wait"
+        );
+    }
+
+    #[test]
+    fn test_smart_debouncer_max_wait_zero_fires_immediately() {
+        let mut debouncer = SmartDebouncer::with_timings(0, 1000).with_max_wait(0);
+        debouncer.add(FileChange {
+            kind: FileChangeKind::Modify,
+            path: PathBuf::from("/src/app.tsx"),
+        });
+        debouncer.add(FileChange {
+            kind: FileChangeKind::Modify,
+            path: PathBuf::from("/src/Button.tsx"),
+        });
+
+        // max_wait=0 means multi-file batch fires immediately
+        assert!(
+            debouncer.is_ready(),
+            "max_wait=0 should make multi-file batch immediately ready"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds a `max_wait` field (default 100ms) to `SmartDebouncer` that caps how long the batch phase can delay dispatch
- Previously, rapid continuous events could reset `last_event_time` indefinitely, preventing batch dispatch
- Now `is_ready()` checks `first_event_time.elapsed() >= max_wait` as an override in batch mode
- Adds `with_max_wait()` builder method for custom configuration

## Public API Changes

- `SmartDebouncer::with_max_wait(ms: u64) -> Self` — new builder method
- `SmartDebouncer.max_wait` — new `pub` field (default 100ms)
- No breaking changes to existing API

## Test plan

- [x] Test: max-wait fires despite long batch_debounce (sleep-based)
- [x] Test: rapid continuous events fire within max_wait window (the actual bug scenario)
- [x] Test: `with_max_wait(0)` makes multi-file batch fire immediately
- [x] Test: default max_wait is 100ms
- [x] Hardened existing `multi_file_waits_for_batch` test with explicit `with_max_wait(2000)` to avoid CI timing sensitivity
- [x] All 1325 Rust tests pass
- [x] Clippy + fmt clean

Fixes #2086

🤖 Generated with [Claude Code](https://claude.com/claude-code)