### PR TITLE
chore(docs): remove Bun references from docs and scaffolding

### DIFF
--- a/packages/create-vertz-app/src/__tests__/scaffold.test.ts
+++ b/packages/create-vertz-app/src/__tests__/scaffold.test.ts
@@ -121,7 +121,6 @@ describe('scaffold', () => {
       const content = await fs.readFile(projectPath('package.json'), 'utf-8');
       const pkg = JSON.parse(content);
       expect(pkg.devDependencies['@vertz/cli']).toBeDefined();
-      expect(pkg.devDependencies['bun-types']).toBeDefined();
     });
 
     it('package.json includes #generated imports map', async () => {
@@ -151,7 +150,7 @@ describe('scaffold', () => {
       expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
       expect(tsconfig.compilerOptions.jsxImportSource).toBe('@vertz/ui');
       expect(tsconfig.compilerOptions.strict).toBe(true);
-      expect(tsconfig.compilerOptions.types).toContain('bun-types');
+      expect(tsconfig.compilerOptions.types).toEqual([]);
     });
 
     it('vertz.config.ts includes codegen config', async () => {
@@ -177,21 +176,16 @@ describe('scaffold', () => {
       expect(content).toContain('PORT=3000');
     });
 
-    it('bunfig.toml registers Vertz compiler plugin for dev server', async () => {
+    it('does NOT generate bunfig.toml (vtz runtime handles compiler plugin)', async () => {
       await scaffold(tempDir, defaultOptions);
 
-      const content = await fs.readFile(projectPath('bunfig.toml'), 'utf-8');
-      expect(content).toContain('[serve.static]');
-      expect(content).toContain('bun-plugin-shim.ts');
+      expect(await exists(projectPath('bunfig.toml'))).toBe(false);
     });
 
-    it('bun-plugin-shim.ts bridges createVertzBunPlugin for bunfig.toml', async () => {
+    it('does NOT generate bun-plugin-shim.ts (vtz runtime handles compiler plugin)', async () => {
       await scaffold(tempDir, defaultOptions);
 
-      const content = await fs.readFile(projectPath('bun-plugin-shim.ts'), 'utf-8');
-      expect(content).toContain('createVertzBunPlugin');
-      expect(content).toContain("from 'vertz/ui-server/bun-plugin'");
-      expect(content).toContain('export default plugin');
+      expect(await exists(projectPath('bun-plugin-shim.ts'))).toBe(false);
     });
 
     it('package.json does not need @vertz/ui-server (provided by vertz meta-package)', async () => {
@@ -521,16 +515,12 @@ describe('scaffold', () => {
       expect(content).toContain("from 'vertz/ui'");
     });
 
-    it('reuses shared templates (tsconfig, bunfig, gitignore, theme, favicon)', async () => {
+    it('reuses shared templates (tsconfig, gitignore, theme, favicon)', async () => {
       await scaffold(tempDir, helloOptions);
 
       // tsconfig
       const tsconfig = JSON.parse(await fs.readFile(projectPath('tsconfig.json'), 'utf-8'));
       expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
-
-      // bunfig
-      const bunfig = await fs.readFile(projectPath('bunfig.toml'), 'utf-8');
-      expect(bunfig).toContain('[serve.static]');
 
       // gitignore
       const gitignore = await fs.readFile(projectPath('.gitignore'), 'utf-8');
@@ -543,6 +533,12 @@ describe('scaffold', () => {
       // favicon
       const favicon = await fs.readFile(projectPath('public', 'favicon.svg'), 'utf-8');
       expect(favicon).toContain('viewBox');
+    });
+
+    it('does NOT generate bunfig.toml', async () => {
+      await scaffold(tempDir, helloOptions);
+
+      expect(await exists(projectPath('bunfig.toml'))).toBe(false);
     });
 
     it('throws error if project directory already exists', async () => {
@@ -707,14 +703,11 @@ describe('scaffold', () => {
       expect(content).toContain('createRouter');
     });
 
-    it('reuses shared templates (tsconfig, bunfig, gitignore, theme, favicon)', async () => {
+    it('reuses shared templates (tsconfig, gitignore, theme, favicon)', async () => {
       await scaffold(tempDir, landingOptions);
 
       const tsconfig = JSON.parse(await fs.readFile(projectPath('tsconfig.json'), 'utf-8'));
       expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
-
-      const bunfig = await fs.readFile(projectPath('bunfig.toml'), 'utf-8');
-      expect(bunfig).toContain('[serve.static]');
 
       const gitignore = await fs.readFile(projectPath('.gitignore'), 'utf-8');
       expect(gitignore).toContain('node_modules');
@@ -724,6 +717,12 @@ describe('scaffold', () => {
 
       const favicon = await fs.readFile(projectPath('public', 'favicon.svg'), 'utf-8');
       expect(favicon).toContain('viewBox');
+    });
+
+    it('does NOT generate bunfig.toml', async () => {
+      await scaffold(tempDir, landingOptions);
+
+      expect(await exists(projectPath('bunfig.toml'))).toBe(false);
     });
 
     // ── Component content ──────────────────────────────────

--- a/packages/create-vertz-app/src/scaffold.ts
+++ b/packages/create-vertz-app/src/scaffold.ts
@@ -3,8 +3,6 @@ import path from 'node:path';
 import {
   apiDevelopmentRuleTemplate,
   appComponentTemplate,
-  bunfigTemplate,
-  bunPluginShimTemplate,
   claudeMdTemplate,
   clientTemplate,
   dbTemplate,
@@ -112,9 +110,6 @@ async function scaffoldHelloWorld(projectDir: string, projectName: string): Prom
     writeFile(projectDir, 'tsconfig.json', tsconfigTemplate()),
     writeFile(projectDir, 'vertz.config.ts', helloWorldVertzConfigTemplate()),
     writeFile(projectDir, '.gitignore', gitignoreTemplate()),
-    writeFile(projectDir, 'bunfig.toml', bunfigTemplate()),
-    writeFile(projectDir, 'bun-plugin-shim.ts', bunPluginShimTemplate()),
-
     // UI source files
     writeFile(srcDir, 'app.tsx', helloWorldAppTemplate()),
     writeFile(srcDir, 'entry-client.ts', entryClientTemplate()),
@@ -161,8 +156,6 @@ async function scaffoldTodoApp(projectDir: string, projectName: string): Promise
     writeFile(projectDir, '.env', envTemplate()),
     writeFile(projectDir, '.env.example', envExampleTemplate()),
     writeFile(projectDir, '.gitignore', gitignoreTemplate()),
-    writeFile(projectDir, 'bunfig.toml', bunfigTemplate()),
-    writeFile(projectDir, 'bun-plugin-shim.ts', bunPluginShimTemplate()),
 
     // API source files
     writeFile(apiDir, 'env.ts', envModuleTemplate()),
@@ -213,9 +206,6 @@ async function scaffoldLandingPage(projectDir: string, projectName: string): Pro
     writeFile(projectDir, 'tsconfig.json', tsconfigTemplate()),
     writeFile(projectDir, 'vertz.config.ts', helloWorldVertzConfigTemplate()),
     writeFile(projectDir, '.gitignore', gitignoreTemplate()),
-    writeFile(projectDir, 'bunfig.toml', bunfigTemplate()),
-    writeFile(projectDir, 'bun-plugin-shim.ts', bunPluginShimTemplate()),
-
     // UI source files
     writeFile(srcDir, 'app.tsx', landingPageAppTemplate()),
     writeFile(srcDir, 'entry-client.ts', entryClientTemplate()),

--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'bun:test';
 import {
   apiDevelopmentRuleTemplate,
   appComponentTemplate,
-  bunfigTemplate,
-  bunPluginShimTemplate,
   claudeMdTemplate,
   clientTemplate,
   dbTemplate,
@@ -51,7 +49,6 @@ describe('templates', () => {
       const result = packageJsonTemplate('test-app');
       const pkg = JSON.parse(result);
       expect(pkg.devDependencies['@vertz/cli']).toBeDefined();
-      expect(pkg.devDependencies['bun-types']).toBeDefined();
     });
 
     it('includes #generated imports map', () => {
@@ -89,10 +86,10 @@ describe('templates', () => {
       expect(tsconfig.compilerOptions.jsxImportSource).toBe('@vertz/ui');
     });
 
-    it('includes bun-types', () => {
+    it('has empty types array (no bun-types)', () => {
       const result = tsconfigTemplate();
       const tsconfig = JSON.parse(result);
-      expect(tsconfig.compilerOptions.types).toContain('bun-types');
+      expect(tsconfig.compilerOptions.types).toEqual([]);
     });
   });
 
@@ -119,26 +116,6 @@ describe('templates', () => {
   describe('envExampleTemplate', () => {
     it('contains PORT=3000', () => {
       expect(envExampleTemplate()).toContain('PORT=3000');
-    });
-  });
-
-  describe('bunfigTemplate', () => {
-    it('registers bun-plugin-shim.ts under [serve.static]', () => {
-      const result = bunfigTemplate();
-      expect(result).toContain('[serve.static]');
-      expect(result).toContain('bun-plugin-shim.ts');
-    });
-  });
-
-  describe('bunPluginShimTemplate', () => {
-    it('imports createVertzBunPlugin from vertz/ui-server/bun-plugin', () => {
-      const result = bunPluginShimTemplate();
-      expect(result).toContain("from 'vertz/ui-server/bun-plugin'");
-      expect(result).toContain('createVertzBunPlugin');
-    });
-
-    it('exports plugin as default', () => {
-      expect(bunPluginShimTemplate()).toContain('export default plugin');
     });
   });
 
@@ -388,10 +365,10 @@ describe('templates', () => {
       expect(result).toContain('Vertz');
     });
 
-    it('includes dev commands', () => {
+    it('includes vtz dev commands', () => {
       const result = claudeMdTemplate('test-app');
-      expect(result).toContain('bun run dev');
-      expect(result).toContain('bun run build');
+      expect(result).toContain('vtz dev');
+      expect(result).toContain('vtz build');
     });
 
     it('points to docs.vertz.dev', () => {
@@ -691,8 +668,6 @@ describe('templates', () => {
         envExampleTemplate,
         envModuleTemplate,
         gitignoreTemplate,
-        bunfigTemplate,
-        bunPluginShimTemplate,
         serverTemplate,
         schemaTemplate,
         dbTemplate,

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -10,7 +10,7 @@ A full-stack TypeScript application built with [Vertz](https://vertz.dev).
 
 ## Stack
 
-- Runtime: Bun
+- Runtime: Vertz (vtz)
 - Framework: Vertz (full-stack TypeScript)
 - Language: TypeScript (strict mode)
 - Docs: https://docs.vertz.dev
@@ -18,9 +18,9 @@ A full-stack TypeScript application built with [Vertz](https://vertz.dev).
 ## Development
 
 \`\`\`bash
-bun install          # Install dependencies
-bun run dev          # Start dev server with HMR
-bun run build        # Production build
+vtz install          # Install dependencies
+vtz dev              # Start dev server with HMR
+vtz build            # Production build
 \`\`\`
 
 The dev server automatically runs codegen and migrations when files change.
@@ -48,7 +48,7 @@ const contactForm = form(api.support.send);     // service action
 \`\`\`
 
 Raw \`fetch()\` bypasses type safety, SSR integration, caching, and optimistic updates.
-The SDK runs codegen automatically during \`bun run dev\` and \`bun run build\`.
+The SDK runs codegen automatically during \`vtz dev\` and \`vtz build\`.
 `;
 }
 
@@ -570,7 +570,6 @@ export function packageJsonTemplate(projectName: string): string {
     },
     devDependencies: {
       '@vertz/cli': '^0.2.0',
-      'bun-types': '^1.0.0',
       typescript: '^5.8.0',
     },
   };
@@ -595,7 +594,7 @@ export function tsconfigTemplate(): string {
       skipLibCheck: true,
       strict: true,
       target: 'ES2022',
-      types: ['bun-types'],
+      types: [],
     },
     include: ['src', '.vertz/generated'],
   };
@@ -632,34 +631,6 @@ DATABASE_URL=local.db
 export function envExampleTemplate(): string {
   return `PORT=3000
 DATABASE_URL=local.db
-`;
-}
-
-/**
- * bunfig.toml template — registers Vertz compiler plugin for Bun's dev server
- */
-export function bunfigTemplate(): string {
-  return `[serve.static]
-plugins = ["./bun-plugin-shim.ts"]
-`;
-}
-
-/**
- * bun-plugin-shim.ts — bridges bunfig.toml plugin format with createVertzBunPlugin
- */
-export function bunPluginShimTemplate(): string {
-  return `/**
- * Thin shim that wraps @vertz/ui-server/bun-plugin for bunfig.toml consumption.
- *
- * bunfig.toml \`[serve.static] plugins\` requires a default export of type BunPlugin.
- * The @vertz/ui-server/bun-plugin package exports a factory function (createVertzBunPlugin)
- * as a named export — this shim bridges the two.
- */
-import { createVertzBunPlugin } from 'vertz/ui-server/bun-plugin';
-
-const { plugin } = createVertzBunPlugin();
-
-export default plugin;
 `;
 }
 
@@ -1092,7 +1063,7 @@ A UI-only TypeScript application built with [Vertz](https://vertz.dev).
 
 ## Stack
 
-- Runtime: Bun
+- Runtime: Vertz (vtz)
 - Framework: Vertz (UI)
 - Language: TypeScript (strict mode)
 - Docs: https://docs.vertz.dev
@@ -1100,9 +1071,9 @@ A UI-only TypeScript application built with [Vertz](https://vertz.dev).
 ## Development
 
 \`\`\`bash
-bun install          # Install dependencies
-bun run dev          # Start dev server with HMR
-bun run build        # Production build
+vtz install          # Install dependencies
+vtz dev              # Start dev server with HMR
+vtz build            # Production build
 \`\`\`
 
 ## Adding a Backend
@@ -1141,7 +1112,6 @@ export function helloWorldPackageJsonTemplate(projectName: string): string {
     },
     devDependencies: {
       '@vertz/cli': '^0.2.0',
-      'bun-types': '^1.0.0',
       typescript: '^5.8.0',
     },
   };
@@ -1402,7 +1372,6 @@ export function landingPagePackageJsonTemplate(projectName: string): string {
     },
     devDependencies: {
       '@vertz/cli': '^0.2.0',
-      'bun-types': '^1.0.0',
       typescript: '^5.8.0',
     },
   };

--- a/packages/mint-docs/guides/deploy/node.mdx
+++ b/packages/mint-docs/guides/deploy/node.mdx
@@ -15,7 +15,7 @@ Use `createNodeHandler` when deploying to any Node.js-based platform:
 - AWS Lambda (with a Node HTTP adapter)
 - Any platform that gives you `IncomingMessage` + `ServerResponse`
 
-If you're deploying to **Cloudflare Workers** or **Bun**, use the web-standard `createSSRHandler` instead — those runtimes handle `Request`/`Response` natively with no conversion cost.
+If you're deploying to **Cloudflare Workers** or another runtime with native web APIs, use the web-standard `createSSRHandler` instead — those runtimes handle `Request`/`Response` natively with no conversion cost.
 
 ## Quick start
 
@@ -46,7 +46,7 @@ That's it. The handler:
 
 ## Why not `createSSRHandler`?
 
-`createSSRHandler` returns a web-standard `(Request) => Promise<Response>` handler. On Bun and Cloudflare Workers, `Request` and `Response` are native — zero conversion cost.
+`createSSRHandler` returns a web-standard `(Request) => Promise<Response>` handler. On runtimes with native web APIs (Cloudflare Workers, Deno, etc.), `Request` and `Response` are native — zero conversion cost.
 
 On Node.js, bridging between Node's `IncomingMessage`/`ServerResponse` and web `Request`/`Response` adds two conversions per request:
 
@@ -207,7 +207,7 @@ Node's HTTP server has keep-alive enabled by default. For long-lived SSE connect
 |                      | `createSSRHandler`               | `createNodeHandler`                         |
 | -------------------- | -------------------------------- | ------------------------------------------- |
 | **Signature**        | `(Request) => Promise<Response>` | `(IncomingMessage, ServerResponse) => void` |
-| **Best for**         | Bun, Cloudflare Workers, Deno    | Node.js, Express, Fastify                   |
+| **Best for**         | Cloudflare Workers, Deno         | Node.js, Express, Fastify                   |
 | **Conversion cost**  | None (native)                    | None (writes directly)                      |
 | **Backpressure**     | Web stream API                   | Node `drain` events                         |
 | **Progressive HTML** | `ReadableStream` response body   | Direct `res.write()` chunks                 |

--- a/packages/mint-docs/guides/deploy/og-images.mdx
+++ b/packages/mint-docs/guides/deploy/og-images.mdx
@@ -29,6 +29,7 @@ Create a generation script at `scripts/generate-og.ts`. The "component" is a pla
 
 ```ts
 // scripts/generate-og.ts
+import { writeFile } from 'node:fs/promises';
 import satori from 'satori';
 import { Resvg } from '@resvg/resvg-js';
 
@@ -105,7 +106,7 @@ const svg = await satori(OGImage() as React.ReactNode, {
 const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: WIDTH } });
 const png = resvg.render().asPng();
 
-await Bun.write('public/og.png', png);
+await writeFile('public/og.png', png);
 console.log(`✓ Generated OG image (${(png.byteLength / 1024).toFixed(1)} KB)`);
 ```
 
@@ -221,9 +222,11 @@ Call the OG generation script from your build script so images are always up to 
 
 ```ts
 // In scripts/build.ts
-const ogProc = Bun.spawnSync(['bun', 'run', 'scripts/generate-og.ts'], {
+import { execSync } from 'node:child_process';
+
+execSync('vtz run scripts/generate-og.ts', {
   cwd: ROOT,
-  stdio: ['inherit', 'inherit', 'inherit'],
+  stdio: 'inherit',
 });
 ```
 

--- a/packages/mint-docs/guides/deploy/static-sites.mdx
+++ b/packages/mint-docs/guides/deploy/static-sites.mdx
@@ -79,26 +79,17 @@ mount(App, {
 
 For local development, use the standard Vertz dev server:
 
-```ts
-// src/dev-server.ts
-import { createBunDevServer } from '@vertz/ui-server/bun-dev-server';
+The `vtz` runtime includes a built-in dev server with HMR, SSR, and the Vertz compiler — no additional configuration required. Just run:
 
-const devServer = createBunDevServer({
-  entry: './src/app.tsx',
-  clientEntry: './src/entry-client.ts',
-  port: 4000,
-  ssrModule: true,
-  title: 'My Site',
-});
-
-await devServer.start();
+```bash
+vtz dev
 ```
 
 ## Build script
 
 The build script produces a self-contained `dist/` directory. It:
 
-1. **Builds the client JS bundle** using `Bun.build()` with the Vertz compiler plugin
+1. **Builds the client JS bundle** with the Vertz compiler plugin
 2. **Extracts CSS** from component `css()` calls
 3. **Copies public assets** to `dist/public/`
 4. **SSR-renders the page** by starting the dev server and capturing its output
@@ -107,9 +98,17 @@ The build script produces a self-contained `dist/` directory. It:
 
 ```ts
 // scripts/build.ts
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { resolve } from 'node:path';
-import { createVertzBunPlugin } from '@vertz/ui-server/bun-plugin';
+import { execSync, spawn } from 'node:child_process';
 
 const ROOT = resolve(import.meta.dir, '..');
 const DIST = resolve(ROOT, 'dist');
@@ -119,55 +118,18 @@ const PORT = 4100;
 rmSync(DIST, { recursive: true, force: true });
 mkdirSync(resolve(DIST, 'assets'), { recursive: true });
 
-const { plugin, fileExtractions } = createVertzBunPlugin({
-  hmr: false,
-  fastRefresh: false,
-  projectRoot: ROOT,
-});
+// Use `vtz build` for the client bundle in production.
+// The build output goes to dist/assets/ with hashed filenames.
+execSync('vtz build', { cwd: ROOT, stdio: 'inherit' });
 
-const clientResult = await Bun.build({
-  entrypoints: [resolve(ROOT, 'src/entry-client.ts')],
-  plugins: [plugin],
-  target: 'browser',
-  minify: true,
-  splitting: true,
-  outdir: resolve(DIST, 'assets'),
-  naming: '[name]-[hash].[ext]',
-});
-
-if (!clientResult.success) {
-  console.error('Client build failed:', clientResult.logs);
-  process.exit(1);
-}
-
-// Collect output paths
-let clientJsPath = '';
-const clientCssPaths: string[] = [];
-
-for (const output of clientResult.outputs) {
-  const rel = output.path.replace(DIST, '');
-  if (output.kind === 'entry-point') clientJsPath = rel;
-  else if (output.path.endsWith('.css')) clientCssPaths.push(rel);
-}
-
-// ── 2. Extract component CSS ───────────────────────────────
-let extractedCss = '';
-for (const [, extraction] of fileExtractions) {
-  if (extraction.css) extractedCss += `${extraction.css}\n`;
-}
-if (extractedCss) {
-  writeFileSync(resolve(DIST, 'assets/vertz.css'), extractedCss);
-  clientCssPaths.push('/assets/vertz.css');
-}
-
-// ── 3. Copy public/ → dist/public/ ────────────────────────
+// ── 2. Copy public/ → dist/public/ ────────────────────────
 const publicDir = resolve(ROOT, 'public');
 if (existsSync(publicDir)) {
   cpSync(publicDir, resolve(DIST, 'public'), { recursive: true });
 }
 
-// ── 4. SSR-render the page ─────────────────────────────────
-const server = Bun.spawn(['bun', 'run', 'src/dev-server.ts'], {
+// ── 3. SSR-render the page ─────────────────────────────────
+const server = spawn('vtz', ['dev', '--port', String(PORT)], {
   cwd: ROOT,
   env: { ...process.env, PORT: String(PORT) },
   stdio: ['ignore', 'pipe', 'pipe'],
@@ -178,32 +140,37 @@ for (let i = 0; i < 60; i++) {
   try {
     if ((await fetch(`http://localhost:${PORT}`)).ok) break;
   } catch {}
-  await Bun.sleep(500);
+  await new Promise((r) => setTimeout(r, 500));
 }
 
 const html = await fetch(`http://localhost:${PORT}`).then((r) => r.text());
 server.kill();
 
-// ── 5. Strip dev-only scripts ──────────────────────────────
+// ── 4. Strip dev-only scripts ──────────────────────────────
 let clean = html
-  .replace(/<style>bun-hmr\{display:none!important\}[\s\S]*?\}\)\(\)<\/script>/g, '')
-  .replace(/<script>\(function\(\)\{var K="__vertz_reload_count"[\s\S]*?\}\)\(\)<\/script>/g, '')
-  .replace(/<script type="text\/plain"[^>]*data-bun-dev-server-script[^>]*><\/script>/g, '')
-  .replace(/<script>\(\(a\)=>\{document\.addEventListener[\s\S]*?\)<\/script>/g, '')
-  .replace(/<script>\(function\(\)\{var el=document\.querySelector[\s\S]*?\}\)\(\)<\/script>/g, '')
+  .replace(/<style>[\s\S]*?<\/style>/g, (match) => (match.includes('hmr') ? '' : match))
+  .replace(/<script[^>]*data-dev-server[^>]*>[\s\S]*?<\/script>/g, '')
   .replace(/<script type="module" src="\/src\/entry-client\.ts"><\/script>/g, '');
 
-// ── 6. Inject production head + client bundle ──────────────
-const cssLinks = clientCssPaths.map((p) => `  <link rel="stylesheet" href="${p}" />`).join('\n');
+// ── 5. Inject production head + client bundle ──────────────
+// Find the built client JS in dist/assets/
+const assets = existsSync(resolve(DIST, 'assets')) ? readdirSync(resolve(DIST, 'assets')) : [];
+const clientJs = assets.find((f) => f.startsWith('entry-client') && f.endsWith('.js'));
+const clientCss = assets.filter((f) => f.endsWith('.css'));
 
-clean = clean.replace(/(<title>[^<]*<\/title>)/, `$1\n${cssLinks}`);
+if (clientJs) {
+  clean = clean.replace(
+    /<\/body>/,
+    `  <script type="module" crossorigin src="/assets/${clientJs}"></script>\n</body>`,
+  );
+}
 
-clean = clean.replace(
-  /<\/body>/,
-  `  <script type="module" crossorigin src="${clientJsPath}"></script>\n</body>`,
-);
+const cssLinks = clientCss.map((f) => `  <link rel="stylesheet" href="/assets/${f}" />`).join('\n');
+if (cssLinks) {
+  clean = clean.replace(/(<title>[^<]*<\/title>)/, `$1\n${cssLinks}`);
+}
 
-await Bun.write(resolve(DIST, 'index.html'), clean);
+writeFileSync(resolve(DIST, 'index.html'), clean);
 console.log('✓ Build complete: dist/');
 ```
 
@@ -298,9 +265,8 @@ dist/
 ```
 
 <Warning>
-  The dev server's SSR output includes HMR scripts, WebSocket overlays, and Bun dev server
-  bootstrapping code. The build script strips all of these — never deploy the raw dev server output
-  directly.
+  The dev server's SSR output includes HMR scripts, WebSocket overlays, and dev server bootstrapping
+  code. The build script strips all of these — never deploy the raw dev server output directly.
 </Warning>
 
 ## How it differs from full-stack deployment

--- a/packages/mint-docs/guides/openapi.mdx
+++ b/packages/mint-docs/guides/openapi.mdx
@@ -14,7 +14,7 @@ description: 'Generate typed TypeScript SDKs from external OpenAPI 3.x specs'
 ## Install
 
 ```bash
-bun add -d @vertz/openapi
+vtz add -d @vertz/openapi
 ```
 
 ## Quick start
@@ -69,7 +69,7 @@ CLI flags override config file values.
 Install `@vertz/fetch` in the project that consumes the SDK:
 
 ```bash
-bun add @vertz/fetch
+vtz add @vertz/fetch
 ```
 
 ```ts

--- a/packages/mint-docs/guides/ui/compiler.mdx
+++ b/packages/mint-docs/guides/ui/compiler.mdx
@@ -163,17 +163,7 @@ vtz dev            # Compiler runs automatically via the dev server
 vtz run build      # Compiler runs during production build
 ```
 
-For manual setup, add the compiler plugin to your Bun configuration:
-
-```tsx
-import { vertzPlugin } from 'vertz/ui-compiler';
-
-Bun.plugin(
-  vertzPlugin({
-    // Options
-  }),
-);
-```
+The compiler is integrated into the `vtz` runtime and runs automatically during `vtz dev` and `vtz build`. No manual plugin setup is required.
 
 ## TypeScript configuration
 

--- a/packages/mint-docs/guides/ui/overview.mdx
+++ b/packages/mint-docs/guides/ui/overview.mdx
@@ -7,7 +7,7 @@ description: 'vertz/ui — a compiled UI layer with fine-grained reactivity, rou
 
 ## How the compiler works
 
-The Vertz compiler runs as a build plugin (Bun or Vite). It analyzes your component code and applies three key transforms:
+The Vertz compiler runs as a build plugin. It analyzes your component code and applies three key transforms:
 
 <Steps>
   <Step title="let becomes a signal">

--- a/packages/mint-docs/guides/ui/ssr.mdx
+++ b/packages/mint-docs/guides/ui/ssr.mdx
@@ -286,10 +286,11 @@ This gives SPA navigation the data freshness of server rendering.
 For production deployments, `createSSRHandler()` creates a web-standard `(Request) => Promise<Response>` handler:
 
 ```ts
+import { readFileSync } from 'node:fs';
 import { createSSRHandler } from '@vertz/ui-server';
 
 const module = await import('./dist/server/index.js');
-const template = await Bun.file('./dist/client/index.html').text();
+const template = readFileSync('./dist/client/index.html', 'utf-8');
 
 const handler = createSSRHandler({
   module,
@@ -297,12 +298,7 @@ const handler = createSSRHandler({
   ssrTimeout: 300,
 });
 
-Bun.serve({
-  fetch(request) {
-    // Serve static files first, then SSR
-    return handler(request);
-  },
-});
+// Use any web-standard server — the handler accepts (Request) => Promise<Response>
 ```
 
 The handler uses single-pass rendering: a lightweight discovery pass captures queries without producing HTML, data is prefetched, then a single render pass produces the final output.
@@ -362,10 +358,11 @@ To disable AOT rendering (e.g., for benchmarking the DOM shim path), omit the `a
 When writing a custom production server, load the manifest explicitly:
 
 ```ts
+import { readFileSync } from 'node:fs';
 import { createSSRHandler, loadAotManifest } from '@vertz/ui-server';
 
 const module = await import('./dist/server/index.js');
-const template = await Bun.file('./dist/client/index.html').text();
+const template = readFileSync('./dist/client/index.html', 'utf-8');
 
 const aotManifest = await loadAotManifest('./dist/server');
 

--- a/packages/mint-docs/runtime.mdx
+++ b/packages/mint-docs/runtime.mdx
@@ -3,7 +3,7 @@ title: Runtime
 description: 'The Vertz native runtime — fast dev server, built-in test runner'
 ---
 
-Vertz ships a native runtime (`vtz`) — a standalone binary that replaces Bun for development. It starts in ~5ms, includes a V8-based dev server with SSR, HMR, and a built-in test runner.
+Vertz ships a native runtime (`vtz`) — a standalone binary for development. It starts in ~5ms, includes a V8-based dev server with SSR, HMR, and a built-in test runner.
 
 ## How it works
 
@@ -87,7 +87,7 @@ vtz remove <pkg>     # Remove a package
 vtz update [pkg]     # Update packages (or all if no pkg specified)
 vtz run <script>     # Run a package.json script
 vtz exec <cmd>       # Run a command from node_modules/.bin
-vtzx <cmd>           # Shorthand for vtz exec (like npx/bunx)
+vtzx <cmd>           # Shorthand for vtz exec (like npx)
 vtz self-update      # Update the vtz binary itself
 ```
 


### PR DESCRIPTION
## Summary

- Remove all Bun-specific references from scaffolded project templates (`create-vertz-app`) — `Runtime: Bun` → `Runtime: Vertz (vtz)`, `bun install/run dev/run build` → `vtz install/dev/build`, removed `bunfig.toml`, `bun-plugin-shim.ts`, and `bun-types` from generated projects
- Remove Bun references from Mintlify docs — replaced `bun add` with `vtz add`, replaced `Bun.file()`/`Bun.serve()`/`Bun.build()` code examples with Node.js standard APIs, made deploy docs runtime-agnostic
- Updated all related tests to verify Bun files are NOT generated and that `vtz` commands are used instead

LLMs were using Bun instead of the vtz runtime when scaffolding Vertz projects because the generated CLAUDE.md and docs prominently featured Bun commands. This ensures the vtz runtime is presented as the default development experience.

## Test plan

- [x] `bun test` in `packages/create-vertz-app` — 204 pass, 0 fail
- [x] `bun run typecheck` in `packages/create-vertz-app` — clean
- [x] `vtz run lint` — 0 errors (1022 pre-existing warnings)
- [x] `vtz run format` — all files formatted
- [x] Pre-push quality gates (lint + trojan-source + turbo build/typecheck/test) — all pass