### PR TITLE
fix(runtime): form validation tests fail — schema runtime gaps (#2144)

### DIFF
--- a/native/vertz-compiler-core/src/typescript_strip.rs
+++ b/native/vertz-compiler-core/src/typescript_strip.rs
@@ -550,6 +550,26 @@ impl<'a, 'b, 'c> Visit<'c> for InlineTsStripper<'a, 'b> {
         walk::walk_property_definition(self, prop);
     }
 
+    fn visit_formal_parameter(&mut self, param: &FormalParameter<'c>) {
+        if self.is_in_removed_span(param.span.start) {
+            return;
+        }
+
+        // Strip `?` optional marker from function parameters.
+        // `formData?: Record<string, unknown>` → `formData`
+        // (type annotation is stripped separately by visit_ts_type_annotation)
+        if param.optional {
+            let pat_end = param.pattern.span().end;
+            let after_pat = self.ms.slice(pat_end, param.span.end);
+            if after_pat.starts_with('?') {
+                self.ms.overwrite(pat_end, pat_end + 1, "");
+            }
+        }
+
+        // Continue the default walk (handles type annotations, binding patterns, etc.)
+        walk::walk_formal_parameter(self, param);
+    }
+
     fn visit_method_definition(&mut self, method: &MethodDefinition<'c>) {
         if self.is_in_removed_span(method.span.start) {
             return;
@@ -1623,6 +1643,50 @@ export const x = 1;"#,
         assert!(
             result.contains("isVertz"),
             "param isVertz missing: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_optional_function_param() {
+        let result = strip(
+            r#"export function validateField(
+  schema: any,
+  fieldName: string,
+  value: unknown,
+  formData?: Record<string, unknown>,
+) {
+  return true;
+}"#,
+        );
+        assert!(
+            !result.contains('?'),
+            "optional marker `?` not stripped: {}",
+            result
+        );
+        assert!(
+            result.contains("formData"),
+            "param name removed: {}",
+            result
+        );
+        assert!(
+            !result.contains("Record<string, unknown>"),
+            "type annotation survived: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_multiple_optional_params() {
+        let result = strip(r#"function foo(a: string, b?: number, c?: boolean) {}"#);
+        assert!(
+            !result.contains('?'),
+            "optional marker not stripped: {}",
+            result
+        );
+        assert!(
+            result.contains("function foo(a, b, c)"),
+            "params not cleaned: {}",
             result
         );
     }

--- a/native/vtz/src/test/dom_shim.rs
+++ b/native/vtz/src/test/dom_shim.rs
@@ -1766,6 +1766,36 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
     }
   }
 
+  // --- Blob & File ---
+  class Blob {
+    constructor(parts, options) {
+      this._parts = parts || [];
+      this.type = (options && options.type) || '';
+      let size = 0;
+      for (const p of this._parts) {
+        if (typeof p === 'string') size += p.length;
+        else if (p instanceof ArrayBuffer) size += p.byteLength;
+        else if (p instanceof Blob) size += p.size;
+      }
+      this.size = size;
+    }
+    slice(start, end, contentType) {
+      return new Blob([], { type: contentType || '' });
+    }
+    async text() {
+      return this._parts.map(p => typeof p === 'string' ? p : '').join('');
+    }
+    async arrayBuffer() { return new ArrayBuffer(0); }
+  }
+
+  class File extends Blob {
+    constructor(parts, name, options) {
+      super(parts, options);
+      this.name = name || '';
+      this.lastModified = (options && options.lastModified) || Date.now();
+    }
+  }
+
   // --- FormData ---
   class FormData {
     constructor(formElement) {
@@ -1798,14 +1828,30 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
       return this._data.filter(([k]) => k === name).map(([, v]) => v);
     }
 
-    set(name, value) {
+    set(name, value, filename) {
+      let stored;
+      if (value instanceof Blob) {
+        stored = (filename !== undefined)
+          ? new File([value], filename, { type: value.type })
+          : value;
+      } else {
+        stored = String(value);
+      }
       const idx = this._data.findIndex(([k]) => k === name);
-      if (idx >= 0) this._data[idx] = [name, String(value)];
-      else this._data.push([name, String(value)]);
+      if (idx >= 0) this._data[idx] = [name, stored];
+      else this._data.push([name, stored]);
     }
 
-    append(name, value) {
-      this._data.push([name, String(value)]);
+    append(name, value, filename) {
+      let stored;
+      if (value instanceof Blob) {
+        stored = (filename !== undefined)
+          ? new File([value], filename, { type: value.type })
+          : value;
+      } else {
+        stored = String(value);
+      }
+      this._data.push([name, stored]);
     }
 
     has(name) {
@@ -2110,7 +2156,7 @@ pub const TEST_DOM_SHIM_JS: &str = r#"
     HTMLHeadElement, HTMLBodyElement, HTMLHtmlElement,
     Text, Comment, DocumentFragment,
     Document, NodeFilter, TreeWalker,
-    FormData, CSSStyleSheet,
+    Blob, File, FormData, CSSStyleSheet,
     MutationObserver, ResizeObserver, IntersectionObserver,
   });
 

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -440,6 +440,11 @@ if (typeof globalThis.HTMLElement === 'undefined') {
         `Expected ${formatValue(actual)} ${negated ? 'not ' : ''}to be NaN`
       );
     };
+    matchers.toBeArray = () => {
+      assert(Array.isArray(actual), () =>
+        `Expected ${formatValue(actual)} ${negated ? 'not ' : ''}to be an array`
+      );
+    };
 
     // Strings & Arrays
     matchers.toContain = (item) => {
@@ -691,7 +696,7 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     const builtinNames = [
       'toBe', 'toEqual', 'toStrictEqual', 'toBeTruthy', 'toBeFalsy', 'toBeNull', 'toBeUndefined',
       'toBeDefined', 'toBeGreaterThan', 'toBeGreaterThanOrEqual', 'toBeLessThan',
-      'toBeLessThanOrEqual', 'toBeNaN', 'toContain', 'toContainEqual', 'toHaveLength', 'toMatch',
+      'toBeLessThanOrEqual', 'toBeNaN', 'toBeArray', 'toContain', 'toContainEqual', 'toHaveLength', 'toMatch',
       'toBeCloseTo', 'toBeTypeOf', 'toBeFunction', 'toHaveProperty', 'toBeInstanceOf',
       'toMatchObject', 'toThrow', 'toThrowError', 'toHaveBeenCalled', 'toHaveBeenCalledOnce',
       'toHaveBeenCalledTimes', 'toHaveBeenCalledWith', 'toHaveBeenLastCalledWith',

--- a/reviews/fix-form-validation-tests/phase-01-runtime-gaps.md
+++ b/reviews/fix-form-validation-tests/phase-01-runtime-gaps.md
@@ -1,0 +1,48 @@
+# Phase 1: Fix Form Validation Tests — Schema Runtime Gaps
+
+- **Author:** Claude Opus 4.6
+- **Reviewer:** Claude Opus 4.6 (adversarial)
+- **Date:** 2026-04-05
+
+## Changes
+
+- `native/vertz-compiler-core/src/typescript_strip.rs` (modified) — Added `visit_formal_parameter` to strip `?` from optional function params
+- `native/vtz/src/runtime/module_loader.rs` (modified) — Added self-referencing package resolution + 2 unit tests
+- `native/vtz/src/test/dom_shim.rs` (modified) — Added Blob/File classes, fixed FormData to preserve Blob instances
+- `native/vtz/src/test/globals.rs` (modified) — Added `toBeArray` matcher
+
+## CI Status
+
+- [x] Quality gates passed — `cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check`
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for (4 form validation tests passing)
+- [x] TDD compliance (tests written for each fix)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc (N/A — internal runtime fixes)
+
+## Findings
+
+### Approved
+
+**Should-fix items identified and resolved:**
+
+1. **Self-referencing resolution unit tests** — Added `test_resolve_self_referencing_with_exports_subpath` and `test_resolve_self_referencing_main_entry` to prevent regressions.
+
+2. **FormData filename argument** — Updated `set(name, value, filename)` and `append(name, value, filename)` to support the optional third argument per Web API spec.
+
+**Nits (accepted as-is):**
+
+- `Blob.size` uses string `.length` (UTF-16 code units) instead of byte length. Acceptable for test shim.
+- `Blob._parts` uses underscore convention but is technically accessible. No code accesses it.
+- `Blob.stream()` not implemented. Not needed by any current test.
+- Test assertion `!result.contains('?')` could false-positive with ternary operators, but test input is controlled.
+
+**Pre-existing issue found:**
+- `form.reset()` not implemented in DOM shim — tracked as #2329.
+
+## Resolution
+
+All should-fix items addressed. No remaining blockers.


### PR DESCRIPTION
## Summary

Fixes #2144 — 4 form-related tests fail when run through `vertz test` due to independent runtime gaps.

- **TypeScript optional param stripping** — Added `visit_formal_parameter` handler to the AST-based TypeScript stripper (`typescript_strip.rs`). Previously only class field `?` markers were stripped; function parameters like `formData?: Record<string, unknown>` survived compilation, causing V8 `Unexpected token '?'` errors.
- **Self-referencing package resolution** — Added Node.js-spec self-referencing resolution to `module_loader.rs`. A package can now import itself via its own name (e.g., `@vertz/ui/internals` from within `@vertz/ui`), which fixes the `form-on-change-e2e.test.ts` load error.
- **Blob/File DOM shim** — Added `Blob` and `File` classes to the test DOM shim. Updated `FormData.set()`/`append()` to preserve Blob/File instances instead of stringifying them, fixing the "skips File entries" test.
- **`toBeArray` matcher** — Added the missing `toBeArray` expect matcher to the test harness.

## Public API Changes

None — all changes are internal to the native runtime and test runner.

## Files Changed

- [`native/vertz-compiler-core/src/typescript_strip.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-form-validation/native/vertz-compiler-core/src/typescript_strip.rs) — `visit_formal_parameter` + 2 tests
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-form-validation/native/vtz/src/runtime/module_loader.rs) — Self-referencing resolution + 2 unit tests
- [`native/vtz/src/test/dom_shim.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-form-validation/native/vtz/src/test/dom_shim.rs) — Blob, File, FormData fixes
- [`native/vtz/src/test/globals.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-form-validation/native/vtz/src/test/globals.rs) — `toBeArray` matcher

## Test Results

- `form-data.test.ts`: 20/20 pass
- `form-integration.test.ts`: 10/10 pass
- `form-on-change-e2e.test.ts`: 5/6 pass (1 pre-existing failure: `form.reset()` — tracked in #2329)
- All Rust tests pass
- Clippy clean, rustfmt clean

## Review

Adversarial review completed — see `reviews/fix-form-validation-tests/phase-01-runtime-gaps.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)