### PR TITLE
docs(runtime): document self-update and update notifications

### DIFF
--- a/packages/mint-docs/runtime.mdx
+++ b/packages/mint-docs/runtime.mdx
@@ -84,9 +84,11 @@ vtz test             # Run tests
 vtz install          # Install dependencies
 vtz add <pkg>        # Add a package
 vtz remove <pkg>     # Remove a package
+vtz update [pkg]     # Update packages (or all if no pkg specified)
 vtz run <script>     # Run a package.json script
 vtz exec <cmd>       # Run a command from node_modules/.bin
 vtzx <cmd>           # Shorthand for vtz exec (like npx/bunx)
+vtz self-update      # Update the vtz binary itself
 ```
 
 ### Dev server options
@@ -98,15 +100,57 @@ vtz dev --open            # Open browser on start
 vtz dev --no-typecheck    # Skip TypeScript checking
 ```
 
+## Updating
+
+### Self-update (recommended)
+
+The fastest way to update the `vtz` binary:
+
+```bash
+vtz self-update
+```
+
+This downloads the latest release from GitHub and replaces the current binary in place. To update to a specific version:
+
+```bash
+vtz self-update --version 0.3.0
+```
+
+### Via npm
+
+If you installed the runtime through npm, update the package instead:
+
+```bash
+vtz update @vertz/runtime
+```
+
+### Automatic update notifications
+
+`vtz` checks for new versions automatically after running `dev` and `install` commands. When an update is available, you'll see:
+
+```
+  Update available: 0.2.46 → 0.2.47
+  Run `vtz self-update` to update
+```
+
+The check is non-blocking (won't slow down your workflow), cached for 24 hours, and silently skipped if the network is unavailable.
+
+To disable update checks (e.g. in CI):
+
+```bash
+VTZ_NO_UPDATE_CHECK=1 vtz dev
+```
+
 ## Verifying your installation
 
 ```bash
 vtz --version
-# vtz 0.2.46
+# vtz 0.2.47
 ```
 
-If you see a version mismatch warning when using the CLI, update the runtime:
+If you see a version mismatch warning between the CLI and the runtime, update both:
 
 ```bash
-vtz update @vertz/runtime
+vtz self-update          # update the runtime binary
+vtz update @vertz/cli    # update the CLI package
 ```


### PR DESCRIPTION
## Summary

- Document `vtz self-update` command and `--version` flag
- Document automatic update notifications (runs after `dev`/`install`, 24h cache, `VTZ_NO_UPDATE_CHECK` env var)
- Add `self-update` and `update` to the CLI commands reference list
- Update the "Verifying your installation" section with version mismatch resolution steps

## Test plan

- [x] Docs-only change, no code changes
- [ ] Verify Mintlify renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)