### PR TITLE
fix(ci): re-link runtime binary after downloading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,9 @@ jobs:
             fi
           done
 
+      - name: Re-link runtime binary
+        run: bash scripts/link-runtime.sh
+
       - name: Build runtime selector package
         working-directory: packages/runtime
         run: bun build index.ts --outdir . --target node


### PR DESCRIPTION
The release workflow installs dependencies before downloading binary artifacts, so link-runtime.sh creates a fallback shim that only supports `run` and `exec`. When publish.sh later calls `vtz publish`, it hits the shim instead of the real binary and every source package fails to publish.

Re-run link-runtime.sh after binaries are downloaded so the symlink points to the actual native binary.

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

## Test plan

<!-- How was this tested? Checklist of what to verify. -->
