### PR TITLE
fix(ci): download vtz binary from latest v* release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,9 +203,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "No binary artifacts from this run — downloading from latest GitHub release"
-          gh release download --pattern 'vtz-linux-x64' --dir /tmp/vtz-release || {
-            echo "::warning::Could not download vtz binary from latest release"
+          echo "No binary artifacts from this run — downloading from latest v* GitHub release"
+          # Find the latest v* release (changeset creates per-package releases that
+          # take over "Latest", so we can't rely on the default)
+          VTZ_TAG=$(gh release list --limit 50 --json tagName --jq '[.[] | select(.tagName | startswith("v0."))][0].tagName')
+          if [ -z "$VTZ_TAG" ]; then
+            echo "::warning::Could not find a v* release with runtime binaries"
+            exit 0
+          fi
+          echo "Found release: $VTZ_TAG"
+          gh release download "$VTZ_TAG" --pattern 'vtz-linux-x64' --dir /tmp/vtz-release || {
+            echo "::warning::Could not download vtz binary from release $VTZ_TAG"
             exit 0
           }
           cp /tmp/vtz-release/vtz-linux-x64 packages/runtime-linux-x64/vtz


### PR DESCRIPTION
## Summary

- Fix the release workflow's runtime binary download step to target the latest `v*`-tagged release instead of relying on GitHub's "Latest" tag

## Root Cause

When `build-binaries` is skipped (no `native/` changes), the release job downloads the `vtz` binary from a GitHub release. It used `gh release download` without a tag, which defaults to "Latest". However, changeset creates per-package releases (e.g. `@vertz/openapi@0.1.6`) that take over the "Latest" tag — these have no binary assets. The actual binaries live in `v*` releases (e.g. `v0.2.49`).

Now explicitly finds the latest `v*`-tagged release using `gh release list` with a `jq` filter.

## Public API Changes

None.

## Test plan

- [ ] Verify the Release workflow succeeds on the next push to `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)