### PR TITLE
fix(ssr): 404 status for unmatched routes + favicon auto-detect

### DIFF
--- a/native/vtz/src/bridge/mod.rs
+++ b/native/vtz/src/bridge/mod.rs
@@ -131,6 +131,7 @@ pub(crate) mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         (state, tmp)

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -139,6 +139,8 @@ pub struct SsrResponse {
     pub head_tags: Option<String>,
     /// Redirect URL set by ProtectedRoute during SSR (server should return 302).
     pub redirect: Option<String>,
+    /// Route patterns that matched the current URL (empty = 404).
+    pub matched_route_patterns: Vec<String>,
 }
 
 /// A component render request for the persistent isolate.
@@ -1304,6 +1306,7 @@ const SSR_RENDER_FRAMEWORK_JS: &str = r#"
         headTags: result.headTags || '',
         redirect: result.redirect ? result.redirect.to : null,
         isSsr: (result.html || '').length > 0,
+        matchedRoutePatterns: result.matchedRoutePatterns || [],
     });
 })()
 "#;
@@ -1480,6 +1483,16 @@ async fn dispatch_ssr_request(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        let matched_route_patterns = parsed
+            .get("matchedRoutePatterns")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(SsrResponse {
             content,
             css_entries: vec![],
@@ -1490,6 +1503,7 @@ async fn dispatch_ssr_request(
             ssr_data,
             head_tags,
             redirect,
+            matched_route_patterns,
         })
     } else {
         // Check if legacy fallback is inappropriate (framework app detected at init).
@@ -1551,6 +1565,7 @@ async fn dispatch_ssr_request(
             ssr_data: None,
             head_tags: None,
             redirect: None,
+            matched_route_patterns: vec![],
         })
     }
 }
@@ -1809,6 +1824,7 @@ mod tests {
             ssr_data: Some(r#"[{"key":"tasks","data":[]}]"#.to_string()),
             head_tags: Some(r#"<link rel="preload" href="/font.woff2" />"#.to_string()),
             redirect: None,
+            matched_route_patterns: vec![],
         };
         assert_eq!(
             resp.ssr_data,

--- a/native/vtz/src/server/html_shell.rs
+++ b/native/vtz/src/server/html_shell.rs
@@ -61,6 +61,12 @@ pub fn generate_html_shell_with_hmr(
         "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n",
     );
     html.push_str(&format!("  <title>{}</title>\n", escape_html(title)));
+
+    // Favicon detection
+    if let Some(tag) = crate::ssr::html_document::detect_favicon_tag(root_dir) {
+        html.push_str(&format!("  {}\n", tag));
+    }
+
     // Project root path for editor link construction in the error overlay.
     html.push_str(&format!(
         "  <meta name=\"vertz-root\" content=\"{}\" />\n",

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -165,6 +165,9 @@ pub fn build_router(
     // Load theme CSS from the project (if available)
     let theme_css = theme_css::load_theme_css(&config.root_dir);
 
+    // Detect favicon in public/ directory
+    let favicon_tag = crate::ssr::html_document::detect_favicon_tag(&config.root_dir);
+
     let hmr_hub = HmrHub::new();
     let audit_log = crate::server::audit_log::AuditLog::default();
     let error_broadcaster =
@@ -328,6 +331,7 @@ pub fn build_router(
         ssr_pool,
         api_proxy,
         last_file_change: Arc::new(std::sync::Mutex::new(None)),
+        favicon_tag,
     });
 
     // Routes: HMR WebSocket, error WebSocket, diagnostics, AI API, fallback
@@ -476,11 +480,18 @@ async fn ai_render_handler(
 
             match isolate.handle_ssr(ssr_req).await {
                 Ok(ssr_resp) => {
+                    // Return 404 when no route matched (fallback content rendered but URL is invalid)
+                    let status_code = if ssr_resp.matched_route_patterns.is_empty() {
+                        404u16
+                    } else {
+                        200u16
+                    };
+
                     state
                         .audit_log
                         .record(crate::server::audit_log::AuditEvent::ssr_render(
                             &url,
-                            200,
+                            status_code,
                             0,
                             ssr_resp.is_ssr,
                             ssr_resp.render_time_ms,
@@ -507,11 +518,18 @@ async fn ai_render_handler(
                             ssr_data: ssr_resp.ssr_data.as_deref(),
                             head_tags: ssr_resp.head_tags.as_deref(),
                             root_dir: Some(&state.root_dir.to_string_lossy()),
+                            favicon_tag: state.favicon_tag.as_deref(),
                         },
                     );
 
+                    let status = if status_code == 404 {
+                        StatusCode::NOT_FOUND
+                    } else {
+                        StatusCode::OK
+                    };
+
                     return axum::response::Response::builder()
-                        .status(StatusCode::OK)
+                        .status(status)
                         .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
                         .header(header::CACHE_CONTROL, "no-cache")
                         .header(
@@ -926,10 +944,16 @@ async fn dev_server_handler(
                                 }
                             );
                             eprintln!("[SSR] {}", render_msg);
+                            // Return 404 when no route matched
+                            let status_code = if ssr_resp.matched_route_patterns.is_empty() {
+                                404u16
+                            } else {
+                                200u16
+                            };
                             state.audit_log.record(
                                 crate::server::audit_log::AuditEvent::ssr_render(
                                     &path,
-                                    200,
+                                    status_code,
                                     0,
                                     ssr_resp.is_ssr,
                                     ssr_resp.render_time_ms,
@@ -945,6 +969,13 @@ async fn dev_server_handler(
                                 .body(Body::empty())
                                 .unwrap();
                         }
+
+                        // Return 404 when no route matched (fallback content rendered but URL is invalid)
+                        let status = if ssr_resp.matched_route_patterns.is_empty() {
+                            StatusCode::NOT_FOUND
+                        } else {
+                            StatusCode::OK
+                        };
 
                         // Assemble the full HTML document from SSR response.
                         // Framework path returns pre-formatted CSS HTML (with <style> tags);
@@ -970,11 +1001,12 @@ async fn dev_server_handler(
                                 ssr_data: ssr_resp.ssr_data.as_deref(),
                                 head_tags: ssr_resp.head_tags.as_deref(),
                                 root_dir: Some(&state.root_dir.to_string_lossy()),
+                                favicon_tag: state.favicon_tag.as_deref(),
                             },
                         );
 
                         return axum::response::Response::builder()
-                            .status(StatusCode::OK)
+                            .status(status)
                             .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
                             .header(header::CACHE_CONTROL, "no-cache")
                             .body(Body::from(html))

--- a/native/vtz/src/server/mcp.rs
+++ b/native/vtz/src/server/mcp.rs
@@ -351,6 +351,7 @@ pub(crate) async fn execute_tool(
                                     ssr_data: ssr_resp.ssr_data.as_deref(),
                                     head_tags: ssr_resp.head_tags.as_deref(),
                                     root_dir: Some(&state.root_dir.to_string_lossy()),
+                                    favicon_tag: state.favicon_tag.as_deref(),
                                 },
                             );
 
@@ -1176,6 +1177,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         })
     }
 
@@ -1210,6 +1212,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         })
     }
 
@@ -1919,6 +1922,7 @@ mod tests {
                 api_proxy: None,
                 auto_installer: None,
                 last_file_change: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                favicon_tag: None,
             })
         };
 

--- a/native/vtz/src/server/module_server.rs
+++ b/native/vtz/src/server/module_server.rs
@@ -71,6 +71,9 @@ pub struct DevServerState {
     /// after the watcher already cleared it).
     /// `None` until the first file change is detected.
     pub last_file_change: Arc<std::sync::Mutex<Option<std::time::Instant>>>,
+    /// Pre-detected favicon link tag (e.g., `<link rel="icon" ... />`).
+    /// Detected at startup from `public/favicon.{svg,ico,png}`.
+    pub favicon_tag: Option<String>,
 }
 
 /// Handle requests for source files: `GET /src/**/*.tsx` → compiled JavaScript.
@@ -875,6 +878,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         })
     }
 
@@ -1515,6 +1519,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         let req = Request::builder()
@@ -1672,6 +1677,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         let req = Request::builder()
@@ -1727,6 +1733,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         let req = Request::builder()
@@ -1811,6 +1818,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         };
 
         // helper-lib/index.js is not in root's node_modules directly,
@@ -1863,6 +1871,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         };
 
         let result = re_resolve_dep("some-dep/index.js", &state);
@@ -1916,6 +1925,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         // Request the bare specifier (no subpath) which should resolve via package.json exports
@@ -2079,6 +2089,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         let req = Request::builder()
@@ -2182,6 +2193,7 @@ mod tests {
             api_proxy: None,
             auto_installer: None,
             last_file_change: Arc::new(std::sync::Mutex::new(None)),
+            favicon_tag: None,
         });
 
         let req = Request::builder()

--- a/native/vtz/src/ssr/html_document.rs
+++ b/native/vtz/src/ssr/html_document.rs
@@ -43,6 +43,8 @@ pub struct SsrHtmlOptions<'a> {
     pub head_tags: Option<&'a str>,
     /// Absolute path to the project root directory (for editor link construction in the error overlay).
     pub root_dir: Option<&'a str>,
+    /// Favicon link tag to inject into `<head>` (e.g., `<link rel="icon" ... />`).
+    pub favicon_tag: Option<&'a str>,
 }
 
 /// Assemble a complete SSR HTML document.
@@ -81,6 +83,11 @@ pub fn assemble_ssr_document(options: &SsrHtmlOptions<'_>) -> String {
         "  <title>{}</title>\n",
         escape_html(options.title)
     ));
+
+    // Favicon link tag
+    if let Some(favicon) = options.favicon_tag {
+        html.push_str(&format!("  {}\n", favicon));
+    }
 
     // Project root path for editor link construction in the error overlay.
     if let Some(root) = options.root_dir {
@@ -178,6 +185,28 @@ pub fn entry_path_to_url(entry_path: &Path, root_dir: &Path) -> String {
     }
 }
 
+/// Detect a favicon file in `public/` and return the appropriate `<link>` tag.
+///
+/// Checks for (in order): `favicon.svg`, `favicon.ico`, `favicon.png`.
+/// Returns `None` if no favicon file is found.
+pub fn detect_favicon_tag(root_dir: &Path) -> Option<String> {
+    let public_dir = root_dir.join("public");
+    let candidates = [
+        ("favicon.svg", "image/svg+xml"),
+        ("favicon.ico", "image/x-icon"),
+        ("favicon.png", "image/png"),
+    ];
+    for (filename, mime_type) in &candidates {
+        if public_dir.join(filename).exists() {
+            return Some(format!(
+                r#"<link rel="icon" type="{}" href="/{}" />"#,
+                mime_type, filename
+            ));
+        }
+    }
+    None
+}
+
 /// Basic HTML escaping for text content.
 fn escape_html(s: &str) -> String {
     s.replace('&', "&amp;")
@@ -203,6 +232,7 @@ mod tests {
             ssr_data: None,
             head_tags: None,
             root_dir: None,
+            favicon_tag: None,
         }
     }
 
@@ -380,6 +410,7 @@ mod tests {
             ssr_data: None,
             head_tags: None,
             root_dir: None,
+            favicon_tag: None,
         };
         let html = assemble_ssr_document(&opts);
 
@@ -476,5 +507,84 @@ mod tests {
         let app_pos = html.find("<div id=\"app\">").unwrap();
         assert!(data_pos > app_pos, "SSR data should be after app content");
         assert!(data_pos < body_end, "SSR data should be before </body>");
+    }
+
+    #[test]
+    fn test_favicon_tag_injected_in_head() {
+        let opts = SsrHtmlOptions {
+            favicon_tag: Some(r#"<link rel="icon" type="image/svg+xml" href="/favicon.svg" />"#),
+            ..default_options()
+        };
+        let html = assemble_ssr_document(&opts);
+        assert!(html.contains(r#"<link rel="icon" type="image/svg+xml" href="/favicon.svg" />"#));
+        let favicon_pos = html.find("favicon.svg").unwrap();
+        let head_end = html.find("</head>").unwrap();
+        assert!(favicon_pos < head_end, "Favicon tag should be in <head>");
+    }
+
+    #[test]
+    fn test_favicon_tag_omitted_when_none() {
+        let opts = SsrHtmlOptions {
+            favicon_tag: None,
+            ..default_options()
+        };
+        let html = assemble_ssr_document(&opts);
+        assert!(
+            !html.contains("favicon"),
+            "Should NOT contain favicon when None"
+        );
+    }
+
+    #[test]
+    fn test_detect_favicon_svg() {
+        let temp = tempfile::tempdir().unwrap();
+        let public_dir = temp.path().join("public");
+        std::fs::create_dir_all(&public_dir).unwrap();
+        std::fs::write(public_dir.join("favicon.svg"), "<svg></svg>").unwrap();
+
+        let tag = detect_favicon_tag(temp.path());
+        assert_eq!(
+            tag,
+            Some(r#"<link rel="icon" type="image/svg+xml" href="/favicon.svg" />"#.to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_favicon_ico() {
+        let temp = tempfile::tempdir().unwrap();
+        let public_dir = temp.path().join("public");
+        std::fs::create_dir_all(&public_dir).unwrap();
+        std::fs::write(public_dir.join("favicon.ico"), [0u8; 4]).unwrap();
+
+        let tag = detect_favicon_tag(temp.path());
+        assert_eq!(
+            tag,
+            Some(r#"<link rel="icon" type="image/x-icon" href="/favicon.ico" />"#.to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_favicon_priority() {
+        let temp = tempfile::tempdir().unwrap();
+        let public_dir = temp.path().join("public");
+        std::fs::create_dir_all(&public_dir).unwrap();
+        std::fs::write(public_dir.join("favicon.svg"), "<svg></svg>").unwrap();
+        std::fs::write(public_dir.join("favicon.ico"), [0u8; 4]).unwrap();
+
+        let tag = detect_favicon_tag(temp.path());
+        assert!(
+            tag.unwrap().contains("image/svg+xml"),
+            "SVG should take priority over ICO"
+        );
+    }
+
+    #[test]
+    fn test_detect_favicon_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let public_dir = temp.path().join("public");
+        std::fs::create_dir_all(&public_dir).unwrap();
+
+        let tag = detect_favicon_tag(temp.path());
+        assert!(tag.is_none(), "Should return None when no favicon exists");
     }
 }

--- a/native/vtz/tests/ssr_render.rs
+++ b/native/vtz/tests/ssr_render.rs
@@ -276,6 +276,7 @@ fn test_full_ssr_document_structure() {
         ssr_data: None,
         head_tags: None,
         root_dir: None,
+        favicon_tag: None,
     });
 
     // Document is valid HTML5

--- a/packages/ui-server/src/node-handler.ts
+++ b/packages/ui-server/src/node-handler.ts
@@ -175,7 +175,9 @@ export function createNodeHandler(
         if (linkHeader) headers.Link = linkHeader;
         if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-        res.writeHead(200, headers);
+        // Return 404 when no route matched (fallback content rendered but URL is invalid)
+        const status = result.matchedRoutePatterns?.length ? 200 : 404;
+        res.writeHead(status, headers);
         res.end(html);
       } catch (err) {
         console.error('[SSR] Render failed:', err instanceof Error ? err.message : err);
@@ -262,7 +264,9 @@ async function handleProgressiveRequest(
   if (linkHeader) headers.Link = linkHeader;
   if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-  res.writeHead(200, headers);
+  // Return 404 when no route matched
+  const status = result.matchedRoutePatterns?.length ? 200 : 404;
+  res.writeHead(status, headers);
 
   // 1. Send head chunk immediately
   res.write(headChunk);

--- a/packages/ui-server/src/ssr-handler.ts
+++ b/packages/ui-server/src/ssr-handler.ts
@@ -350,6 +350,9 @@ async function handleProgressiveHTMLRequest(
     if (linkHeader) headers.Link = linkHeader;
     if (cacheControl) headers['Cache-Control'] = cacheControl;
 
+    // Return 404 when no route matched (fallback content was rendered but URL is invalid)
+    const status = result.matchedRoutePatterns?.length ? 200 : 404;
+
     return buildProgressiveResponse({
       headChunk,
       renderStream: result.renderStream!,
@@ -357,6 +360,7 @@ async function handleProgressiveHTMLRequest(
       ssrData: result.ssrData,
       nonce,
       headers,
+      status,
     });
   } catch (err) {
     console.error('[SSR] Render failed:', err instanceof Error ? err.message : err);
@@ -450,7 +454,9 @@ async function handleHTMLRequest(
     if (linkHeader) headers.Link = linkHeader;
     if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-    return new Response(html, { status: 200, headers });
+    // Return 404 when no route matched (fallback content was rendered but URL is invalid)
+    const status = result.matchedRoutePatterns?.length ? 200 : 404;
+    return new Response(html, { status, headers });
   } catch (err) {
     console.error('[SSR] Render failed:', err instanceof Error ? err.message : err);
     return new Response('Internal Server Error', {

--- a/packages/ui-server/src/ssr-progressive-response.ts
+++ b/packages/ui-server/src/ssr-progressive-response.ts
@@ -25,6 +25,8 @@ export interface ProgressiveResponseOptions {
   nonce?: string;
   /** Additional response headers (e.g., Link for font preloads). */
   headers?: Record<string, string>;
+  /** HTTP status code (default: 200). */
+  status?: number;
 }
 
 /**
@@ -85,5 +87,5 @@ export function buildProgressiveResponse(options: ProgressiveResponseOptions): R
     ...headers,
   };
 
-  return new Response(stream, { status: 200, headers: responseHeaders });
+  return new Response(stream, { status: options.status ?? 200, headers: responseHeaders });
 }


### PR DESCRIPTION
## Summary
- **#2344**: SSR responses now return HTTP 404 when no route matches, instead of always 200. `matchedRoutePatterns` is propagated from JS SSR result through V8 bridge to Rust HTTP handlers.
- **#2347**: Rust runtime auto-detects `public/favicon.{svg,ico,png}` at startup and injects `<link rel="icon">` into SSR documents and client shells, matching Bun dev server behavior.

## Changes

### #2344 — 404 status codes
- **TypeScript** (`ssr-handler.ts`, `node-handler.ts`, `ssr-progressive-response.ts`): All three handler variants (web, node, progressive) now check `matchedRoutePatterns?.length` and return 404 when empty
- **Rust bridge** (`persistent_isolate.rs`): Parse `matchedRoutePatterns` array from JS SSR result JSON, add `matched_route_patterns: Vec<String>` to `SsrResponse`
- **Rust HTTP** (`http.rs`): Both dev and production handlers use `matched_route_patterns.is_empty()` to set `StatusCode::NOT_FOUND` vs `StatusCode::OK`

### #2347 — Favicon auto-detection
- **`html_document.rs`**: New `detect_favicon_tag(root_dir)` function checks `public/favicon.{svg,ico,png}` (in priority order), new `favicon_tag` field on `SsrHtmlOptions`
- **`html_shell.rs`**: Client-only shell also calls `detect_favicon_tag()` 
- **`http.rs`**: Detects favicon at server startup, stores in `DevServerState`, passes to all `SsrHtmlOptions` construction sites
- 5 new tests for favicon detection + injection

## Test plan
- [x] `cargo test -p vtz --lib` — 2980 tests pass
- [x] `cargo clippy -p vtz --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bunx tsc --noEmit -p packages/ui-server/tsconfig.json` — clean
- [ ] `cargo test -p vtz --test ssr_render` — 5 pre-existing failures (need `@vertz/ui-server` dist rebuild, not related to this PR)

Closes #2344
Closes #2347

🤖 Generated with [Claude Code](https://claude.com/claude-code)