### PR TITLE
fix(ci): fallback to latest vtz when version.txt ahead of npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve vtz version
+        id: resolve-vtz
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          if npm view "@vertz/runtime-linux-x64@${VERSION}" version &>/dev/null 2>&1; then
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            LATEST=$(npm view @vertz/runtime-linux-x64 dist-tags.latest 2>/dev/null)
+            echo "::warning::vtz ${VERSION} not yet published on npm, using ${LATEST}"
+            echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup vtz
         uses: vertz-dev/setup-vtz@v1
+        with:
+          version: ${{ steps.resolve-vtz.outputs.version }}
 
       # TODO: Switch to `vtz install --frozen` once the next vtz release
       # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
@@ -255,8 +269,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve vtz version
+        id: resolve-vtz
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          if npm view "@vertz/runtime-linux-x64@${VERSION}" version &>/dev/null 2>&1; then
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            LATEST=$(npm view @vertz/runtime-linux-x64 dist-tags.latest 2>/dev/null)
+            echo "::warning::vtz ${VERSION} not yet published on npm, using ${LATEST}"
+            echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup vtz
         uses: vertz-dev/setup-vtz@v1
+        with:
+          version: ${{ steps.resolve-vtz.outputs.version }}
 
       # TODO: Switch to `vtz install --frozen` once the next vtz release
       # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,8 +34,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve vtz version
+        id: resolve-vtz
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          if npm view "@vertz/runtime-linux-x64@${VERSION}" version &>/dev/null 2>&1; then
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            LATEST=$(npm view @vertz/runtime-linux-x64 dist-tags.latest 2>/dev/null)
+            echo "::warning::vtz ${VERSION} not yet published on npm, using ${LATEST}"
+            echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup vtz
         uses: vertz-dev/setup-vtz@v1
+        with:
+          version: ${{ steps.resolve-vtz.outputs.version }}
 
       # TODO: Switch to `vtz install --frozen` once the next vtz release
       # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve vtz version
+        id: resolve-vtz
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          if npm view "@vertz/runtime-linux-x64@${VERSION}" version &>/dev/null 2>&1; then
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            LATEST=$(npm view @vertz/runtime-linux-x64 dist-tags.latest 2>/dev/null)
+            echo "::warning::vtz ${VERSION} not yet published on npm, using ${LATEST}"
+            echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup vtz
         uses: vertz-dev/setup-vtz@v1
+        with:
+          version: ${{ steps.resolve-vtz.outputs.version }}
 
       # TODO: Switch to `vtz install --frozen` once the next vtz release
       # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).


### PR DESCRIPTION
## Summary

- All three CI workflows (CI, Release, Coverage) fail on `main` because `version.txt` was bumped to `0.2.58` by the "Version Packages" PR, but `@vertz/runtime-linux-x64@0.2.58` hasn't been published to npm yet
- Added a "Resolve vtz version" step before `setup-vtz` in all workflows that checks npm availability and falls back to the latest published version

## Root Cause

The `setup-vtz@v1` action reads `version.txt` to determine which vtz binary to download from npm. When changesets bumps `version.txt` (merge of "Version Packages" PR), the new version doesn't exist on npm yet — the release workflow that publishes it also needs `setup-vtz`, creating a chicken-and-egg failure.

## Changes

- `.github/workflows/ci.yml` — Added fallback for both `lint` and `build-test` jobs
- `.github/workflows/coverage.yml` — Added fallback for `coverage` job
- `.github/workflows/release.yml` — Added fallback for `release` job

## Test plan

- [ ] CI workflows pass on this PR (validates the fallback works for PR context)
- [ ] After merge, main CI should pass (the fallback resolves to `0.2.57` until `0.2.58` is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)