### PR TITLE
chore(ci): update NAPI test imports from bun:test to @vertz/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,9 +399,13 @@ jobs:
         with:
           workspaces: native
 
-      # NAPI tests use bun test because they import workspace packages
-      # (@vertz/ui etc.) which require Bun's module resolution.
+      # NAPI tests use bun test because the vtz runtime doesn't support
+      # require()/createRequire() for loading .node (NAPI) binaries.
+      # TODO: Switch to vtz test once the runtime supports NAPI loading.
       - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build native compiler
         working-directory: native

--- a/native/vertz-compiler/__tests__/aot-ssr.test.ts
+++ b/native/vertz-compiler/__tests__/aot-ssr.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface AotComponentInfo {
@@ -15,10 +15,7 @@ interface AotCompileResult {
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compileForSsrAot: (
-      source: string,
-      options?: { filename?: string },
-    ) => AotCompileResult;
+    compileForSsrAot: (source: string, options?: { filename?: string }) => AotCompileResult;
   };
 }
 
@@ -55,11 +52,7 @@ const __ssr_style_object = (obj: Record<string, unknown>): string => {
 };
 
 /** Evaluate the generated AOT function by extracting and running __ssr_* functions. */
-function evalAot(
-  code: string,
-  fnName: string,
-  args: Record<string, unknown> = {},
-): string {
+function evalAot(code: string, fnName: string, args: Record<string, unknown> = {}): string {
   // Extract all __ssr_* function declarations from generated code
   const fnRegex =
     /(?:export\s+)?function\s+(__ssr_\w+)\s*\([^)]*\)\s*\{[^}]*(?:\{[^}]*\}[^}]*)*\}/g;
@@ -67,9 +60,7 @@ function evalAot(
   let match;
   while ((match = fnRegex.exec(code)) !== null) {
     // Strip export keyword and type annotations
-    let fn = match[0]
-      .replace(/^export\s+/, '')
-      .replace(/\)\s*:\s*string\s*\{/, ') {');
+    let fn = match[0].replace(/^export\s+/, '').replace(/\)\s*:\s*string\s*\{/, ') {');
     fns.push(fn);
   }
 
@@ -85,13 +76,7 @@ function evalAot(
     ...argNames,
     `${aotCode}\nreturn ${fnName};`,
   );
-  const fn = wrapper(
-    __esc,
-    __esc_attr,
-    __ssr_spread,
-    __ssr_style_object,
-    ...argValues,
-  );
+  const fn = wrapper(__esc, __esc_attr, __ssr_spread, __ssr_style_object, ...argValues);
 
   if (args.__ctx) {
     return fn(args.__data ?? {}, args.__ctx);
@@ -102,11 +87,13 @@ function evalAot(
 describe('compileForSsrAot() — native AOT SSR', () => {
   describe('Tier 1: static components', () => {
     it('Then compiles static HTML to string concatenation', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Footer() {
   return <footer class="app-footer"><p>Built with Vertz</p></footer>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__ssr_Footer');
       expect(result.components).toHaveLength(1);
@@ -115,35 +102,33 @@ function Footer() {
       expect(result.components[0]!.holes).toEqual([]);
 
       const html = evalAot(result.code, '__ssr_Footer');
-      expect(html).toBe(
-        '<footer class="app-footer"><p>Built with Vertz</p></footer>',
-      );
+      expect(html).toBe('<footer class="app-footer"><p>Built with Vertz</p></footer>');
     });
 
     it('Then handles void elements (no closing tag)', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Form() {
   return <div><input type="text" name="title" disabled /><br /><hr /></div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       const html = evalAot(result.code, '__ssr_Form');
-      expect(html).toBe(
-        '<div><input type="text" name="title" disabled><br><hr></div>',
-      );
+      expect(html).toBe('<div><input type="text" name="title" disabled><br><hr></div>');
     });
 
     it('Then handles fragments', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Badges() {
   return <><span class="open">Open</span><span class="closed">Closed</span></>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       const html = evalAot(result.code, '__ssr_Badges');
-      expect(html).toBe(
-        '<span class="open">Open</span><span class="closed">Closed</span>',
-      );
+      expect(html).toBe('<span class="open">Open</span><span class="closed">Closed</span>');
     });
 
     it('Then returns empty components for non-component files', () => {
@@ -155,11 +140,13 @@ function Badges() {
 
   describe('Tier 2: data-driven components', () => {
     it('Then escapes dynamic text content with __esc()', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Greeting({ name }: { name: string }) {
   return <h1>Hello, {name}!</h1>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__esc(');
       expect(result.components[0]!.tier).toBe('data-driven');
@@ -171,26 +158,28 @@ function Greeting({ name }: { name: string }) {
     });
 
     it('Then escapes HTML special characters in text', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Greeting({ name }: { name: string }) {
   return <span>{name}</span>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       const html = evalAot(result.code, '__ssr_Greeting', {
         __props: { name: '<script>alert("xss")</script>' },
       });
-      expect(html).toBe(
-        '<span>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</span>',
-      );
+      expect(html).toBe('<span>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</span>');
     });
 
     it('Then escapes dynamic attribute values with __esc_attr()', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Card({ id }: { id: string }) {
   return <div data-testid={id}>card</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__esc_attr(');
 
@@ -201,11 +190,13 @@ function Card({ id }: { id: string }) {
     });
 
     it('Then maps className to class attribute', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Box({ cls }: { cls: string }) {
   return <div className={cls}>content</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).not.toMatch(/__ssr_Box[^]*className/);
       const html = evalAot(result.code, '__ssr_Box', {
@@ -215,11 +206,13 @@ function Box({ cls }: { cls: string }) {
     });
 
     it('Then maps htmlFor to for attribute', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Field({ fieldId }: { fieldId: string }) {
   return <label htmlFor={fieldId}>Label</label>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).not.toMatch(/__ssr_Field[^]*htmlFor/);
       const html = evalAot(result.code, '__ssr_Field', {
@@ -229,11 +222,13 @@ function Field({ fieldId }: { fieldId: string }) {
     });
 
     it('Then strips event handlers from output', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Button({ label }: { label: string }) {
   return <button onClick={() => {}}>{label}</button>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).not.toMatch(/__ssr_Button[^]*onClick/);
       const html = evalAot(result.code, '__ssr_Button', {
@@ -245,11 +240,13 @@ function Button({ label }: { label: string }) {
 
   describe('Tier 3: conditional/dynamic components', () => {
     it('Then handles ternary conditionals with markers', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Status({ isOnline }: { isOnline: boolean }) {
   return <div>{isOnline ? <span class="on">Online</span> : <span class="off">Offline</span>}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components[0]!.tier).toBe('conditional');
 
@@ -269,11 +266,13 @@ function Status({ isOnline }: { isOnline: boolean }) {
     });
 
     it('Then handles && conditionals with markers', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Alert({ message }: { message: string | null }) {
   return <div>{message && <span class="alert">{message}</span>}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components[0]!.tier).toBe('conditional');
 
@@ -291,29 +290,31 @@ function Alert({ message }: { message: string | null }) {
     });
 
     it('Then handles list rendering with .map()', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function List({ items }: { items: string[] }) {
   return <ul>{items.map(item => <li>{item}</li>)}</ul>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components[0]!.tier).toBe('conditional');
 
       const html = evalAot(result.code, '__ssr_List', {
         __props: { items: ['A', 'B', 'C'] },
       });
-      expect(html).toBe(
-        '<ul><!--list--><li>A</li><li>B</li><li>C</li><!--/list--></ul>',
-      );
+      expect(html).toBe('<ul><!--list--><li>A</li><li>B</li><li>C</li><!--/list--></ul>');
     });
 
     it('Then handles interactive components with data-v-id and child markers', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Counter({ initial }: { initial: number }) {
   let count = initial;
   return <button>{count}</button>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('data-v-id="Counter"');
       expect(result.code).toContain('<!--child-->');
@@ -323,7 +324,8 @@ function Counter({ initial }: { initial: number }) {
 
   describe('Component calls and holes', () => {
     it('Then calls child components as __ssr_* functions', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Badge({ text }: { text: string }) {
   return <span class="badge">{text}</span>;
 }
@@ -331,7 +333,8 @@ function Badge({ text }: { text: string }) {
 function Card({ title }: { title: string }) {
   return <div class="card"><Badge text={title} /></div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__ssr_Badge(');
       const cardInfo = result.components.find((c) => c.name === 'Card');
@@ -341,11 +344,13 @@ function Card({ title }: { title: string }) {
 
   describe('Spread attributes', () => {
     it('Then handles spread attributes with __ssr_spread()', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Box({ className, ...rest }: { className: string; [key: string]: unknown }) {
   return <div className={className} {...rest}>content</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__ssr_spread(');
     });
@@ -353,11 +358,13 @@ function Box({ className, ...rest }: { className: string; [key: string]: unknown
 
   describe('Boolean attributes', () => {
     it('Then handles dynamic boolean attributes correctly', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Toggle({ isDisabled }: { isDisabled: boolean }) {
   return <button disabled={isDisabled}>Click</button>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       const htmlEnabled = evalAot(result.code, '__ssr_Toggle', {
         __props: { isDisabled: false },
@@ -373,24 +380,28 @@ function Toggle({ isDisabled }: { isDisabled: boolean }) {
 
   describe('Guard patterns', () => {
     it('Then classifies guard pattern (if-return + main return) as conditional', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Comp({ loading }: { loading: boolean }) {
   if (loading) return <div>Loading...</div>;
   return <div>Content</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components[0]!.tier).toBe('conditional');
       expect(result.code).toContain('__ssr_Comp');
     });
 
     it('Then classifies non-guard multiple returns as runtime-fallback', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Comp({ x }: { x: number }) {
   try { return <div>OK</div>; }
   catch { return <div>Error</div>; }
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components[0]!.tier).toBe('runtime-fallback');
       expect(result.code).not.toContain('__ssr_Comp');
@@ -399,12 +410,14 @@ function Comp({ x }: { x: number }) {
 
   describe('@vertz-no-aot pragma', () => {
     it('Then skips AOT compilation when pragma is present', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 // @vertz-no-aot
 function Widget({ data }: { data: string }) {
   return <div>{data}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components).toHaveLength(1);
       expect(result.components[0]!.tier).toBe('runtime-fallback');
@@ -414,25 +427,27 @@ function Widget({ data }: { data: string }) {
 
   describe('Style objects and dangerouslySetInnerHTML', () => {
     it('Then handles style objects with __ssr_style_object()', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Styled({ bg }: { bg: string }) {
   return <div style={{ backgroundColor: bg }}>content</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__ssr_style_object(');
     });
 
     it('Then handles dangerouslySetInnerHTML as raw child content', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function RawContent({ html }: { html: string }) {
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }
-      `.trim());
-
-      expect(result.code).not.toMatch(
-        /__ssr_RawContent[^]*dangerouslySetInnerHTML/,
+      `.trim(),
       );
+
+      expect(result.code).not.toMatch(/__ssr_RawContent[^]*dangerouslySetInnerHTML/);
       const output = evalAot(result.code, '__ssr_RawContent', {
         __props: { html: '<strong>bold</strong>' },
       });
@@ -442,42 +457,48 @@ function RawContent({ html }: { html: string }) {
 
   describe('Query-sourced variables', () => {
     it('Then emits queryKeys for query() variables', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 import { query } from '@vertz/ui';
 
 function ProjectsPage() {
   const projects = query(api.projects.list());
   return <div>{projects.data}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components).toHaveLength(1);
       expect(result.components[0]!.queryKeys).toEqual(['projects-list']);
     });
 
     it('Then replaces query().data with ctx.getData(key)', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 import { query } from '@vertz/ui';
 
 function ProjectsPage() {
   const projects = query(api.projects.list());
   return <div>{projects.data}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain("ctx.getData('projects-list')");
       expect(result.code).not.toMatch(/__ssr_ProjectsPage[^]*projects\.data/);
     });
 
     it('Then falls back to runtime-fallback when query() has no extractable key', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 import { query } from '@vertz/ui';
 
 function SearchPage() {
   const results = query(async () => fetchResults());
   return <div>{results.data}</div>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components).toHaveLength(1);
       expect(result.components[0]!.tier).toBe('runtime-fallback');
@@ -486,7 +507,8 @@ function SearchPage() {
 
   describe('Multiple components', () => {
     it('Then handles multiple components in one file', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Header() {
   return <header>Title</header>;
 }
@@ -494,7 +516,8 @@ function Header() {
 function Footer() {
   return <footer>Copyright</footer>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components).toHaveLength(2);
       expect(result.components[0]!.name).toBe('Header');
@@ -510,11 +533,13 @@ function Footer() {
 
   describe('Self-closing non-void elements', () => {
     it('Then renders closing tags for non-void self-closing elements', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function Empty() {
   return <div />;
 }
-      `.trim());
+      `.trim(),
+      );
 
       const html = evalAot(result.code, '__ssr_Empty');
       expect(html).toBe('<div></div>');
@@ -523,7 +548,8 @@ function Empty() {
 
   describe('.map() with closure variables (#1936)', () => {
     it('Then falls back to __esc() when block body has variable declarations', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function CardList({ listings, sellerMap }: { listings: any[]; sellerMap: Map<string, any> }) {
   return (
     <div>
@@ -538,7 +564,8 @@ function CardList({ listings, sellerMap }: { listings: any[]; sellerMap: Map<str
     </div>
   );
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.components).toHaveLength(1);
       expect(result.code).toContain('__esc(');
@@ -547,27 +574,32 @@ function CardList({ listings, sellerMap }: { listings: any[]; sellerMap: Map<str
     });
 
     it('Then still optimizes simple .map() with expression body', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function List({ items }: { items: string[] }) {
   return <ul>{items.map(item => <li>{item}</li>)}</ul>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('<!--list-->');
     });
 
     it('Then still optimizes .map() with block body containing only return', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function List({ items }: { items: string[] }) {
   return <ul>{items.map((item) => { return <li>{item}</li>; })}</ul>;
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('<!--list-->');
     });
 
     it('Then falls back for any non-return statement in block body', () => {
-      const result = compileAot(`
+      const result = compileAot(
+        `
 function ListWithLog({ items }: { items: string[] }) {
   return (
     <ul>
@@ -578,7 +610,8 @@ function ListWithLog({ items }: { items: string[] }) {
     </ul>
   );
 }
-      `.trim());
+      `.trim(),
+      );
 
       expect(result.code).toContain('__esc(');
       expect(result.code).not.toMatch(/__ssr_ListWithLog[^]*<!--list-->/);

--- a/native/vertz-compiler/__tests__/body-jsx-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/body-jsx-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -26,9 +26,7 @@ describe('Feature: Body JSX diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('jsx-outside-tree'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('jsx-outside-tree'));
         expect(diag).toBeDefined();
         expect(diag!.line).toBe(2);
       });

--- a/native/vertz-compiler/__tests__/component-analysis.test.ts
+++ b/native/vertz-compiler/__tests__/component-analysis.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -37,9 +37,7 @@ describe('Feature: Component detection in native compiler', () => {
         expect(result.components!.length).toBe(1);
         expect(result.components![0].name).toBe('TaskCard');
         expect(result.components![0].bodyStart).toBeGreaterThan(0);
-        expect(result.components![0].bodyEnd).toBeGreaterThan(
-          result.components![0].bodyStart,
-        );
+        expect(result.components![0].bodyEnd).toBeGreaterThan(result.components![0].bodyStart);
       });
     });
   });
@@ -62,10 +60,9 @@ describe('Feature: Component detection in native compiler', () => {
     describe('When analyzed', () => {
       it('Then detects the component', () => {
         const { compile } = loadCompiler();
-        const result = compile(
-          'const TaskCard = () => { return <div />; };',
-          { filename: 'test.tsx' },
-        );
+        const result = compile('const TaskCard = () => { return <div />; };', {
+          filename: 'test.tsx',
+        });
         expect(result.components).toBeDefined();
         expect(result.components!.length).toBe(1);
         expect(result.components![0].name).toBe('TaskCard');
@@ -77,10 +74,9 @@ describe('Feature: Component detection in native compiler', () => {
     describe('When analyzed', () => {
       it('Then detects the component', () => {
         const { compile } = loadCompiler();
-        const result = compile(
-          'const Panel = function() { return <div />; };',
-          { filename: 'test.tsx' },
-        );
+        const result = compile('const Panel = function() { return <div />; };', {
+          filename: 'test.tsx',
+        });
         expect(result.components).toBeDefined();
         expect(result.components!.length).toBe(1);
         expect(result.components![0].name).toBe('Panel');
@@ -122,8 +118,7 @@ describe('Feature: Component detection in native compiler', () => {
     describe('When analyzed', () => {
       it('Then detects the exported component', () => {
         const { compile } = loadCompiler();
-        const source =
-          'export function TaskCard() { return <div />; }';
+        const source = 'export function TaskCard() { return <div />; }';
         const result = compile(source, { filename: 'test.tsx' });
         expect(result.components).toBeDefined();
         expect(result.components!.length).toBe(1);
@@ -136,8 +131,7 @@ describe('Feature: Component detection in native compiler', () => {
     describe('When analyzed', () => {
       it('Then detects the exported const component', () => {
         const { compile } = loadCompiler();
-        const source =
-          'export const TaskCard = () => <div />;';
+        const source = 'export const TaskCard = () => <div />;';
         const result = compile(source, { filename: 'test.tsx' });
         expect(result.components).toBeDefined();
         expect(result.components!.length).toBe(1);
@@ -150,8 +144,7 @@ describe('Feature: Component detection in native compiler', () => {
     describe('When analyzed', () => {
       it('Then detects the default exported component', () => {
         const { compile } = loadCompiler();
-        const source =
-          'export default function App() { return <div />; }';
+        const source = 'export default function App() { return <div />; }';
         const result = compile(source, { filename: 'test.tsx' });
         expect(result.components).toBeDefined();
         expect(result.components!.length).toBe(1);

--- a/native/vertz-compiler/__tests__/computed-transform.test.ts
+++ b/native/vertz-compiler/__tests__/computed-transform.test.ts
@@ -1,12 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compile: (
-      source: string,
-      options?: { filename?: string },
-    ) => { code: string };
+    compile: (source: string, options?: { filename?: string }) => { code: string };
   };
 }
 

--- a/native/vertz-compiler/__tests__/context-stable-ids.test.ts
+++ b/native/vertz-compiler/__tests__/context-stable-ids.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -19,7 +19,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled with fastRefresh enabled', () => {
       it('Then injects undefined and stable ID string', () => {
         const { compile } = loadCompiler();
-        const source = "const Ctx = createContext<string>();";
+        const source = 'const Ctx = createContext<string>();';
         const result = compile(source, { filename: 'src/ctx.tsx', fastRefresh: true });
         // TS type parameter <string> is stripped; only the JS args remain
         expect(result.code).toContain("createContext(undefined, 'src/ctx.tsx::Ctx')");
@@ -31,7 +31,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled with fastRefresh enabled', () => {
       it('Then appends stable ID after existing argument', () => {
         const { compile } = loadCompiler();
-        const source = "const Settings = createContext<Config>(defaultConfig);";
+        const source = 'const Settings = createContext<Config>(defaultConfig);';
         const result = compile(source, { filename: 'src/settings.tsx', fastRefresh: true });
         expect(result.code).toContain(", 'src/settings.tsx::Settings'");
       });
@@ -43,8 +43,8 @@ describe('Feature: Context stable ID injection', () => {
       it('Then injects stable IDs for all of them', () => {
         const { compile } = loadCompiler();
         const source = [
-          "const ThemeCtx = createContext<Theme>();",
-          "const AuthCtx = createContext<Auth>();",
+          'const ThemeCtx = createContext<Theme>();',
+          'const AuthCtx = createContext<Auth>();',
         ].join('\n');
         const result = compile(source, { filename: 'src/app.tsx', fastRefresh: true });
         expect(result.code).toContain("'src/app.tsx::ThemeCtx'");
@@ -57,7 +57,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled WITHOUT fastRefresh', () => {
       it('Then does NOT inject stable IDs', () => {
         const { compile } = loadCompiler();
-        const source = "const Ctx = createContext<string>();";
+        const source = 'const Ctx = createContext<string>();';
         const result = compile(source, { filename: 'src/ctx.tsx' });
         expect(result.code).not.toContain('::Ctx');
       });
@@ -68,7 +68,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled with fastRefresh enabled', () => {
       it('Then does not modify the call', () => {
         const { compile } = loadCompiler();
-        const source = "const data = fetchData();";
+        const source = 'const data = fetchData();';
         const result = compile(source, { filename: 'src/data.tsx', fastRefresh: true });
         expect(result.code).not.toContain('::');
         expect(result.code).toContain('fetchData()');
@@ -95,7 +95,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled with fastRefresh enabled', () => {
       it('Then injects stable ID for export const pattern', () => {
         const { compile } = loadCompiler();
-        const source = "export const RouterCtx = createContext<Router>();";
+        const source = 'export const RouterCtx = createContext<Router>();';
         const result = compile(source, { filename: 'src/router.tsx', fastRefresh: true });
         expect(result.code).toContain("'src/router.tsx::RouterCtx'");
       });
@@ -106,7 +106,7 @@ describe('Feature: Context stable ID injection', () => {
     describe('When compiled with fastRefresh enabled', () => {
       it('Then also injects stable ID (matches TS behavior)', () => {
         const { compile } = loadCompiler();
-        const source = "let Ctx = createContext<string>();";
+        const source = 'let Ctx = createContext<string>();';
         const result = compile(source, { filename: 'src/ctx.tsx', fastRefresh: true });
         expect(result.code).toContain("'src/ctx.tsx::Ctx'");
       });

--- a/native/vertz-compiler/__tests__/cross-file-manifest.test.ts
+++ b/native/vertz-compiler/__tests__/cross-file-manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/css-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/css-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -27,9 +27,7 @@ describe('Feature: CSS diagnostics', () => {
   return <div class={styles.container}>Hello</div>;
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
-        const cssDiags = (result.diagnostics ?? []).filter((d) =>
-          d.message.includes('css-'),
-        );
+        const cssDiags = (result.diagnostics ?? []).filter((d) => d.message.includes('css-'));
         expect(cssDiags.length).toBe(0);
       });
     });
@@ -47,9 +45,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('css-unknown-property'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('css-unknown-property'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('xyz');
       });
@@ -68,9 +64,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('css-invalid-spacing'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('css-invalid-spacing'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('99');
       });
@@ -89,9 +83,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('css-unknown-color-token'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('css-unknown-color-token'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('nonexistent');
       });
@@ -110,9 +102,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('css-malformed-shorthand'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('css-malformed-shorthand'));
         expect(diag).toBeDefined();
       });
     });
@@ -126,9 +116,7 @@ describe('Feature: CSS diagnostics', () => {
   return <div>Hello</div>;
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
-        const cssDiags = (result.diagnostics ?? []).filter((d) =>
-          d.message.includes('css-'),
-        );
+        const cssDiags = (result.diagnostics ?? []).filter((d) => d.message.includes('css-'));
         expect(cssDiags.length).toBe(0);
       });
     });
@@ -145,9 +133,7 @@ describe('Feature: CSS diagnostics', () => {
   return <div class={styles.btn}>Hello</div>;
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
-        const cssDiags = (result.diagnostics ?? []).filter((d) =>
-          d.message.includes('css-'),
-        );
+        const cssDiags = (result.diagnostics ?? []).filter((d) => d.message.includes('css-'));
         expect(cssDiags.length).toBe(0);
       });
     });
@@ -165,9 +151,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const cssDiags = result.diagnostics!.filter((d) =>
-          d.message.includes('css-'),
-        );
+        const cssDiags = result.diagnostics!.filter((d) => d.message.includes('css-'));
         expect(cssDiags.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -185,9 +169,7 @@ describe('Feature: CSS diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('css-unknown-color-token'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('css-unknown-color-token'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('fakecolor');
       });

--- a/native/vertz-compiler/__tests__/css-transform.test.ts
+++ b/native/vertz-compiler/__tests__/css-transform.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/fast-refresh.test.ts
+++ b/native/vertz-compiler/__tests__/fast-refresh.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -104,8 +104,12 @@ describe('Feature: Fast Refresh registration', () => {
         const result1 = compile(source1, { filename: 'src/App.tsx', fastRefresh: true });
         const result2 = compile(source2, { filename: 'src/App.tsx', fastRefresh: true });
         // Extract the hash from __$refreshReg calls
-        const hash1 = result1.code.match(/__\$refreshReg\(__\$moduleId, 'App', App, '([^']+)'\)/)?.[1];
-        const hash2 = result2.code.match(/__\$refreshReg\(__\$moduleId, 'App', App, '([^']+)'\)/)?.[1];
+        const hash1 = result1.code.match(
+          /__\$refreshReg\(__\$moduleId, 'App', App, '([^']+)'\)/,
+        )?.[1];
+        const hash2 = result2.code.match(
+          /__\$refreshReg\(__\$moduleId, 'App', App, '([^']+)'\)/,
+        )?.[1];
         expect(hash1).toBeDefined();
         expect(hash2).toBeDefined();
         expect(hash1).not.toBe(hash2);

--- a/native/vertz-compiler/__tests__/field-selection.test.ts
+++ b/native/vertz-compiler/__tests__/field-selection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface NestedFieldAccess {

--- a/native/vertz-compiler/__tests__/hydration-markers.test.ts
+++ b/native/vertz-compiler/__tests__/hydration-markers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/import-injection.test.ts
+++ b/native/vertz-compiler/__tests__/import-injection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -77,7 +77,7 @@ describe('Feature: Import injection', () => {
         const { compile } = loadCompiler();
         const source = 'const x = 1; export default x;';
         const result = compile(source, { filename: 'src/utils.ts' });
-        expect(result.code).not.toContain("import {");
+        expect(result.code).not.toContain('import {');
       });
     });
   });
@@ -92,7 +92,9 @@ describe('Feature: Import injection', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         // Extract the internals import
-        const internalsMatch = result.code.match(/import \{ ([^}]+) \} from '@vertz\/ui\/internals'/);
+        const internalsMatch = result.code.match(
+          /import \{ ([^}]+) \} from '@vertz\/ui\/internals'/,
+        );
         expect(internalsMatch).toBeTruthy();
         const imports = internalsMatch![1].split(', ');
         const sorted = [...imports].sort();
@@ -168,8 +170,8 @@ describe('Feature: Import injection', () => {
         const result = compile(source, { filename: 'src/App.tsx' });
         const lines = result.code.split('\n');
         // After the "// compiled by vertz-native" line, imports should come first
-        const importLineIndex = lines.findIndex(l => l.startsWith('import'));
-        const functionLineIndex = lines.findIndex(l => l.includes('function App'));
+        const importLineIndex = lines.findIndex((l) => l.startsWith('import'));
+        const functionLineIndex = lines.findIndex((l) => l.includes('function App'));
         expect(importLineIndex).toBeLessThan(functionLineIndex);
       });
     });

--- a/native/vertz-compiler/__tests__/jsx-transform.test.ts
+++ b/native/vertz-compiler/__tests__/jsx-transform.test.ts
@@ -1,12 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compile: (
-      source: string,
-      options?: { filename?: string },
-    ) => { code: string };
+    compile: (source: string, options?: { filename?: string }) => { code: string };
   };
 }
 
@@ -20,9 +17,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a simple HTML element', () => {
     describe('When compiled', () => {
       it('Then produces __element() call', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div></div>;\n}`);
         expect(code).toContain('__element("div")');
         expect(code).not.toContain('<div>');
       });
@@ -32,9 +27,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a self-closing HTML element', () => {
     describe('When compiled', () => {
       it('Then produces __element() call', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input />;\n}`);
         expect(code).toContain('__element("input")');
         expect(code).not.toContain('<input');
       });
@@ -44,9 +37,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an element with static string attribute', () => {
     describe('When compiled', () => {
       it('Then sets attribute with setAttribute', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div title="hello"></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div title="hello"></div>;\n}`);
         expect(code).toContain('__element("div")');
         expect(code).toContain('.setAttribute("title", "hello")');
       });
@@ -67,9 +58,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an element with static text child', () => {
     describe('When compiled', () => {
       it('Then uses __staticText', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div>hello world</div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div>hello world</div>;\n}`);
         expect(code).toContain('__staticText("hello world")');
       });
     });
@@ -90,9 +79,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an element with static expression child', () => {
     describe('When compiled', () => {
       it('Then uses __insert (no effect overhead)', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div>{"hello"}</div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div>{"hello"}</div>;\n}`);
         expect(code).toContain('__insert(');
         expect(code).not.toContain('__child(');
       });
@@ -143,9 +130,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a component call (PascalCase)', () => {
     describe('When compiled', () => {
       it('Then calls the component as a function with props object', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <Button label="hi" />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <Button label="hi" />;\n}`);
         expect(code).toContain('Button(');
         expect(code).toContain('label: "hi"');
         expect(code).not.toContain('<Button');
@@ -240,9 +225,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a boolean shorthand attribute', () => {
     describe('When compiled', () => {
       it('Then sets attribute with empty string', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input disabled />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input disabled />;\n}`);
         expect(code).toContain('.setAttribute("disabled", "")');
       });
     });
@@ -251,9 +234,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an element with spread attributes', () => {
     describe('When compiled', () => {
       it('Then uses __spread', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div {...props}></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div {...props}></div>;\n}`);
         expect(code).toContain('__spread(');
       });
     });
@@ -283,9 +264,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a ref attribute', () => {
     describe('When compiled', () => {
       it('Then assigns .current on the element variable', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input ref={myRef} />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input ref={myRef} />;\n}`);
         expect(code).toContain('myRef.current');
       });
     });
@@ -318,9 +297,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a self-closing element with no attributes', () => {
     describe('When compiled', () => {
       it('Then produces a simple __element call with no children', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <br />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <br />;\n}`);
         expect(code).toContain('__element("br")');
         expect(code).not.toContain('__enterChildren');
         expect(code).not.toContain('__exitChildren');
@@ -331,9 +308,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an empty element (no children)', () => {
     describe('When compiled', () => {
       it('Then omits __enterChildren/__exitChildren', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div></div>;\n}`);
         expect(code).toContain('__element("div")');
         expect(code).not.toContain('__enterChildren');
         expect(code).not.toContain('__exitChildren');
@@ -356,9 +331,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a component with boolean shorthand prop', () => {
     describe('When compiled', () => {
       it('Then passes true as the prop value', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <Button disabled />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <Button disabled />;\n}`);
         expect(code).toContain('Button(');
         expect(code).toContain('disabled: true');
       });
@@ -475,9 +448,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a literal expression attribute', () => {
     describe('When compiled', () => {
       it('Then uses guarded setAttribute (guards null/false/true)', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div tabIndex={0}></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div tabIndex={0}></div>;\n}`);
         expect(code).toContain('const __v = 0');
         expect(code).toContain('.setAttribute("tabIndex"');
       });
@@ -489,9 +460,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an input with IDL value attribute (static)', () => {
     describe('When compiled', () => {
       it('Then uses direct property assignment instead of setAttribute', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input value={someVar} />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input value={someVar} />;\n}`);
         expect(code).toContain('.value = __v');
         expect(code).not.toContain('.setAttribute("value"');
       });
@@ -501,9 +470,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given an input with IDL checked attribute (boolean shorthand)', () => {
     describe('When compiled', () => {
       it('Then uses direct property assignment with true', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input checked />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input checked />;\n}`);
         expect(code).toContain('.checked = true');
         expect(code).not.toContain('.setAttribute("checked"');
       });
@@ -695,9 +662,7 @@ describe('Feature: JSX element transform', () => {
   describe('Given a non-IDL boolean shorthand on non-input element', () => {
     describe('When compiled', () => {
       it('Then uses setAttribute (not property assignment)', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <button disabled />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <button disabled />;\n}`);
         expect(code).toContain('.setAttribute("disabled", "")');
       });
     });
@@ -1060,9 +1025,7 @@ describe('Feature: .map() callback with block body preserves pre-return code', (
   describe('Given an input with static debounce attribute', () => {
     describe('When compiled', () => {
       it('Then renames to data-vertz-debounce', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <input debounce={300} />;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <input debounce={300} />;\n}`);
         expect(code).toContain('"data-vertz-debounce"');
         expect(code).not.toContain('"debounce"');
       });
@@ -1109,9 +1072,7 @@ describe('Feature: .map() callback with block body preserves pre-return code', (
   describe('Given a div with debounce attribute', () => {
     describe('When compiled', () => {
       it('Then passes through as regular attribute (no rename)', () => {
-        const code = compileAndGetCode(
-          `function App() {\n  return <div debounce={300}></div>;\n}`,
-        );
+        const code = compileAndGetCode(`function App() {\n  return <div debounce={300}></div>;\n}`);
         expect(code).toContain('"debounce"');
         expect(code).not.toContain('"data-vertz-debounce"');
       });
@@ -1198,7 +1159,9 @@ describe('Feature: .map() callback with block body preserves pre-return code', (
           `function App() {\n  return <form onChange={handleChange}></form>;\n}`,
         );
         expect(code).toContain('__formOnChange');
-        expect(code).toMatch(/import\s*\{[^}]*__formOnChange[^}]*\}\s*from\s*['"]@vertz\/ui\/internals['"]/);
+        expect(code).toMatch(
+          /import\s*\{[^}]*__formOnChange[^}]*\}\s*from\s*['"]@vertz\/ui\/internals['"]/,
+        );
       });
     });
   });

--- a/native/vertz-compiler/__tests__/load-compiler.ts
+++ b/native/vertz-compiler/__tests__/load-compiler.ts
@@ -6,8 +6,4 @@ function resolveBinaryName(): string {
   return `vertz-compiler.${platform}-${arch}.node`;
 }
 
-export const NATIVE_MODULE_PATH = join(
-  import.meta.dir,
-  '..',
-  resolveBinaryName(),
-);
+export const NATIVE_MODULE_PATH = join(import.meta.dir, '..', resolveBinaryName());

--- a/native/vertz-compiler/__tests__/mount-frame.test.ts
+++ b/native/vertz-compiler/__tests__/mount-frame.test.ts
@@ -1,12 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compile: (
-      source: string,
-      options?: { filename?: string },
-    ) => { code: string };
+    compile: (source: string, options?: { filename?: string }) => { code: string };
   };
 }
 
@@ -20,9 +17,7 @@ describe('Feature: Mount frame transform', () => {
   describe('Given a component with a single return statement', () => {
     describe('When compiled', () => {
       it('Then wraps body with __pushMountFrame / try-catch / __flushMountFrame', () => {
-        const code = compileAndGetCode(
-          `function MyComponent() {\n  return <div>Hello</div>;\n}`,
-        );
+        const code = compileAndGetCode(`function MyComponent() {\n  return <div>Hello</div>;\n}`);
         expect(code).toContain('__pushMountFrame()');
         expect(code).toContain('__flushMountFrame()');
         expect(code).toContain('__discardMountFrame(__mfDepth)');
@@ -31,9 +26,7 @@ describe('Feature: Mount frame transform', () => {
       });
 
       it('Then generates __mfDepth = __pushMountFrame() and __discardMountFrame(__mfDepth)', () => {
-        const code = compileAndGetCode(
-          `function MyComponent() {\n  return <div>Hello</div>;\n}`,
-        );
+        const code = compileAndGetCode(`function MyComponent() {\n  return <div>Hello</div>;\n}`);
         expect(code).toContain('const __mfDepth = __pushMountFrame()');
         expect(code).toContain('__discardMountFrame(__mfDepth)');
       });
@@ -87,9 +80,7 @@ describe('Feature: Mount frame transform', () => {
   describe('Given an arrow component with expression body', () => {
     describe('When compiled', () => {
       it('Then converts to block body with mount frame wrapping', () => {
-        const code = compileAndGetCode(
-          `const MyComponent = () => <div>Hello</div>;`,
-        );
+        const code = compileAndGetCode(`const MyComponent = () => <div>Hello</div>;`);
         expect(code).toContain('__pushMountFrame()');
         expect(code).toContain('__flushMountFrame()');
       });
@@ -99,9 +90,7 @@ describe('Feature: Mount frame transform', () => {
   describe('Given a component that does NOT use onMount', () => {
     describe('When compiled', () => {
       it('Then still injects mount frame (unconditional)', () => {
-        const code = compileAndGetCode(
-          `function MyComponent() {\n  return <div>Hello</div>;\n}`,
-        );
+        const code = compileAndGetCode(`function MyComponent() {\n  return <div>Hello</div>;\n}`);
         expect(code).toContain('__pushMountFrame()');
         expect(code).toContain('__flushMountFrame()');
       });

--- a/native/vertz-compiler/__tests__/mutation-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/mutation-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -27,9 +27,7 @@ describe('Feature: Mutation diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('non-reactive-mutation'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('non-reactive-mutation'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('push');
         expect(diag!.message).toContain('items');
@@ -101,9 +99,7 @@ describe('Feature: Mutation diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('non-reactive-mutation'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('non-reactive-mutation'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('obj');
       });
@@ -121,9 +117,7 @@ describe('Feature: Mutation diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('non-reactive-mutation'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('non-reactive-mutation'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('sort');
       });

--- a/native/vertz-compiler/__tests__/mutation-transform.test.ts
+++ b/native/vertz-compiler/__tests__/mutation-transform.test.ts
@@ -1,12 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compile: (
-      source: string,
-      options?: { filename?: string },
-    ) => { code: string };
+    compile: (source: string, options?: { filename?: string }) => { code: string };
   };
 }
 

--- a/native/vertz-compiler/__tests__/native-compiler.test.ts
+++ b/native/vertz-compiler/__tests__/native-compiler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -6,7 +6,11 @@ function loadCompiler() {
     compile: (
       source: string,
       options?: { filename?: string },
-    ) => { code: string; map?: string; diagnostics?: Array<{ message: string; line?: number; column?: number }> };
+    ) => {
+      code: string;
+      map?: string;
+      diagnostics?: Array<{ message: string; line?: number; column?: number }>;
+    };
   };
 }
 

--- a/native/vertz-compiler/__tests__/parity/parity-1911.test.ts
+++ b/native/vertz-compiler/__tests__/parity/parity-1911.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from '../load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/prefetch-manifest.test.ts
+++ b/native/vertz-compiler/__tests__/prefetch-manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface ExtractedRoute {

--- a/native/vertz-compiler/__tests__/props-destructuring.test.ts
+++ b/native/vertz-compiler/__tests__/props-destructuring.test.ts
@@ -1,12 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
   return require(NATIVE_MODULE_PATH) as {
-    compile: (
-      source: string,
-      options?: { filename?: string },
-    ) => { code: string };
+    compile: (source: string, options?: { filename?: string }) => { code: string };
   };
 }
 

--- a/native/vertz-compiler/__tests__/query-auto-thunk.test.ts
+++ b/native/vertz-compiler/__tests__/query-auto-thunk.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/reactivity-analysis.test.ts
+++ b/native/vertz-compiler/__tests__/reactivity-analysis.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 interface VariableInfo {
@@ -110,15 +110,9 @@ describe('Feature: Reactivity classification', () => {
           }
         `;
         const result = compile(source, { filename: 'test.tsx' });
-        expect(findVar(result.components, 'Counter', 'count')!.kind).toBe(
-          'signal',
-        );
-        expect(findVar(result.components, 'Counter', 'doubled')!.kind).toBe(
-          'computed',
-        );
-        expect(findVar(result.components, 'Counter', 'label')!.kind).toBe(
-          'computed',
-        );
+        expect(findVar(result.components, 'Counter', 'count')!.kind).toBe('signal');
+        expect(findVar(result.components, 'Counter', 'doubled')!.kind).toBe('computed');
+        expect(findVar(result.components, 'Counter', 'label')!.kind).toBe('computed');
       });
     });
   });
@@ -221,11 +215,7 @@ describe('Feature: Reactivity classification', () => {
           }
         `;
         const result = compile(source, { filename: 'test.tsx' });
-        const errorMsgVar = findVar(
-          result.components,
-          'TaskList',
-          'errorMsg',
-        );
+        const errorMsgVar = findVar(result.components, 'TaskList', 'errorMsg');
         expect(errorMsgVar).toBeDefined();
         expect(errorMsgVar!.kind).toBe('computed');
       });
@@ -263,12 +253,8 @@ describe('Feature: Reactivity classification', () => {
           }
         `;
         const result = compile(source, { filename: 'test.tsx' });
-        expect(findVar(result.components, 'App', 'visible')!.kind).toBe(
-          'signal',
-        );
-        expect(
-          findVar(result.components, 'App', 'internalCounter')!.kind,
-        ).toBe('static');
+        expect(findVar(result.components, 'App', 'visible')!.kind).toBe('signal');
+        expect(findVar(result.components, 'App', 'internalCounter')!.kind).toBe('static');
       });
     });
   });
@@ -286,12 +272,8 @@ describe('Feature: Reactivity classification', () => {
           }
         `;
         const result = compile(source, { filename: 'test.tsx' });
-        expect(findVar(result.components, 'App', 'temp')!.kind).toBe(
-          'static',
-        );
-        expect(findVar(result.components, 'App', 'derived')!.kind).toBe(
-          'static',
-        );
+        expect(findVar(result.components, 'App', 'temp')!.kind).toBe('static');
+        expect(findVar(result.components, 'App', 'derived')!.kind).toBe('static');
       });
     });
   });
@@ -309,13 +291,9 @@ describe('Feature: Reactivity classification', () => {
         `;
         const result = compile(source, { filename: 'test.tsx' });
         // temp is transitively JSX-reachable (through derived) → signal
-        expect(findVar(result.components, 'App', 'temp')!.kind).toBe(
-          'signal',
-        );
+        expect(findVar(result.components, 'App', 'temp')!.kind).toBe('signal');
         // derived depends on a signal → computed
-        expect(findVar(result.components, 'App', 'derived')!.kind).toBe(
-          'computed',
-        );
+        expect(findVar(result.components, 'App', 'derived')!.kind).toBe('computed');
       });
     });
   });

--- a/native/vertz-compiler/__tests__/route-splitting.test.ts
+++ b/native/vertz-compiler/__tests__/route-splitting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/signal-transform.test.ts
+++ b/native/vertz-compiler/__tests__/signal-transform.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {

--- a/native/vertz-compiler/__tests__/ssr-safety-diagnostics.test.ts
+++ b/native/vertz-compiler/__tests__/ssr-safety-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -27,9 +27,7 @@ describe('Feature: SSR safety diagnostics', () => {
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
         expect(result.diagnostics!.length).toBeGreaterThanOrEqual(1);
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('localStorage'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('localStorage'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('ssr-unsafe-api');
         expect(diag!.line).toBe(2);
@@ -102,9 +100,7 @@ describe('Feature: SSR safety diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const diag = result.diagnostics!.find((d) =>
-          d.message.includes('document.querySelector'),
-        );
+        const diag = result.diagnostics!.find((d) => d.message.includes('document.querySelector'));
         expect(diag).toBeDefined();
         expect(diag!.message).toContain('ssr-unsafe-api');
         expect(diag!.line).toBe(2);
@@ -142,16 +138,10 @@ describe('Feature: SSR safety diagnostics', () => {
 }`;
         const result = compile(source, { filename: 'src/App.tsx' });
         expect(result.diagnostics).toBeDefined();
-        const ssrDiags = result.diagnostics!.filter((d) =>
-          d.message.includes('ssr-unsafe-api'),
-        );
+        const ssrDiags = result.diagnostics!.filter((d) => d.message.includes('ssr-unsafe-api'));
         expect(ssrDiags.length).toBeGreaterThanOrEqual(2);
-        expect(ssrDiags.some((d) => d.message.includes('localStorage'))).toBe(
-          true,
-        );
-        expect(ssrDiags.some((d) => d.message.includes('navigator'))).toBe(
-          true,
-        );
+        expect(ssrDiags.some((d) => d.message.includes('localStorage'))).toBe(true);
+        expect(ssrDiags.some((d) => d.message.includes('navigator'))).toBe(true);
       });
     });
   });

--- a/native/vertz-compiler/__tests__/typescript-strip.test.ts
+++ b/native/vertz-compiler/__tests__/typescript-strip.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from '@vertz/test';
 import { NATIVE_MODULE_PATH } from './load-compiler';
 
 function loadCompiler() {
@@ -85,7 +85,7 @@ describe('Feature: TypeScript syntax stripping', () => {
           }
         `);
 
-        expect(code).not.toContain("type Status");
+        expect(code).not.toContain('type Status');
         expect(code).not.toContain("'active' | 'inactive'");
       });
     });
@@ -153,7 +153,7 @@ describe('Feature: TypeScript syntax stripping', () => {
           }
         `);
 
-        expect(code).not.toContain("import type");
+        expect(code).not.toContain('import type');
         expect(code).not.toContain("from 'react'");
       });
     });

--- a/native/vertz-compiler/package.json
+++ b/native/vertz-compiler/package.json
@@ -16,5 +16,7 @@
     "test": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/*.test.ts || echo 'Skipping native tests (binary not found)'",
     "test:parity": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/parity/ || echo 'Skipping parity tests'"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@vertz/test": "workspace:*"
+  }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -17,6 +17,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }


### PR DESCRIPTION
## Summary

Closes #2495

- Replace `bun:test` imports with `@vertz/test` in all 26 NAPI binding test files
- Add `@vertz/test` as devDependency to `@vertz/native-compiler`
- Add `bun install --frozen-lockfile` step to NAPI CI job (needed for workspace resolution)
- Add `"bun"` export condition to `@vertz/test` for source resolution without build
- Auto-format test files with oxfmt

### Blockers for full migration (tracked separately)

Switching the test runner from `bun test` to `vtz test` is blocked by:
1. vtz runtime doesn't support `require()`/`createRequire()` for `.node` NAPI binaries
2. `vtz install` fails on darwin-arm64 (bin-stub bug in v0.2.57)

## Public API Changes

None — CI/test infrastructure only.

## Test plan

- [x] NAPI CI job passes with `@vertz/test` imports
- [x] All 26 test files use `@vertz/test` imports
- [x] Rust Checks pass
- [x] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)