### PR TITLE
fix(runtime): resolve self-referencing package imports in module loader (#2145)

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -466,12 +466,13 @@ impl VertzModuleLoader {
             }
         }
 
-        // Last resort: resolve subpath directly under src/
-        if let Some(sub) = subpath {
-            let src_path = pkg_dir.join("src").join(sub);
-            if let Ok(resolved) = self.resolve_with_extensions(&src_path) {
-                return Ok(resolved);
-            }
+        // Last resort: resolve directly under src/
+        let src_target = match subpath {
+            Some(sub) => pkg_dir.join("src").join(sub),
+            None => pkg_dir.join("src").join("index"),
+        };
+        if let Ok(resolved) = self.resolve_with_extensions(&src_target) {
+            return Ok(resolved);
         }
 
         let display_specifier = match subpath {
@@ -2986,5 +2987,42 @@ export function Hello() {
             "Cross-package import should resolve via node_modules"
         );
         assert_eq!(result.unwrap().to_file_path().unwrap(), canon(&pkg_b_entry));
+    }
+
+    #[test]
+    fn test_self_reference_exports_without_src_in_dist_path() {
+        // Given a package with exports: "./dist/index.js" (no src/ in dist path)
+        // When the source is at src/index.ts
+        // Then self-reference resolves to source
+        let tmp = create_temp_dir();
+
+        let pkg_dir = tmp.path().join("packages").join("my-server");
+        let src_dir = pkg_dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let src_entry = src_dir.join("index.ts");
+        std::fs::write(&src_entry, "export const x = 1;").unwrap();
+
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            r#"{ "name": "@scope/server", "exports": { ".": { "import": "./dist/index.js" } } }"#,
+        )
+        .unwrap();
+
+        let test_dir = src_dir.join("__tests__");
+        std::fs::create_dir_all(&test_dir).unwrap();
+        let test_file = test_dir.join("app.test.ts");
+        std::fs::write(&test_file, "import '@scope/server';").unwrap();
+
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
+        let referrer = ModuleSpecifier::from_file_path(&test_file).unwrap();
+        let result = loader.resolve("@scope/server", referrer.as_str(), ResolutionKind::Import);
+
+        assert!(
+            result.is_ok(),
+            "Self-reference with ./dist/index.js exports should resolve: {:?}",
+            result
+        );
+        assert_eq!(result.unwrap().to_file_path().unwrap(), canon(&src_entry));
     }
 }


### PR DESCRIPTION
## Summary

- Add self-reference detection to `VertzModuleLoader::resolve_node_module()` — before walking `node_modules/`, check if the import matches the `name` field of an ancestor `package.json`
- When a self-reference is detected, resolve using dist/ if built, otherwise map exports paths to source files (strip `dist/` prefix, resolve with `.ts`/`.tsx` extensions)
- Handle both `./dist/src/index.js` and `./dist/index.js` export layouts

Fixes #2145

## Changed Files

- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-self-ref-imports/native/vtz/src/runtime/module_loader.rs) — added `try_resolve_self_reference()` and `resolve_self_reference_source()` methods + 5 tests

## Public API Changes

None — internal module loader behavior only.

## Test plan

- [x] 5 new unit tests: main entry resolution, subpath resolution, dist-preferred-when-built, cross-package-not-affected, exports-without-src-in-dist-path
- [x] All 47 module_loader tests pass
- [x] `cargo test --all` — all Rust tests pass
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Full pre-push quality gates pass (lint, typecheck, TS tests, Rust tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)