### PR TITLE
fix(runtime): fix island/hydration test failures in vertz test (#2143)

### DIFF
--- a/native/vtz/src/test/dom_shim.rs
+++ b/native/vtz/src/test/dom_shim.rs
@@ -641,8 +641,8 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
     }
 
     // Query methods (delegate to basic selector matching)
-    querySelector(sel) { return querySelect(this, sel); }
-    querySelectorAll(sel) { const r = []; querySelectAll(this, sel, r); return r; }
+    querySelector(sel) { const prev = __queryScope; __queryScope = this; const r = querySelect(this, sel); __queryScope = prev; return r; }
+    querySelectorAll(sel) { const prev = __queryScope; __queryScope = this; const r = []; querySelectAll(this, sel, r); __queryScope = prev; return r; }
     getElementById(id) { return findById(this, id); }
   }
 
@@ -785,8 +785,8 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
     }
 
     // --- Query (basic for Phase 1, full selector engine in Phase 3) ---
-    querySelector(sel) { return querySelect(this, sel); }
-    querySelectorAll(sel) { const r = []; querySelectAll(this, sel, r); return r; }
+    querySelector(sel) { const prev = __queryScope; __queryScope = this; const r = querySelect(this, sel); __queryScope = prev; return r; }
+    querySelectorAll(sel) { const prev = __queryScope; __queryScope = this; const r = []; querySelectAll(this, sel, r); __queryScope = prev; return r; }
     getElementsByTagName(tag) {
       const results = [];
       const upper = tag.toUpperCase();
@@ -1255,6 +1255,11 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
 
   // --- Basic selector matching (Phase 1: supports tag, .class, #id, [attr], [attr="val"]) ---
   // Phase 3 will replace this with a full selector engine.
+
+  // Tracks the element on which querySelector/querySelectorAll was called.
+  // Used to resolve the :scope pseudo-class.
+  let __queryScope = null;
+
   function matchesSimpleSelector(el, selector) {
     if (!selector || el.nodeType !== ELEMENT_NODE) return false;
     // Handle comma-separated selectors (respecting parentheses)
@@ -1496,6 +1501,9 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
           pos += 8;
         } else if (sel.slice(pos, pos + 6) === ':focus') {
           if (!_document || _document.activeElement !== el) return false;
+          pos += 6;
+        } else if (sel.slice(pos, pos + 6) === ':scope') {
+          if (el !== __queryScope) return false;
           pos += 6;
         } else {
           return false; // Unsupported pseudo-class
@@ -1873,13 +1881,16 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
     }
 
     querySelector(sel) {
-      return querySelect(this.documentElement, sel);
+      const prev = __queryScope; __queryScope = this.documentElement;
+      const r = querySelect(this.documentElement, sel);
+      __queryScope = prev; return r;
     }
 
     querySelectorAll(sel) {
+      const prev = __queryScope; __queryScope = this.documentElement;
       const results = [];
       querySelectAll(this.documentElement, sel, results);
-      return results;
+      __queryScope = prev; return results;
     }
 
     getElementsByTagName(tag) {

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -867,4 +867,60 @@ mod tests {
         assert_eq!(result_with_root.tests.len(), 1);
         assert_eq!(result_with_root.tests[0].status, TestStatus::Pass);
     }
+
+    #[test]
+    fn test_scope_pseudo_class_in_queryselector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = write_test_file(
+            tmp.path(),
+            "scope-selector.test.ts",
+            r#"
+            describe(':scope pseudo-class', () => {
+                it('querySelector with :scope > child finds direct children only', () => {
+                    document.body.innerHTML = `
+                        <div id="root">
+                            <script data-test type="application/json">{"a":1}</script>
+                            <div>
+                                <script data-test type="application/json">{"b":2}</script>
+                            </div>
+                        </div>
+                    `;
+                    const root = document.getElementById('root')!;
+                    const result = root.querySelector(':scope > script[data-test]');
+                    expect(result).not.toBeNull();
+                    expect(result!.textContent).toBe('{"a":1}');
+                });
+
+                it('querySelector with :scope > child returns null for non-direct descendants', () => {
+                    document.body.innerHTML = `
+                        <div id="root">
+                            <div><span class="deep">nested</span></div>
+                        </div>
+                    `;
+                    const root = document.getElementById('root')!;
+                    expect(root.querySelector(':scope > span.deep')).toBeNull();
+                });
+
+                it('querySelectorAll with :scope > child finds all direct children', () => {
+                    document.body.innerHTML = `
+                        <ul id="list"><li>one</li><li>two</li><li>three</li></ul>
+                    `;
+                    const list = document.getElementById('list')!;
+                    const items = list.querySelectorAll(':scope > li');
+                    expect(items.length).toBe(3);
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file(&file);
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(result.passed(), 3, "Tests: {:?}", result.tests);
+        assert_eq!(result.failed(), 0);
+    }
 }

--- a/packages/ui/src/island/__tests__/island.test.ts
+++ b/packages/ui/src/island/__tests__/island.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { endHydration, getIsHydrating, startHydration } from '../../hydrate/hydration-context';
+import {
+  claimElement,
+  endHydration,
+  getIsHydrating,
+  startHydration,
+} from '../../hydrate/hydration-context';
 import { Island } from '../island';
 
 describe('Feature: Island component', () => {
@@ -193,8 +198,7 @@ describe('Feature: Island component', () => {
           component: () => {
             // During hydration, the cursor is inside the island wrapper,
             // past the script tag. The button is the next claimable element.
-            const { claimElement: claim } = require('../../hydrate/hydration-context');
-            const btn = claim('button');
+            const btn = claimElement('button');
             if (btn) {
               clickHandler = mock(() => {});
               btn.addEventListener('click', clickHandler);


### PR DESCRIPTION
## Summary

- Fix 2 test failures in `island.test.ts` and `island-hydrate.test.ts` when run through `vertz test`
- Add `:scope` pseudo-class support to the test runner DOM shim
- Replace CJS `require()` with ESM static import in island test

## Root Causes

**Bug 1 — `island.test.ts` (1 failure):** Test used `require('../../hydrate/hydration-context')` inside a component callback. The V8 test runner uses ES modules and doesn't provide `require()`. Fixed by importing `claimElement` as a static import at the top of the file.

**Bug 2 — `island-hydrate.test.ts` (1 failure):** `deserializeIslandProps()` uses `:scope > script[data-v-island-props]` selector, but the DOM shim didn't support the `:scope` pseudo-class. `querySelector` returned `null`, so props were always `{}`. Fixed by tracking the query root element (`__queryScope`) and matching it in the pseudo-class handler.

## Changes

- [`packages/ui/src/island/__tests__/island.test.ts`](https://github.com/vertz-dev/vertz/blob/fix/island-hydration-tests-2143/packages/ui/src/island/__tests__/island.test.ts) — Replace `require()` with static `claimElement` import
- [`native/vtz/src/test/dom_shim.rs`](https://github.com/vertz-dev/vertz/blob/fix/island-hydration-tests-2143/native/vtz/src/test/dom_shim.rs) — Add `:scope` pseudo-class support to selector engine
- [`native/vtz/src/test/executor.rs`](https://github.com/vertz-dev/vertz/blob/fix/island-hydration-tests-2143/native/vtz/src/test/executor.rs) — Add Rust-level test for `:scope` support

## Public API Changes

None — internal test runner fix only.

## Test plan

- [x] `island.test.ts`: 11/11 passing (was 10/11)
- [x] `island-hydrate.test.ts`: 7/7 passing (was 6/7)
- [x] All other hydrate tests: no regressions (89/91 — 2 pre-existing failures unrelated to this PR)
- [x] Rust test `test_scope_pseudo_class_in_queryselector`: passing
- [x] `cargo clippy` + `cargo fmt`: clean
- [x] Adversarial review: approved

Closes #2143

🤖 Generated with [Claude Code](https://claude.com/claude-code)