### PR TITLE
test(ci): add tests for invalid glob patterns in condition evaluation

### DIFF
--- a/native/vtz/src/ci/changes.rs
+++ b/native/vtz/src/ci/changes.rs
@@ -840,4 +840,36 @@ mod tests {
         // Empty Any = vacuously false
         assert!(!evaluate_condition(&cond, &changes, "main"));
     }
+
+    // -- invalid glob patterns --
+
+    #[test]
+    fn cond_changed_invalid_glob_returns_false() {
+        let changes = make_changes(&["packages/ui/src/index.ts"]);
+        let cond = Condition::Changed {
+            patterns: vec!["[unclosed".to_string()],
+        };
+        // Invalid pattern is skipped (with warning), no match → false
+        assert!(!evaluate_condition(&cond, &changes, "main"));
+    }
+
+    #[test]
+    fn cond_branch_invalid_glob_returns_false() {
+        let changes = make_changes(&[]);
+        let cond = Condition::Branch {
+            names: vec!["[unclosed".to_string()],
+        };
+        // Invalid pattern is skipped (with warning), no match → false
+        assert!(!evaluate_condition(&cond, &changes, "main"));
+    }
+
+    #[test]
+    fn cond_changed_mixed_valid_and_invalid_patterns() {
+        let changes = make_changes(&["packages/ui/src/index.ts"]);
+        let cond = Condition::Changed {
+            patterns: vec!["[unclosed".to_string(), "packages/**".to_string()],
+        };
+        // Invalid pattern skipped, valid pattern matches → true
+        assert!(evaluate_condition(&cond, &changes, "main"));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds tests for malformed glob patterns (e.g. `[unclosed`) in CI condition evaluation (`changes.rs`)
- Verifies invalid `Changed` and `Branch` patterns return `false` without panicking
- Verifies valid patterns still match when mixed with invalid ones

Closes #2272

## Test plan

- [x] `cargo test -p vtz --lib ci::changes` — all 36 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)