### PR TITLE
feat(runtime): implement vi.setSystemTime() in vtz test runner

### DIFF
--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -907,7 +907,6 @@ if (typeof globalThis.HTMLElement === 'undefined') {
   const realSetInterval = globalThis.setInterval;
   const realClearInterval = globalThis.clearInterval;
   const RealDate = globalThis.Date;
-  const realDateNow = Date.now;
   let fakeNow = 0;
 
   function installFakeDate() {
@@ -1072,6 +1071,9 @@ if (typeof globalThis.HTMLElement === 'undefined') {
   }
 
   function setSystemTime(date) {
+    if (date == null) {
+      throw new Error('vi.setSystemTime() requires a Date, number, or string argument');
+    }
     const ts = typeof date === 'number' ? date
       : typeof date === 'string' ? new RealDate(date).getTime()
       : date.getTime();
@@ -2737,9 +2739,12 @@ mod tests {
                     vi.useRealTimers();
                 });
                 it('works without useFakeTimers (clock-only)', () => {
+                    const realST = globalThis.setTimeout;
                     vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
                     expect(Date.now()).toBe(1735689600000);
                     expect(new Date().toISOString()).toBe('2025-01-01T00:00:00.000Z');
+                    // setTimeout must NOT be replaced in clock-only mode
+                    expect(globalThis.setTimeout).toBe(realST);
                     vi.useRealTimers();
                 });
                 it('useRealTimers restores real Date', () => {
@@ -2891,11 +2896,13 @@ mod tests {
                 it('fires overdue timer without moving fakeNow backwards', () => {
                     vi.useFakeTimers();
                     vi.setSystemTime(1000);
-                    setTimeout(() => {}, 100);
+                    const log = [];
+                    setTimeout(() => log.push('fired'), 100);
                     vi.setSystemTime(5000);
                     const before = Date.now();
                     vi.advanceTimersToNextTimer();
                     expect(Date.now()).toBe(before);
+                    expect(log).toEqual(['fired']);
                     vi.useRealTimers();
                 });
                 it('is a no-op with no pending timers', () => {


### PR DESCRIPTION
## Summary

Implements `vi.setSystemTime()` and related timer utility methods in the vtz test runner, closing #2257.

### New APIs
- **`vi.setSystemTime(date)`** — Set fake system time (`Date.now()` + `new Date()`). Accepts Date objects, numbers, or strings. Works standalone (clock-only mode) or with `vi.useFakeTimers()`.
- **`vi.getTimerCount()`** — Returns number of pending fake timers.
- **`vi.advanceTimersToNextTimer()`** — Fires only the nearest pending timer.
- **`vi.isFakeTimers()`** — Returns whether fake timers/clock are active.

### Bug Fix
- **`vi.useFakeTimers()` now mocks `new Date()`** — Previously only `Date.now()` was mocked. V8's `new Date()` calls the C++ clock directly, so it was returning real time even with fake timers active. Fixed by replacing the `Date` constructor.

## Public API Changes

| Method | Status |
|--------|--------|
| `vi.setSystemTime(date)` | New |
| `vi.getTimerCount()` | New |
| `vi.advanceTimersToNextTimer()` | New |
| `vi.isFakeTimers()` | New |
| `vi.useFakeTimers()` | Fixed — now also mocks `new Date()` |

## Files Changed

- [`native/vtz/src/test/globals.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vi-set-system-time/native/vtz/src/test/globals.rs) — Timer mocking implementation + 26 new test cases

## Design Decisions

- **Clock-only mode**: `setSystemTime` works without `useFakeTimers()` for vitest compatibility. Only `Date` is mocked, `setTimeout`/`setInterval` remain real.
- **`Date` constructor replacement**: Uses `new.target` check so `Date()` without `new` returns a string per ES spec. `instanceof Date` works via shared prototype.
- **Overdue timer handling**: `advanceTimersToNextTimer` clamps negative deltas to prevent `fakeNow` from moving backwards after `setSystemTime` jumps.

## Test plan

- [x] 14 tests for `setSystemTime` (Date/number/string args, clock-only mode, new Date() mocking, constructor edge cases)
- [x] 12 tests for utility methods (getTimerCount, advanceTimersToNextTimer with overdue handling, isFakeTimers in both modes)
- [x] All 2333 existing tests pass
- [x] Clippy clean, rustfmt clean
- [x] Adversarial review completed

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)