### PR TITLE
chore(ci): use vertz-dev/setup-vtz action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,26 +257,11 @@ jobs:
           bun install --frozen-lockfile
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Install vtz runtime
-        run: |
-          VTZ_VERSION=$(cat version.txt | tr -d '[:space:]')
-          npm pack "@vertz/runtime-linux-x64@${VTZ_VERSION}" --pack-destination /tmp
-          tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
-          cp /tmp/package/vtz packages/runtime-linux-x64/vtz
-          chmod +x packages/runtime-linux-x64/vtz
-          # Build @vertz/ci so the config can import it
-          cd packages/ci && bun run build && cd ../..
-          # Verify it works
-          vtz --version
+      - name: Setup vtz
+        uses: vertz-dev/setup-vtz@v1
 
-      - name: Restore vtz ci cache
-        uses: actions/cache@v4
-        with:
-          path: .pipe/cache
-          key: vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
-            vtz-ci-${{ runner.os }}-
+      - name: Build @vertz/ci
+        run: cd packages/ci && bun run build
 
       - name: Build & typecheck
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,23 +43,11 @@ jobs:
           bun install --frozen-lockfile
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Install vtz runtime
-        run: |
-          VTZ_VERSION=$(cat version.txt | tr -d '[:space:]')
-          npm pack "@vertz/runtime-linux-x64@${VTZ_VERSION}" --pack-destination /tmp
-          tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
-          cp /tmp/package/vtz packages/runtime-linux-x64/vtz
-          chmod +x packages/runtime-linux-x64/vtz
-          cd packages/ci && bun run build && cd ../..
+      - name: Setup vtz
+        uses: vertz-dev/setup-vtz@v1
 
-      - name: Restore vtz ci cache
-        uses: actions/cache@v4
-        with:
-          path: .pipe/cache
-          key: vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            vtz-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
-            vtz-ci-${{ runner.os }}-
+      - name: Build @vertz/ci
+        run: cd packages/ci && bun run build
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary

- Created new repo [`vertz-dev/setup-vtz`](https://github.com/vertz-dev/setup-vtz) — a composite GitHub Action that installs the `vtz` runtime binary and adds it to `$GITHUB_PATH`
- Replaced inline vtz install scripts in `ci.yml` and `coverage.yml` with `uses: vertz-dev/setup-vtz@v1`

## What the action does

1. Resolves version from `version.txt` (or explicit `version` input)
2. Maps `runner.os`/`runner.arch` to the correct `@vertz/runtime-{os}-{arch}` npm package
3. Downloads and installs the binary to PATH
4. Verifies the installed version matches
5. Optionally restores `.pipe/cache` via `actions/cache`

## Before / After

```yaml
# BEFORE — ~20 lines repeated per workflow
- name: Install vtz runtime
  run: |
    VTZ_VERSION=$(cat version.txt | tr -d '[:space:]')
    npm pack "@vertz/runtime-linux-x64@${VTZ_VERSION}" --pack-destination /tmp
    tar -xzf "/tmp/vertz-runtime-linux-x64-${VTZ_VERSION}.tgz" -C /tmp
    cp /tmp/package/vtz packages/runtime-linux-x64/vtz
    chmod +x packages/runtime-linux-x64/vtz
    vtz --version
- name: Restore vtz ci cache
  uses: actions/cache@v4
  ...

# AFTER — one line
- uses: vertz-dev/setup-vtz@v1
```

## Changes in this PR

- [`.github/workflows/ci.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/setup-vtz-action/.github/workflows/ci.yml) — replaced install + cache steps with `setup-vtz@v1` + separate `packages/ci` build step
- [`.github/workflows/coverage.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/setup-vtz-action/.github/workflows/coverage.yml) — same migration

## Test plan

- [x] `setup-vtz` self-tests pass on ubuntu-latest (auto + pinned version) and macos-14
- [ ] CI in this PR passes with the action (validates the migration works)

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)