### PR TITLE
fix(vtz): resolve clippy errors breaking CI

### DIFF
--- a/native/vtz/src/errors/categories.rs
+++ b/native/vtz/src/errors/categories.rs
@@ -243,8 +243,8 @@ pub fn refine_error_line(source: &str, approx_line: u32, error_message: &str) ->
     let end = (approx_idx + range + 1).min(lines.len());
 
     // Search for the error text in nearby lines.
-    for i in start..end {
-        if lines[i].contains(search_text) {
+    for (i, line) in lines.iter().enumerate().take(end).skip(start) {
+        if line.contains(search_text) {
             return (i + 1) as u32;
         }
     }

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -620,10 +620,7 @@ async fn client_error_handler(
     let clean_message = req
         .message
         .strip_prefix("Uncaught ")
-        .and_then(|rest| {
-            // "TypeError: foo" → "TypeError: foo", "foo" → "foo"
-            Some(rest.to_string())
-        })
+        .map(|rest| rest.to_string())
         .unwrap_or_else(|| req.message.clone());
     // Strip the origin prefix from file paths so they're relative to the project.
     let mut error = DevError::runtime(&clean_message);

--- a/native/vtz/src/ssr/html_document.rs
+++ b/native/vtz/src/ssr/html_document.rs
@@ -379,6 +379,7 @@ mod tests {
             enable_hmr: true,
             ssr_data: None,
             head_tags: None,
+            root_dir: None,
         };
         let html = assemble_ssr_document(&opts);
 

--- a/native/vtz/tests/ssr_render.rs
+++ b/native/vtz/tests/ssr_render.rs
@@ -275,6 +275,7 @@ fn test_full_ssr_document_structure() {
         enable_hmr: false,
         ssr_data: None,
         head_tags: None,
+        root_dir: None,
     });
 
     // Document is valid HTML5


### PR DESCRIPTION
## Summary

- Fix `needless_range_loop` clippy lint in `native/vtz/src/errors/categories.rs` — use iterator with `enumerate().take().skip()` instead of indexing
- Add missing `root_dir` field to `SsrHtmlOptions` test initializers in `html_document.rs` and `tests/ssr_render.rs`
- Replace `.and_then(|x| Some(y))` with `.map()` in `native/vtz/src/server/http.rs`

These are all pre-existing clippy errors on `main` that are blocking CI for all open PRs.

## Test plan

- [x] `cargo clippy --all-targets --release -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)