### PR TITLE
fix(native-compiler): emit __spread reactive source for destructured props

### DIFF
--- a/native/vertz-compiler-core/src/jsx_transformer.rs
+++ b/native/vertz-compiler-core/src/jsx_transformer.rs
@@ -25,6 +25,11 @@ struct ReactivityContext {
     /// Callback-local reactive variables to inline: name → replacement expression.
     /// Set only when processing JSX inside a .map() callback with reactive locals.
     inline_locals: HashMap<String, String>,
+    /// The component's __props parameter name (e.g., "__props").
+    /// When set, __spread calls emit a third argument for reactive source:
+    ///   __spread(el, rest, __props)
+    /// Only set when the component had destructured props that were rewritten.
+    props_param: Option<String>,
 }
 
 // ─── IDL properties ──────────────────────────────────────────────────────────
@@ -77,6 +82,13 @@ pub fn transform_jsx(
             .map(|v| v.name.clone())
             .collect(),
         inline_locals: HashMap::new(),
+        // If the component had destructured props, transform_props rewrote them to __props.
+        // Pass __props as the reactive source for __spread calls.
+        props_param: if !component.destructured_prop_names.is_empty() {
+            Some("__props".to_string())
+        } else {
+            None
+        },
     };
 
     let mut counter = 0;
@@ -1301,7 +1313,11 @@ fn process_attr(
             expr_end,
         } => {
             let expr_text = ms.get_transformed_slice(*expr_start, *expr_end);
-            Some(format!("__spread({}, {})", el_var, expr_text))
+            if let Some(ref pp) = rx.props_param {
+                Some(format!("__spread({}, {}, {})", el_var, expr_text, pp))
+            } else {
+                Some(format!("__spread({}, {})", el_var, expr_text))
+            }
         }
     }
 }
@@ -2010,6 +2026,7 @@ fn build_extended_rx_for_list(
             field_signal_api_vars: rx.field_signal_api_vars.clone(),
             reactive_sources: rx.reactive_sources.clone(),
             inline_locals: HashMap::new(),
+            props_param: rx.props_param.clone(),
         };
     }
 
@@ -2027,5 +2044,6 @@ fn build_extended_rx_for_list(
         field_signal_api_vars: rx.field_signal_api_vars.clone(),
         reactive_sources: rx.reactive_sources.clone(),
         inline_locals,
+        props_param: rx.props_param.clone(),
     }
 }

--- a/native/vertz-compiler/__tests__/jsx-transform.test.ts
+++ b/native/vertz-compiler/__tests__/jsx-transform.test.ts
@@ -265,6 +265,27 @@ describe('Feature: JSX element transform', () => {
     });
   });
 
+  describe('Given a component with destructured props that spreads onto a native element', () => {
+    describe('When compiled', () => {
+      it('Then emits __spread(el, rest, __props) to preserve reactive getters', () => {
+        const code = compileAndGetCode(
+          `function ComposedInput({ classes, ...props }: { classes?: Record<string, string>; [key: string]: unknown }) {\n  return <input {...props} />;\n}`,
+        );
+        expect(code).toContain('__spread(');
+        expect(code).toMatch(/__spread\([^,]+,\s*props,\s*__props\)/);
+      });
+
+      it('Then does NOT emit __props for non-destructured props', () => {
+        const code = compileAndGetCode(
+          `function App() {\n  const rest = { 'data-testid': 'btn' };\n  return <input {...rest} />;\n}`,
+        );
+        expect(code).toContain('__spread(');
+        expect(code).toMatch(/__spread\([^,]+,\s*rest\)/);
+        expect(code).not.toContain('__props');
+      });
+    });
+  });
+
   describe('Given a ref attribute', () => {
     describe('When compiled', () => {
       it('Then assigns .current on the element variable', () => {


### PR DESCRIPTION
## Summary

Mirrors the TypeScript compiler fix from #2149 in the native Rust compiler. When a component has destructured props (rewritten to `__props` by `props_transformer`), the native compiler now passes `__props` as the third argument to `__spread()`:

```js
// Before (bug)
__spread(__el0, props)

// After (fix)
__spread(__el0, props, __props)
```

Without the third argument, `__spread` falls back to one-shot attribute setting — spread props lose all reactivity. With `__props` as the source, `__spread` detects getter descriptors and creates `deferredDomEffect` bindings for reactive updates.

## Changes

- `native/vertz-compiler-core/src/jsx_transformer.rs`: Add `props_param` field to `ReactivityContext`, set it when the component had destructured props, emit third argument in spread codegen
- `native/vertz-compiler/__tests__/jsx-transform.test.ts`: 2 new tests (destructured props case + non-destructured negative test)

## Public API Changes

None — internal compiler codegen change only.

## Test plan

- [x] 69 JSX transform tests pass (2 new)
- [x] 508 total native compiler JS tests pass
- [x] 18 Rust unit tests pass
- [x] 17 cross-compiler equivalence tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -D warnings` clean

## Related

- #2140 (original bug report)
- #2149 (TypeScript compiler fix, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)