### PR TITLE
fix(cli): add process.exit(0) to one-shot CLI commands

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,6 +47,7 @@ export function createCLI(): Command {
         console.error(result.error.message);
         process.exit(1);
       }
+      process.exit(0);
     });
 
   program
@@ -79,6 +80,7 @@ export function createCLI(): Command {
         console.error(result.error.message);
         process.exit(1);
       }
+      process.exit(0);
     });
 
   // Unified dev command - Phase 1 implementation
@@ -222,6 +224,7 @@ export function createCLI(): Command {
       }
 
       console.log(result.data.output);
+      process.exit(0);
     });
 
   program
@@ -474,6 +477,7 @@ export function createCLI(): Command {
         console.error(result.error.message);
         process.exit(1);
       }
+      process.exit(0);
     });
 
   docsCommand
@@ -490,6 +494,7 @@ export function createCLI(): Command {
         console.error(result.error.message);
         process.exit(1);
       }
+      process.exit(0);
     });
 
   docsCommand
@@ -518,6 +523,7 @@ export function createCLI(): Command {
         console.error(result.error.message);
         process.exit(1);
       }
+      process.exit(0);
     });
 
   return program;


### PR DESCRIPTION
## Summary

- `bun run build` hung indefinitely because the `vertz build` CLI command never called `process.exit(0)` on success — dangling event loop handles from the SSR module import kept the Bun process alive
- Added `process.exit(0)` to all one-shot commands: `build`, `create`, `codegen`, `docs init`, `docs build`, `docs check`
- Full monorepo build now completes in ~12s instead of hanging forever

## Test plan

- [x] `bun run build` completes and exits (was hanging indefinitely)
- [x] `turbo run build --filter='@vertz/landing' --force` exits in ~7s
- [x] CLI tests pass (`turbo run test --filter='@vertz/cli'`)
- [x] Typecheck passes (`turbo run typecheck --filter='@vertz/cli'`)
- [x] Lint clean (`oxlint packages/cli/src/cli.ts`)