### PR TITLE
fix: landing-page walkthrough — CSS compiler, create-vertz, docs

### DIFF
--- a/native/vertz-compiler-core/src/css_token_tables.rs
+++ b/native/vertz-compiler-core/src/css_token_tables.rs
@@ -410,6 +410,45 @@ fn resolve_color_token(token: &str) -> Option<String> {
     None
 }
 
+/// Multi-mode property resolution. Some properties (like `font`, `text`, `border`) resolve
+/// to different CSS properties depending on the value.
+/// Returns Some((css_properties, resolved_value)) if this is a multi-mode match.
+pub fn resolve_multi_mode(property: &str, value: &str) -> Option<(Vec<&'static str>, String)> {
+    match property {
+        "font" => {
+            // Check font-weight first, then fall through to font-size
+            if let Some(weight) = font_weight_scale(value) {
+                return Some((vec!["font-weight"], weight.to_string()));
+            }
+            if let Some(size) = font_size_scale(value) {
+                return Some((vec!["font-size"], size.to_string()));
+            }
+            None
+        }
+        "text" => {
+            // Check text-align first, then fall through to color
+            if is_text_align_keyword(value) {
+                return Some((vec!["text-align"], value.to_string()));
+            }
+            if let Some(color) = resolve_color(value) {
+                return Some((vec!["color"], color));
+            }
+            None
+        }
+        "border" => {
+            // Check border-width first, then fall through to border-color
+            if is_border_width(value) {
+                return Some((vec!["border-width"], format!("{value}px")));
+            }
+            if let Some(color) = resolve_color(value) {
+                return Some((vec!["border-color"], color));
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Resolve a value token based on its type.
 pub fn resolve_value(value: &str, value_type: &str, property: &str) -> Option<String> {
     match value_type {
@@ -1210,5 +1249,94 @@ mod tests {
     #[test]
     fn resolve_ring_non_number_returns_none() {
         assert!(resolve_value("abc", "ring", "ring").is_none());
+    }
+
+    // ── resolve_multi_mode ──────────────────────────────────────
+
+    #[test]
+    fn multi_mode_font_bold_resolves_to_font_weight() {
+        let result = resolve_multi_mode("font", "bold");
+        assert!(result.is_some(), "font:bold should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["font-weight"]);
+        assert_eq!(val, "700");
+    }
+
+    #[test]
+    fn multi_mode_font_semibold_resolves_to_font_weight() {
+        let result = resolve_multi_mode("font", "semibold");
+        assert!(result.is_some(), "font:semibold should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["font-weight"]);
+        assert_eq!(val, "600");
+    }
+
+    #[test]
+    fn multi_mode_font_lg_resolves_to_font_size() {
+        let result = resolve_multi_mode("font", "lg");
+        assert!(result.is_some(), "font:lg should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["font-size"]);
+        assert_eq!(val, "1.125rem");
+    }
+
+    #[test]
+    fn multi_mode_font_unknown_returns_none() {
+        assert!(resolve_multi_mode("font", "notavalue").is_none());
+    }
+
+    #[test]
+    fn multi_mode_text_center_resolves_to_text_align() {
+        let result = resolve_multi_mode("text", "center");
+        assert!(result.is_some(), "text:center should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["text-align"]);
+        assert_eq!(val, "center");
+    }
+
+    #[test]
+    fn multi_mode_text_left_resolves_to_text_align() {
+        let result = resolve_multi_mode("text", "left");
+        assert!(result.is_some(), "text:left should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["text-align"]);
+        assert_eq!(val, "left");
+    }
+
+    #[test]
+    fn multi_mode_text_foreground_resolves_to_color() {
+        let result = resolve_multi_mode("text", "foreground");
+        assert!(result.is_some(), "text:foreground should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["color"]);
+        assert_eq!(val, "var(--color-foreground)");
+    }
+
+    #[test]
+    fn multi_mode_text_unknown_returns_none() {
+        assert!(resolve_multi_mode("text", "notavalue").is_none());
+    }
+
+    #[test]
+    fn multi_mode_border_numeric_resolves_to_border_width() {
+        let result = resolve_multi_mode("border", "1");
+        assert!(result.is_some(), "border:1 should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["border-width"]);
+        assert_eq!(val, "1px");
+    }
+
+    #[test]
+    fn multi_mode_border_color_resolves_to_border_color() {
+        let result = resolve_multi_mode("border", "primary");
+        assert!(result.is_some(), "border:primary should resolve");
+        let (props, val) = result.unwrap();
+        assert_eq!(props, vec!["border-color"]);
+        assert_eq!(val, "var(--color-primary)");
+    }
+
+    #[test]
+    fn multi_mode_unknown_property_returns_none() {
+        assert!(resolve_multi_mode("bg", "primary").is_none());
     }
 }

--- a/native/vertz-compiler-core/src/css_transform.rs
+++ b/native/vertz-compiler-core/src/css_transform.rs
@@ -320,6 +320,23 @@ fn djb2_hash(s: &str) -> u32 {
     hash as u32
 }
 
+// ─── camelCase → kebab-case ──────────────────────────────────────
+
+fn camel_to_kebab(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 4);
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i > 0 {
+                result.push('-');
+            }
+            result.push(c.to_ascii_lowercase());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 // ─── CSS Rule Building ──────────────────────────────────────────
 
 fn build_css_rules(class_name: &str, entries: &[CssEntry]) -> Vec<String> {
@@ -363,7 +380,8 @@ fn build_css_rules(class_name: &str, entries: &[CssEntry]) -> Vec<String> {
                     }
                 }
                 for (prop, val) in raw_declarations {
-                    nested_decls.push(format!("{prop}: {val};"));
+                    let kebab_prop = camel_to_kebab(prop);
+                    nested_decls.push(format!("{kebab_prop}: {val};"));
                 }
                 if !nested_decls.is_empty() {
                     if selector.starts_with('@') {
@@ -468,6 +486,17 @@ fn resolve_shorthand(parsed: &ParsedShorthand) -> Option<Vec<String>> {
     }
 
     let value = parsed.value.as_deref().unwrap();
+
+    // Try multi-mode resolution first (font, text, border)
+    if let Some((css_properties, resolved)) = css_token_tables::resolve_multi_mode(property, value)
+    {
+        return Some(
+            css_properties
+                .iter()
+                .map(|p| format!("{p}: {resolved};"))
+                .collect(),
+        );
+    }
 
     if let Some((css_properties, value_type)) = css_token_tables::property_map(property) {
         let resolved = css_token_tables::resolve_value(value, value_type, property)?;
@@ -881,6 +910,93 @@ const b = css({ root: ['grid'] });
     fn multi_property_shorthand() {
         let (_, css) = transform("const s = css({ root: ['px:4'] });");
         assert!(css.contains("padding-inline: 1rem;"), "css: {}", css);
+    }
+
+    // ── Multi-mode properties ───────────────────────────────────
+
+    #[test]
+    fn font_bold_resolves_to_font_weight() {
+        let (_, css) = transform("const s = css({ root: ['font:bold'] });");
+        assert!(
+            css.contains("font-weight: 700;"),
+            "font:bold should produce font-weight: 700: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn font_semibold_resolves_to_font_weight() {
+        let (_, css) = transform("const s = css({ root: ['font:semibold'] });");
+        assert!(
+            css.contains("font-weight: 600;"),
+            "font:semibold should produce font-weight: 600: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn font_lg_still_resolves_to_font_size() {
+        let (_, css) = transform("const s = css({ root: ['font:lg'] });");
+        assert!(
+            css.contains("font-size: 1.125rem;"),
+            "font:lg should produce font-size: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn text_center_resolves_to_text_align() {
+        let (_, css) = transform("const s = css({ root: ['text:center'] });");
+        assert!(
+            css.contains("text-align: center;"),
+            "text:center should produce text-align: center: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn text_foreground_still_resolves_to_color() {
+        let (_, css) = transform("const s = css({ root: ['text:foreground'] });");
+        assert!(
+            css.contains("color: var(--color-foreground);"),
+            "text:foreground should produce color: css={}",
+            css
+        );
+    }
+
+    // ── camelCase → kebab-case for raw declarations ──────────────
+
+    #[test]
+    fn raw_declarations_camel_case_to_kebab() {
+        let source = r#"const s = css({ root: [{ '&:hover': { gridTemplateColumns: 'repeat(3, 1fr)' } }] });"#;
+        let (_, css) = transform(source);
+        assert!(
+            css.contains("grid-template-columns: repeat(3, 1fr);"),
+            "camelCase should be converted to kebab-case: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn raw_declarations_already_kebab_untouched() {
+        let source = r#"const s = css({ root: [{ '&:hover': { color: 'red' } }] });"#;
+        let (_, css) = transform(source);
+        assert!(
+            css.contains("color: red;"),
+            "already kebab should be untouched: css={}",
+            css
+        );
+    }
+
+    #[test]
+    fn raw_declarations_background_color_camel() {
+        let source = r#"const s = css({ root: [{ '&:focus': { backgroundColor: 'blue' } }] });"#;
+        let (_, css) = transform(source);
+        assert!(
+            css.contains("background-color: blue;"),
+            "backgroundColor → background-color: css={}",
+            css
+        );
     }
 
     // ── Full integration via compile() ───────────────────────────

--- a/packages/create-vertz-app/bin/create-vertz-app.ts
+++ b/packages/create-vertz-app/bin/create-vertz-app.ts
@@ -27,8 +27,8 @@ program
       console.log(`\n✓ Created ${resolved.projectName}`);
       console.log(`\nNext steps:`);
       console.log(`  cd ${resolved.projectName}`);
-      console.log(`  bun install`);
-      console.log(`  bun run dev`);
+      console.log(`  vtz install`);
+      console.log(`  vtz dev`);
     } catch (error) {
       console.error('Error:', error instanceof Error ? error.message : error);
       process.exit(1);

--- a/packages/create-vertz/bin/create-vertz.ts
+++ b/packages/create-vertz/bin/create-vertz.ts
@@ -6,10 +6,20 @@ import { resolveOptions, scaffold } from '@vertz/create-vertz-app';
 
 const pkg = JSON.parse(readFileSync(resolve(import.meta.dir, '../package.json'), 'utf-8'));
 
-const name = process.argv[2];
+// Parse args: create-vertz [name] [--template <type>]
+let name: string | undefined;
+let template: string | undefined;
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--template' && i + 1 < args.length) {
+    template = args[++i];
+  } else if (!args[i].startsWith('-') && !name) {
+    name = args[i];
+  }
+}
 
 try {
-  const resolved = await resolveOptions({ projectName: name });
+  const resolved = await resolveOptions({ projectName: name, template });
 
   console.log(`Creating Vertz app: ${resolved.projectName} (v${pkg.version})`);
 
@@ -19,8 +29,8 @@ try {
   console.log(`\n✓ Created ${resolved.projectName}`);
   console.log(`\nNext steps:`);
   console.log(`  cd ${resolved.projectName}`);
-  console.log(`  bun install`);
-  console.log(`  bun run dev`);
+  console.log(`  vtz install`);
+  console.log(`  vtz dev`);
 } catch (error) {
   console.error('Error:', error instanceof Error ? error.message : error);
   process.exit(1);

--- a/packages/mint-docs/quickstart.mdx
+++ b/packages/mint-docs/quickstart.mdx
@@ -6,8 +6,8 @@ description: 'Get up and running with Vertz in under 5 minutes'
 Scaffold a full-stack task manager with a database, API, and UI — all typed end-to-end.
 
 <Tip>
-  Want a minimal starting point instead? Use the `hello-world` template for a UI-only counter app:
-  ```bash vtz create hello-world my-app ```
+  **Other templates:** Use `--template hello-world` for a minimal counter app, or `--template
+  landing-page` for a multi-page marketing site with nav, hero, features, and pricing.
 </Tip>
 
 ## Create a new project


### PR DESCRIPTION
## Summary

Fixes found during a public walkthrough of the Vertz getting-started experience with the `landing-page` template.

- **fix(native-compiler): multi-mode CSS resolution** — `font:bold`, `text:center`, and `border:1` were silently dropped because the Rust CSS compiler's token tables only mapped these properties to a single mode (`font` → font-size only, `text` → color only, `border` → border-color only). Added `resolve_multi_mode()` that checks weight/alignment/width tokens first, matching the TS runtime's multi-mode resolvers.
- **fix(native-compiler): camelCase→kebab-case for raw declarations** — Nested CSS objects like `{ gridTemplateColumns: 'repeat(3, 1fr)' }` were output as `gridTemplateColumns:` instead of `grid-template-columns:`. Added `camel_to_kebab()` conversion.
- **fix(create-vertz): parse --template flag** — The `create-vertz` bin wrapper ignored the `--template` flag, always using the default template. Rewrote arg parsing. (#2341)
- **fix(create-vertz): success message says vtz** — Changed `bun install`/`bun run dev` → `vtz install`/`vtz dev` in both `create-vertz` and `create-vertz-app` bin scripts. (#2346)
- **docs: add landing-page template to quickstart** — Quickstart now mentions all three templates (`todo-app`, `hello-world`, `landing-page`). (#2345)

## Issues addressed

- Fixes #2343 (CSS utilities silently dropped + camelCase properties)
- Fixes #2341 (create-vertz --template flag ignored)
- Fixes #2345 (landing-page missing from docs)
- Fixes #2346 (scaffold message references bun)

## Public API Changes

None — these are bug fixes in the compiler internals and scaffolding tooling.

## Test plan

- [x] 19 new Rust tests for multi-mode resolution and camelCase→kebab-case
- [x] Full `cargo test --all` passes (1133 tests in compiler-core)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `oxlint` + `oxfmt` clean on changed files
- [x] Pre-push hooks pass (all quality gates green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)