### PR TITLE
fix(desktop): fs.remove handles non-empty directories (#2411)

### DIFF
--- a/.changeset/fix-fs-remove-dirs.md
+++ b/.changeset/fix-fs-remove-dirs.md
@@ -1,0 +1,5 @@
+---
+'@vertz/desktop': patch
+---
+
+fix(desktop): `fs.remove()` now removes non-empty directories recursively

--- a/native/vtz/src/webview/ipc_handlers/fs.rs
+++ b/native/vtz/src/webview/ipc_handlers/fs.rs
@@ -144,7 +144,7 @@ pub async fn remove(params: FsPathParams) -> Result<serde_json::Value, IpcError>
         .map_err(|e| map_io_error(e, &path))?;
 
     if metadata.is_dir() {
-        tokio::fs::remove_dir(&path)
+        tokio::fs::remove_dir_all(&path)
             .await
             .map_err(|e| map_io_error(e, &path))?;
     } else {
@@ -452,6 +452,31 @@ mod tests {
         .await;
         assert!(result.is_ok());
         assert!(tokio::fs::metadata(path).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_non_empty_directory() {
+        let dir = "/tmp/vtz_ipc_remove_nonempty";
+        let _ = tokio::fs::remove_dir_all(dir).await;
+        tokio::fs::create_dir_all(format!("{dir}/sub/deep"))
+            .await
+            .unwrap();
+        tokio::fs::write(format!("{dir}/root.txt"), "root")
+            .await
+            .unwrap();
+        tokio::fs::write(format!("{dir}/sub/nested.txt"), "nested")
+            .await
+            .unwrap();
+        tokio::fs::write(format!("{dir}/sub/deep/deep.txt"), "deep")
+            .await
+            .unwrap();
+
+        let result = remove(FsPathParams {
+            path: dir.to_string(),
+        })
+        .await;
+        assert!(result.is_ok());
+        assert!(tokio::fs::metadata(dir).await.is_err());
     }
 
     #[tokio::test]

--- a/native/vtz/src/webview/ipc_handlers/fs.rs
+++ b/native/vtz/src/webview/ipc_handlers/fs.rs
@@ -455,6 +455,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn remove_empty_directory() {
+        let dir = "/tmp/vtz_ipc_remove_empty";
+        let _ = tokio::fs::remove_dir_all(dir).await;
+        tokio::fs::create_dir_all(dir).await.unwrap();
+
+        let result = remove(FsPathParams {
+            path: dir.to_string(),
+        })
+        .await;
+        assert!(result.is_ok());
+        assert!(tokio::fs::metadata(dir).await.is_err());
+    }
+
+    #[tokio::test]
     async fn remove_non_empty_directory() {
         let dir = "/tmp/vtz_ipc_remove_nonempty";
         let _ = tokio::fs::remove_dir_all(dir).await;

--- a/packages/desktop/src/fs.ts
+++ b/packages/desktop/src/fs.ts
@@ -71,7 +71,7 @@ export function createDir(
 }
 
 /**
- * Remove a file or empty directory.
+ * Remove a file or directory. Directories are removed recursively.
  */
 export function remove(
   path: string,


### PR DESCRIPTION
## Summary

- **`fs.remove()`** now uses `tokio::fs::remove_dir_all` instead of `tokio::fs::remove_dir`, enabling recursive removal of non-empty directories
- Updated JSDoc to reflect the new behavior ("Remove a file or directory. Directories are removed recursively.")

## Public API Changes

- `fs.remove(path)` — **behavior change**: previously failed on non-empty directories with an IO error, now removes them recursively

## Test Plan

- [x] `remove_non_empty_directory` — removes directory with nested files and subdirectories (3 levels deep)
- [x] `remove_empty_directory` — regression test ensuring empty dirs still work with `remove_dir_all`
- [x] All existing fs tests pass (`remove_file`, `remove_not_found`)
- [x] Clippy + fmt clean
- [x] TypeScript typecheck passes

## Review

Adversarial review completed: `reviews/fix-fs-remove-dirs/phase-01-fix.md`
- 1 should-fix (add empty dir regression test) → addressed

Fixes #2411

🤖 Generated with [Claude Code](https://claude.com/claude-code)