### PR TITLE
feat(landing): add docs CTA to hero section

### DIFF
--- a/packages/landing/src/components/hero.tsx
+++ b/packages/landing/src/components/hero.tsx
@@ -190,6 +190,22 @@ const s = css({
       '@media (min-width: 640px)': { display: 'inline-flex' },
     },
   ],
+  docsLink: [
+    'flex',
+    'items:center',
+    'justify:center',
+    'gap:2',
+    'py:3',
+    'px:6',
+    'font:sm',
+    'uppercase',
+    'tracking:wider',
+    'transition:colors',
+    { '&': { color: '#6B6560' } },
+    {
+      '@media (min-width: 640px)': { display: 'inline-flex' },
+    },
+  ],
   // Code group styles
   codeGroup: [
     'border:1',
@@ -1077,6 +1093,13 @@ export function Hero() {
           <div className={s.ctas}>
             <Island component={CopyButton} />
             <Island component={SocialLinks} />
+            <a
+              href="https://docs.vertz.dev"
+              className={s.docsLink}
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              Read the Docs →
+            </a>
           </div>
         </div>
 

--- a/sites/landing-nextjs-vercel/src/components/hero.tsx
+++ b/sites/landing-nextjs-vercel/src/components/hero.tsx
@@ -50,6 +50,12 @@ export function Hero() {
         >
           View on GitHub →
         </a>
+        <a
+          href="https://docs.vertz.dev"
+          className="inline-flex items-center justify-center gap-2 py-3 px-6 text-sm uppercase tracking-wider transition-colors text-gray-400 font-[family-name:var(--font-mono)]"
+        >
+          Read the Docs →
+        </a>
       </div>
     </section>
   );

--- a/sites/landing-nextjs/src/components/hero.tsx
+++ b/sites/landing-nextjs/src/components/hero.tsx
@@ -50,6 +50,12 @@ export function Hero() {
         >
           View on GitHub →
         </a>
+        <a
+          href="https://docs.vertz.dev"
+          className="inline-flex items-center justify-center gap-2 py-3 px-6 text-sm uppercase tracking-wider transition-colors text-gray-400 font-[family-name:var(--font-mono)]"
+        >
+          Read the Docs →
+        </a>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

- Adds a prominent "Read the Docs →" CTA link in the hero section pointing to `docs.vertz.dev`
- Applied to all 3 landing deployments: `packages/landing` (Vertz), `sites/landing-nextjs-vercel`, `sites/landing-nextjs`
- The nav already had a "Docs" link, but the hero CTAs only had GitHub and Discord — agents/users missed the docs path

Fixes #2125

## Test plan

- [ ] Verify "Read the Docs →" appears in the hero section on vertz.dev
- [ ] Verify link navigates to docs.vertz.dev
- [ ] Verify styling is consistent with existing CTA links (GitHub, Discord)

🤖 Generated with [Claude Code](https://claude.com/claude-code)