### PR TITLE
fix(ci): remove unsupported --provenance flag from vtz publish

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -108,7 +108,7 @@ for pkg_json in packages/*/package.json; do
   fi
 
   echo "Publishing $name@$version..."
-  if (cd "$dir" && vtz publish --access public --provenance); then
+  if (cd "$dir" && vtz publish --access public); then
     echo "Published $name@$version"
   else
     echo "Failed to publish $name@$version"


### PR DESCRIPTION
## Summary

Two fixes for the release pipeline:

1. **Remove `--provenance` from `vtz publish`** — The Rust CLI doesn't support this flag (only `--tag`, `--access`, `--dry-run`, `--json`). It was carried over from the `bun publish` call in #2364 when #2365 switched back to `vtz publish`.

2. **Download vtz binary from latest `v*` release, not "Latest"** — Changeset creates per-package releases (e.g. `@vertz/openapi@0.1.6`) that take over GitHub's "Latest" tag. The download step was using `gh release download` without a tag (defaulting to "Latest"), which found no binary assets. Now explicitly finds the latest `v*` release tag where the runtime binaries are uploaded.

## Public API Changes

None.

## Test plan

- [ ] Verify the Release workflow succeeds on the next push to `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)