### PR TITLE
fix(ci): re-link runtime binary after artifact download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,9 @@ jobs:
             fi
           done
 
+      - name: Re-link runtime binary
+        run: bash scripts/link-runtime.sh
+
       - name: Build runtime selector package
         working-directory: packages/runtime
         run: bun build index.ts --outdir . --target node


### PR DESCRIPTION
## Summary

- The release workflow runs `bun install` (which creates a fallback `vtz` shim) **before** downloading native binary artifacts. When `publish.sh` later calls `vtz publish`, it hits the shim instead of the real binary, failing every source package with _"native binary not available"_.
- Adds a `Re-link runtime binary` step after artifact download that re-runs `link-runtime.sh`, so the symlink points to the actual native binary.

## Test plan

- [ ] Merge and verify the next release workflow run publishes source packages successfully (no more "vtz shim: native binary not available" errors)
- [ ] Confirm runtime binary packages still publish as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)