### PR TITLE
chore(cli): add changeset for cloudflare production deployment

### DIFF
--- a/.changeset/cloudflare-production-deploy.md
+++ b/.changeset/cloudflare-production-deploy.md
@@ -1,0 +1,5 @@
+---
+'@vertz/cli': patch
+---
+
+Add production deployment pipeline for Cloudflare Workers: `vertz build --target cloudflare`, production constraint enforcement for `vertz start`, and `vertz deploy` command with dry-run support.


### PR DESCRIPTION
## Summary

Adds the missing changeset for #2032 (production deployment pipeline). The feature PR #2118 was squash-merged before this changeset was pushed.

- `@vertz/cli`: patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)