### PR TITLE
fix(openapi): add bunup config with adapters entry point (#2380)

### DIFF
--- a/.changeset/fix-openapi-adapters-export.md
+++ b/.changeset/fix-openapi-adapters-export.md
@@ -1,0 +1,5 @@
+---
+'@vertz/openapi': patch
+---
+
+Fix `@vertz/openapi/adapters` export missing from dist. Add bunup config with all entry points (index, cli, adapters).

--- a/packages/openapi/bunup.config.ts
+++ b/packages/openapi/bunup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'bunup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts', 'src/adapters/index.ts'],
+  format: ['esm'],
+  dts: { inferTypes: true },
+  clean: true,
+});


### PR DESCRIPTION
## Summary

- The `@vertz/openapi` package was missing a `bunup.config.ts`, so the build only produced `dist/index.js` by default
- The `./adapters` export declared in `package.json` pointed to `dist/adapters/index.js` which was never built
- Added explicit build config with all three entry points: `index`, `cli`, and `adapters`
- Used `dts: { inferTypes: true }` to match monorepo convention

## Public API Changes

None — this fixes the build to produce the already-declared `./adapters` export.

## Files Changed

- [`packages/openapi/bunup.config.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-openapi-adapters/packages/openapi/bunup.config.ts) (new) — Build configuration with all entry points
- [`.changeset/fix-openapi-adapters-export.md`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-openapi-adapters/.changeset/fix-openapi-adapters-export.md) (new) — Patch changeset

## Test plan

- [x] `bun run build` produces `dist/adapters/index.js` and `dist/adapters/index.d.ts`
- [x] `import { fastapi, nestjs } from './dist/adapters/index.js'` resolves correctly
- [x] 297 existing tests pass
- [x] Typecheck clean
- [x] Lint clean

Closes #2380

🤖 Generated with [Claude Code](https://claude.com/claude-code)