### PR TITLE
docs: llms.txt discoverability + fix outdated CLI refs + /api/ prefix docs

### DIFF
--- a/packages/landing/public/robots.txt
+++ b/packages/landing/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://vertz.dev/sitemap.xml
+Llms-Txt: https://vertz.dev/llms.txt

--- a/packages/landing/scripts/build.ts
+++ b/packages/landing/scripts/build.ts
@@ -220,6 +220,9 @@ const PRODUCTION_HEAD = `
   <!-- Canonical -->
   <link rel="canonical" href="https://vertz.dev" />
 
+  <!-- LLM Discovery -->
+  <link rel="alternate" type="text/plain" href="/llms.txt" />
+
   <!-- Production CSS -->
 ${cssInjection.html}`;
 

--- a/packages/landing/src/llms-txt.ts
+++ b/packages/landing/src/llms-txt.ts
@@ -18,23 +18,24 @@ export const LLMS_TXT = `# Vertz
 ## Quick Start
 
 \`\`\`bash
-bunx @vertz/create-vertz-app@latest my-app
+vtz create vertz my-app
 cd my-app
-bun install
-bun run dev
+vtz install
+vtz dev
 \`\`\`
 
 ## Templates
 
-- \`--template todo-app\` (default): Full-stack app with database, API, entities, and UI
-- \`--template hello-world\`: UI-only counter app — minimal starting point
+- \`todo-app\` (default): Full-stack app with database, API, entities, and UI
+- \`hello-world\`: UI-only counter app — minimal starting point
 
 ## Key Concepts
 
 - **Schema**: \`d.table()\` and \`d.model()\` define your data shape (\`vertz/db\`)
-- **Entities**: \`entity()\` generates typed CRUD endpoints (\`vertz/server\`)
+- **Entities**: \`entity()\` generates typed CRUD endpoints under \`/api/\` (\`vertz/server\`)
+- **Routes**: All endpoints mount under \`/api/\` by default (e.g. \`GET /api/tasks\`, \`POST /api/tasks\`)
 - **UI**: Compiler-driven reactivity — \`let\` becomes signals, \`const\` becomes computed (\`vertz/ui\`)
-- **One dependency**: \`bun add vertz\` — meta-package includes all framework packages
+- **One dependency**: \`vtz add vertz\` — meta-package includes all framework packages
 
 ## Stack
 

--- a/packages/mint-docs/guides/llm-quick-reference.mdx
+++ b/packages/mint-docs/guides/llm-quick-reference.mdx
@@ -10,7 +10,6 @@ Quick overview of Vertz patterns. Each section links to its full guide.
 See [Installation](/installation) and [Quickstart](/quickstart).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vertz-dev/vertz/main/install.sh | sh
 vtz create vertz my-app
 cd my-app && vtz install && vtz dev
 ```
@@ -73,9 +72,23 @@ const button = variants({
 });
 ```
 
+## Route Convention
+
+All server endpoints live under `/api/` by default. Entity routes follow `REST` conventions:
+
+```
+GET    /api/tasks          → list
+POST   /api/tasks          → create
+GET    /api/tasks/:id      → get
+PATCH  /api/tasks/:id      → update
+DELETE /api/tasks/:id      → delete
+```
+
+Domains add a prefix: `/api/billing/invoices`. Customizable via `apiPrefix` in `createServer()`. See [API Prefix](/guides/server/overview#api-prefix).
+
 ## Entities (Server)
 
-`entity()` generates typed CRUD endpoints with access control. Routes are under `/api/` by default. See [Entities](/guides/server/entities).
+`entity()` generates typed CRUD endpoints with access control. See [Entities](/guides/server/entities).
 
 ```ts
 import { entity, rules } from 'vertz/server';


### PR DESCRIPTION
## Summary

- Add `Llms-Txt:` directive to landing page `robots.txt` for LLM crawler discovery
- Add `<link rel="alternate" type="text/plain" href="/llms.txt">` to production HTML `<head>` for browser/agent discoverability
- Fix outdated CLI commands in [`packages/landing/src/llms-txt.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/docs-only-issues/packages/landing/src/llms-txt.ts) (`bunx @vertz/create-vertz-app@latest` → `vtz create vertz`, `bun add` → `vtz add`)
- Fix outdated `curl` install line in [`packages/mint-docs/guides/llm-quick-reference.mdx`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/docs-only-issues/packages/mint-docs/guides/llm-quick-reference.mdx)
- Add dedicated "Route Convention" section with `/api/` prefix and full REST route table to LLM Quick Reference

## Related Issues

- Partially addresses #2181 — CLI-first getting started rewrite is blocked on #2179 (`vertz add entity`)
- Mintlify auto-generated `llms.txt` is intentionally **not** overridden (it's auto-generated from docs pages via `llmsTxt.enabled: true` in `docs.json`)

## Public API Changes

None — documentation and static asset changes only.

## Test plan

- [ ] Verify `https://vertz.dev/robots.txt` includes `Llms-Txt:` directive after deploy
- [ ] Verify `https://vertz.dev/llms.txt` serves updated content with `vtz` CLI commands
- [ ] Verify production HTML `<head>` includes `<link rel="alternate" ... href="/llms.txt">`
- [ ] Verify LLM Quick Reference page renders correctly on docs.vertz.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)