### PR TITLE
fix(build): use native compiler in CI so library children are thunked

### DIFF
--- a/.changeset/fix-library-children-thunks.md
+++ b/.changeset/fix-library-children-thunks.md
@@ -1,0 +1,12 @@
+---
+'@vertz/ui-primitives': patch
+'@vertz/theme-shadcn': patch
+'@vertz/ui-server': patch
+---
+
+fix(build): use native compiler for library builds so Provider children are thunked
+
+Library packages (ui-primitives, theme-shadcn) were compiled with Bun's JSX fallback
+instead of the native Rust compiler. The fallback doesn't wrap JSX children in thunks,
+causing context-based components (List, Tabs, Dialog, etc.) to throw "must be used
+inside" errors because children evaluate before the Provider sets up context.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,21 @@ jobs:
         working-directory: packages/runtime
         run: bun build index.ts --outdir . --target node
 
+      - name: Install Rust (for native compiler)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+          key: compiler-only
+
+      - name: Build native compiler for library builds
+        run: |
+          cargo build --release --manifest-path native/Cargo.toml -p vertz-compiler
+          cp native/target/release/libvertz_compiler.so native/vertz-compiler/vertz-compiler.linux-x64.node
+          echo "Native compiler binary ready: $(ls -la native/vertz-compiler/vertz-compiler.linux-x64.node)"
+
       - name: Build TS packages
         run: turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' --filter='!@vertz/landing' --filter='!@vertz/component-docs' --filter='!@vertz/site' --filter='!@vertz/og' --filter='!@vertz/mint-docs' --filter='!@vertz-benchmarks/*' --filter='!contacts-api-example' --filter='!create-vertz'
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -5734,7 +5734,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "napi",
  "napi-build",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -5766,7 +5766,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/native/vertz-compiler/__tests__/aot-ssr.test.ts
+++ b/native/vertz-compiler/__tests__/aot-ssr.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface AotComponentInfo {
   name: string;

--- a/native/vertz-compiler/__tests__/body-jsx-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/body-jsx-diagnostics.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/component-analysis.test.ts
+++ b/native/vertz-compiler/__tests__/component-analysis.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/computed-transform.test.ts
+++ b/native/vertz-compiler/__tests__/computed-transform.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/context-stable-ids.test.ts
+++ b/native/vertz-compiler/__tests__/context-stable-ids.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/cross-file-manifest.test.ts
+++ b/native/vertz-compiler/__tests__/cross-file-manifest.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/css-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/css-diagnostics.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/css-transform.test.ts
+++ b/native/vertz-compiler/__tests__/css-transform.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/fast-refresh.test.ts
+++ b/native/vertz-compiler/__tests__/fast-refresh.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/field-selection.test.ts
+++ b/native/vertz-compiler/__tests__/field-selection.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface NestedFieldAccess {
   field: string;

--- a/native/vertz-compiler/__tests__/hydration-markers.test.ts
+++ b/native/vertz-compiler/__tests__/hydration-markers.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/import-injection.test.ts
+++ b/native/vertz-compiler/__tests__/import-injection.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/jsx-transform.test.ts
+++ b/native/vertz-compiler/__tests__/jsx-transform.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/load-compiler.ts
+++ b/native/vertz-compiler/__tests__/load-compiler.ts
@@ -1,0 +1,13 @@
+import { join } from 'node:path';
+
+function resolveBinaryName(): string {
+  const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  return `vertz-compiler.${platform}-${arch}.node`;
+}
+
+export const NATIVE_MODULE_PATH = join(
+  import.meta.dir,
+  '..',
+  resolveBinaryName(),
+);

--- a/native/vertz-compiler/__tests__/mount-frame.test.ts
+++ b/native/vertz-compiler/__tests__/mount-frame.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/mutation-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/mutation-diagnostics.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/mutation-transform.test.ts
+++ b/native/vertz-compiler/__tests__/mutation-transform.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/native-compiler.test.ts
+++ b/native/vertz-compiler/__tests__/native-compiler.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/parity/parity-1911.test.ts
+++ b/native/vertz-compiler/__tests__/parity/parity-1911.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from '../load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/prefetch-manifest.test.ts
+++ b/native/vertz-compiler/__tests__/prefetch-manifest.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface ExtractedRoute {
   pattern: string;

--- a/native/vertz-compiler/__tests__/props-destructuring.test.ts
+++ b/native/vertz-compiler/__tests__/props-destructuring.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/query-auto-thunk.test.ts
+++ b/native/vertz-compiler/__tests__/query-auto-thunk.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/reactivity-analysis.test.ts
+++ b/native/vertz-compiler/__tests__/reactivity-analysis.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface VariableInfo {
   name: string;

--- a/native/vertz-compiler/__tests__/route-splitting.test.ts
+++ b/native/vertz-compiler/__tests__/route-splitting.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/signal-transform.test.ts
+++ b/native/vertz-compiler/__tests__/signal-transform.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/ssr-safety-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/ssr-safety-diagnostics.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/__tests__/typescript-strip.test.ts
+++ b/native/vertz-compiler/__tests__/typescript-strip.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { join } from 'node:path';
-
-const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  'vertz-compiler.darwin-arm64.node',
-);
+import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {

--- a/native/vertz-compiler/package.json
+++ b/native/vertz-compiler/package.json
@@ -11,10 +11,10 @@
     "vertz-compiler.*.node"
   ],
   "scripts": {
-    "build": "which cargo > /dev/null 2>&1 && cargo build --release --manifest-path ../Cargo.toml && cp ../target/release/libvertz_compiler.dylib ./vertz-compiler.darwin-arm64.node || echo 'Skipping native build (cargo not found)'",
-    "build:debug": "cargo build --manifest-path ../Cargo.toml && cp ../target/debug/libvertz_compiler.dylib ./vertz-compiler.darwin-arm64.node",
-    "test": "test -f vertz-compiler.darwin-arm64.node && bun test __tests__/*.test.ts || echo 'Skipping native tests (binary not found)'",
-    "test:parity": "test -f vertz-compiler.darwin-arm64.node && bun test __tests__/parity/ || echo 'Skipping parity tests'"
+    "build": "which cargo > /dev/null 2>&1 && bash -c 'cargo build --release --manifest-path ../Cargo.toml -p vertz-compiler && if [ \"$(uname)\" = \"Darwin\" ]; then cp ../target/release/libvertz_compiler.dylib ./vertz-compiler.darwin-$([ \"$(uname -m)\" = \"arm64\" ] && echo arm64 || echo x64).node; else cp ../target/release/libvertz_compiler.so ./vertz-compiler.linux-$([ \"$(uname -m)\" = \"aarch64\" ] && echo arm64 || echo x64).node; fi' || echo 'Skipping native build (cargo not found)'",
+    "build:debug": "cargo build --manifest-path ../Cargo.toml -p vertz-compiler && if [ \"$(uname)\" = \"Darwin\" ]; then cp ../target/debug/libvertz_compiler.dylib ./vertz-compiler.darwin-arm64.node; else cp ../target/debug/libvertz_compiler.so ./vertz-compiler.linux-x64.node; fi",
+    "test": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/*.test.ts || echo 'Skipping native tests (binary not found)'",
+    "test:parity": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/parity/ || echo 'Skipping parity tests'"
   },
   "devDependencies": {}
 }

--- a/packages/ui-server/src/compiler/native-compiler.ts
+++ b/packages/ui-server/src/compiler/native-compiler.ts
@@ -126,6 +126,9 @@ interface RawNativeCompiler {
 
 // ─── Loader ─────────────────────────────────────────────────────────
 
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
 let cachedCompiler: RawNativeCompiler | null = null;
 let nativeUnavailable = false;
 
@@ -133,6 +136,45 @@ function resolveBinaryName(): string {
   const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
   return `vertz-compiler.${platform}-${arch}.node`;
+}
+
+/**
+ * Resolve the native compiler binary path.
+ *
+ * 1. Try `require.resolve('@vertz/native-compiler/<binary>')` — works when
+ *    the package is installed as a regular npm dependency.
+ * 2. Walk up from this file to find the monorepo root (`native/vertz-compiler/`)
+ *    and load the binary directly — works in Bun workspace monorepos where
+ *    `require.resolve` doesn't resolve workspace-linked packages with subpath
+ *    exports.
+ */
+function resolveBinaryPath(binaryName: string): string | null {
+  // Try 1: standard npm module resolution
+  try {
+    return require.resolve(`@vertz/native-compiler/${binaryName}`);
+  } catch {
+    // Fall through to workspace resolution
+  }
+
+  // Try 2: workspace-relative resolution (monorepo / CI)
+  // Walk up from this file's directory to find `native/vertz-compiler/`
+  const startDir =
+    (typeof import.meta !== 'undefined' && import.meta.dir) ||
+    (typeof __dirname !== 'undefined' ? __dirname : null);
+  if (!startDir) return null;
+
+  let dir = dirname(startDir);
+  for (let i = 0; i < 10; i++) {
+    const candidate = resolve(dir, 'native', 'vertz-compiler', binaryName);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
 }
 
 /**
@@ -144,17 +186,17 @@ export function loadNativeCompiler(): NativeCompiler {
   }
 
   const binaryName = resolveBinaryName();
+  const binaryPath = resolveBinaryPath(binaryName);
 
-  try {
-    const modulePath = require.resolve(`@vertz/native-compiler/${binaryName}`);
-    cachedCompiler = require(modulePath) as RawNativeCompiler;
-    return wrapCompiler(cachedCompiler);
-  } catch {
+  if (!binaryPath) {
     throw new Error(
       `Failed to load native compiler binary: @vertz/native-compiler/${binaryName}. ` +
         'Ensure @vertz/native-compiler is installed with the correct platform binary.',
     );
   }
+
+  cachedCompiler = require(binaryPath) as RawNativeCompiler;
+  return wrapCompiler(cachedCompiler);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Root cause**: The Release CI job builds library packages (ui-primitives, theme-shadcn) via `createVertzLibraryPlugin()`, which calls `compile()` from `@vertz/ui-server`. Without Rust installed on the runner, `compile()` silently falls back to Bun's JSX transpiler — which does NOT wrap children in thunks. Published packages ship un-thunked children, causing `List.Item must be used inside a <List>` errors because children evaluate before the Provider sets up context.
- **Fix**: Install Rust + build the native compiler NAPI binary (`vertz-compiler`) in the Release job before building TS packages. Also add workspace-relative binary resolution so the loader finds the binary in monorepo/CI environments where `require.resolve` fails for workspace-linked packages with subpath exports.
- **Native compiler package.json**: Fix build/test scripts to handle both macOS and Linux (previously hardcoded macOS `.dylib` only).

## Changes

- [`.github/workflows/release.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-lib-build-thunks/.github/workflows/release.yml) — Add Rust toolchain, Cargo cache, and native compiler build steps before TS package builds
- [`packages/ui-server/src/compiler/native-compiler.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-lib-build-thunks/packages/ui-server/src/compiler/native-compiler.ts) — Add `resolveBinaryPath()` with workspace-relative fallback when `require.resolve` fails
- [`native/vertz-compiler/package.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-lib-build-thunks/native/vertz-compiler/package.json) — Fix build/test scripts for cross-platform support

## Test plan

- [x] Built native compiler locally, rebuilt ui-primitives and theme-shadcn — verified output contains children thunks (`() => ...`)
- [x] Copied rebuilt dist to a test app created from default template — List and Tabs render without "must be used inside" errors
- [x] Verified `resolveBinaryPath()` finds binary via workspace walk when `require.resolve` fails
- [ ] CI Release job should now install Rust, build the NAPI binary, and produce correctly compiled library packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)