### PR TITLE
fix(ui,runtime): fix todo-app template, DialogStackProvider hydration, routerless 404, API init race

### DIFF
--- a/.changeset/fix-todo-dialog-provider.md
+++ b/.changeset/fix-todo-dialog-provider.md
@@ -1,0 +1,7 @@
+---
+'@vertz/create-vertz-app': patch
+---
+
+fix(create-vertz-app): add DialogStackProvider to todo-app template
+
+The todo-app template's `app.tsx` was missing `DialogStackProvider`, causing a runtime crash when the `TaskItem` component called `useDialogStack()` for delete confirmation.

--- a/.changeset/fix-todo-dialog-provider.md
+++ b/.changeset/fix-todo-dialog-provider.md
@@ -1,7 +1,21 @@
 ---
 '@vertz/create-vertz-app': patch
+'@vertz/ui': patch
+'@vertz/ui-server': patch
 ---
 
 fix(create-vertz-app): add DialogStackProvider to todo-app template
 
 The todo-app template's `app.tsx` was missing `DialogStackProvider`, causing a runtime crash when the `TaskItem` component called `useDialogStack()` for delete confirmation.
+
+fix(ui): fix DialogStackProvider hydration — children silently dropped
+
+`DialogStackProvider` used `DocumentFragment` + `__insert` which no-ops Node values during hydration. Restructured to use `__enterChildren`/`__exitChildren`/`__append` pattern (matching `ThemeProvider`) so children are properly claimed from SSR DOM.
+
+fix(runtime): return 200 for routerless apps instead of 404
+
+Changed `matched_route_patterns` from `Vec<String>` to `Option<Vec<String>>` — `None` means no router (200), `Some(empty)` means router matched nothing (404).
+
+fix(runtime): wait for API isolate init instead of returning 503
+
+The API handler now calls `wait_for_init()` instead of returning 503 immediately when the isolate hasn't finished initializing, preventing race conditions on first request.

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -139,8 +139,11 @@ pub struct SsrResponse {
     pub head_tags: Option<String>,
     /// Redirect URL set by ProtectedRoute during SSR (server should return 302).
     pub redirect: Option<String>,
-    /// Route patterns that matched the current URL (empty = 404).
-    pub matched_route_patterns: Vec<String>,
+    /// Route patterns that matched the current URL.
+    /// `None` = app has no router (always 200).
+    /// `Some(vec![])` = router present but no route matched (404).
+    /// `Some(vec![...])` = router matched these patterns (200).
+    pub matched_route_patterns: Option<Vec<String>>,
 }
 
 /// A component render request for the persistent isolate.
@@ -1482,8 +1485,7 @@ async fn dispatch_ssr_request(
                 arr.iter()
                     .filter_map(|v| v.as_str().map(String::from))
                     .collect()
-            })
-            .unwrap_or_default();
+            });
 
         Ok(SsrResponse {
             content,
@@ -1557,7 +1559,7 @@ async fn dispatch_ssr_request(
             ssr_data: None,
             head_tags: None,
             redirect: None,
-            matched_route_patterns: vec![],
+            matched_route_patterns: None,
         })
     }
 }
@@ -1816,7 +1818,7 @@ mod tests {
             ssr_data: Some(r#"[{"key":"tasks","data":[]}]"#.to_string()),
             head_tags: Some(r#"<link rel="preload" href="/font.woff2" />"#.to_string()),
             redirect: None,
-            matched_route_patterns: vec![],
+            matched_route_patterns: None,
         };
         assert_eq!(
             resp.ssr_data,

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -492,11 +492,11 @@ async fn ai_render_handler(
 
             match isolate.handle_ssr(ssr_req).await {
                 Ok(ssr_resp) => {
-                    // Return 404 when no route matched (fallback content rendered but URL is invalid)
-                    let status_code = if ssr_resp.matched_route_patterns.is_empty() {
-                        404u16
-                    } else {
-                        200u16
+                    // None = no router (always 200), Some(empty) = router but no match (404)
+                    let status_code = match &ssr_resp.matched_route_patterns {
+                        None => 200u16,
+                        Some(patterns) if patterns.is_empty() => 404u16,
+                        Some(_) => 200u16,
                     };
 
                     state
@@ -956,11 +956,11 @@ async fn dev_server_handler(
                                 }
                             );
                             eprintln!("[SSR] {}", render_msg);
-                            // Return 404 when no route matched
-                            let status_code = if ssr_resp.matched_route_patterns.is_empty() {
-                                404u16
-                            } else {
-                                200u16
+                            // None = no router (200), Some(empty) = router but no match (404)
+                            let status_code = match &ssr_resp.matched_route_patterns {
+                                None => 200u16,
+                                Some(patterns) if patterns.is_empty() => 404u16,
+                                Some(_) => 200u16,
                             };
                             state.audit_log.record(
                                 crate::server::audit_log::AuditEvent::ssr_render(
@@ -982,11 +982,11 @@ async fn dev_server_handler(
                                 .unwrap();
                         }
 
-                        // Return 404 when no route matched (fallback content rendered but URL is invalid)
-                        let status = if ssr_resp.matched_route_patterns.is_empty() {
-                            StatusCode::NOT_FOUND
-                        } else {
-                            StatusCode::OK
+                        // None = no router (200), Some(empty) = router but no match (404)
+                        let status = match &ssr_resp.matched_route_patterns {
+                            None => StatusCode::OK,
+                            Some(patterns) if patterns.is_empty() => StatusCode::NOT_FOUND,
+                            Some(_) => StatusCode::OK,
                         };
 
                         // Assemble the full HTML document from SSR response.
@@ -1224,13 +1224,16 @@ async fn handle_api_request(
     };
 
     if !isolate.is_initialized() {
-        return axum::response::Response::builder()
-            .status(StatusCode::SERVICE_UNAVAILABLE)
-            .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
-            .body(Body::from(
-                r#"{"error":"API isolate is still initializing. Try again shortly."}"#,
-            ))
-            .unwrap();
+        if let Err(e) = isolate.wait_for_init().await {
+            return axum::response::Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
+                .body(Body::from(format!(
+                    r#"{{"error":"API isolate failed to initialize: {}"}}"#,
+                    e.to_string().replace('"', "\\\"")
+                )))
+                .unwrap();
+        }
     }
 
     if !isolate.has_api_handler() {

--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -281,6 +281,12 @@ describe('templates', () => {
       expect(appComponentTemplate()).toContain('ThemeProvider');
     });
 
+    it('wraps the tree with DialogStackProvider for useDialogStack support', () => {
+      const result = appComponentTemplate();
+      expect(result).toContain('DialogStackProvider');
+      expect(result).toContain('<DialogStackProvider>');
+    });
+
     it('renders HomePage', () => {
       expect(appComponentTemplate()).toContain('HomePage');
     });

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -825,7 +825,7 @@ export const api = createClient();
  * src/app.tsx — SSR module exports + ThemeProvider + render HomePage
  */
 export function appComponentTemplate(): string {
-  return `import { css, getInjectedCSS, globalCss, ThemeProvider } from 'vertz/ui';
+  return `import { css, DialogStackProvider, getInjectedCSS, globalCss, ThemeProvider } from 'vertz/ui';
 import { HomePage } from './pages/home';
 import { appTheme, themeGlobals } from './styles/theme';
 
@@ -859,14 +859,16 @@ export function App() {
   return (
     <div data-testid="app-root">
       <ThemeProvider theme="light">
-        <div className={styles.shell}>
-          <header className={styles.header}>
-            <div className={styles.title}>My Vertz App</div>
-          </header>
-          <main className={styles.main}>
-            <HomePage />
-          </main>
-        </div>
+        <DialogStackProvider>
+          <div className={styles.shell}>
+            <header className={styles.header}>
+              <div className={styles.title}>My Vertz App</div>
+            </header>
+            <main className={styles.main}>
+              <HomePage />
+            </main>
+          </div>
+        </DialogStackProvider>
       </ThemeProvider>
     </div>
   );

--- a/packages/ui-server/src/node-handler.ts
+++ b/packages/ui-server/src/node-handler.ts
@@ -175,8 +175,13 @@ export function createNodeHandler(
         if (linkHeader) headers.Link = linkHeader;
         if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-        // Return 404 when no route matched (fallback content rendered but URL is invalid)
-        const status = result.matchedRoutePatterns?.length ? 200 : 404;
+        // undefined = no router (200), empty array = router but no match (404)
+        const status =
+          result.matchedRoutePatterns === undefined
+            ? 200
+            : result.matchedRoutePatterns.length > 0
+              ? 200
+              : 404;
         res.writeHead(status, headers);
         res.end(html);
       } catch (err) {
@@ -264,8 +269,13 @@ async function handleProgressiveRequest(
   if (linkHeader) headers.Link = linkHeader;
   if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-  // Return 404 when no route matched
-  const status = result.matchedRoutePatterns?.length ? 200 : 404;
+  // undefined = no router (200), empty array = router but no match (404)
+  const status =
+    result.matchedRoutePatterns === undefined
+      ? 200
+      : result.matchedRoutePatterns.length > 0
+        ? 200
+        : 404;
   res.writeHead(status, headers);
 
   // 1. Send head chunk immediately

--- a/packages/ui-server/src/ssr-handler.ts
+++ b/packages/ui-server/src/ssr-handler.ts
@@ -350,8 +350,13 @@ async function handleProgressiveHTMLRequest(
     if (linkHeader) headers.Link = linkHeader;
     if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-    // Return 404 when no route matched (fallback content was rendered but URL is invalid)
-    const status = result.matchedRoutePatterns?.length ? 200 : 404;
+    // undefined = no router (200), empty array = router but no match (404)
+    const status =
+      result.matchedRoutePatterns === undefined
+        ? 200
+        : result.matchedRoutePatterns.length > 0
+          ? 200
+          : 404;
 
     return buildProgressiveResponse({
       headChunk,
@@ -454,8 +459,13 @@ async function handleHTMLRequest(
     if (linkHeader) headers.Link = linkHeader;
     if (cacheControl) headers['Cache-Control'] = cacheControl;
 
-    // Return 404 when no route matched (fallback content was rendered but URL is invalid)
-    const status = result.matchedRoutePatterns?.length ? 200 : 404;
+    // undefined = no router (200), empty array = router but no match (404)
+    const status =
+      result.matchedRoutePatterns === undefined
+        ? 200
+        : result.matchedRoutePatterns.length > 0
+          ? 200
+          : 404;
     return new Response(html, { status, headers });
   } catch (err) {
     console.error('[SSR] Render failed:', err instanceof Error ? err.message : err);

--- a/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
+++ b/packages/ui/src/dialog/__tests__/dialog-stack.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
 import { createContext, getContextScope, useContext } from '../../component/context';
-import { __element } from '../../dom/element';
+import { __append, __element, __enterChildren, __exitChildren } from '../../dom/element';
 import { __on } from '../../dom/events';
 import { form, type SdkMethod } from '../../form/form';
+import { endHydration, startHydration } from '../../hydrate/hydration-context';
 import type { DialogHandle, DialogStack } from '../dialog-stack';
 import {
   createDialogStack,
@@ -1023,6 +1024,66 @@ describe('Feature: dialogs.confirm()', () => {
 
         const result = await resultPromise;
         expect(result).toBe(false);
+      });
+    });
+  });
+});
+
+describe('Feature: DialogStackProvider hydration', () => {
+  afterEach(() => {
+    endHydration();
+  });
+
+  describe('Given SSR output with DialogStackProvider wrapping children', () => {
+    describe('When hydration runs', () => {
+      it('Then the result is an HTMLElement with data-dialog-container', () => {
+        // Simulate SSR output: <div data-dialog-container><span>child</span></div>
+        const root = document.createElement('div');
+        root.innerHTML = '<div data-dialog-container=""><span>child</span></div>';
+
+        startHydration(root);
+
+        let dialogs: DialogStack | undefined;
+        const result = DialogStackProvider({
+          children: () => {
+            dialogs = useDialogStack();
+            // During hydration, __element should claim the existing <span>
+            const child = __element('span');
+            return child;
+          },
+        });
+
+        endHydration();
+
+        // Result must be an HTMLElement (not a DocumentFragment)
+        expect(result).toBeInstanceOf(HTMLElement);
+        // The container div should have the marker attribute
+        expect((result as HTMLElement).getAttribute('data-dialog-container')).toBe('');
+        // Children should be inside the container
+        expect((result as HTMLElement).querySelector('span')).toBeTruthy();
+        expect(dialogs).toBeDefined();
+      });
+
+      it('Then children are claimed from SSR DOM (not recreated)', () => {
+        const root = document.createElement('div');
+        root.innerHTML = '<div data-dialog-container=""><span>content</span></div>';
+        const ssrSpan = root.querySelector('span')!;
+
+        startHydration(root);
+
+        let claimedSpan: Element | undefined;
+        DialogStackProvider({
+          children: () => {
+            useDialogStack();
+            claimedSpan = __element('span');
+            return claimedSpan;
+          },
+        });
+
+        endHydration();
+
+        // The span should be the same DOM node (claimed, not recreated)
+        expect(claimedSpan).toBe(ssrSpan);
       });
     });
   });

--- a/packages/ui/src/dialog/dialog-stack.ts
+++ b/packages/ui/src/dialog/dialog-stack.ts
@@ -1,7 +1,9 @@
+import type { ChildValue } from '../component/children';
+import { resolveChildren } from '../component/children';
 import type { ContextScope } from '../component/context';
 import { createContext, getContextScope, setContextScope, useContext } from '../component/context';
 import { onAnimationsComplete } from '../dom/animation';
-import { __element, __insert } from '../dom/element';
+import { __append, __element, __enterChildren, __exitChildren } from '../dom/element';
 import { popScope, pushScope, runCleanups } from '../runtime/disposal';
 import type { DisposeFn } from '../runtime/signal-types';
 
@@ -132,7 +134,12 @@ interface StackEntry {
  *
  * Creates a hydration-safe container div via `__element`, initializes the
  * dialog stack, and wraps children in `DialogStackContext.Provider`.
- * The container renders after children — dialogs portal into it.
+ *
+ * Uses `__enterChildren`/`__exitChildren`/`__append` so that during
+ * hydration it claims existing SSR nodes instead of creating new elements.
+ * The container div doubles as the wrapper element — children render inside
+ * it, and dialogs portal into it via `showModal()` (top-layer, so DOM
+ * position doesn't matter).
  */
 export function DialogStackProvider({ children }: { children?: unknown }): HTMLElement {
   const container = __element('div', { 'data-dialog-container': '' });
@@ -141,10 +148,13 @@ export function DialogStackProvider({ children }: { children?: unknown }): HTMLE
   return DialogStackContext.Provider({
     value: stack,
     children: () => {
-      const frag = document.createDocumentFragment();
-      __insert(frag, children as Parameters<typeof __insert>[1]);
-      frag.appendChild(container);
-      return frag;
+      __enterChildren(container);
+      const nodes = resolveChildren(children as ChildValue);
+      for (const node of nodes) {
+        __append(container, node);
+      }
+      __exitChildren();
+      return container;
     },
   });
 }


### PR DESCRIPTION
## Summary

- **Template fix**: Adds `DialogStackProvider` to the todo-app template's `app.tsx` — fixes runtime crash when `TaskItem` calls `useDialogStack()` for delete confirmation
- **DialogStackProvider hydration fix**: Restructured from `DocumentFragment` + `__insert` to `__enterChildren`/`__exitChildren`/`__append` pattern (matching `ThemeProvider`) so children are properly claimed from SSR DOM during hydration instead of being silently dropped
- **Routerless apps 404 fix**: Changed `matched_route_patterns` from `Vec<String>` to `Option<Vec<String>>` in Rust, and updated all JS handlers — `None` = no router (200), `Some(empty)` = router matched nothing (404), `Some(patterns)` = matched (200)
- **API init race fix**: API handler now calls `wait_for_init()` instead of returning 503 immediately when the V8 isolate hasn't finished initializing

Fixes #2462

## Public API Changes

None — these are internal fixes (template, hydration, runtime behavior).

## Changed Files

- [`packages/create-vertz-app/src/templates/index.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/packages/create-vertz-app/src/templates/index.ts) — template fix
- [`packages/ui/src/dialog/dialog-stack.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/packages/ui/src/dialog/dialog-stack.ts) — hydration fix
- [`packages/ui/src/dialog/__tests__/dialog-stack.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/packages/ui/src/dialog/__tests__/dialog-stack.test.ts) — hydration tests
- [`packages/ui-server/src/ssr-handler.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/packages/ui-server/src/ssr-handler.ts) — routerless status code fix
- [`packages/ui-server/src/node-handler.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/packages/ui-server/src/node-handler.ts) — routerless status code fix
- [`native/vtz/src/runtime/persistent_isolate.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/native/vtz/src/runtime/persistent_isolate.rs) — `Option<Vec>` type change + legacy path
- [`native/vtz/src/server/http.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-todo-template-dialog/native/vtz/src/server/http.rs) — status code logic + `wait_for_init()`

## Test plan

- [x] Template tests: 118 pass (includes DialogStackProvider assertion)
- [x] Dialog-stack tests: 50 pass (includes 2 new hydration tests)
- [x] TypeScript typecheck: clean for `@vertz/ui` and `@vertz/ui-server`
- [x] Rust: `cargo check`, `cargo clippy`, `cargo fmt` all pass
- [x] Pre-push hooks: all 6 checks pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)
- [x] Adversarial review: approved with no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)