### PR TITLE
fix(ci): remove stale coverage package refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         run: |
           # On push to main or workflow_dispatch, mark all packages as changed so we get full coverage
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
               echo "${pkg//-/_}=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -280,7 +280,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
 
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
             if echo "$CHANGED_FILES" | grep -q "^packages/$pkg/"; then
               echo "${pkg//-/_}=true" >> "$GITHUB_OUTPUT"
             else
@@ -329,7 +329,7 @@ jobs:
 
           # On push to main or workflow_dispatch, run coverage for all packages
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+            for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
               run_coverage "$pkg"
             done
             exit 0
@@ -339,7 +339,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
 
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
             if echo "$CHANGED_FILES" | grep -q "^packages/$pkg/"; then
               run_coverage "$pkg"
             else
@@ -349,7 +349,7 @@ jobs:
 
       - name: Verify coverage output
         run: |
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
             if [ -f "packages/$pkg/coverage/lcov.info" ]; then
               echo "OK: packages/$pkg/coverage/lcov.info (bun test)"
             elif [ -f "packages/$pkg/coverage/coverage-summary.json" ]; then
@@ -373,7 +373,7 @@ jobs:
 
           # Upload each package's coverage with its own flag
           # bun test produces lcov.info (relative paths), vitest produces coverage-final.json (absolute paths)
-          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-compiler ui-primitives ui-server; do
+          for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
             if [ -f "packages/$pkg/coverage/lcov.info" ]; then
               echo "Uploading coverage for $pkg (lcov)"
               # bun test emits relative SF: paths (e.g. "src/foo.ts").

--- a/codecov.yml
+++ b/codecov.yml
@@ -94,10 +94,6 @@ flags:
     paths:
       - packages/ui/src/
     carryforward: true
-  ui-compiler:
-    paths:
-      - packages/ui-compiler/src/
-    carryforward: true
   ui-primitives:
     paths:
       - packages/ui-primitives/src/

--- a/scripts/__tests__/ci-coverage-packages.test.ts
+++ b/scripts/__tests__/ci-coverage-packages.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PROJECT_ROOT = resolve(import.meta.dir, '../..');
+const CI_WORKFLOW_PATH = resolve(PROJECT_ROOT, '.github/workflows/ci.yml');
+const CODECOV_CONFIG_PATH = resolve(PROJECT_ROOT, 'codecov.yml');
+
+function extractWorkflowPackageLists(ciWorkflow: string): string[][] {
+  return [...ciWorkflow.matchAll(/for pkg in ([^;]+); do/g)].map((match) =>
+    match[1].trim().split(/\s+/).filter(Boolean),
+  );
+}
+
+function extractCodecovFlags(codecovConfig: string): string[] {
+  const flagsBlock = codecovConfig.split('\nflags:\n')[1];
+  if (!flagsBlock) {
+    throw new TypeError('Missing flags block in codecov.yml');
+  }
+
+  return [...flagsBlock.matchAll(/^  ([a-z0-9-]+):$/gm)].map((match) => match[1]);
+}
+
+function missingPackageDirs(packageNames: string[]): string[] {
+  return packageNames.filter(
+    (packageName) => !existsSync(resolve(PROJECT_ROOT, `packages/${packageName}`)),
+  );
+}
+
+describe('CI coverage package configuration', () => {
+  it('only references package directories that exist in the coverage workflow', () => {
+    const ciWorkflow = readFileSync(CI_WORKFLOW_PATH, 'utf8');
+    const workflowPackageLists = extractWorkflowPackageLists(ciWorkflow);
+
+    expect(workflowPackageLists.length).toBeGreaterThan(0);
+
+    for (const packageList of workflowPackageLists) {
+      expect(missingPackageDirs(packageList)).toEqual([]);
+    }
+  });
+
+  it('only declares Codecov flags for package directories that exist', () => {
+    const codecovConfig = readFileSync(CODECOV_CONFIG_PATH, 'utf8');
+    const codecovFlags = extractCodecovFlags(codecovConfig);
+
+    expect(codecovFlags.length).toBeGreaterThan(0);
+    expect(missingPackageDirs(codecovFlags)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove stale `ui-compiler` package references from the coverage workflow and Codecov flags so `Coverage report` stops failing on `main`.
- Add a regression test that fails if CI coverage config references a non-existent package directory.
- Public API Changes: none.

## Test plan

- [x] `bun test scripts/__tests__/ci-coverage-packages.test.ts`
- [x] `bunx oxlint scripts/__tests__/ci-coverage-packages.test.ts`
- [x] `bunx oxfmt --check scripts/__tests__/ci-coverage-packages.test.ts`
- [x] `bun run ci:build-typecheck`
- [ ] `bun run ci:test` (currently fails locally in unrelated existing `@vertz/ui-server` tests; recent `main` runs on March 31, 2026 had green `Build, typecheck & test` and failed only in `Coverage report` due to `packages/ui-compiler`.)
