### PR TITLE
fix(ui,theme-shadcn): context scope preservation and dialog centering

### DIFF
--- a/.changeset/fix-dialog-centering-list-context.md
+++ b/.changeset/fix-dialog-centering-list-context.md
@@ -1,0 +1,7 @@
+---
+'@vertz/ui': patch
+'@vertz/theme-shadcn': patch
+---
+
+fix(ui): preserve context scope in useContext for effect re-runs (#2477)
+fix(theme-shadcn): center dialog wrapper with viewport sizing and flexbox (#2478)

--- a/packages/theme-shadcn/src/__tests__/styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/styles.test.ts
@@ -4,6 +4,7 @@ import { createAlertStyles } from '../styles/alert';
 import { badgeConfig, createBadge } from '../styles/badge';
 import { buttonConfig, createButton } from '../styles/button';
 import { createCard } from '../styles/card';
+import { createDialogGlobalStyles } from '../styles/dialog';
 import { createFormGroup } from '../styles/form-group';
 import { createInput } from '../styles/input';
 import { createLabel } from '../styles/label';
@@ -185,6 +186,25 @@ describe('textarea', () => {
   it('has a non-empty class name string', () => {
     expect(typeof textarea.base).toBe('string');
     expect(textarea.base.length).toBeGreaterThan(0);
+  });
+});
+
+describe('dialog global styles', () => {
+  it('dialog wrapper has centering properties for viewport coverage', () => {
+    const output = createDialogGlobalStyles();
+    const css = output.css;
+
+    // Dialog wrapper must fill the viewport
+    expect(css).toContain('width: 100vw');
+    expect(css).toContain('height: 100vh');
+
+    // Dialog wrapper must center its panel child
+    expect(css).toContain('display: flex');
+    expect(css).toContain('align-items: center');
+    expect(css).toContain('justify-content: center');
+
+    // Dialog wrapper must not have browser-default margin
+    expect(css).toMatch(/dialog\[data-dialog-wrapper\]\s*\{[^}]*margin:\s*0/);
   });
 });
 

--- a/packages/theme-shadcn/src/styles/dialog.ts
+++ b/packages/theme-shadcn/src/styles/dialog.ts
@@ -53,13 +53,12 @@ export function createDialogStyles(): CSSOutput<DialogBlocks> {
         // No fixed/z-index/inset needed — the browser handles positioning.
         '&': {
           display: 'grid',
-          width: '100%',
-          'max-width': 'calc(100% - 2rem)',
+          width: 'calc(100vw - 2rem)',
+          'max-width': 'calc(100vw - 2rem)',
           'box-shadow': '0 0 0 1px color-mix(in oklch, var(--color-foreground) 10%, transparent)',
           'border-radius': 'calc(var(--radius) * 2)',
           padding: '1rem',
           'font-size': '0.875rem',
-          margin: 'auto',
           height: 'fit-content',
           outline: 'none',
           border: 'none',
@@ -178,12 +177,22 @@ export function createDialogStyles(): CSSOutput<DialogBlocks> {
 export function createDialogGlobalStyles(): GlobalCSSOutput {
   const output = globalCss({
     // ── Dialog wrapper (native <dialog>) ──
+    // Fill the viewport and center the panel via flexbox.
+    // Without explicit sizing + centering the browser's UA dialog centering
+    // breaks because theme overrides (border: none, padding: 0) remove the
+    // constraints the UA stylesheet relies on.
     'dialog[data-dialog-wrapper]': {
       background: 'transparent',
       border: 'none',
       padding: '0',
+      width: '100vw',
+      height: '100vh',
       maxWidth: '100vw',
       maxHeight: '100vh',
+      margin: '0',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       overflow: 'visible',
     },
     'dialog[data-dialog-wrapper]::backdrop': {
@@ -202,13 +211,12 @@ export function createDialogGlobalStyles(): GlobalCSSOutput {
       position: 'relative',
       display: 'grid',
       gap: '1rem',
-      width: '100%',
-      maxWidth: 'calc(100% - 2rem)',
+      width: 'calc(100vw - 2rem)',
+      maxWidth: 'calc(100vw - 2rem)',
       boxShadow: '0 0 0 1px color-mix(in oklch, var(--color-foreground) 10%, transparent)',
       borderRadius: 'calc(var(--radius) * 2)',
       padding: '1rem',
       fontSize: '0.875rem',
-      margin: 'auto',
       height: 'fit-content',
       outline: 'none',
       containerType: 'inline-size',

--- a/packages/ui/src/component/context.ts
+++ b/packages/ui/src/component/context.ts
@@ -274,7 +274,29 @@ export function createContext<T>(defaultValue?: T, __stableId?: string): Context
 export function useContext<T>(ctx: Context<T>): UnwrapSignals<T> | undefined {
   // Synchronous path: Provider is currently on the call stack
   if (ctx._stack.length > 0) {
-    return ctx._stack[ctx._stack.length - 1] as UnwrapSignals<T>;
+    const value = ctx._stack[ctx._stack.length - 1] as UnwrapSignals<T>;
+
+    // Augment the effect's captured scope so that on re-runs (when the
+    // Provider is no longer on the call stack) the context is still found
+    // via the scope path. This fixes the case where __listValue creates
+    // its domEffect outside a Provider but the rendered output is placed
+    // inside one — the first run succeeds via _stack, and re-runs succeed
+    // via the augmented scope. See #2477.
+    //
+    // Safety: this mutates the ContextScope Map by reference. This is safe
+    // because each Provider creates a fresh Map via `new Map(parentScope)`,
+    // so child scopes are clones. The `!scope.has(key)` guard prevents
+    // overwriting an existing value (e.g., from a nested Provider for the
+    // same context). The augmented entry persists on the Map, which is the
+    // desired behavior — the effect's `_contextScope` reference is the
+    // same Map, so re-runs see the augmented value.
+    const key = asKey(ctx);
+    const scope = getContextScope();
+    if (scope && !scope.has(key)) {
+      scope.set(key, value);
+    }
+
+    return value;
   }
   // Async path: check the captured context scope
   const key = asKey(ctx);

--- a/packages/ui/src/dom/__tests__/list-value.test.ts
+++ b/packages/ui/src/dom/__tests__/list-value.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, spyOn } from '@vertz/test';
+import { createContext, useContext } from '../../component/context';
 import { signal } from '../../runtime/signal';
 import { __listValue, _resetUnkeyedListValueWarning } from '../list-value';
 
@@ -448,6 +449,123 @@ describe('__listValue', () => {
     // Adding items works
     items.value = [{ id: 1, text: 'A' }];
     expect(container.childNodes.length).toBe(3);
+  });
+
+  describe('context scope preservation', () => {
+    it('renderFn can access context when children thunk resolves inside Provider', () => {
+      // Simulates the real compiled output: the parent component wraps
+      // children in a thunk `() => __listValue(...)`, and the List component
+      // resolves this thunk inside its Provider via __insert/resolveAndInsert.
+      const TestContext = createContext<{ label: string }>();
+      const items = signal<{ id: number }[]>([]);
+
+      const contextValues: (string | undefined)[] = [];
+
+      // 1. Children thunk (what the compiler generates for parent component)
+      const childrenThunk = () =>
+        __listValue(
+          items,
+          (item) => item.id,
+          (_item) => {
+            const ctx = useContext(TestContext);
+            contextValues.push(ctx?.label);
+            const li = document.createElement('li');
+            li.textContent = ctx?.label ?? 'no-context';
+            return li;
+          },
+        );
+
+      // 2. Resolve the thunk INSIDE the Provider (simulates __insert in ComposedListRoot)
+      const container = document.createElement('div');
+      TestContext.Provider({ label: 'from-provider' }, () => {
+        const fragment = childrenThunk();
+        container.appendChild(fragment);
+      });
+
+      // 3. Trigger reactive update — items arrive after initial empty render
+      items.value = [{ id: 1 }, { id: 2 }];
+
+      // renderFn should find the context on reactive re-runs via scope
+      expect(contextValues.length).toBe(2);
+      expect(contextValues[0]).toBe('from-provider');
+      expect(contextValues[1]).toBe('from-provider');
+    });
+
+    it('renderFn preserves context across multiple reactive updates', () => {
+      const TestContext = createContext<{ label: string }>();
+      const items = signal<{ id: number }[]>([{ id: 1 }]);
+
+      const contextValues: (string | undefined)[] = [];
+
+      const childrenThunk = () =>
+        __listValue(
+          items,
+          (item) => item.id,
+          (_item) => {
+            const ctx = useContext(TestContext);
+            contextValues.push(ctx?.label);
+            const li = document.createElement('li');
+            li.textContent = ctx?.label ?? 'no-context';
+            return li;
+          },
+        );
+
+      const container = document.createElement('div');
+      TestContext.Provider({ label: 'from-provider' }, () => {
+        const fragment = childrenThunk();
+        container.appendChild(fragment);
+      });
+
+      // First render: 1 item rendered with context
+      expect(contextValues.length).toBe(1);
+      expect(contextValues[0]).toBe('from-provider');
+
+      // Second update: add new items — context must still be available
+      items.value = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      expect(contextValues.length).toBe(3);
+      expect(contextValues[1]).toBe('from-provider');
+      expect(contextValues[2]).toBe('from-provider');
+
+      // Third update: remove and add — context still works
+      items.value = [{ id: 4 }];
+      expect(contextValues.length).toBe(4);
+      expect(contextValues[3]).toBe('from-provider');
+    });
+
+    it('uses inner Provider value when same context is nested', () => {
+      const TestContext = createContext<{ label: string }>();
+      const items = signal<{ id: number }[]>([]);
+
+      const contextValues: (string | undefined)[] = [];
+
+      const childrenThunk = () =>
+        __listValue(
+          items,
+          (item) => item.id,
+          (_item) => {
+            const ctx = useContext(TestContext);
+            contextValues.push(ctx?.label);
+            const li = document.createElement('li');
+            li.textContent = ctx?.label ?? 'no-context';
+            return li;
+          },
+        );
+
+      // Nested Providers: outer provides 'outer', inner provides 'inner'
+      const container = document.createElement('div');
+      TestContext.Provider({ label: 'outer' }, () => {
+        TestContext.Provider({ label: 'inner' }, () => {
+          const fragment = childrenThunk();
+          container.appendChild(fragment);
+        });
+      });
+
+      items.value = [{ id: 1 }];
+
+      // Should see the inner Provider's value, not the outer
+      expect(contextValues.length).toBe(1);
+      expect(contextValues[0]).toBe('inner');
+    });
   });
 
   describe('index parameter', () => {


### PR DESCRIPTION
## Summary

- **fix(ui): preserve context scope in `useContext` for effect re-runs (#2477)** — When `useContext` finds a value via the synchronous `_stack` path (Provider on call stack), it now augments the current effect's captured `ContextScope` Map. On reactive re-runs (Provider no longer on call stack), the context is still found via the scope path. This fixes `List.Item` losing `ListContext` inside reactive `.map()`.

- **fix(theme-shadcn): center dialog wrapper with viewport sizing and flexbox (#2478)** — `createDialogGlobalStyles()` now sets `width: 100vw`, `height: 100vh`, `display: flex`, `align-items: center`, `justify-content: center` on `dialog[data-dialog-wrapper]`, fixing confirm dialogs rendering in the top-left corner instead of centered.

## Public API Changes

None — both fixes are internal behavior corrections with no API surface changes.

## Files Changed

- [`packages/ui/src/component/context.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-dialog-and-list-ctx/packages/ui/src/component/context.ts) — Scope augmentation in `useContext()` synchronous path
- [`packages/ui/src/dom/__tests__/list-value.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-dialog-and-list-ctx/packages/ui/src/dom/__tests__/list-value.test.ts) — 3 new context scope preservation tests
- [`packages/theme-shadcn/src/styles/dialog.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-dialog-and-list-ctx/packages/theme-shadcn/src/styles/dialog.ts) — Viewport sizing + flexbox centering on dialog wrapper
- [`packages/theme-shadcn/src/__tests__/styles.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-dialog-and-list-ctx/packages/theme-shadcn/src/__tests__/styles.test.ts) — Dialog centering assertion

## Test plan

- [x] `list-value.test.ts`: 3 new tests — empty-then-populated items, multiple reactive updates, nested Provider override
- [x] `styles.test.ts`: Dialog wrapper centering properties assertion
- [x] All 23 list-value tests pass
- [x] Typecheck clean on both `@vertz/ui` and `@vertz/theme-shadcn`
- [x] Lint/format clean
- [x] Pre-push hooks pass (lint, quality-gates, trojan-source)

Closes #2477
Closes #2478

🤖 Generated with [Claude Code](https://claude.com/claude-code)