### PR TITLE
docs(fetch): update README to reflect Result-based API

### DIFF
--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -294,18 +294,18 @@ if (isErr(result)) {
 
 **Available error classes:**
 
-| Class | Status | Description |
-|-------|--------|-------------|
-| `BadRequestError` | 400 | Invalid request |
-| `UnauthorizedError` | 401 | Authentication required |
-| `ForbiddenError` | 403 | Insufficient permissions |
-| `NotFoundError` | 404 | Resource not found |
-| `ConflictError` | 409 | Resource conflict |
-| `GoneError` | 410 | Resource no longer available |
-| `UnprocessableEntityError` | 422 | Validation failed |
-| `RateLimitError` | 429 | Too many requests |
-| `InternalServerError` | 500 | Server error |
-| `ServiceUnavailableError` | 503 | Service down |
+| Class                      | Status | Description                  |
+| -------------------------- | ------ | ---------------------------- |
+| `BadRequestError`          | 400    | Invalid request              |
+| `UnauthorizedError`        | 401    | Authentication required      |
+| `ForbiddenError`           | 403    | Insufficient permissions     |
+| `NotFoundError`            | 404    | Resource not found           |
+| `ConflictError`            | 409    | Resource conflict            |
+| `GoneError`                | 410    | Resource no longer available |
+| `UnprocessableEntityError` | 422    | Validation failed            |
+| `RateLimitError`           | 429    | Too many requests            |
+| `InternalServerError`      | 500    | Server error                 |
+| `ServiceUnavailableError`  | 503    | Service down                 |
 
 All error classes extend `FetchError`:
 


### PR DESCRIPTION
## Summary

- Replace all `try/catch` examples with the actual `Result`-based error handling patterns (`isOk`/`isErr`, `unwrap`, `matchError`)
- Document convenience methods (`.get()`, `.post()`, `.put()`, `.patch()`, `.delete()`) that were missing from the README
- Fix `FetchError` properties to match implementation (`status` + `body`, removed nonexistent `statusText`)
- Add error classes reference table and clarify `requestStream` throws vs returning `Result`

## Test plan

- [ ] Verify code examples in README match actual `@vertz/fetch` API signatures
- [ ] Confirm `FetchClient` methods return `Result<T, FetchError>` as documented