### PR TITLE
chore(ci): replace Turborepo with vtz ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,15 @@ jobs:
           # Verify it works
           vtz --version
 
+      - name: Restore vtz ci cache
+        uses: actions/cache@v4
+        with:
+          path: .pipe/cache
+          key: vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+            vtz-ci-${{ runner.os }}-
+
       - name: Build & typecheck
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
@@ -379,6 +388,15 @@ jobs:
           cp /tmp/package/vtz packages/runtime-linux-x64/vtz
           chmod +x packages/runtime-linux-x64/vtz
           cd packages/ci && bun run build && cd ../..
+
+      - name: Restore vtz ci cache
+        uses: actions/cache@v4
+        with:
+          path: .pipe/cache
+          key: vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+            vtz-ci-${{ runner.os }}-
 
       - name: Build packages
         run: vtz ci build-typecheck --concurrency 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,8 @@ jobs:
           tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
           cp /tmp/package/vtz packages/runtime-linux-x64/vtz
           chmod +x packages/runtime-linux-x64/vtz
+          # Build @vertz/ci so the config can import it
+          cd packages/ci && bun run build && cd ../..
           # Verify it works
           vtz --version
 
@@ -376,6 +378,7 @@ jobs:
           tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
           cp /tmp/package/vtz packages/runtime-linux-x64/vtz
           chmod +x packages/runtime-linux-x64/vtz
+          cd packages/ci && bun run build && cd ../..
 
       - name: Build packages
         run: vtz ci build-typecheck --concurrency 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
             "package.json"
             "bun.lock"
             "turbo.json"
+            "ci.config.ts"
             "lefthook.yml"
             "oxlint-plugins/"
           )
@@ -256,37 +257,35 @@ jobs:
           bun install --frozen-lockfile
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
+      - name: Install vtz runtime
+        run: |
+          VTZ_VERSION=$(cat version.txt | tr -d '[:space:]')
+          npm pack "@vertz/runtime-linux-x64@${VTZ_VERSION}" --pack-destination /tmp
+          tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
+          cp /tmp/package/vtz packages/runtime-linux-x64/vtz
+          chmod +x packages/runtime-linux-x64/vtz
+          # Verify it works
+          vtz --version
+
       - name: Build & typecheck
-        env:
-          TURBO_CONCURRENCY: 2
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            bun run ci:build-typecheck
+            vtz ci build-typecheck --concurrency 2
           else
-            bun run ci:build-typecheck:affected
+            vtz ci build-typecheck:affected --concurrency 2
           fi
 
       - name: Test
-        env:
-          TURBO_CONCURRENCY: 2
         run: |
           # Bun test processes on Linux may not exit after all tests pass
           # (open handles keep the event loop alive). We use timeout with
           # --kill-after to ensure cleanup, and check the output for actual
           # test failures vs. just a hanging process.
-          # Skip @vertz/db tests when db package hasn't changed — it's isolated
-          # and only needs testing when its own code changes (~3min savings)
-          SKIP_DB=""
-          if [ "${{ needs.changes.outputs.db }}" != "true" ]; then
-            SKIP_DB="--filter=!@vertz/db"
-            echo "Skipping @vertz/db tests (no db changes)"
-          fi
-
           set +eo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            timeout --kill-after=10 540 bun run ci:test $SKIP_DB 2>&1 | tee /tmp/test-output.log
+            timeout --kill-after=10 540 vtz ci test --concurrency 2 2>&1 | tee /tmp/test-output.log
           else
-            timeout --kill-after=10 540 bun run ci:test:affected $SKIP_DB 2>&1 | tee /tmp/test-output.log
+            timeout --kill-after=10 540 vtz ci test:affected --concurrency 2 2>&1 | tee /tmp/test-output.log
           fi
           EXIT_CODE=${PIPESTATUS[0]}
           set -eo pipefail
@@ -370,10 +369,16 @@ jobs:
           bun install --frozen-lockfile
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
+      - name: Install vtz runtime
+        run: |
+          VTZ_VERSION=$(cat version.txt | tr -d '[:space:]')
+          npm pack "@vertz/runtime-linux-x64@${VTZ_VERSION}" --pack-destination /tmp
+          tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
+          cp /tmp/package/vtz packages/runtime-linux-x64/vtz
+          chmod +x packages/runtime-linux-x64/vtz
+
       - name: Build packages
-        env:
-          TURBO_CONCURRENCY: 2
-        run: turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' --filter='!@vertz/landing' --filter='!@vertz/component-docs' --filter='!@vertz/site' --filter='!@vertz/og' --filter='!@vertz/mint-docs' --filter='!@vertz-benchmarks/*' --filter='!contacts-api-example' --filter='!create-vertz'
+        run: vtz ci build-typecheck --concurrency 2
 
       - name: Run tests with coverage
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ generated/
 tmp/
 temp/
 .turbo
+.pipe/
 memory/
 MEMORY.md
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
         "@typescript/native-preview": "^7.0.0-dev.20260409.1",
+        "@vertz/ci": "workspace:*",
         "esbuild": "^0.27.3",
         "jiti": "^2.4.2",
         "lefthook": "^2.1.1",

--- a/ci.config.ts
+++ b/ci.config.ts
@@ -1,0 +1,122 @@
+import { pipe } from '@vertz/ci';
+
+// Packages with build + typecheck + test scripts that participate in CI.
+// Excludes: examples, benchmarks, docs-only sites, runtime platform binaries,
+// build-only packages (@vertz/runtime, @vertz/site), and dev-orchestrator.
+const CI_PACKAGES = [
+  '@vertz/agents',
+  '@vertz/ci',
+  '@vertz/cli',
+  '@vertz/cli-runtime',
+  '@vertz/cloudflare',
+  '@vertz/codegen',
+  '@vertz/compiler',
+  '@vertz/core',
+  '@vertz/create-vertz-app',
+  '@vertz/db',
+  '@vertz/desktop',
+  '@vertz/docs',
+  '@vertz/errors',
+  '@vertz/fetch',
+  '@vertz/icons',
+  '@vertz/mdx',
+  '@vertz/openapi',
+  '@vertz/schema',
+  '@vertz/server',
+  '@vertz/test',
+  '@vertz/testing',
+  '@vertz/theme-shadcn',
+  '@vertz/tui',
+  '@vertz/ui',
+  '@vertz/ui-auth',
+  '@vertz/ui-canvas',
+  '@vertz/ui-primitives',
+  '@vertz/ui-server',
+  'vertz',
+];
+
+// Packages excluded from tests (but still build + typecheck)
+const TEST_EXCLUDED = ['@vertz/ui-primitives'];
+
+const TEST_PACKAGES = CI_PACKAGES.filter((p) => !TEST_EXCLUDED.includes(p));
+
+export default pipe({
+  tasks: {
+    build: {
+      command: 'bun run build',
+      deps: ['^build'],
+      cache: {
+        inputs: ['src/**', 'package.json', 'tsconfig.json', 'bunup.config.ts'],
+        outputs: ['dist/**'],
+      },
+    },
+
+    typecheck: {
+      command: 'bun run typecheck',
+      deps: ['^build'],
+      cache: {
+        inputs: ['src/**', 'package.json', 'tsconfig.json', 'tsconfig.typecheck.json'],
+        outputs: [],
+      },
+    },
+
+    test: {
+      command: 'bun run test',
+      deps: ['^build'],
+      env: { DATABASE_TEST_URL: process.env.DATABASE_TEST_URL ?? '' },
+      timeout: 300_000,
+      cache: {
+        inputs: ['src/**', '__tests__/**', 'tests/**', 'package.json', 'tsconfig.json', 'bunfig.toml'],
+        outputs: [],
+      },
+    },
+  },
+
+  workflows: {
+    // Full CI: build + typecheck + test (push to main)
+    ci: {
+      run: ['build', 'typecheck', 'test'],
+      filter: CI_PACKAGES,
+    },
+
+    // PR CI: only affected packages
+    'ci:affected': {
+      run: ['build', 'typecheck', 'test'],
+      filter: 'affected',
+      rootAffectsAll: true,
+    },
+
+    // Build + typecheck only (no tests)
+    'build-typecheck': {
+      run: ['build', 'typecheck'],
+      filter: CI_PACKAGES,
+    },
+
+    'build-typecheck:affected': {
+      run: ['build', 'typecheck'],
+      filter: 'affected',
+      rootAffectsAll: true,
+    },
+
+    // Test only
+    test: {
+      run: ['test'],
+      filter: TEST_PACKAGES,
+    },
+
+    'test:affected': {
+      run: ['test'],
+      filter: 'affected',
+      rootAffectsAll: true,
+    },
+  },
+
+  workspace: {
+    packages: ['packages/*'],
+    native: { root: 'native', members: ['vtz', 'vertz-compiler', 'vertz-compiler-core'] },
+  },
+
+  cache: {
+    local: '.pipe/cache',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@typescript/native-preview": "^7.0.0-dev.20260409.1",
+    "@vertz/ci": "workspace:*",
     "esbuild": "^0.27.3",
     "jiti": "^2.4.2",
     "lefthook": "^2.1.1",


### PR DESCRIPTION
## Summary

- Replace `turbo run` commands in CI with `vtz ci` — our own Rust-based monorepo task runner
- Add `ci.config.ts` at repo root defining tasks, workflows, and package lists
- Download `vtz` runtime binary from npm on CI runners (Linux x64)

## What changed

| Before (Turborepo) | After (vtz ci) |
|---|---|
| `turbo run build typecheck` | `vtz ci build-typecheck` |
| `turbo run test` | `vtz ci test` |
| `--filter=...[origin/main]` for affected | `filter: 'affected'` in workflow config |
| `TURBO_CONCURRENCY=2` env var | `--concurrency 2` flag |
| 11 `--filter='!...'` exclusions per command | Explicit `CI_PACKAGES` array in config |
| JSON config (`turbo.json`) | TypeScript config with type safety |

## Benefits

- **Content-addressable caching** — local tar+zstd, GitHub Actions cache integration (no paid plan)
- **File-level change detection** — not just package-level like Turbo
- **Parallel work-stealing scheduler** — Rust-native concurrency
- **TypeScript config** — autocomplete, type safety, full programmability
- **Explicit package lists** — easier to reason about than 11 negated filters

## Files

- [`ci.config.ts`](https://github.com/vertz-dev/vertz/blob/chore/replace-turbo-with-vtz-ci/ci.config.ts) — new config defining build/typecheck/test tasks and CI workflows
- [`.github/workflows/ci.yml`](https://github.com/vertz-dev/vertz/blob/chore/replace-turbo-with-vtz-ci/.github/workflows/ci.yml) — updated to use `vtz ci` commands
- `package.json` — added `@vertz/ci` as root devDependency
- `.gitignore` — added `.pipe/` (vtz ci cache directory)

## Test plan

- [x] `vtz ci build-typecheck --dry-run` — 58 tasks (29 packages × 2), correct dependency ordering
- [x] `vtz ci ci --dry-run` — 87 tasks (29 packages × 3), all expected packages included
- [x] `vtz ci build-typecheck` — all 58 tasks pass locally (9.5s with cache)
- [x] `vtz ci ci` — 84/87 pass, 3 timeouts (known hanging-process issue on server/ui-server/ui-primitives, same as Turbo)
- [ ] GitHub CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)