### PR TITLE
fix(ci): restore missing turbo filters in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,9 +370,9 @@ jobs:
             TEST_SCRIPT=$(node -e "console.log(require('./package.json').scripts?.test ?? '')")
 
             if echo "$TEST_SCRIPT" | grep -q "bun test"; then
-              bun test --coverage || true
+              timeout --kill-after=10 120 bun test --coverage || true
             else
-              vitest run \
+              timeout --kill-after=10 120 vitest run \
                 --coverage \
                 --coverage.reporter=json-summary \
                 --coverage.reporter=json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         run: bun build index.ts --outdir . --target node
 
       - name: Build TS packages
-        run: turbo run build --filter='!@vertz/landing' --filter='!@vertz/component-docs' --filter='!@vertz/site' --filter='!@vertz/og' --filter='!@vertz/mint-docs' --filter='!@vertz-benchmarks/*' --filter='!contacts-api-example' --filter='!create-vertz'
+        run: turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' --filter='!@vertz/landing' --filter='!@vertz/component-docs' --filter='!@vertz/site' --filter='!@vertz/og' --filter='!@vertz/mint-docs' --filter='!@vertz-benchmarks/*' --filter='!contacts-api-example' --filter='!create-vertz'
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary

- **Release workflow**: The `bun→vtz` migration (#2252) changed `bun run build --filter=...` to `turbo run build --filter=...` in `release.yml`, but the old `bun run build` expanded the root `package.json` `build` script which included filters for `@vertz/landing-nextjs` and `@vertz/landing-nextjs-vercel`. The direct turbo call lost those base filters, causing the release build to attempt building `landing-nextjs` (which uses `vinext` requiring Node 22's `fs.glob` API, unavailable on CI's Node 20).

- **Coverage timeout**: Added a 2-minute per-package timeout to coverage runs so a single hanging `bun test --coverage` process (open handles in bun) can't block the entire coverage job until its 30-minute deadline. The `ui-server` package was hanging indefinitely.

## Test plan

- [ ] Release workflow succeeds on merge to main (no `@vertz/landing-nextjs` build attempt)
- [ ] Coverage job completes within timeout (no 30-min hang on `ui-server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)