### PR TITLE
chore(test): migrate remaining bun:test imports to @vertz/test

### DIFF
--- a/packages/desktop/src/__tests__/app.test-d.ts
+++ b/packages/desktop/src/__tests__/app.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { app } from '../index.js';
 import type { DesktopError } from '../types.js';

--- a/packages/desktop/src/__tests__/clipboard.test-d.ts
+++ b/packages/desktop/src/__tests__/clipboard.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { clipboard } from '../index.js';
 import type { DesktopError } from '../types.js';

--- a/packages/desktop/src/__tests__/dialog.test-d.ts
+++ b/packages/desktop/src/__tests__/dialog.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { dialog } from '../index.js';
 import type { DesktopError } from '../types.js';

--- a/packages/desktop/src/__tests__/fs.test-d.ts
+++ b/packages/desktop/src/__tests__/fs.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { fs } from '../index.js';
 import type { DesktopError, DirEntry, FileStat } from '../types.js';

--- a/packages/desktop/src/__tests__/permissions.test-d.ts
+++ b/packages/desktop/src/__tests__/permissions.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type {
   DesktopPermissionConfig,
   IpcCapabilityGroup,

--- a/packages/desktop/src/__tests__/shell.test-d.ts
+++ b/packages/desktop/src/__tests__/shell.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { shell } from '../index.js';
 import type { DesktopError, ShellOutput } from '../types.js';

--- a/packages/desktop/src/__tests__/window.test-d.ts
+++ b/packages/desktop/src/__tests__/window.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'bun:test';
+import { describe, expectTypeOf, it } from '@vertz/test';
 import type { Result } from '@vertz/errors';
 import { appWindow } from '../index.js';
 import type { DesktopError, WindowSize } from '../types.js';

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -167,7 +167,30 @@ export interface Vi {
   importActual: (specifier: string) => Promise<unknown>;
 }
 
-export type ExpectTypeOf = <T = unknown>() => unknown;
+export interface ExpectTypeOfMatchers<Actual> {
+  toEqualTypeOf<Expected>(...args: [Expected] | []): void;
+  toMatchTypeOf<Expected>(...args: [Expected] | []): void;
+  toBeAny(): void;
+  toBeUnknown(): void;
+  toBeNever(): void;
+  toBeFunction(): void;
+  toBeObject(): void;
+  toBeArray(): void;
+  toBeNumber(): void;
+  toBeString(): void;
+  toBeBoolean(): void;
+  toBeVoid(): void;
+  toBeSymbol(): void;
+  toBeNull(): void;
+  toBeUndefined(): void;
+  toBeNullable(): void;
+  not: ExpectTypeOfMatchers<Actual>;
+}
+
+export interface ExpectTypeOf {
+  <Actual>(actual: Actual): ExpectTypeOfMatchers<Actual>;
+  <Actual>(): ExpectTypeOfMatchers<Actual>;
+}
 
 // ---------------------------------------------------------------------------
 // Runtime resolution: Bun re-export or stubs
@@ -277,7 +300,8 @@ const mock: Mock = _runtime?.mock ?? stubMock;
 const spyOn: SpyOn =
   _runtime?.spyOn ?? ((_obj: object, _method: string | symbol): MockFunction => stub());
 const vi: Vi = _runtime?.jest ?? _runtime?.vi ?? stubVi;
-const expectTypeOf: ExpectTypeOf = _runtime?.expectTypeOf ?? (<_T = unknown>(): unknown => stub());
+const expectTypeOf: ExpectTypeOf =
+  _runtime?.expectTypeOf ?? (<_T = unknown>(_actual?: _T): ExpectTypeOfMatchers<_T> => stub());
 
 export {
   afterAll,


### PR DESCRIPTION
## Summary

- Migrate all 7 remaining `bun:test` imports in `packages/desktop/src/__tests__/*.test-d.ts` to `@vertz/test`
- Expand `ExpectTypeOf` type in `@vertz/test` from opaque `<T>() => unknown` to a proper interface with `toEqualTypeOf`, `toMatchTypeOf`, and other assertion methods

## Public API Changes

- `ExpectTypeOf` type in `@vertz/test` now returns `ExpectTypeOfMatchers<Actual>` instead of `unknown`, enabling proper type checking for type-level tests

## Test plan

- [x] No `bun:test` imports remain in any `.ts`/`.tsx` file
- [x] `@vertz/desktop` typecheck passes
- [x] `@vertz/test` typecheck passes
- [x] Lint and format clean

Closes #2499

🤖 Generated with [Claude Code](https://claude.com/claude-code)