### PR TITLE
docs(design): design doc for #1748

### DIFF
--- a/plans/issue-1748.md
+++ b/plans/issue-1748.md
@@ -1,0 +1,528 @@
+# Server-Side Query Cache for `@vertz/db`
+
+**Issue:** #1748
+**Status:** Draft
+**Date:** 2026-04-04
+
+## Problem
+
+Hot read paths in server-side applications repeatedly query for the same rows. During the rinha-de-backend benchmark challenge, adding an in-memory `Map<code, row>` cache to avoid redundant `SELECT` queries improved throughput from ~1500 rps to ~2450 rps — a **63% improvement**. This pattern is common and should be automated by the framework.
+
+## Proposal
+
+Add an opt-in server-side query cache to `@vertz/db` that:
+1. Caches query results keyed by query shape
+2. Supports TTL-based expiry
+3. Uses LRU eviction for memory bounds
+4. Provides explicit invalidation APIs
+5. Is transparent to correctness (stale reads are worse than slow reads)
+
+---
+
+## 1. API Surface
+
+### 1.1 `QueryCache` — core cache interface
+
+```typescript
+// packages/db/src/cache/query-cache.ts
+
+/**
+ * In-memory query cache with TTL expiry and LRU eviction.
+ * Thread-safe for multi-isolate use (uses atomic operations).
+ */
+export class QueryCache {
+  constructor(options?: {
+    /** Maximum entries before LRU eviction (default: 1000) */
+    maxSize?: number;
+    /** Default TTL in milliseconds (default: 30_000 = 30s) */
+    defaultTtl?: number;
+  });
+
+  /** Get cached result for a query key */
+  get<T>(key: string): CachedResult<T> | undefined;
+
+  /** Set a cached result with optional custom TTL */
+  set<T>(key: string, result: T, options?: { ttl?: number }): void;
+
+  /** Invalidate a single key */
+  delete(key: string): void;
+
+  /** Invalidate all keys matching a table prefix (e.g., "urls:") */
+  deleteByPrefix(prefix: string): void;
+
+  /** Invalidate by exact query shape (supports wildcards) */
+  invalidate(query: QueryPattern): void;
+
+  /** Clear all entries */
+  clear(): void;
+
+  /** Get cache statistics */
+  stats(): CacheStats;
+}
+
+interface CachedResult<T> {
+  readonly data: T;
+  readonly cachedAt: number;
+  readonly expiresAt: number;
+}
+
+interface CacheStats {
+  readonly size: number;
+  readonly hits: number;
+  readonly misses: number;
+  readonly evictions: number;
+}
+
+type QueryPattern = 
+  | { table: string; where?: Record<string, unknown> }
+  | { table: string; id?: string }
+  | { table: string; '*': true }; // wildcard = all rows of table
+```
+
+### 1.2 `createDb()` with cache configuration
+
+```typescript
+// packages/db/src/index.ts
+
+import { createDb } from '@vertz/db';
+import { QueryCache } from '@vertz/db/cache';
+
+const db = createDb({
+  url: process.env.DATABASE_URL,
+  
+  // Cache configuration (opt-in)
+  cache: {
+    // Enable caching (must be explicit)
+    enabled: true,
+    
+    // Cache instance (share across requests)
+    store: new QueryCache({ 
+      maxSize: 5000,
+      defaultTtl: 60_000, // 60 seconds
+    }),
+    
+    // Per-query overrides
+    queries: {
+      // Cache findUnique by primary key for 5 minutes
+      findUnique: { ttl: 300_000 },
+      
+      // Don't cache update/delete operations (default: false)
+      update: { cache: false },
+      delete: { cache: false },
+      create: { cache: false },
+    },
+    
+    // Table-level overrides
+    tables: {
+      urls: {
+        // Cache all reads on the urls table for 30 seconds
+        defaultTtl: 30_000,
+      },
+      sessions: {
+        // Never cache sessions (security-sensitive)
+        cache: false,
+      },
+    },
+  },
+});
+```
+
+### 1.3 Per-query cache control
+
+```typescript
+// Individual queries can override cache behavior
+
+// Explicitly use cache (with custom TTL)
+const url = await db.urls.findUnique({
+  where: { id },
+  cache: { ttl: 60_000 }, // override default
+});
+
+// Bypass cache for this query (e.g., admin panel needs fresh data)
+const adminUrl = await db.urls.findUnique({
+  where: { id },
+  cache: false, // explicitly no cache
+});
+
+// Cache with table invalidation pattern
+const users = await db.users.findMany({
+  where: { active: true },
+  cache: { 
+    ttl: 120_000,
+    invalidateOn: ['users'], // invalidate this cache entry when users table is written to
+  },
+});
+```
+
+### 1.4 Cache invalidation API
+
+```typescript
+// Manual invalidation (useful after bulk operations)
+
+const cache = db.getCache();
+
+// Invalidate specific row
+cache.delete('urls:id=abc123');
+
+// Invalidate all rows for a table
+cache.deleteByPrefix('urls:*');
+
+// Invalidate using pattern
+cache.invalidate({ table: 'urls', id: 'abc123' });
+cache.invalidate({ table: 'urls', '*': true }); // all urls
+
+// Subscribe to write events for automatic invalidation
+cache.on('write', (event) => {
+  // event: { table: 'urls', operation: 'update' | 'delete', rowIds: ['abc123'] }
+  cache.invalidate({ table: event.table, id: event.rowIds[0] });
+});
+```
+
+### 1.5 Cache-aware query result
+
+```typescript
+// Query result includes cache metadata (optional)
+
+const result = await db.urls.findUnique({
+  where: { id },
+  cache: { includeMetadata: true },
+});
+
+result.data;     // The cached/fresh data
+result.cached;  // true if served from cache
+result.cacheAge; // milliseconds since cache hit
+```
+
+### 1.6 Public exports
+
+```typescript
+// packages/db/src/cache/index.ts
+export { QueryCache } from './query-cache';
+export type { CachedResult, CacheStats, QueryPattern, CacheOptions } from './types';
+```
+
+```typescript
+// packages/db/src/index.ts — additions
+export { QueryCache } from './cache';
+export type { CacheOptions, CacheQueryOptions, CacheTableOptions } from './cache/types';
+```
+
+---
+
+## 2. Manifesto Alignment
+
+### Explicit Over Implicit
+- Caching is **opt-in** at the `createDb()` level and per-query level
+- No magic: developers must explicitly enable and configure caching
+- Cache behavior is visible in the query API (`cache: { ttl: ... }`)
+
+### One Way to Do Things
+- Single cache mechanism: `QueryCache` with TTL + LRU
+- No separate "hot path" vs "cold path" APIs
+- Write operations (`create`, `update`, `delete`) have a single invalidation path
+
+### If It Builds, It Works
+- Type-safe cache options with sensible defaults
+- Compiler ensures `cache: false` is respected
+- No runtime surprises: invalid queries throw, not silently ignore
+
+### LLM-First
+- `QueryCache`, `cache: { ttl: 60_000 }` — obvious naming
+- Clear semantics: TTL = time-to-live, invalidation = explicit removal
+- No special decorators or class inheritance needed
+
+---
+
+## 3. Non-Goals
+
+1. **Client-side caching** — Already handled by `@vertz/ui` EntityStore/MemoryCache
+2. **HTTP-level caching** — CDN, Cache-Control headers, etags are a separate layer
+3. **Automatic write invalidation** — Scoping writes to invalidate cache entries is O(n) without schema metadata. Manual `cache.invalidate()` is the primary pattern. Automatic invalidation can be explored as a Phase 2 POC.
+4. **Distributed cache** — Single-process in-memory cache only. Multi-instance deployments need external cache (Redis) — out of scope for v1.
+5. **Query result pagination caching** — Cursor/offset pagination with cache invalidation is complex. Single-row lookups by PK are the primary use case.
+6. **Soft deletes handling** — If rows are soft-deleted, the cache may still return stale results. This requires explicit user configuration, not automatic detection.
+
+---
+
+## 4. Unknowns
+
+1. **Automatic invalidation on writes** — The original benchmark used O(n) scan to invalidate on UPDATE/DELETE. With schema metadata (which tables have which PKs), we could do O(1) invalidation. **Resolution needed:** Should Phase 1 include automatic invalidation, or defer to manual pattern?
+
+2. **Integration with prepared statements** — The prepared statement fix (`prepare: true`) was a separate optimization. How does caching interact with prepared statements? **Resolution:** Caching happens after query execution, before result return. Prepared statements are unaffected.
+
+3. **Multi-tenant isolation** — If tenants share a cache but have different row-level permissions, stale data could leak. **Resolution:** Cache key should include tenant context. Need to verify `createDb()` receives tenant context.
+
+4. **Memory pressure in serverless** — In-memory caches grow until process restart. In serverless (Lambda, Cloudflare Workers), memory is bounded. **Resolution:** `maxSize` option with LRU eviction prevents unbounded growth. Default of 1000 entries (~few MB) is conservative.
+
+5. **Cache warming on startup** — Should the cache be pre-populated with "hot" queries? **Resolution:** Out of scope for Phase 1. Manual `cache.set()` can be used for warming.
+
+---
+
+## 5. POC Results
+
+Not applicable — this design doc is the starting point for exploration. A POC should be created to validate:
+
+1. **Key question: Transparent vs explicit integration**
+   - Try: Transparent hook into `db.query()` — does it add unexpected latency?
+   - Try: Explicit `cache.query()` wrapper — is the ergonomics acceptable?
+
+2. **Key question: Invalidation granularity**
+   - Try: O(n) scan invalidation on writes (like the benchmark)
+   - Try: O(1) invalidation using table metadata
+   - Measure: Invalidation time for 10K cached entries
+
+3. **Key question: API ergonomics**
+   - Survey: Would developers prefer `cache: true` shorthand or explicit options?
+
+---
+
+## 6. Type Flow Map
+
+```
+createDb({ cache: { enabled: true, store: new QueryCache() } })
+        ↓
+CacheOptions
+        ↓
+createDbInternal() passes cache to QueryCacheProvider
+        ↓
+db.query() reads from QueryCacheProvider
+        ↓
+QueryCache.get(key) → CachedResult<T> | undefined
+        ↓
+QueryCache.set(key, result) → stores with TTL metadata
+        ↓
+Cache invalidation: QueryCache.delete() / deleteByPrefix() / invalidate()
+```
+
+### Type generics trace
+
+```typescript
+// User-facing: QueryCache<T>
+QueryCache<Url>  // T = row type
+
+// Internal: Query key derivation
+deriveCacheKey(table: string, query: FindOptions<T>): string
+// → "urls:findUnique:where:id=abc123"
+
+// Cached result wrapping
+CachedResult<T> = { data: T, cachedAt: number, expiresAt: number }
+
+// Cache options on queries
+CacheQueryOptions: { ttl?: number; cache?: boolean | CacheOptions; invalidateOn?: string[] }
+
+// Table-level overrides
+CacheTableOptions: { defaultTtl?: number; cache?: boolean }
+```
+
+---
+
+## 7. E2E Acceptance Test
+
+From a developer's perspective, using the public `@vertz/db` API:
+
+```typescript
+import { createDb, QueryCache } from '@vertz/db';
+
+const cache = new QueryCache({ maxSize: 100, defaultTtl: 60_000 });
+
+const db = createDb({
+  url: process.env.DATABASE_URL,
+  cache: {
+    enabled: true,
+    store: cache,
+    tables: {
+      urls: { defaultTtl: 30_000 },
+    },
+  },
+});
+
+// Seed
+const url = await db.urls.create({
+  data: { slug: 'test', target: 'https://example.com' },
+});
+
+// First call: cache miss, fetches from DB
+const result1 = await db.urls.findUnique({ where: { id: url.id } });
+expect(result1.slug).toBe('test');
+
+// Second call: cache hit
+const result2 = await db.urls.findUnique({ where: { id: url.id } });
+expect(result2.slug).toBe('test');
+
+// Verify cache was used
+const stats = cache.stats();
+expect(stats.hits).toBe(1);
+expect(stats.misses).toBe(1);
+
+// Cache hit includes metadata
+const result3 = await db.urls.findUnique({ 
+  where: { id: url.id },
+  cache: { includeMetadata: true },
+});
+expect(result3.cached).toBe(true);
+
+// Update invalidates the cache entry
+await db.urls.update({
+  where: { id: url.id },
+  data: { slug: 'updated' },
+});
+
+// Next read is a fresh fetch
+const result4 = await db.urls.findUnique({ where: { id: url.id } });
+expect(result4.slug).toBe('updated');
+
+// Manual invalidation
+cache.delete(`urls:findUnique:${JSON.stringify({ where: { id: url.id } })}`);
+
+// Per-query cache override
+const fresh = await db.urls.findUnique({
+  where: { id: url.id },
+  cache: false, // bypass cache
+});
+expect(fresh.slug).toBe('updated');
+
+// Custom TTL
+const cached = await db.urls.findUnique({
+  where: { id: url.id },
+  cache: { ttl: 5_000 }, // 5 seconds
+});
+
+// Cache by prefix invalidation
+cache.deleteByPrefix('urls:*'); // clear all urls entries
+
+// @ts-expect-error — cache must be boolean or object
+await db.urls.findUnique({ where: { id }, cache: 'yes' });
+
+// @ts-expect-error — invalid table name
+db.getCache().invalidate({ table: 123 });
+```
+
+---
+
+## 8. Implementation Plan
+
+### Phase 1: Core Query Cache (MVP)
+
+**Goal:** Thin vertical slice — in-memory cache with TTL, basic invalidation.
+
+**Scope:**
+- `QueryCache` class with `get`/`set`/`delete`/`clear`
+- TTL expiry using `setTimeout` (or timestamp check)
+- LRU eviction when `maxSize` exceeded
+- `createDb()` accepts `cache.enabled` + `cache.store`
+- Per-query `cache` option on `findUnique`/`findFirst`/`findMany`
+- Cache key derivation from query shape
+
+**Acceptance criteria:**
+- [ ] `QueryCache.get()` returns cached result if TTL not expired
+- [ ] `QueryCache.set()` stores with TTL metadata
+- [ ] LRU eviction removes oldest entry when `maxSize` exceeded
+- [ ] `createDb({ cache: { enabled: true, store } })` configures cache
+- [ ] `db.urls.findUnique({ where, cache: true })` uses cache
+- [ ] Unit tests for `QueryCache` pass
+- [ ] Integration test: cache hit/miss scenarios work
+
+**Files:**
+| File | Change |
+|------|--------|
+| `packages/db/src/cache/query-cache.ts` | New — `QueryCache` class |
+| `packages/db/src/cache/types.ts` | New — cache type definitions |
+| `packages/db/src/cache/index.ts` | New — exports |
+| `packages/db/src/client/create-db.ts` | Accept cache config |
+| `packages/db/src/query/crud.ts` | Hook cache into find queries |
+| `packages/db/src/index.ts` | Re-export cache types |
+| `packages/db/src/__tests__/cache.test.ts` | Unit tests |
+
+---
+
+### Phase 2: Invalidation & Statistics
+
+**Goal:** Complete the cache lifecycle — invalidation, stats, table-level config.
+
+**Scope:**
+- `deleteByPrefix()` for table-level invalidation
+- `invalidate()` with `QueryPattern`
+- `stats()` for cache metrics (hits, misses, size, evictions)
+- Table-level TTL overrides (`tables.urls.defaultTtl`)
+- Query-level cache overrides (`queries.findUnique.ttl`)
+- `on('write')` event subscription for automatic invalidation
+
+**Acceptance criteria:**
+- [ ] `cache.deleteByPrefix('urls:*')` invalidates all url entries
+- [ ] `cache.stats().hits` increments on cache hits
+- [ ] `tables.urls.defaultTtl` overrides global TTL for that table
+- [ ] `cache.on('write', handler)` fires on mutations
+- [ ] Integration test: invalidation clears correct entries
+
+**Files:**
+| File | Change |
+|------|--------|
+| `packages/db/src/cache/query-cache.ts` | Add invalidation methods, stats |
+| `packages/db/src/cache/types.ts` | Add `QueryPattern`, event types |
+| `packages/db/src/client/create-db.ts` | Parse table/query overrides |
+| `packages/db/src/query/crud.ts` | Emit write events |
+| `packages/db/src/__tests__/cache-invalidation.test.ts` | Invalidation tests |
+
+---
+
+### Phase 3: Production Hardening
+
+**Goal:** Make cache production-ready with observability and edge cases.
+
+**Scope:**
+- Thread-safety (atomic operations for multi-isolate)
+- Memory pressure handling (evict on low memory)
+- Error handling (cache failures don't break queries)
+- Metrics integration (emit to observability)
+- Cache warm-up helper
+- Documentation in `packages/mint-docs/`
+
+**Acceptance criteria:**
+- [ ] Cache operations don't throw on OOM — graceful degradation
+- [ ] Metrics exported for hits/misses/evictions
+- [ ] Cache survives 10K entries without memory leak
+- [ ] Docs updated with cache usage guide
+
+**Files:**
+| File | Change |
+|------|--------|
+| `packages/db/src/cache/query-cache.ts` | Thread-safety, error handling |
+| `packages/db/src/cache/metrics.ts` | New — metrics export |
+| `packages/mint-docs/` | Cache documentation |
+| `packages/db/src/__tests__/cache-stress.test.ts` | Stress tests |
+
+---
+
+## Appendix: Benchmark Reference
+
+From the rinha-de-backend URL shortener challenge:
+
+```typescript
+// What worked in the benchmark
+const redirectCache = new Map<string, UrlRow>();
+
+// GET /:code — hot path
+app.get('/:code', async (req, res) => {
+  const cached = redirectCache.get(req.params.code);
+  if (cached) return res.redirect(cached.target);
+  
+  const row = await db.query('SELECT * FROM urls WHERE code = $1', [req.params.code]);
+  redirectCache.set(req.params.code, row);
+  res.redirect(row.target);
+});
+
+// Invalidation on write
+app.post('/urls', async (req, res) => {
+  await db.query('INSERT INTO urls ...', [...]);
+  // Invalidate all entries (O(n) scan — acceptable for small caches)
+  for (const key of redirectCache.keys()) {
+    redirectCache.delete(key);
+  }
+});
+```
+
+Key learnings:
+1. FIFO eviction was sufficient (simple `Map`)
+2. Cache invalidation by scanning was O(n) but fast for small maps
+3. Write-heavy endpoints don't benefit from caching
+4. Single-row lookups by PK were the primary use case

--- a/reviews/issue-1748/dx.md
+++ b/reviews/issue-1748/dx.md
@@ -1,0 +1,293 @@
+# DX Review: Server-Side Query Cache for `@vertz/db`
+
+**Verdict: CONDITIONAL APPROVAL — Needs significant API adjustments before implementation**
+
+## Summary
+
+The design doc is thoughtful about transparency and explicitness, but the proposed API has several inconsistencies with the current `@vertz/db` API that will confuse developers. Key issues: stale method names, Result type incompatibility, and complex nested config that's hard to discover.
+
+---
+
+## Issues
+
+### 🔴 BLOCKER: Stale API Names in Design Doc
+
+The design doc uses `findUnique`/`findMany`/`findFirst` throughout, but the actual `@vertz/db` API uses:
+- `get` / `getOrThrow` (was `findOne`/`findOneOrThrow`, now deprecated)
+- `list` / `listAndCount` (was `findMany`/`findManyAndCount`, now deprecated)
+
+**Impact**: A developer reading this doc will try `db.urls.findUnique({ where: { id } })` and get a TypeScript error. This creates immediate friction.
+
+**Fix**: Update all examples in the design doc to use `get`, `list`, `create`, `update`, `delete`.
+
+---
+
+### 🔴 BLOCKER: Result Type Incompatibility
+
+The current `@vertz/db` API returns `Promise<Result<T, ReadError>>`:
+
+```typescript
+// Current API (database.ts)
+get<TOptions>(options?: TOptions): Promise<Result<FindResult<...>, ReadError>>
+
+// Design doc proposes:
+result.cached;  // true if served from cache
+result.cacheAge; // milliseconds since cache hit
+```
+
+**Problem**: The `Result` type is a discriminated union `{ ok: true, value: T } | { ok: false, error: E }`. Adding cache metadata to the success path (`result.cached`) requires either:
+1. Changing `T` to include cache metadata (breaking change)
+2. Wrapping in a new type that adds cache metadata alongside Result (ugly)
+
+**Example of proposed broken API**:
+```typescript
+// What the design doc shows:
+const result = await db.urls.findUnique({ where: { id }, cache: { includeMetadata: true } });
+result.cached; // This doesn't fit with Result<T, ReadError>
+result.data;   // How to get data from Result<T, ReadError>?
+```
+
+**Fix**: Define a `CachedResult<T>` that properly composes with `Result`:
+```typescript
+type CachedResult<T, E> = 
+  | { ok: true; value: T; cached: boolean; cacheAge?: number }
+  | { ok: false; error: E };
+```
+
+Or keep it simple and return cache metadata separately:
+```typescript
+const [result, stats] = await db.urls.findUnique({ where: { id }, cache: true });
+// result is the data
+// stats.cached indicates cache hit
+```
+
+---
+
+### 🔴 BLOCKER: Cache Key Format is Opaque
+
+The design doc mentions:
+```
+deriveCacheKey(table: string, query: FindOptions<T>): string
+// → "urls:findUnique:where:id=abc123"
+```
+
+But there's no public API to inspect cache keys. Developers using `deleteByPrefix('urls:*')` or `cache.delete('urls:id=abc123')` must guess the format.
+
+**Impact**: Debugging cache misses is painful. Developers will resort to console.log debugging.
+
+**Fix**: Expose a method to derive cache keys:
+```typescript
+// In QueryCache
+deriveKey<T>(table: string, operation: string, options: object): string
+
+// Or better: make invalidation use the same query options
+cache.invalidate('urls', 'get', { where: { id: 'abc123' } });
+cache.invalidateByTable('urls'); // clear all 'urls' entries
+```
+
+---
+
+### 🟡 SHOULD-FIX: Complex Nested Configuration
+
+The `createDb` cache config has 3 levels of nesting:
+
+```typescript
+createDb({
+  cache: {
+    enabled: true,
+    store: new QueryCache(),
+    queries: {           // Level 1: operation-level overrides
+      findUnique: { ttl: 300_000 },
+      update: { cache: false },
+    },
+    tables: {             // Level 2: table-level overrides
+      urls: {
+        defaultTtl: 30_000,
+      },
+      sessions: {
+        cache: false,
+      },
+    },
+  },
+});
+```
+
+**Problems**:
+1. `queries.findUnique` doesn't match current API (`get`, not `findUnique`)
+2. "Operation-level" vs "table-level" distinction is confusing
+3. No way to see what the effective cache config is for a given query
+
+**Fix**: Flatten the config or use a more intuitive pattern:
+```typescript
+cache: {
+  enabled: true,
+  store: new QueryCache(),
+  defaults: {
+    ttl: 60_000,
+    cacheReadOperations: true,
+  },
+  tables: {
+    urls: {
+      ttl: 30_000,
+      skipCache: false,
+    },
+    sessions: {
+      skipCache: true, // security-sensitive
+    },
+  },
+}
+```
+
+---
+
+### 🟡 SHOULD-FIX: No `db.getCache()` Method Documented in Usage Examples
+
+The design doc shows `const cache = db.getCache();` but this method isn't in the `DatabaseClient` type definition. Is this adding a new method to `DatabaseClient`?
+
+**Fix**: Explicitly define this in the API surface section:
+```typescript
+// New method on DatabaseClient
+interface DatabaseClient<TModels> {
+  // ...existing methods...
+  getCache(): QueryCache;
+}
+```
+
+---
+
+### 🟡 SHOULD-FIX: `QueryPattern` Type is Confusing
+
+```typescript
+type QueryPattern = 
+  | { table: string; where?: Record<string, unknown> }
+  | { table: string; id?: string }
+  | { table: string; '*': true }; // wildcard = all rows of table
+```
+
+**Problems**:
+1. The `id` variant overlaps semantically with `where: { id: string }`
+2. Using `'*': true` as a sentinel is unconventional
+3. `invalidate` with different patterns has inconsistent behavior
+
+**Fix**: Make invalidation simpler:
+```typescript
+// Just invalidate by table
+cache.invalidateByTable('urls');
+
+// Or invalidate specific rows using the same query options
+cache.invalidate('urls', { where: { id: 'abc123' } });
+cache.invalidateAll(); // clear everything
+```
+
+---
+
+### 🟡 SHOULD-FIX: Event Subscription API is Under-specified
+
+```typescript
+cache.on('write', (event) => {
+  cache.invalidate({ table: event.table, id: event.rowIds[0] });
+});
+```
+
+**Problems**:
+1. What events are available? (`'write'` only?)
+2. When does the event fire — before or after the write?
+3. How do you unsubscribe?
+4. How does this interact with transactions?
+
+**Fix**: Define the full event API:
+```typescript
+// Event types
+type CacheEvent = 
+  | { type: 'write'; table: string; operation: 'create' | 'update' | 'delete'; rowIds: string[] }
+  | { type: 'evict'; table: string; reason: 'ttl' | 'lru' | 'manual' };
+
+// Subscription returns unsubscribe function
+const unsubscribe = cache.on('write', handler);
+unsubscribe(); // clean up
+
+// Or with cleanup on db close
+const cache = db.getCache();
+cache.on('write', handler, { autoCleanup: true });
+```
+
+---
+
+### 🟡 SHOULD-FIX: `cache: false` Bypass Has Wrong Mental Model
+
+```typescript
+// Bypass cache for this query (e.g., admin panel needs fresh data)
+const adminUrl = await db.urls.findUnique({
+  where: { id },
+  cache: false, // explicitly no cache
+});
+```
+
+**Problem**: The comment suggests this is for "admin panel needs fresh data", but if the cache has TTL=60s and the row was just updated, a cache hit is correct data. The admin panel should use `cache: false` only if it needs to bypass caching entirely (e.g., very sensitive data that should never be cached at all).
+
+**Fix**: Clarify the semantics or add a more explicit option:
+```typescript
+// Option 1: Clearer semantics
+cache: { enabled: false }  // Don't cache this specific query
+
+// Option 2: Add "stale" awareness
+cache: { ttl: 0 }  // Zero TTL = don't use cache
+
+// Option 3: Separate concerns
+cache: true,           // Use caching
+cachePolicy: 'strict'  // Never serve stale data
+```
+
+---
+
+### 🟡 SHOULD-FIX: Missing `includeMetadata` in `TypedGetOptions`
+
+The design doc shows `cache: { includeMetadata: true }` as an option, but this needs to be added to the `TypedGetOptions` type definition:
+
+```typescript
+type TypedGetOptions<TEntry> = {
+  readonly where?: FilterType<EntryColumns<TEntry>>;
+  readonly select?: SelectOption<EntryColumns<TEntry>>;
+  // ...existing options...
+  
+  // Need to add:
+  readonly cache?: boolean | CacheQueryOptions;
+};
+```
+
+---
+
+### 🟢 NIT: Missing Examples for Common Patterns
+
+The design doc lacks examples for:
+1. **Cache warming on startup** — mentioned in Non-Goals but should show workaround
+2. **Testing with mocked cache** — how to test cache behavior?
+3. **Monitoring cache health** — what to log/monitor in production?
+
+**Fix**: Add a "Real-world Patterns" section with these examples.
+
+---
+
+## What Works Well ✅
+
+1. **Opt-in by default**: `enabled: true` requirement is good — no surprise caching
+2. **QueryCache as first-class export**: `import { QueryCache } from '@vertz/db'` is intuitive
+3. **TTL + LRU combo**: Addresses real performance concerns from the benchmark
+4. **Explicit invalidation**: `cache.invalidate()` is clear and controllable
+5. **Manifesto alignment**: The design doc explicitly maps to framework principles
+
+---
+
+## Recommendations
+
+1. **Before Phase 1**: Fix API naming to match current `@vertz/db` methods (`get`/`list`, not `findUnique`/`findMany`)
+2. **Before Phase 1**: Define how `CachedResult` composes with `Result<T, E>` without breaking changes
+3. **Phase 1 scope reduction**: Start with `QueryCache` + `get`/`list` + basic TTL + manual invalidation. Defer `invalidateOn`, events, and table-level overrides.
+4. **Add public key derivation**: Developers need to know what keys are in the cache
+5. **Write integration tests first**: The E2E test in the doc is good — keep it as the source of truth for API behavior
+
+---
+
+## DX Score: 6/10
+
+The concept is solid and the performance motivation is clear. But the API needs significant refinement to match the existing `@vertz/db` patterns before implementation.

--- a/reviews/issue-1748/product.md
+++ b/reviews/issue-1748/product.md
@@ -1,0 +1,104 @@
+# Product/Scope Review: Server-Side Query Cache for `@vertz/db`
+
+**Reviewer:** Product Review  
+**Date:** 2026-04-04  
+**Verdict:** ✅ APPROVED with should-fix items
+
+---
+
+## Summary
+
+The design doc addresses a real, validated pain point (63% throughput improvement in benchmark) and fits squarely within Vertz's vision of "the only stack you need — from database to browser." The proposal is well-scoped, opt-in, and aligns with the manifesto principles (Explicit Over Implicit, One Way to Do Things, LLM-First). **This should proceed.**
+
+---
+
+## Roadmap Fit
+
+**Does it fit?** ✅ Yes.
+
+The `@vertz/db` package is explicitly on the critical path — the VISION.md states:
+> "We'll build the database layer — because an ORM that doesn't share your schema language is just another seam to maintain."
+
+A query cache is a natural evolution of `@vertz/db` as a best-in-class database layer. The motivating benchmark (rinha-de-backend URL shortener) represents exactly the kind of hot-path read scenario that server-side Vertz apps face. This is not speculative — it's validated performance work.
+
+The phased implementation plan is appropriate:
+- Phase 1: MVP with core cache mechanics
+- Phase 2: Invalidation + statistics  
+- Phase 3: Production hardening
+
+This matches the pattern used by other `@vertz/db` features (e.g., `1742-groupby-expressions`, `1743-db-update-expressions`).
+
+---
+
+## Scope Appropriateness
+
+**Is the scope right?** ✅ Yes, with one clarification needed.
+
+### What's right
+
+1. **Opt-in is correct.** The design requires `cache: { enabled: true }` at `createDb()` level. This is the only acceptable approach — automatic caching would violate "Explicit Over Implicit" and risk stale reads.
+
+2. **Single-instance in-memory only for v1.** Distributed cache (Redis) is correctly scoped out. The Non-Goals section is honest about this. Developers needing Redis can add it on top.
+
+3. **Non-Goals are well-chosen:**
+   - Client-side caching (handled by `@vertz/ui` EntityStore)
+   - HTTP-level caching (separate layer)
+   - Query pagination caching (complex, secondary use case)
+
+4. **Per-query override API (`cache: { ttl: ... }`, `cache: false`)** is the right granularity. This gives developers escape hatches without compromising the defaults.
+
+### Items needing clarification
+
+| Item | Issue | Recommendation |
+|------|-------|----------------|
+| **Unknown #1: Automatic invalidation** | Phase 1 defers automatic invalidation on writes. But the E2E test in Section 7 expects update to invalidate cache: `await db.urls.update(...)` followed by `findUnique` returns fresh data. This is a contradiction. | **Must clarify:** Does Phase 1 include automatic invalidation or not? If not, the E2E test is wrong. If yes, Phase 1 scope is larger than stated. |
+| **Unknown #3: Multi-tenant isolation** | Cache keys don't include tenant context. If tenants share a cache, stale data leaks between tenants. The proposal acknowledges this but defers resolution. | **Should-fix:** Add `tenantId` to cache key derivation in Phase 1, even if tenants don't share a cache instance. Otherwise, this becomes a breaking change later. |
+| **Phase 1 acceptance criteria** | Missing `db.getCache()` in acceptance criteria, though API Section 1.2 and E2E test use it. | Add `db.getCache()` returns the configured cache instance to Phase 1 acceptance criteria. |
+
+---
+
+## Manifesto Alignment
+
+| Principle | Alignment | Notes |
+|----------|-----------|-------|
+| Explicit Over Implicit | ✅ Strong | `cache: { enabled: true }` is required. No magic. |
+| One Way to Do Things | ✅ Strong | Single `QueryCache` mechanism. No hot/cold path split. |
+| If It Builds, It Works | ✅ Strong | Type-safe `cache` options. `@ts-expect-error` tests included. |
+| LLM-First | ✅ Strong | `QueryCache`, `ttl`, `invalidate` — obvious naming. |
+| Performance is Not Optional | ✅ Strong | 63% improvement is the motivation, not a side effect. |
+
+---
+
+## Risks and Open Questions
+
+1. **🔴 Blocker: E2E test contradiction** — The E2E test (Section 7) expects automatic invalidation on `update()`, but Unknown #1 defers this. Either the test is wrong, or Phase 1 scope is larger than stated. **Resolution required before implementation.**
+
+2. **🟡 Should-fix: Tenant isolation** — Cache key derivation must include tenant context to prevent cross-tenant data leakage. This should be specified now, even if not enabled by default.
+
+3. **🟢 Non-issue: Soft deletes** — Correctly scoped to "explicit user configuration" (Non-Goal #6). This is the right call.
+
+4. **🟢 Non-issue: Serverless memory** — `maxSize` with LRU eviction is a reasonable bound. Default of 1000 entries is conservative.
+
+---
+
+## Recommendations
+
+1. **Resolve the automatic invalidation contradiction immediately.** This is a blocking ambiguity that will cause scope creep or broken tests.
+
+2. **Add tenant context to cache key derivation in the Type Flow Map (Section 6).** Even if the default is single-tenant, the type should reflect the requirement.
+
+3. **Add `db.getCache()` to Phase 1 acceptance criteria.**
+
+4. **Consider a Phase 1.5 for automatic invalidation** if it's needed for the demo. The 63% benchmark improvement likely depends on it.
+
+---
+
+## Verdict
+
+**Proceed with the following pre-conditions:**
+
+1. Resolve the automatic invalidation ambiguity (Section 4, Unknown #1) — state explicitly whether Phase 1 includes it.
+2. Add tenant-aware cache key derivation to the API design.
+3. Add `db.getCache()` to Phase 1 acceptance criteria.
+
+Once these are addressed, this is a well-scoped, well-motivated feature that belongs on the roadmap.

--- a/reviews/issue-1748/technical.md
+++ b/reviews/issue-1748/technical.md
@@ -1,0 +1,367 @@
+# Technical Review: Server-Side Query Cache for `@vertz/db`
+
+## Summary Verdict
+
+**BUILDABLE with significant work.** The core ideas (LRU + TTL cache, opt-in API, per-query overrides) are sound and achievable. However, there are critical API mismatches, type flow gaps, and hidden complexity that must be resolved before implementation.
+
+---
+
+## Critical Issues (Blockers)
+
+### 1. API Name Mismatch — `findUnique`/`findMany` vs `get`/`list`
+
+The design doc uses the old API names (`findUnique`, `findMany`) throughout, but the current codebase has been migrated to `get`, `getOrThrow`, `list`, `listAndCount`.
+
+**Evidence:** `packages/db/src/query/crud.ts` defines:
+- `get()` — single row or null
+- `getOrThrow()` — single row or NotFoundError
+- `list()` — multiple rows
+- `listAndCount()` — multiple rows with total count
+
+The `ModelDelegate` interface in `database.ts` exposes these methods, not `findUnique`/`findMany`.
+
+**Impact:** The entire design doc examples are written against the wrong API. The implementation plan files also reference the wrong method names.
+
+**Required action:** Update all design doc examples and implementation plan files to use `get`/`getOrThrow`/`list`/`listAndCount`, OR add backward-compatible aliases if the old names are intended to be supported.
+
+---
+
+### 2. `CreateDbOptions` Has No `cache` Field
+
+The design doc specifies:
+
+```typescript
+const db = createDb({
+  url: process.env.DATABASE_URL,
+  cache: {
+    enabled: true,
+    store: new QueryCache({ ... }),
+  },
+});
+```
+
+But the current `CreateDbOptions` interface in `database.ts` does not include a `cache` field:
+
+```typescript
+interface CreateDbBaseOptions<TModels extends Record<string, ModelEntry>> {
+  readonly models: TModels;
+  readonly casing?: 'snake_case' | 'camelCase';
+  readonly casingOverrides?: Record<string, string>;
+  readonly log?: (message: string) => void;
+  readonly _queryFn?: QueryFn;
+  // ... no cache field
+}
+```
+
+**Impact:** This is a core API addition that must be designed carefully:
+- Does it live in `CreateDbBaseOptions` or only in PostgreSQL variant?
+- Should SQLite/D1 users be able to use it?
+- How does it interact with `_queryFn` (testing escape hatch)?
+
+**Required action:** Extend `CreateDbOptions` to include `cache?: CacheConfig`, define the `CacheConfig` interface, and ensure it works across all dialect variants.
+
+---
+
+### 3. Per-Query Cache Options — Type Integration
+
+The design doc shows:
+
+```typescript
+const url = await db.urls.findUnique({
+  where: { id },
+  cache: { ttl: 60_000 },
+});
+
+const adminUrl = await db.urls.findUnique({
+  where: { id },
+  cache: false,
+});
+```
+
+But `TypedGetOptions` in `database.ts` is:
+
+```typescript
+type TypedGetOptions<TEntry extends ModelEntry, TModels> = {
+  readonly where?: FilterType<EntryColumns<TEntry>>;
+  readonly select?: SelectOption<EntryColumns<TEntry>>;
+  readonly orderBy?: OrderByType<EntryColumns<TEntry>>;
+  readonly include?: IncludeOption<...>;
+  // ... no cache field
+}
+```
+
+**Impact:** Adding `cache` to every query option type requires modifying multiple type definitions and propagating the cache option through `buildDelegates()` to the underlying CRUD functions.
+
+**Required action:** Define `CacheQueryOptions` type, extend all `Typed*Options` types to accept `cache?: CacheQueryOptions | boolean`, and update `buildDelegates()` implementation.
+
+---
+
+## Should-Fix Issues
+
+### 4. Cache Key Derivation — Object Key Ordering
+
+The design doc shows cache keys like:
+
+```
+"urls:findUnique:where:id=abc123"
+"urls:findMany:where:active=true:select:..."
+```
+
+**Hidden complexity:** `JSON.stringify` produces different strings for the same data if key order differs:
+
+```typescript
+JSON.stringify({ a: 1, b: 2 }) !== JSON.stringify({ b: 2, a: 1 })
+// But these represent the same query!
+```
+
+**Impact:** 
+- Developer error: same query produces different cache results due to accidental key reordering
+- `include` parameter adds complexity — should `{ posts: true }` and `{ posts: { where: {} } }` share the same cache entry?
+
+**Required action:** 
+- Document the requirement for consistent key ordering in cache keys
+- Consider a hash-based approach (stable serialization)
+- Define behavior for `include` parameter in cache keys
+
+---
+
+### 5. TTL Implementation — Timer vs Lazy Expiry
+
+The design doc mentions:
+
+> TTL expiry using `setTimeout` (or timestamp check)
+
+**Hidden complexity:**
+- `setTimeout` timers prevent Node.js process from exiting cleanly
+- `setTimeout` timers are not freed when entries are manually deleted
+- Timer drift: `setTimeout` is not precise for long durations
+
+**Recommendation:** Use **lazy expiry with timestamp check**:
+
+```typescript
+get(key: string): CachedResult<T> | undefined {
+  const entry = cache.get(key);
+  if (entry && entry.expiresAt > Date.now()) {
+    return entry;
+  }
+  // Entry expired — delete and return undefined
+  cache.delete(key);
+  return undefined;
+}
+```
+
+Add optional background cleanup for memory hygiene (remove expired entries on `set()` when size is high), but don't rely on timers for correctness.
+
+---
+
+### 6. LRU Implementation — Not Built-in to Map
+
+The design doc requires LRU eviction when `maxSize` exceeded. JavaScript `Map` maintains insertion order, not access order.
+
+**Hidden complexity:**
+- Simple `Map` eviction is FIFO (first-in-first-out), not LRU (least-recently-used)
+- True LRU requires double-linked list + hash map
+- Implementations like `lru-cache` package handle this correctly
+
+**Recommendation:** Either:
+1. Use an existing LRU library (e.g., `lru-cache` npm package)
+2. Implement custom linked-list-based LRU (higher effort, more control)
+
+**Required action:** Choose implementation strategy before Phase 1.
+
+---
+
+### 7. `include` Relations — Caching Complexity
+
+The current API supports eager loading of relations:
+
+```typescript
+db.users.get({ where: { id }, include: { posts: true, comments: true } })
+```
+
+**Hidden complexity:**
+- Should relations be included in the cache key? (`include` changes shape)
+- Should related rows be cached separately?
+- If table A is updated, should cached entries for table B that included A be invalidated?
+
+**The design doc is silent on this.**
+
+**Required action:** Define behavior for `include` parameter:
+- Option A: Include `include` specifier in cache key
+- Option B: Don't cache queries with `include` (safer, simpler)
+- Document the chosen approach
+
+---
+
+### 8. Multi-Tenant Isolation Not Resolved
+
+The design doc lists as "Unknown #3":
+
+> Cache key should include tenant context. Need to verify `createDb()` receives tenant context.
+
+**Current state:** `createDb()` does NOT receive tenant context at runtime. Tenant scoping is defined at **model definition time** via `.tenant()` on table definitions, not at query time.
+
+**Impact:** If different tenants query the same table, they share cache entries, potentially leaking data.
+
+**Example of current behavior:**
+```typescript
+// Model defined with tenant scoping
+d.table('posts', {
+  id: d.text(),
+  title: d.text(),
+}).tenant('tenantId'); // All queries scoped to current tenant
+
+// But cache key doesn't include tenant!
+cacheKey = "posts:where:id=123" // No tenant context
+```
+
+**Required action:** Define how tenant context is passed to the cache. Options:
+1. Thread tenant ID through `request-scope.ts` session vars
+2. Require tenants to have separate `createDb()` instances with separate caches
+3. Include tenant in cache key derivation (requires integration with request scope)
+
+---
+
+## Nit Issues
+
+### 9. Type Name Conflict — `CachedResult` vs `QueryResult`
+
+The design doc defines `CachedResult<T>`:
+
+```typescript
+interface CachedResult<T> {
+  readonly data: T;
+  readonly cachedAt: number;
+  readonly expiresAt: number;
+}
+```
+
+But the codebase already has `QueryResult<T>` in `database.ts`:
+
+```typescript
+interface QueryResult<T> {
+  readonly rows: readonly T[];
+  readonly rowCount: number;
+}
+```
+
+**Recommendation:** Rename to avoid confusion:
+- `CachedResult<T>` → `CacheEntry<T>`
+- Or use a different name altogether
+
+---
+
+### 10. `includeMetadata` Return Type
+
+The design doc shows:
+
+```typescript
+result.data;     // The cached/fresh data
+result.cached;    // true if served from cache
+result.cacheAge;  // milliseconds since cache hit
+```
+
+But the current return types (`Result<T, E>`) always unwrap the value. Adding metadata would require changing the return shape or adding a wrapper type.
+
+**Recommendation:** Consider returning a `CacheResult<T>` wrapper when `includeMetadata: true`:
+```typescript
+interface CacheResult<T> {
+  readonly data: T;
+  readonly cached: boolean;
+  readonly cacheAge: number;
+}
+```
+
+---
+
+## Architecture Observations
+
+### 11. `buildDelegates()` Is the Integration Point
+
+The current architecture creates model delegates dynamically in `buildDelegates()`:
+
+```typescript
+function buildDelegates<TModels>(
+  qfn: QueryFn,
+  models: TModels,
+  dialectObj: Dialect,
+  modelsRegistry: Record<string, TableRegistryEntry>,
+): Record<string, ModelDelegate<ModelEntry>>
+```
+
+**Implication:** To inject cache, you would need to:
+1. Pass `QueryCache` instance to `buildDelegates()`
+2. Modify each `impl*` function to check cache before calling CRUD
+3. Handle cache invalidation after write operations
+
+This is cleaner than hooking into the lower-level `queryFn`, but requires careful handling of the `AnyResult` type (currently `any`).
+
+---
+
+### 12. `QueryFn` Is the Low-Level Hook
+
+`QueryFn` is the primitive query function:
+
+```typescript
+type QueryFn = <T>(sqlStr: string, params: readonly unknown[]) => Promise<{
+  rows: readonly T[];
+  rowCount: number;
+}>;
+```
+
+The design doc says:
+
+> Caching happens after query execution, before result return. Prepared statements are unaffected.
+
+**This suggests:**
+- Cache should be at the `ModelDelegate` level (above `QueryFn`)
+- NOT at the `QueryFn` level (which operates on raw SQL)
+- Reason: cache key must derive from query shape (typed), not raw SQL
+
+This is the correct architectural choice given the typed API.
+
+---
+
+## Recommendations
+
+### Must Fix Before Phase 1
+
+1. **Update API names:** Replace all `findUnique`/`findMany` with `get`/`list` in the design doc
+2. **Extend `CreateDbOptions`:** Add `cache?: CacheConfig` to the options interface
+3. **Extend query option types:** Add `cache` field to `TypedGetOptions`, `TypedListOptions`, etc.
+4. **Resolve tenant isolation:** Define how tenant context flows to cache
+
+### Should Fix Before Phase 1
+
+5. **Document cache key derivation:** Clarify object key ordering requirements
+6. **Choose LRU strategy:** Library vs custom implementation
+7. **Define `include` behavior:** Document whether cached queries can include relations
+
+### Consider
+
+8. **Rename `CachedResult`:** Avoid collision with existing `QueryResult`
+9. **Decide on `includeMetadata`:** Optional return shape vs always included
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| API mismatch causes rework | High | Medium | Update design doc before implementation |
+| Tenant data leakage | Medium | High | Define tenant integration upfront |
+| Cache key instability | Medium | Medium | Use stable serialization |
+| Timer prevents graceful shutdown | Low | Low | Use lazy expiry (timestamp check) |
+| LRU implementation bugs | Medium | Medium | Use well-tested library |
+
+---
+
+## Conclusion
+
+The design is **architecturally sound** but requires significant clarification before implementation:
+- Core API mismatches (method names) must be resolved
+- Type integration points must be designed
+- Multi-tenant isolation is a critical undecided issue
+- Several hidden complexities (LRU, cache key derivation, `include` handling) need explicit decisions
+
+**Recommended next step:** Create a detailed type flow diagram showing how `cache` flows from `createDb()` through `buildDelegates()` to individual query methods, using the **current API names** (`get`/`list` not `findUnique`/`findMany`).


### PR DESCRIPTION
## Summary

Design doc for **#1748** — Server-Side Query Cache for `@vertz/db`.

### Problem
Hot read paths in server-side applications repeatedly query for the same rows. During the rinha-de-backend benchmark challenge, adding an in-memory cache improved throughput from ~1500 rps to ~2450 rps — a **63% improvement**.

### Proposal
Add an opt-in server-side query cache to `@vertz/db` that:
- Caches query results keyed by query shape
- Supports TTL-based expiry
- Uses LRU eviction for memory bounds
- Provides explicit invalidation APIs
- Is transparent to correctness

### Implementation Phases
1. **Phase 1:** Core Query Cache (MVP) — `QueryCache` class, TTL/LRU, basic integration
2. **Phase 2:** Invalidation & Statistics — pattern-based invalidation, cache metrics
3. **Phase 3:** Production Hardening — thread-safety, error handling, documentation

---

## Review Findings

### DX Review
**Verdict: CONDITIONAL APPROVAL** — Needs significant API adjustments before implementation.

**Blockers:**
- API names in design doc use stale methods (`findUnique`/`findMany`) instead of current API (`get`/`list`)
- `CachedResult` type doesn't compose properly with existing `Result<T, E>` type
- Cache key format is opaque — no public API to derive keys

**Should-fix:**
- Complex nested configuration (3 levels deep)
- Event subscription API under-specified
- `includeMetadata` missing from typed options

### Product Review
**Verdict: ✅ APPROVED** with pre-conditions.

**Scope fit:** Strong alignment with roadmap and manifesto principles (Explicit Over Implicit, One Way to Do Things, LLM-First).

**Pre-conditions:**
1. Resolve automatic invalidation ambiguity (E2E test contradicts Unknown #1)
2. Add tenant-aware cache key derivation
3. Add `db.getCache()` to Phase 1 acceptance criteria

### Technical Review
**Verdict: BUILDABLE** with significant work.

**Blockers:**
- API name mismatch throughout the doc
- `CreateDbOptions` has no `cache` field — must be added
- Per-query cache options need type integration

**Should-fix:**
- Cache key derivation — object key ordering affects cache hits
- TTL implementation — use lazy expiry (timestamp check) instead of `setTimeout`
- LRU implementation — `Map` is FIFO, not LRU; need library or custom implementation
- `include` relations caching behavior undefined
- Multi-tenant isolation not resolved

---

## Files
- `plans/issue-1748.md` — Design document
- `reviews/issue-1748/dx.md` — DX review
- `reviews/issue-1748/product.md` — Product review
- `reviews/issue-1748/technical.md` — Technical review