### PR TITLE
fix(create-vertz): broken npm dep chain + docs template listing

### DIFF
--- a/.changeset/fix-create-vertz-dep.md
+++ b/.changeset/fix-create-vertz-dep.md
@@ -1,0 +1,5 @@
+---
+'create-vertz': patch
+---
+
+Fix broken npm dependency: use `workspace:^` so the published `create-vertz` accepts any compatible `@vertz/create-vertz-app` version instead of pinning to an exact (possibly unpublished) version.

--- a/packages/create-vertz/package.json
+++ b/packages/create-vertz/package.json
@@ -20,6 +20,6 @@
     "provenance": true
   },
   "dependencies": {
-    "@vertz/create-vertz-app": "workspace:*"
+    "@vertz/create-vertz-app": "workspace:^"
   }
 }

--- a/packages/mint-docs/installation.mdx
+++ b/packages/mint-docs/installation.mdx
@@ -32,7 +32,15 @@ vtz dev
 
 This scaffolds a project with the compiler, dev server, SSR, and a starter template — everything configured and ready to go.
 
-Available templates: `todo-app` (default), `hello-world` (minimal counter), `landing-page` (multi-page marketing site). Pass `--template <name>` to choose.
+Available templates: `todo-app` (default), `hello-world` (minimal counter), `landing-page` (multi-page marketing site). Pass `--template <name>` to choose:
+
+```bash
+vtz create vertz my-app --template landing-page
+```
+
+<Note>
+  Alternatively, you can use npx: `npx @vertz/create-vertz-app my-app --template landing-page`
+</Note>
 
 ## Manual setup
 


### PR DESCRIPTION
## Summary

- **Fix broken npm dependency chain**: `create-vertz@0.2.49` pinned `@vertz/create-vertz-app@0.2.48` which was never published to npm (version skipped from 0.2.47 → 0.2.49). Changed `workspace:*` → `workspace:^` so the published package uses a caret range (e.g. `^0.2.50`) that tolerates version skips.
- **Docs**: Added template selection examples and `npx` alternative to installation page. Listed all three available templates (`todo-app`, `hello-world`, `landing-page`).

## Public API Changes

None — dependency specifier fix and docs only.

## Smoke Test

Verified the `landing-page` template end-to-end using public npm packages:
- `npx @vertz/create-vertz-app@0.2.49 my-landing-page --template landing-page` ✅
- `vtz install` ✅ (204 packages)
- `vtz dev` ✅ (SSR + HMR working, ready in 3ms)
- All 3 pages render correctly (Home, Features, Pricing)
- Client-side navigation works
- SSR works on direct page load

Closes #2342

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>