### PR TITLE
fix(ci): revert to bun install until vtz bin-stub fix ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
             ".oxfmtrc.json"
             "tsconfig.json"
             "package.json"
+            "bun.lock"
             "vertz.lock"
             "turbo.json"
             "ci.config.ts"
@@ -237,8 +238,18 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
+      # TODO: Switch to `vtz install --frozen` once the next vtz release
+      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: Install dependencies
-        run: vtz install --frozen
+        run: |
+          bun install --frozen-lockfile
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          # Remove fallback vtz shell script so the native binary from setup-vtz is used
+          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
 
       - name: Lint
         run: oxlint packages/
@@ -279,8 +290,18 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
+      # TODO: Switch to `vtz install --frozen` once the next vtz release
+      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: Install dependencies
-        run: vtz install --frozen
+        run: |
+          bun install --frozen-lockfile
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          # Remove fallback vtz shell script so the native binary from setup-vtz is used
+          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
 
       - name: Build @vertz/ci
         run: cd packages/ci && vtz run build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,8 +51,18 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
+      # TODO: Switch to `vtz install --frozen` once the next vtz release
+      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: Install dependencies
-        run: vtz install --frozen
+        run: |
+          bun install --frozen-lockfile
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          # Remove fallback vtz shell script so the native binary from setup-vtz is used
+          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
 
       - name: Build @vertz/ci
         run: cd packages/ci && vtz run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,8 +174,18 @@ jobs:
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
 
+      # TODO: Switch to `vtz install --frozen` once the next vtz release
+      # ships with the scoped-bin-stub fix (native/vtz/src/pm/bin.rs).
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: Install dependencies
-        run: vtz install --frozen
+        run: |
+          bun install --frozen-lockfile
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          # Remove fallback vtz shell script so the native binary from setup-vtz is used
+          rm -f node_modules/.bin/vtz node_modules/.bin/vertz
 
       - name: Download darwin-arm64 binary
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the remaining CI failure after #2501. The `setup-vtz` version mismatch is resolved, but `vtz install --frozen` (v0.2.57) doesn't create bin stubs for scoped packages or hoist them to root `node_modules/.bin`, causing `oxlint`, `bunup`, `turbo`, etc. to be missing from PATH.

**Changes:**
- Restored `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile` in all 3 workflows
- Restored explicit `GITHUB_PATH` setup for `node_modules/.bin`
- Restored removal of vtz/vertz shell stubs so the native binary from setup-vtz is used
- Added `bun.lock` back to CI change detection config patterns
- TODO comments mark when we can switch to `vtz install`: after the scoped-bin-stub fix in `native/vtz/src/pm/bin.rs` ships

This effectively reverts the install portion of #2494 while keeping the rest of the `bun→vtz` migration intact.

## Test plan

- [ ] CI workflow passes (lint finds oxlint, build finds bunup/turbo)
- [ ] Coverage workflow passes
- [ ] After merge, all workflows green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)