### PR TITLE
fix(openapi): add @vertz/fetch peer dependency (#2217)

### DIFF
--- a/.changeset/openapi-fetch-peer-dep.md
+++ b/.changeset/openapi-fetch-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@vertz/openapi': patch
+---
+
+Add `@vertz/fetch` as a peer dependency (`>=0.2.47`) so package managers enforce the version that includes the `QueryParams` type fix (#2217).

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -47,6 +47,9 @@
     "bunup": "^0.16.31",
     "typescript": "^5.7.0"
   },
+  "peerDependencies": {
+    "@vertz/fetch": ">=0.2.47"
+  },
   "engines": {
     "node": ">=22"
   }


### PR DESCRIPTION
## Summary

- Adds `@vertz/fetch` as a `peerDependency` (`>=0.2.47`) to `@vertz/openapi`
- The `QueryParams` type fix shipped in `@vertz/fetch@0.2.47` (PR #2243), but since `@vertz/openapi` doesn't depend on `@vertz/fetch`, users could upgrade openapi without upgrading fetch and still hit TS2322 errors
- With this peer dep, package managers will warn when the fetch version is too old

## Public API Changes

None — this only adds package metadata.

## Test plan

- [x] Verified `@vertz/openapi` tests still pass (5 pre-existing failures unrelated to this change)
- [x] Verified formatting passes (`oxfmt --check`)

Closes #2217

🤖 Generated with [Claude Code](https://claude.com/claude-code)