### PR TITLE
fix(runtime): chunked timer sleep prevents test timeouts

### DIFF
--- a/native/vertz-runtime/src/runtime/ops/timers.rs
+++ b/native/vertz-runtime/src/runtime/ops/timers.rs
@@ -13,11 +13,37 @@ pub fn op_decls() -> Vec<OpDecl> {
 }
 
 /// JavaScript bootstrap code for timer globals.
-/// Uses a simple cancelled flag instead of AbortController (not available in bare V8).
+///
+/// Cancelled timers are handled by breaking long sleeps into short chunks
+/// (max 100ms each) and checking the `cancelled` flag between chunks.
+/// This ensures that `clearTimeout`/`clearInterval` causes the underlying
+/// `op_timer_sleep` ops to drain quickly instead of keeping the event loop
+/// alive for the full original duration.
+///
+/// Without this, a cancelled 1-hour timer would block `run_event_loop()`
+/// for up to 1 hour — causing test file timeouts in `vertz test`.
 pub const TIMERS_BOOTSTRAP_JS: &str = r#"
 ((globalThis) => {
   let nextId = 1;
   const activeTimers = new Map();
+
+  // Maximum sleep chunk in ms. Cancelled timers drain within this interval.
+  const CANCEL_CHECK_MS = 100;
+
+  async function sleepCancellable(state, delay) {
+    let remaining = Math.max(0, delay);
+    if (remaining <= CANCEL_CHECK_MS) {
+      // Short delay — sleep in one go (common fast path)
+      await Deno.core.ops.op_timer_sleep(BigInt(remaining));
+      return;
+    }
+    // Long delay — chunk into CANCEL_CHECK_MS slices, bail on cancellation
+    while (remaining > 0 && !state.cancelled) {
+      const chunk = Math.min(remaining, CANCEL_CHECK_MS);
+      await Deno.core.ops.op_timer_sleep(BigInt(chunk));
+      remaining -= chunk;
+    }
+  }
 
   globalThis.setTimeout = function(callback, delay = 0) {
     const id = nextId++;
@@ -26,7 +52,7 @@ pub const TIMERS_BOOTSTRAP_JS: &str = r#"
 
     (async () => {
       try {
-        await Deno.core.ops.op_timer_sleep(BigInt(Math.max(0, delay)));
+        await sleepCancellable(state, delay);
         if (!state.cancelled) {
           activeTimers.delete(id);
           callback();
@@ -55,7 +81,7 @@ pub const TIMERS_BOOTSTRAP_JS: &str = r#"
     (async () => {
       try {
         while (!state.cancelled) {
-          await Deno.core.ops.op_timer_sleep(BigInt(Math.max(0, delay)));
+          await sleepCancellable(state, delay);
           if (!state.cancelled) {
             callback();
           }
@@ -181,5 +207,105 @@ mod tests {
         rt.run_event_loop().await.unwrap();
         let output = rt.captured_output();
         assert_eq!(output.stdout, vec!["zero delay"]);
+    }
+
+    /// Cancelled long-lived timers must not keep the event loop alive.
+    /// Before the fix, a cancelled 10-second timer would block run_event_loop()
+    /// for 10 seconds (or hit the file-level timeout).
+    #[tokio::test]
+    async fn test_cancelled_timer_frees_event_loop() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            // Schedule a long timer and immediately cancel it
+            const id = setTimeout(() => console.log('should not fire'), 60000);
+            clearTimeout(id);
+            // Schedule a short timer to prove the event loop completes quickly
+            setTimeout(() => console.log('done'), 5);
+        "#,
+        )
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        rt.run_event_loop().await.unwrap();
+        let elapsed = start.elapsed();
+
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["done"]);
+        // Event loop must complete in well under 1 second (not 60s).
+        // The chunked sleep drains cancelled timers in <= 100ms.
+        assert!(
+            elapsed.as_millis() < 1000,
+            "Event loop took {}ms — cancelled timer kept it alive",
+            elapsed.as_millis()
+        );
+    }
+
+    /// Cancelled interval must not keep the event loop alive.
+    #[tokio::test]
+    async fn test_cancelled_interval_frees_event_loop() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            const id = setInterval(() => {}, 60000);
+            clearInterval(id);
+            setTimeout(() => console.log('done'), 5);
+        "#,
+        )
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        rt.run_event_loop().await.unwrap();
+        let elapsed = start.elapsed();
+
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["done"]);
+        assert!(
+            elapsed.as_millis() < 1000,
+            "Event loop took {}ms — cancelled interval kept it alive",
+            elapsed.as_millis()
+        );
+    }
+
+    /// Self-rescheduling setTimeout chain (like RelativeTime component) must
+    /// clean up properly when clearTimeout cancels the pending timer.
+    #[tokio::test]
+    async fn test_self_rescheduling_timer_cleanup() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            let timerId;
+            let count = 0;
+            function tick() {
+                count++;
+                console.log('tick ' + count);
+                timerId = setTimeout(tick, 10);
+            }
+            timerId = setTimeout(tick, 10);
+
+            // After 50ms, cancel the chain
+            setTimeout(() => {
+                clearTimeout(timerId);
+                console.log('stopped');
+            }, 55);
+        "#,
+        )
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        rt.run_event_loop().await.unwrap();
+        let elapsed = start.elapsed();
+
+        let output = rt.captured_output();
+        assert!(output.stdout.last().unwrap() == "stopped");
+        // Must complete quickly after cancellation, not hang
+        assert!(
+            elapsed.as_millis() < 1000,
+            "Event loop took {}ms",
+            elapsed.as_millis()
+        );
     }
 }

--- a/packages/ui/src/router/__tests__/server-nav.test.ts
+++ b/packages/ui/src/router/__tests__/server-nav.test.ts
@@ -108,18 +108,20 @@ describe('prefetchNavData', () => {
   it('sends fetch with X-Vertz-Nav header', () => {
     const mockFetch = mock(() => new Promise<Response>(() => {}));
     globalThis.fetch = mockFetch;
-    prefetchNavData('/tasks');
+    const handle = prefetchNavData('/tasks');
     expect(mockFetch).toHaveBeenCalled();
     const callArgs = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
     const [url, opts] = callArgs;
     expect(url).toBe('/tasks');
     expect((opts.headers as Record<string, string>)['X-Vertz-Nav']).toBe('1');
+    handle.abort();
   });
 
   it('sets __VERTZ_NAV_PREFETCH_ACTIVE__ to true when starting', () => {
     globalThis.fetch = mock(() => new Promise<Response>(() => {}));
-    prefetchNavData('/tasks');
+    const handle = prefetchNavData('/tasks');
     expect(isNavPrefetchActive()).toBe(true);
+    handle.abort();
   });
 
   it('pushes received SSE data into hydration bus', async () => {
@@ -219,11 +221,13 @@ describe('prefetchNavData', () => {
     const mockFetch = mock(() => new Promise<Response>(() => {}));
     globalThis.fetch = mockFetch;
 
-    prefetchNavData('/tasks');
-    prefetchNavData('/tasks/123');
+    const handleA = prefetchNavData('/tasks');
+    const handleB = prefetchNavData('/tasks/123');
 
     // Both calls should initiate fetches — the caller (router) manages aborting
     expect(mockFetch).toHaveBeenCalledTimes(2);
+    handleA.abort();
+    handleB.abort();
   });
 
   it('ignores unknown event types without crashing', async () => {


### PR DESCRIPTION
## Summary

- **Root cause**: `clearTimeout`/`clearInterval` only set a JS `cancelled` flag but the underlying `op_timer_sleep` Tokio future continued sleeping for the full original duration. `run_event_loop()` waits for all pending ops, so a cancelled 1-hour timer blocked the event loop for 1 hour — causing test file timeouts in `vertz test`.
- **Fix**: Break long timer sleeps (>100ms) into 100ms chunks with cancellation checks between chunks. Short sleeps (<=100ms) use a single `op_timer_sleep` call (common fast path, zero overhead).
- **Also fix**: 3 tests in `server-nav.test.ts` created mock fetches that never resolve without aborting the handle, leaving dangling promises that blocked `run_event_loop()` past the 5s file timeout. Added `handle.abort()` calls.

## Public API Changes

None. Internal runtime timer implementation only.

## Results

| File | Before | After |
|---|---|---|
| `relative-time-component.test.ts` | TIMEOUT (5s limit) | 16/16 PASS in ~400ms |
| `server-nav.test.ts` | TIMEOUT (5s limit) | 15/20 pass in ~470ms (5 pre-existing SSE parsing failures) |
| Rust timer tests | 5 pass | 8 pass (3 new cancellation tests) |
| Full Rust test suite | — | 1692/1692 pass |

## Test plan

- [x] 3 new Rust tests for timer cancellation (cancelled setTimeout, cancelled setInterval, self-rescheduling chain cleanup)
- [x] `relative-time-component.test.ts` passes all 16 tests
- [x] `server-nav.test.ts` no longer times out
- [x] Full Rust test suite (1692 tests) — zero regressions
- [x] Adversarial review completed (`reviews/runtime-test-timeouts/phase-01-timer-fix.md`)

Closes #2146

🤖 Generated with [Claude Code](https://claude.com/claude-code)