### PR TITLE
chore(ci): switch from bun install to vtz install --frozen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             ".oxfmtrc.json"
             "tsconfig.json"
             "package.json"
-            "bun.lock"
+            "vertz.lock"
             "turbo.json"
             "ci.config.ts"
             "lefthook.yml"
@@ -234,18 +234,8 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
-      # TODO: Switch to `vtz install --frozen` once the next vtz release
-      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          # Remove fallback vtz shell script so the native binary from setup-vtz is used
-          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
+        run: vtz install --frozen
 
       - name: Lint
         run: oxlint packages/
@@ -286,18 +276,8 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
-      # TODO: Switch to `vtz install --frozen` once the next vtz release
-      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          # Remove fallback vtz shell script so the native binary from setup-vtz is used
-          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
+        run: vtz install --frozen
 
       - name: Build @vertz/ci
         run: cd packages/ci && vtz run build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,18 +51,8 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
-      # TODO: Switch to `vtz install --frozen` once the next vtz release
-      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          # Remove fallback vtz shell script so the native binary from setup-vtz is used
-          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
+        run: vtz install --frozen
 
       - name: Build @vertz/ci
         run: cd packages/ci && vtz run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,18 +174,8 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
-      # TODO: Switch to `vtz install --frozen` once the next vtz release
-      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          # Remove fallback vtz shell script so the native binary from setup-vtz is used
-          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
+        run: vtz install --frozen
 
       - name: Download darwin-arm64 binary
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Replace `bun install --frozen-lockfile` with `vtz install --frozen` in ci.yml, release.yml, and coverage.yml
- Remove `oven-sh/setup-bun` from lint and build-test jobs (no longer needed)
- Remove the `rm -f node_modules/.bin/vtz` workaround (no longer needed since vtz handles the install)
- Update CI config trigger from `bun.lock` to `vertz.lock`

The scoped bin stub fix shipped in v0.2.58, so `vtz install` can now handle all dependency installs including packages with scoped bin names (e.g. `@babel/parser`).

**NAPI tests still use `bun test`** — they need Bun's module resolution for workspace packages. This is tracked separately.

## Test plan
- [ ] CI lint job passes with `vtz install --frozen`
- [ ] CI build-test job passes with `vtz install --frozen`
- [ ] NAPI tests still pass (unchanged, still uses bun test)
- [ ] Rust checks still pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)