### PR TITLE
fix(ci): download vtz binary from GitHub release when not built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,20 @@ jobs:
             fi
           done
 
+      - name: Download runtime from latest release (when not built from source)
+        if: ${{ !contains(needs.build-binaries.result, 'success') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "No binary artifacts from this run — downloading from latest GitHub release"
+          gh release download --pattern 'vtz-linux-x64' --dir /tmp/vtz-release || {
+            echo "::warning::Could not download vtz binary from latest release"
+            exit 0
+          }
+          cp /tmp/vtz-release/vtz-linux-x64 packages/runtime-linux-x64/vtz
+          chmod +x packages/runtime-linux-x64/vtz
+          echo "Downloaded vtz binary: $(packages/runtime-linux-x64/vtz --version 2>/dev/null || echo 'unknown')"
+
       - name: Re-link runtime binary
         run: bash scripts/link-runtime.sh
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -108,7 +108,7 @@ for pkg_json in packages/*/package.json; do
   fi
 
   echo "Publishing $name@$version..."
-  if (cd "$dir" && bun publish --access public --provenance); then
+  if (cd "$dir" && vtz publish --access public --provenance); then
     echo "Published $name@$version"
   else
     echo "Failed to publish $name@$version"
@@ -129,4 +129,4 @@ echo ""
 echo "All packages published successfully"
 
 # Create git tags (changeset tag)
-bunx changeset tag 2>/dev/null || true
+vtzx changeset tag 2>/dev/null || true


### PR DESCRIPTION
## Summary

- When `build-binaries` is skipped (no `native/` changes), the release job has no `vtz` binary. This reverts source package publishing back to `vtz publish` (which resolves `workspace:*` protocols) and downloads the binary from the latest GitHub release when it wasn't built from source.
- Reverts the temporary `bun publish` fallback from #2364 since `vtz` is now always available.

## Test plan

- [ ] Merge and verify the next release workflow publishes source packages using `vtz publish`
- [ ] Verify `gh release download` fetches the correct `vtz-linux-x64` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)