### PR TITLE
fix(docs): use 'built-in SQLite driver' instead of bun:sqlite

### DIFF
--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -251,9 +251,8 @@ export async function resolveLocalSqliteDatabase(
         `  better-sqlite3 error: ${betterMsg}\n\n` +
         'To fix this, either:\n' +
         '  1. Run your script with vtz (e.g. vtz run <script> or vtz dev) — the Vertz\n' +
-        '     runtime includes a native SQLite driver. See https://vertz.dev/runtime\n' +
-        '  2. Use the Bun runtime (which includes bun:sqlite), or\n' +
-        '  3. Install better-sqlite3: npm install better-sqlite3',
+        '     runtime includes a built-in SQLite driver. See https://vertz.dev/runtime\n' +
+        '  2. Install better-sqlite3: npm install better-sqlite3',
     );
   }
 }

--- a/packages/mint-docs/guides/common-mistakes.mdx
+++ b/packages/mint-docs/guides/common-mistakes.mdx
@@ -126,17 +126,17 @@ export function TaskCard({ task }: Props) {
 
 ## Running SQLite scripts with `node` instead of `vtz`
 
-SQLite in Vertz uses `bun:sqlite`, which is provided natively by the `vtz` runtime. Running scripts that use `@vertz/db` with SQLite under plain `node` will fail — `bun:sqlite` is not available outside `vtz` or Bun.
+The `vtz` runtime includes a built-in SQLite driver powered by Rust — no extra dependencies needed. Running scripts that use `@vertz/db` with SQLite under plain `node` will fail because Node.js doesn't have the native driver.
 
 ```bash
-# Wrong — plain Node can't resolve bun:sqlite
+# Wrong — plain Node doesn't have the built-in SQLite driver
 node ./scripts/ensure-db.ts
 
-# Right — vtz includes bun:sqlite natively
+# Right — vtz includes a native SQLite driver
 vtz run ensure-db
 ```
 
-**Why it matters:** The `vtz` runtime embeds SQLite via Rust, so any script run through `vtz` (including `vtz run <script>`, `vtz dev`, and `vtz test`) has SQLite available with zero extra dependencies. Running the same script with `node` bypasses the runtime entirely — Node.js has no `bun:sqlite` module, so the import fails.
+**Why it matters:** The `vtz` runtime embeds SQLite via Rust, so any script run through `vtz` (including `vtz run <script>`, `vtz dev`, and `vtz test`) has SQLite available with zero extra dependencies. Running the same script with `node` bypasses the runtime entirely.
 
 If you need to run database scripts outside of `vtz`, use PostgreSQL instead of SQLite, or install `better-sqlite3` as a fallback.
 

--- a/packages/mint-docs/guides/db/overview.mdx
+++ b/packages/mint-docs/guides/db/overview.mdx
@@ -111,8 +111,8 @@ export function createD1Db(d1: D1Database) {
 </Note>
 
 <Warning>
-  **SQLite requires the `vtz` runtime or Bun.** The `vtz` runtime includes a native SQLite driver
-  (`bun:sqlite`) — no extra dependencies needed. If you run scripts with plain `node` instead of
+  **SQLite requires the `vtz` runtime.** The `vtz` runtime includes a built-in SQLite driver
+  powered by Rust — no extra dependencies needed. If you run scripts with plain `node` instead of
   `vtz`, SQLite will fail to initialize. Always use `vtz dev`, `vtz test`, or `vtz run <script>` to
   run code that uses SQLite. For Node.js-only environments (e.g. production without `vtz`), use
   PostgreSQL instead.


### PR DESCRIPTION
## Summary

- Update docs and error message to say "built-in SQLite driver powered by Rust" instead of referencing `bun:sqlite` — the vtz runtime has its own native driver, it's not Bun's
- Drop "Use the Bun runtime" from the error message suggestions since it's not the Vertz way

Follow-up to #2465.

## Test plan

- [x] `local-sqlite-driver.test.ts` — 11/11 pass
- [ ] Verify updated wording on DB overview and common-mistakes docs pages