### PR TITLE
chore(ci): skip native builds when native/ unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
   # ---------------------------------------------------------------------------
   # Detect whether source files changed.
   #
-  # For push-to-main events we always run the full pipeline.
-  # For workflow_dispatch events (triggered by auto-rebase) we also always
-  # run the full pipeline since there is no PR diff context available.
+  # For push-to-main events we always run the full TS pipeline.
+  # Native (Rust) jobs only run if files under native/ actually changed.
+  # For workflow_dispatch events (triggered by auto-rebase) we run the
+  # full pipeline since there is no PR diff context available.
   # For pull requests we compare the PR diff against source patterns.
   # If only non-source files changed (docs, plans, .claude rules, etc.) or
   # only docs-only packages changed (mint-docs, site, og, landing), the
@@ -69,7 +70,14 @@ jobs:
               exit 0
             fi
 
-            if git diff --name-only "$BASE_SHA" "${{ github.sha }}" | grep -q '^native/'; then
+            # Diff may fail if BASE_SHA is unreachable (e.g. force push) — default to running native
+            if ! PUSH_DIFF=$(git diff --name-only "$BASE_SHA" "${{ github.sha }}" 2>&1); then
+              echo "native=true" >> "$GITHUB_OUTPUT"
+              echo "push — diff failed (force push?), running native pipeline"
+              exit 0
+            fi
+
+            if echo "$PUSH_DIFF" | grep -q '^native/'; then
               echo "native=true" >> "$GITHUB_OUTPUT"
               echo "push — native files changed"
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,14 @@ jobs:
             exit 0
           fi
 
-          if git diff --name-only "$BASE_SHA" "${{ github.sha }}" | grep -q '^native/'; then
+          # Diff may fail if BASE_SHA is unreachable (e.g. force push) — default to building
+          if ! PUSH_DIFF=$(git diff --name-only "$BASE_SHA" "${{ github.sha }}" 2>&1); then
+            echo "native=true" >> "$GITHUB_OUTPUT"
+            echo "Diff failed (force push?) — building all binaries"
+            exit 0
+          fi
+
+          if echo "$PUSH_DIFF" | grep -q '^native/'; then
             echo "native=true" >> "$GITHUB_OUTPUT"
             echo "Native files changed — building binaries"
           else


### PR DESCRIPTION
## Summary

- On push-to-main, detect actual `native/` file changes instead of unconditionally running `rust-checks`, `napi-build` (ci.yml), and the 4-platform binary build matrix (release.yml)
- `workflow_dispatch` still runs the full pipeline (no diff context available)
- Falls back to `native=true` if `git diff` fails (e.g. force push with unreachable base SHA)
- Fixes a pre-existing bug where `native` output wasn't explicitly set to `false` when no files changed in a PR

## Public API Changes

None — CI-only change.

## How it works

Uses `github.event.before` (the previous HEAD of main before the push) to diff against `github.sha`. If no files under `native/` changed, the native pipeline is skipped.

**Safety nets:**
- Null SHA (initial push) → runs everything
- Failed diff (force push) → runs everything  
- `publish.sh` already skips `runtime-*` packages when no `vtz` binary exists (line 42)
- Binary artifact downloads in release.yml already use `continue-on-error: true`

## Test plan

- [ ] Push a TS-only change to main → verify `rust-checks` and `napi-build` are skipped in CI
- [ ] Push a change touching `native/` → verify native jobs run normally
- [ ] Verify "Version Packages" PR (which bumps `native/*/Cargo.toml`) still triggers binary builds when merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)