### PR TITLE
fix(runtime): test runner root_dir resolution for workspace imports #2111

### DIFF
--- a/native/vertz-runtime/src/cli.rs
+++ b/native/vertz-runtime/src/cli.rs
@@ -141,6 +141,10 @@ pub struct TestArgs {
     /// Skip preload scripts
     #[arg(long)]
     pub no_preload: bool,
+
+    /// Workspace root directory for module resolution (default: current directory)
+    #[arg(long)]
+    pub root_dir: Option<PathBuf>,
 }
 
 #[derive(Parser, Debug)]
@@ -974,6 +978,18 @@ mod tests {
     fn test_test_no_preload() {
         let args = parse_test(&["vertz-runtime", "test", "--no-preload"]);
         assert!(args.no_preload);
+    }
+
+    #[test]
+    fn test_test_root_dir() {
+        let args = parse_test(&["vertz-runtime", "test", "--root-dir", "/workspace/root"]);
+        assert_eq!(args.root_dir, Some(PathBuf::from("/workspace/root")));
+    }
+
+    #[test]
+    fn test_test_root_dir_default() {
+        let args = parse_test(&["vertz-runtime", "test"]);
+        assert!(args.root_dir.is_none());
     }
 
     #[test]

--- a/native/vertz-runtime/src/main.rs
+++ b/native/vertz-runtime/src/main.rs
@@ -38,8 +38,9 @@ async fn main() {
             }
         }
         Command::Test(args) => {
-            let root_dir =
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let root_dir = args.root_dir.unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+            });
 
             // Load config file (if present)
             let file_config =

--- a/native/vertz-runtime/src/test/executor.rs
+++ b/native/vertz-runtime/src/test/executor.rs
@@ -99,6 +99,9 @@ pub struct ExecuteOptions {
     pub coverage: bool,
     /// Preload script paths (absolute) to execute before the test file.
     pub preload: Vec<std::path::PathBuf>,
+    /// Root directory for module resolution (workspace root).
+    /// When set, overrides the default behavior of using the file's parent directory.
+    pub root_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for ExecuteOptions {
@@ -108,6 +111,7 @@ impl Default for ExecuteOptions {
             timeout_ms: 5000,
             coverage: false,
             preload: vec![],
+            root_dir: None,
         }
     }
 }
@@ -128,12 +132,18 @@ pub fn execute_test_file_with_options(
     let file_str = file_path.to_string_lossy().to_string();
     let start = Instant::now();
 
-    // Determine root dir from file path (parent of the file)
-    let root_dir = file_path
-        .parent()
-        .unwrap_or(Path::new("."))
-        .to_string_lossy()
-        .to_string();
+    // Use explicit root_dir from options (workspace root), falling back to file's parent
+    let root_dir = options
+        .root_dir
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| {
+            file_path
+                .parent()
+                .unwrap_or(Path::new("."))
+                .to_string_lossy()
+                .to_string()
+        });
 
     let result = execute_test_file_inner(file_path, &root_dir, options);
 
@@ -708,5 +718,83 @@ mod tests {
             .as_ref()
             .unwrap()
             .contains("Cannot read preload script"));
+    }
+
+    #[test]
+    fn test_root_dir_affects_bun_cache_resolution() {
+        // The module loader's Bun cache fallback starts from `self.root_dir`.
+        // When root_dir is the workspace root (not the test file's parent),
+        // packages in `node_modules/.bun/node_modules/` are found correctly.
+        //
+        // This test places a package ONLY in the Bun cache at the workspace root
+        // and puts the test file in a sibling directory. Walk-up from the test
+        // file's parent never reaches the workspace, so root_dir is the only
+        // way the module loader finds the Bun cache.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        // Workspace root: package ONLY in Bun's internal cache
+        let workspace = base.join("workspace");
+        let bun_cache_lib = workspace
+            .join("node_modules")
+            .join(".bun")
+            .join("node_modules")
+            .join("my-lib");
+        fs::create_dir_all(&bun_cache_lib).unwrap();
+        fs::write(
+            bun_cache_lib.join("package.json"),
+            r#"{"name": "my-lib", "main": "index.js"}"#,
+        )
+        .unwrap();
+        fs::write(bun_cache_lib.join("index.js"), "export const value = 42;").unwrap();
+
+        // Test file in a sibling directory (NOT under workspace/)
+        let test_dir = base.join("isolated");
+        fs::create_dir_all(&test_dir).unwrap();
+        let test_file = test_dir.join("core.test.ts");
+        fs::write(
+            &test_file,
+            r#"
+            import { value } from 'my-lib';
+            describe('bun cache import', () => {
+                it('resolves from workspace root bun cache', () => {
+                    expect(value).toBe(42);
+                });
+            });
+            "#,
+        )
+        .unwrap();
+
+        // Without root_dir: defaults to file parent (isolated/), walk-up never
+        // reaches workspace/, Bun cache walk-up also starts from isolated/.
+        // Import fails because my-lib is only in workspace's bun cache.
+        let result_no_root = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                root_dir: None,
+                ..Default::default()
+            },
+        );
+        assert!(
+            result_no_root.file_error.is_some(),
+            "Without root_dir, should fail to find package in bun cache"
+        );
+
+        // With root_dir pointing to workspace: Bun cache walk-up starts from
+        // workspace/, finds node_modules/.bun/node_modules/my-lib/.
+        let result_with_root = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                root_dir: Some(workspace),
+                ..Default::default()
+            },
+        );
+        assert!(
+            result_with_root.file_error.is_none(),
+            "With root_dir, should resolve from bun cache: {:?}",
+            result_with_root.file_error
+        );
+        assert_eq!(result_with_root.tests.len(), 1);
+        assert_eq!(result_with_root.tests[0].status, TestStatus::Pass);
     }
 }

--- a/native/vertz-runtime/src/test/runner.rs
+++ b/native/vertz-runtime/src/test/runner.rs
@@ -127,6 +127,7 @@ pub fn run_tests(config: TestRunConfig) -> (TestRunResult, String) {
         timeout_ms: config.timeout_ms,
         coverage: config.coverage,
         preload: preload_paths,
+        root_dir: Some(config.root_dir.clone()),
     });
 
     let mut results = execute_parallel(&files, concurrency, config.bail, exec_options);

--- a/native/vertz-runtime/src/test/watch.rs
+++ b/native/vertz-runtime/src/test/watch.rs
@@ -98,6 +98,7 @@ pub async fn run_watch_mode(config: TestRunConfig) -> Result<(), String> {
         timeout_ms: config.timeout_ms,
         coverage: false,
         preload: preload_paths,
+        root_dir: Some(config.root_dir.clone()),
     });
 
     // Initial run


### PR DESCRIPTION
## Summary

- Thread `root_dir` from `TestRunConfig` (workspace root) to `ExecuteOptions` → `VertzModuleLoader`, so module resolution uses the workspace root instead of the test file's parent directory
- Add `--root-dir` CLI flag as explicit override for workspace root detection
- Non-vacuous test: proves `root_dir` affects Bun cache resolution path by placing test file outside the workspace tree

## Public API Changes

- **New CLI flag:** `vertz test --root-dir <path>` — overrides workspace root for module resolution (default: current directory)
- `ExecuteOptions.root_dir: Option<PathBuf>` — new field, backward-compatible (defaults to file parent when `None`)

## Files Changed

| File | Change |
|------|--------|
| `native/vertz-runtime/src/test/executor.rs` | Add `root_dir` to `ExecuteOptions`, use it for module resolution, add Bun cache resolution test |
| `native/vertz-runtime/src/test/runner.rs` | Pass `config.root_dir` through to `ExecuteOptions` |
| `native/vertz-runtime/src/test/watch.rs` | Same pass-through for watch mode |
| `native/vertz-runtime/src/cli.rs` | Add `--root-dir` flag to `TestArgs`, add CLI parse tests |
| `native/vertz-runtime/src/main.rs` | Wire `--root-dir` flag, fall back to `current_dir()` |

## Test plan

- [x] Unit test: `test_root_dir_affects_bun_cache_resolution` — verifies that without `root_dir`, import fails (walk-up from isolated dir never reaches workspace); with `root_dir`, Bun cache fallback finds the package
- [x] CLI tests: `test_test_root_dir` and `test_test_root_dir_default` — verify flag parsing
- [x] Full `cargo test --all` passes
- [x] `cargo fmt --check` and `cargo clippy -D warnings` clean

Closes #2111

🤖 Generated with [Claude Code](https://claude.com/claude-code)