### PR TITLE
feat(agents): add workflow orchestration — step, workflow, runWorkflow, approval gates

### DIFF
--- a/packages/mint-docs/docs.json
+++ b/packages/mint-docs/docs.json
@@ -98,6 +98,10 @@
             ]
           },
           {
+            "group": "vertz/agents",
+            "pages": ["guides/agents/overview", "guides/agents/workflows"]
+          },
+          {
             "group": "vertz/db",
             "pages": [
               "guides/db/overview",

--- a/packages/mint-docs/guides/agents/overview.mdx
+++ b/packages/mint-docs/guides/agents/overview.mdx
@@ -1,0 +1,95 @@
+---
+title: Overview
+description: 'vertz/agents — AI agent framework with typed tools, ReAct loops, and multi-step workflows'
+---
+
+`@vertz/agents` is the AI agent layer of the Vertz stack. You define agents with typed state, tools, and LLM configuration — the framework runs a ReAct loop, validates inputs/outputs, and manages agent lifecycle. Same config-object pattern as `entity()` and `service()`.
+
+## How it works
+
+<Steps>
+  <Step title="Define tools">
+    Each tool has a description, input/output schemas, and a handler. The LLM sees the description
+    and schema to decide when to call the tool.
+  </Step>
+  <Step title="Define an agent">
+    An agent combines state, tools, an LLM model, and lifecycle hooks into a single definition. The
+    framework manages the ReAct loop — observe, think, act, repeat.
+  </Step>
+  <Step title="Run the agent">
+    Call `run()` with a message and an LLM adapter. The agent iterates until it completes, gets
+    stuck, or hits the iteration limit.
+  </Step>
+</Steps>
+
+## What's included
+
+| Feature                  | Description                                                      |
+| ------------------------ | ---------------------------------------------------------------- |
+| **Tools**                | Typed units of capability with input/output schemas and handlers |
+| **Agents**               | Stateful ReAct agents with lifecycle hooks and stuck detection   |
+| **Workflows**            | Multi-step sequential pipelines coordinating multiple agents     |
+| **Approval gates**       | Human-in-the-loop steps that suspend and resume workflows        |
+| **Agent-to-agent calls** | Tools can invoke other agents via `ctx.agents.invoke()`          |
+| **Session persistence**  | Store and resume agent conversations across requests             |
+| **LLM adapters**         | Pluggable adapters for Cloudflare AI, OpenAI, Anthropic, MiniMax |
+
+## Quick example
+
+```ts
+import { agent, tool, run, createAdapter } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+const greetTool = tool({
+  description: 'Greet a user by name',
+  input: s.object({ name: s.string() }),
+  output: s.object({ greeting: s.string() }),
+  handler(input) {
+    return { greeting: `Hello, ${input.name}!` };
+  },
+});
+
+const greeter = agent('greeter', {
+  state: s.object({ greetCount: s.number() }),
+  initialState: { greetCount: 0 },
+  tools: { greet: greetTool },
+  model: { provider: 'openai', model: 'gpt-4o' },
+});
+
+const llm = createAdapter({ provider: 'openai' });
+const result = await run(greeter, { message: 'Say hi to Alice', llm });
+
+console.log(result.response); // Agent's final response
+console.log(result.status); // 'complete' | 'stuck' | 'max-iterations' | 'error'
+```
+
+## Core concepts
+
+### Config-object pattern
+
+Every factory — `tool()`, `agent()`, `workflow()`, `step()` — takes a name and a config object, returning a frozen definition. This matches the Vertz convention used by `entity()`, `service()`, and `createEnv()`.
+
+### ReAct loop
+
+Agents use a Reasoning + Acting loop. Each iteration:
+
+1. The LLM receives the conversation history and available tools
+2. It decides to call a tool or respond with text
+3. Tool results are added to the conversation
+4. The loop repeats until the LLM responds without tool calls
+
+### Stuck detection
+
+If the agent makes no meaningful progress for N consecutive iterations (repeating the same tool calls), it's considered "stuck." The `onStuck` behavior controls what happens: `'stop'` (default), `'retry'`, or `'escalate'`.
+
+### Frozen definitions
+
+All factories return deeply frozen objects. You can't mutate an agent or tool definition after creation — this prevents accidental state sharing between requests.
+
+## Guides
+
+<CardGroup cols={2}>
+  <Card title="Workflows" icon="diagram-project" href="/guides/agents/workflows">
+    Multi-step pipelines with approval gates and agent coordination.
+  </Card>
+</CardGroup>

--- a/packages/mint-docs/guides/agents/workflows.mdx
+++ b/packages/mint-docs/guides/agents/workflows.mdx
@@ -1,0 +1,432 @@
+---
+title: Workflows
+description: 'Multi-step sequential pipelines with approval gates, agent coordination, and output accumulation'
+---
+
+Workflows coordinate multiple agents into a sequential pipeline. Each step runs an agent, validates the output, and passes it to the next step via `ctx.prev`. Approval gates suspend the workflow until a human approves.
+
+## Defining steps
+
+A step is the unit of workflow execution. Each step optionally invokes an agent and produces an output.
+
+```ts
+import { step } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+const analyzeStep = step('analyze', {
+  agent: analyzerAgent,
+  input: (ctx) => `Analyze this: ${ctx.workflow.input.topic}`,
+  output: s.object({
+    summary: s.string(),
+    score: s.number(),
+  }),
+});
+```
+
+### Step options
+
+| Option     | Type                                          | Description                                                  |
+| ---------- | --------------------------------------------- | ------------------------------------------------------------ |
+| `agent`    | `AgentDefinition`                             | The agent to execute. Omit for approval-only steps.          |
+| `input`    | `(ctx: StepContext) => string \| { message }` | Transform workflow context into the agent's message.         |
+| `output`   | Schema                                        | Schema for validating the agent's response (parsed as JSON). |
+| `approval` | `StepApprovalConfig`                          | Turns the step into a human approval gate.                   |
+
+### Input callbacks
+
+The `input` callback receives a `StepContext` with access to the workflow input and all previous step outputs:
+
+```ts
+step('review', {
+  agent: reviewerAgent,
+  input: (ctx) => {
+    const analysis = ctx.prev['analyze'] as { summary: string };
+    return `Review this analysis: ${analysis.summary}`;
+  },
+  output: s.object({ approved: s.boolean(), feedback: s.string() }),
+});
+```
+
+The callback can return a plain string or `{ message: string }`:
+
+```ts
+// String form
+input: (ctx) => `Analyze: ${ctx.workflow.input.topic}`,
+
+// Object form
+input: (ctx) => ({ message: `Analyze: ${ctx.workflow.input.topic}` }),
+```
+
+If no `input` callback is provided, the agent receives a default message: `"Execute step \"step-name\""`.
+
+## Defining workflows
+
+A workflow groups steps into an ordered pipeline with a validated input schema.
+
+```ts
+import { workflow, step } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+const pipeline = workflow('content-pipeline', {
+  input: s.object({
+    topic: s.string(),
+    tone: s.string(),
+  }),
+  steps: [
+    step('research', {
+      agent: researchAgent,
+      input: (ctx) => `Research the topic: ${ctx.workflow.input.topic}`,
+      output: s.object({ findings: s.string(), sources: s.array(s.string()) }),
+    }),
+
+    step('write', {
+      agent: writerAgent,
+      input: (ctx) => {
+        const research = ctx.prev['research'] as { findings: string };
+        return `Write about this using a ${ctx.workflow.input.tone} tone: ${research.findings}`;
+      },
+      output: s.object({ draft: s.string(), wordCount: s.number() }),
+    }),
+
+    step('edit', {
+      agent: editorAgent,
+      input: (ctx) => {
+        const draft = ctx.prev['write'] as { draft: string };
+        return `Edit this draft: ${draft.draft}`;
+      },
+      output: s.object({ final: s.string() }),
+    }),
+  ],
+});
+```
+
+### Workflow options
+
+| Option   | Type                   | Description                                            |
+| -------- | ---------------------- | ------------------------------------------------------ |
+| `input`  | Schema                 | Schema for validating workflow input.                  |
+| `steps`  | `StepDefinition[]`     | Ordered list of steps. Must have at least one.         |
+| `access` | `{ start?, approve? }` | Access control for starting or approving the workflow. |
+
+### Validation rules
+
+- Workflow names must match `/^[a-z][a-z0-9-]*$/`
+- Step names must match the same pattern
+- At least one step is required
+- Duplicate step names within a workflow throw an error
+- Both workflow and step definitions are deeply frozen after creation
+
+## Running workflows
+
+Use `runWorkflow()` to execute a workflow. It runs each step sequentially, passing outputs forward via `ctx.prev`.
+
+```ts
+import { runWorkflow, createAdapter } from '@vertz/agents';
+
+const llm = createAdapter({ provider: 'openai' });
+
+const result = await runWorkflow(pipeline, {
+  input: { topic: 'TypeScript generics', tone: 'conversational' },
+  llm,
+});
+
+if (result.status === 'complete') {
+  console.log('All steps finished');
+  console.log(result.stepResults);
+} else if (result.status === 'error') {
+  console.log(`Failed at step: ${result.failedStep}`);
+} else if (result.status === 'pending') {
+  console.log(`Waiting for approval at: ${result.pendingStep}`);
+  console.log(result.approvalMessage);
+}
+```
+
+### Result shape
+
+```ts
+interface WorkflowResult {
+  status: 'complete' | 'error' | 'pending';
+  stepResults: Record<string, StepResult>;
+  failedStep?: string; // Only set when status is 'error'
+  pendingStep?: string; // Only set when status is 'pending'
+  approvalMessage?: string; // Only set when status is 'pending'
+}
+
+interface StepResult {
+  status: 'complete' | 'max-iterations' | 'stuck' | 'error';
+  response: string;
+  iterations: number;
+}
+```
+
+### How output accumulation works
+
+Each step's output is stored in `ctx.prev` keyed by step name. If a step has an `output` schema, the agent's response is parsed as JSON and validated against it. Validated data is stored in `prev`. If parsing or validation fails, the raw response is stored as `{ response: string }`.
+
+```
+Step 1 "research" completes → ctx.prev = { research: { findings: "...", sources: [...] } }
+Step 2 "write" completes    → ctx.prev = { research: { ... }, write: { draft: "...", wordCount: 1200 } }
+Step 3 "edit" completes     → ctx.prev = { research: { ... }, write: { ... }, edit: { final: "..." } }
+```
+
+<Note>
+  In v1, `ctx.prev` is typed as `Record<string, unknown>`. You need to cast the values to the expected type. Strongly typed accumulation (where `prev['step-a']` is automatically typed based on step-a's output schema) is planned for v2.
+</Note>
+
+## Approval gates
+
+An approval gate suspends the workflow until a human approves. When `runWorkflow()` hits an approval step, it returns immediately with `status: 'pending'`.
+
+```ts
+const reviewPipeline = workflow('review-pipeline', {
+  input: s.object({ documentPath: s.string() }),
+  steps: [
+    step('auto-review', {
+      agent: reviewerAgent,
+      input: (ctx) => `Review document at: ${ctx.workflow.input.documentPath}`,
+      output: s.object({ approved: s.boolean(), findings: s.array(s.string()) }),
+    }),
+
+    // Approval gate — no agent, just a gate
+    step('human-approval', {
+      approval: {
+        message: (ctx) => {
+          const review = ctx.prev['auto-review'] as { findings: string[] };
+          return `Auto-review found ${review.findings.length} findings. Approve to proceed.`;
+        },
+        timeout: '7d',
+      },
+    }),
+
+    step('publish', {
+      agent: publisherAgent,
+      input: (ctx) => `Publish document at: ${ctx.workflow.input.documentPath}`,
+      output: s.object({ url: s.string() }),
+    }),
+  ],
+});
+```
+
+### Approval config
+
+| Option    | Type                                     | Description                          |
+| --------- | ---------------------------------------- | ------------------------------------ |
+| `message` | `string \| (ctx: StepContext) => string` | Message shown to the human approver. |
+| `timeout` | `string`                                 | How long to wait (e.g., `'7d'`).     |
+
+### Resuming after approval
+
+When the workflow returns `pending`, store the step results. After the human approves, call `runWorkflow()` again with `resumeAfter` pointing to the approval step:
+
+```ts
+// First run — hits approval gate
+const firstRun = await runWorkflow(reviewPipeline, {
+  input: { documentPath: '/docs/api.md' },
+  llm,
+});
+
+// firstRun.status === 'pending'
+// firstRun.pendingStep === 'human-approval'
+// firstRun.approvalMessage === 'Auto-review found 3 findings. Approve to proceed.'
+
+// Store the results somewhere (DB, KV, etc.)
+const savedResults = firstRun.stepResults;
+
+// ... human approves ...
+
+// Resume — skips all steps up to and including 'human-approval'
+const resumed = await runWorkflow(reviewPipeline, {
+  input: { documentPath: '/docs/api.md' },
+  llm,
+  resumeAfter: 'human-approval',
+  previousResults: savedResults,
+});
+
+// resumed.status === 'complete' (if publish step succeeded)
+```
+
+<Warning>
+  The `resumeAfter` step name must match an existing step in the workflow. An invalid name throws an
+  error.
+</Warning>
+
+### Building the approval UX
+
+The approval primitive is transport-agnostic — `runWorkflow()` doesn't dictate how approvals are delivered or collected. Common patterns:
+
+- **HTTP endpoint** — Store pending state in a database, expose `POST /workflows/:id/approve`, render an approval button in a dashboard
+- **Webhook** — Send the approval message to Slack/Discord, listen for a reaction or command
+- **Durable Object** — On Cloudflare, hold workflow state in a Durable Object that wakes when an approval event arrives
+- **CLI prompt** — For dev tooling, prompt in the terminal and resume immediately
+
+## Agent-to-agent invocation
+
+Tools can invoke other agents using `ctx.agents.invoke()`. This enables delegation patterns where a coordinator agent dispatches work to specialized agents.
+
+```ts
+const specialistAgent = agent('specialist', {
+  state: s.object({}),
+  initialState: {},
+  tools: {
+    /* specialist tools */
+  },
+  model: { provider: 'openai', model: 'gpt-4o' },
+});
+
+const delegateTool = tool({
+  description: 'Delegate a task to a specialist agent',
+  input: s.object({ task: s.string() }),
+  output: s.object({ result: s.string() }),
+  async handler(input, ctx) {
+    const result = await ctx.agents.invoke(specialistAgent, {
+      message: input.task,
+    });
+    return { result: result.response };
+  },
+});
+
+const coordinator = agent('coordinator', {
+  state: s.object({}),
+  initialState: {},
+  tools: { delegate: delegateTool },
+  model: { provider: 'openai', model: 'gpt-4o' },
+});
+```
+
+### Invoke options
+
+| Option       | Type     | Description                                           |
+| ------------ | -------- | ----------------------------------------------------- |
+| `message`    | `string` | The message to send to the target agent. **Required** |
+| `instanceId` | `string` | Optional instance ID for the invoked agent.           |
+
+The invoked agent runs a full ReAct loop with the same LLM adapter as the calling agent. It returns `{ response: string }`.
+
+## Session persistence
+
+Agents support persistent sessions via an `AgentStore`. Pass a store to `run()` to enable conversation history across multiple calls.
+
+```ts
+import { run, memoryStore } from '@vertz/agents';
+
+const store = memoryStore();
+
+// First message — creates a new session
+const first = await run(greeter, {
+  message: 'Hi, my name is Alice',
+  llm,
+  store,
+});
+
+console.log(first.sessionId); // 'sess_abc123...'
+
+// Second message — resumes the session
+const second = await run(greeter, {
+  message: 'What was my name?',
+  llm,
+  store,
+  sessionId: first.sessionId,
+});
+// Agent remembers the conversation
+```
+
+### Available stores
+
+| Store         | Import          | Description                     |
+| ------------- | --------------- | ------------------------------- |
+| `memoryStore` | `@vertz/agents` | In-memory, for testing and dev. |
+| `sqliteStore` | `@vertz/agents` | SQLite-backed via `bun:sqlite`. |
+
+### Session options
+
+| Option              | Type         | Description                                        |
+| ------------------- | ------------ | -------------------------------------------------- |
+| `store`             | `AgentStore` | The persistence backend. **Required for sessions** |
+| `sessionId`         | `string`     | Resume an existing session. Omit to create new.    |
+| `maxStoredMessages` | `number`     | Cap messages per session (default: 200).           |
+| `userId`            | `string`     | Session ownership — enforced on resume.            |
+| `tenantId`          | `string`     | Tenant scoping — enforced on resume.               |
+
+## LLM adapters
+
+Agents communicate with LLMs through adapters. Use `createAdapter()` to create one:
+
+```ts
+import { createAdapter } from '@vertz/agents';
+
+const llm = createAdapter({ provider: 'openai' });
+```
+
+### Available providers
+
+| Provider      | Value          | Env variable                                    |
+| ------------- | -------------- | ----------------------------------------------- |
+| OpenAI        | `'openai'`     | `OPENAI_API_KEY`                                |
+| Anthropic     | `'anthropic'`  | `ANTHROPIC_API_KEY`                             |
+| Cloudflare AI | `'cloudflare'` | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` |
+| MiniMax       | `'minimax'`    | `MINIMAX_API_KEY`                               |
+
+### Custom adapters
+
+You can provide a custom `LLMAdapter` directly — any object with a `chat()` method:
+
+```ts
+const customLlm: LLMAdapter = {
+  async chat(messages, tools) {
+    // Call your LLM and return the response
+    return { text: '...', toolCalls: [] };
+  },
+};
+
+const result = await run(myAgent, { message: 'Hello', llm: customLlm });
+```
+
+## Agent lifecycle
+
+Agents have three lifecycle hooks:
+
+```ts
+const myAgent = agent('monitored', {
+  state: s.object({ startedAt: s.string() }),
+  initialState: { startedAt: '' },
+  tools: {
+    /* ... */
+  },
+  model: { provider: 'openai', model: 'gpt-4o' },
+
+  onStart(ctx) {
+    ctx.state.startedAt = new Date().toISOString();
+    console.log(`Agent ${ctx.agent.name} started`);
+  },
+
+  onComplete(ctx) {
+    console.log(`Agent ${ctx.agent.name} completed`);
+  },
+
+  onStuck(ctx) {
+    console.log(`Agent ${ctx.agent.name} got stuck`);
+  },
+});
+```
+
+| Hook         | Called when                                            |
+| ------------ | ------------------------------------------------------ |
+| `onStart`    | Before the ReAct loop begins.                          |
+| `onComplete` | After the loop completes successfully.                 |
+| `onStuck`    | When the agent hits `max-iterations` or `stuck` state. |
+
+## Loop configuration
+
+Control the ReAct loop behavior:
+
+```ts
+agent('careful', {
+  // ...
+  loop: {
+    maxIterations: 50, // Max iterations before stopping (default: 20)
+    onStuck: 'retry', // 'stop' | 'retry' | 'escalate' (default: 'stop')
+    stuckThreshold: 3, // Iterations without progress before stuck (default: 3)
+    checkpointInterval: 5, // Save state every N iterations (default: 5)
+  },
+});
+```

--- a/packages/mint-docs/guides/llm-quick-reference.mdx
+++ b/packages/mint-docs/guides/llm-quick-reference.mdx
@@ -294,3 +294,76 @@ res.body.items; // typed array
 ```
 
 </Warning>
+
+## Agents
+
+Define AI agents with typed tools and run them via a ReAct loop:
+
+```ts
+import { agent, tool, run, createAdapter } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+const searchTool = tool({
+  description: 'Search the knowledge base',
+  input: s.object({ query: s.string() }),
+  output: s.object({ results: s.array(s.string()) }),
+  async handler(input) {
+    return { results: await searchKB(input.query) };
+  },
+});
+
+const assistant = agent('assistant', {
+  state: s.object({}),
+  initialState: {},
+  tools: { search: searchTool },
+  model: { provider: 'openai', model: 'gpt-4o' },
+});
+
+const llm = createAdapter({ provider: 'openai' });
+const result = await run(assistant, { message: 'Find docs about auth', llm });
+```
+
+### Workflows
+
+Coordinate multiple agents into sequential pipelines with approval gates:
+
+```ts
+import { workflow, step, runWorkflow } from '@vertz/agents';
+
+const pipeline = workflow('review-pipeline', {
+  input: s.object({ docPath: s.string() }),
+  steps: [
+    step('review', {
+      agent: reviewerAgent,
+      input: (ctx) => `Review: ${ctx.workflow.input.docPath}`,
+      output: s.object({ approved: s.boolean() }),
+    }),
+    step('human-approval', {
+      approval: { message: 'Review complete. Approve to publish.' },
+    }),
+    step('publish', {
+      agent: publisherAgent,
+      input: (ctx) => `Publish: ${ctx.workflow.input.docPath}`,
+    }),
+  ],
+});
+
+const result = await runWorkflow(pipeline, { input: { docPath: '/api.md' }, llm });
+// result.status: 'complete' | 'error' | 'pending'
+```
+
+### Agent-to-agent invocation
+
+Tools can invoke other agents via `ctx.agents.invoke()`:
+
+```ts
+const delegateTool = tool({
+  description: 'Delegate to specialist',
+  input: s.object({ task: s.string() }),
+  output: s.object({ result: s.string() }),
+  async handler(input, ctx) {
+    const r = await ctx.agents.invoke(specialistAgent, { message: input.task });
+    return { result: r.response };
+  },
+});
+```


### PR DESCRIPTION
## Summary

Implements Phase 2 of `@vertz/agents`: multi-step workflow orchestration with approval gates, output validation, and agent-to-agent invocation.

- `step()` and `workflow()` factories for defining sequential agent pipelines
- `runWorkflow()` execution engine: validates input, runs steps sequentially, accumulates outputs in `ctx.prev`
- Approval gates: steps with `approval` config suspend the workflow (`status: 'pending'`), resumable via `resumeAfter`
- Step output schema validation: agent responses parsed against `stepDef.output`, validated data stored in `prev`
- Agent-to-agent invocation: `ctx.agents.invoke()` on `ToolContext` for in-process agent delegation
- 22 new tests covering all workflow functionality (161 total in package)

## Public API Changes

### Additions
- `workflow(name, config)` — define a multi-step workflow with input schema and ordered steps
- `step(name, config)` — define a workflow step with optional agent, output schema, and approval gate
- `runWorkflow(workflowDef, options)` — execute a workflow sequentially
- `ctx.agents.invoke(agentDef, { message })` — invoke another agent from within a tool handler
- Types: `WorkflowDefinition`, `StepDefinition`, `StepContext`, `StepConfig`, `WorkflowConfig`, `RunWorkflowOptions`, `WorkflowResult`, `StepResult`, `WorkflowStatus`, `StepApprovalConfig`, `AgentInvoker`, `InvokeOptions`

### Deferred
- Typed `ctx.prev` accumulation (v2 — requires builder pattern or recursive tuple types). Tracked in #2147. Runtime validation ensures data integrity.
- Sandbox/Daytona integration (separate PR)

## Phase Summary

| Phase | Description | Commits |
|-------|------------|---------|
| 1 | `step()` + `workflow()` factories with frozen definitions, name validation, type system | `9590deb60` |
| 2 | `runWorkflow()` sequential execution engine with input validation, step context, prev accumulation | `0e4b1a5c8` |
| 3 | Approval gates — suspend/resume with `resumeAfter`, approval message functions, `previousResults` restore | `19e5964d7` |
| 4 | Agent-to-agent invocation — `ctx.agents.invoke()`, `AgentInvoker`/`InvokeOptions` types, recursive `run()` | `cf1ed9fe5` |

## Review Findings & Resolutions

Adversarial review in `reviews/agent-workflows/phase-02-review.md`.

### Blockers (all fixed)
- **B1**: Step output schema validation was not performed → Added `stepDef.output.parse()` after agent completes, stores validated data in `prev`
- **B2**: `resumeAfter` with nonexistent step silently completed → Added pre-loop validation that throws if step not found
- **B3**: Missing `.test-d.ts` for typed `ctx.prev` → Deferred to v2, tracked in #2147. Comment added to `StepContext`.

### Should-Fix (all fixed)
- **S1**: `output` required on approval steps → Made `output` optional on `StepConfig`
- **S2**: `stuck`/`max-iterations` treated as success → Changed to `agentResult.status !== 'complete'` check
- **S3**: No test for `{ message }` form of step input → Added test
- **S4**: `prev` stored raw response wrapper → Now stores validated/parsed output

## Test Plan

- [x] 161 tests pass (`bun test`)
- [x] Typecheck clean (`bun run typecheck`)
- [x] Lint clean (0 errors)
- [x] Format clean (`oxfmt --check`)
- [x] Pre-push hooks pass (lint + turbo build/typecheck/test + trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)