### PR TITLE
test(ci): add tests for --base flag on vtz ci run

### DIFF
--- a/native/vtz/src/ci/changes.rs
+++ b/native/vtz/src/ci/changes.rs
@@ -443,6 +443,14 @@ mod tests {
         assert_eq!(result, "origin/main");
     }
 
+    #[test]
+    fn resolve_base_ref_explicit_overrides_ci_env() {
+        // --base flag takes precedence over GITHUB_BASE_REF even in CI
+        let result =
+            resolve_base_ref_from("origin/main", Some("custom-branch"), Some("develop"), true);
+        assert_eq!(result, "custom-branch");
+    }
+
     // -- map_files_to_packages --
 
     fn make_workspace() -> ResolvedWorkspace {

--- a/native/vtz/src/cli.rs
+++ b/native/vtz/src/cli.rs
@@ -2045,4 +2045,17 @@ mod tests {
         let args = parse_ci(&["vtz", "ci", "test", "--scope", "@vertz/ui"]);
         assert_eq!(args.scope, Some("@vertz/ui".to_string()));
     }
+
+    #[test]
+    fn test_ci_run_base_flag() {
+        let args = parse_ci(&["vtz", "ci", "ci", "--base", "origin/develop"]);
+        assert!(args.command.is_none());
+        assert_eq!(args.base, Some("origin/develop".to_string()));
+    }
+
+    #[test]
+    fn test_ci_run_base_flag_none_by_default() {
+        let args = parse_ci(&["vtz", "ci", "ci"]);
+        assert!(args.base.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds CLI parsing tests verifying `--base` is accepted on `vtz ci run` and defaults to `None`
- Adds unit test confirming explicit `--base` overrides `GITHUB_BASE_REF` in CI environments

## Public API Changes

None — test-only change.

## Context

The `--base` flag plumbing from CLI through `run_task_or_workflow` to affected filtering was implemented in #2270, but the test coverage was missing. This PR adds the missing tests.

Closes #2274

## Test plan

- [x] `test_ci_run_base_flag` — verifies `vtz ci ci --base origin/develop` parses correctly
- [x] `test_ci_run_base_flag_none_by_default` — verifies `base` is `None` when `--base` is omitted
- [x] `resolve_base_ref_explicit_overrides_ci_env` — verifies explicit `--base` takes precedence over `GITHUB_BASE_REF`
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)