### PR TITLE
chore: replace bun:sqlite with @vertz/sqlite (#2496)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -137,6 +137,9 @@
     "native/vertz-compiler": {
       "name": "@vertz/native-compiler",
       "version": "0.1.1",
+      "devDependencies": {
+        "@vertz/test": "workspace:*",
+      },
     },
     "packages/agents": {
       "name": "@vertz/agents",
@@ -144,6 +147,7 @@
       "dependencies": {
         "@vertz/errors": "workspace:^",
         "@vertz/schema": "workspace:^",
+        "@vertz/sqlite": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^25.3.1",
@@ -173,7 +177,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -184,6 +188,7 @@
         "@vertz/db": "workspace:^",
         "@vertz/docs": "workspace:^",
         "@vertz/errors": "workspace:^",
+        "@vertz/sqlite": "workspace:*",
         "@vertz/tui": "workspace:^",
         "@vertz/ui-server": "workspace:^",
         "commander": "^14.0.0",
@@ -205,7 +210,7 @@
     },
     "packages/cli-runtime": {
       "name": "@vertz/cli-runtime",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -218,7 +223,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -237,7 +242,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -251,7 +256,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -284,7 +289,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -298,7 +303,7 @@
     },
     "packages/create-vertz": {
       "name": "create-vertz",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "bin": {
         "create-vertz": "./bin/create-vertz.ts",
       },
@@ -308,7 +313,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -324,11 +329,12 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
         "@vertz/schema": "workspace:^",
+        "@vertz/sqlite": "workspace:*",
         "nanoid": "^5.1.5",
         "uuid": "^13.0.0",
       },
@@ -355,7 +361,7 @@
     },
     "packages/desktop": {
       "name": "@vertz/desktop",
-      "version": "0.2.56",
+      "version": "0.2.57",
       "dependencies": {
         "@vertz/errors": "workspace:*",
       },
@@ -396,7 +402,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
@@ -407,7 +413,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -420,7 +426,7 @@
     },
     "packages/icons": {
       "name": "@vertz/icons",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
         "@vertz/test": "workspace:*",
@@ -444,6 +450,7 @@
         "@vertz/fetch": "workspace:^",
         "@vertz/schema": "workspace:^",
         "@vertz/server": "workspace:^",
+        "@vertz/sqlite": "workspace:*",
         "@vertz/test": "workspace:*",
         "@vertz/theme-shadcn": "workspace:^",
         "@vertz/ui": "workspace:^",
@@ -545,7 +552,7 @@
     },
     "packages/runtime": {
       "name": "@vertz/runtime",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "bin": {
         "vertz": "./cli.sh",
         "vtz": "./cli.sh",
@@ -556,31 +563,31 @@
         "@vertz/test": "workspace:*",
       },
       "optionalDependencies": {
-        "@vertz/runtime-darwin-arm64": "0.2.57",
-        "@vertz/runtime-darwin-x64": "0.2.57",
-        "@vertz/runtime-linux-arm64": "0.2.57",
-        "@vertz/runtime-linux-x64": "0.2.57",
+        "@vertz/runtime-darwin-arm64": "0.2.58",
+        "@vertz/runtime-darwin-x64": "0.2.58",
+        "@vertz/runtime-linux-arm64": "0.2.58",
+        "@vertz/runtime-linux-x64": "0.2.58",
       },
     },
     "packages/runtime-darwin-arm64": {
       "name": "@vertz/runtime-darwin-arm64",
-      "version": "0.2.57",
+      "version": "0.2.58",
     },
     "packages/runtime-darwin-x64": {
       "name": "@vertz/runtime-darwin-x64",
-      "version": "0.2.57",
+      "version": "0.2.58",
     },
     "packages/runtime-linux-arm64": {
       "name": "@vertz/runtime-linux-arm64",
-      "version": "0.2.57",
+      "version": "0.2.58",
     },
     "packages/runtime-linux-x64": {
       "name": "@vertz/runtime-linux-x64",
-      "version": "0.2.57",
+      "version": "0.2.58",
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -594,7 +601,7 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -605,6 +612,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.3.1",
+        "@vertz/sqlite": "workspace:*",
         "@vertz/test": "workspace:*",
         "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
@@ -619,9 +627,18 @@
         "@vertz/docs": "workspace:^",
       },
     },
+    "packages/sqlite": {
+      "name": "@vertz/sqlite",
+      "version": "0.2.58",
+      "devDependencies": {
+        "@types/node": "^25.3.1",
+        "bunup": "^0.16.31",
+        "typescript": "^5.7.0",
+      },
+    },
     "packages/test": {
       "name": "@vertz/test",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "devDependencies": {
         "@types/node": "^25.3.1",
         "bun-types": "^1.3.10",
@@ -631,7 +648,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -648,7 +665,7 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/ui": "workspace:^",
         "@vertz/ui-primitives": "workspace:^",
@@ -664,7 +681,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -678,7 +695,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -709,7 +726,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -727,7 +744,7 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
         "@vertz/ui": "workspace:^",
@@ -743,7 +760,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@capsizecss/unpack": "^4.0.0",
@@ -776,7 +793,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
         "@vertz/cli": "workspace:^",
         "@vertz/cloudflare": "workspace:^",
@@ -1902,6 +1919,8 @@
     "@vertz/server": ["@vertz/server@workspace:packages/server"],
 
     "@vertz/site": ["@vertz/site@workspace:packages/site"],
+
+    "@vertz/sqlite": ["@vertz/sqlite@workspace:packages/sqlite"],
 
     "@vertz/test": ["@vertz/test@workspace:packages/test"],
 
@@ -3075,6 +3094,8 @@
 
     "@vertz/agents/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "@vertz/cli/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@vertz/cli/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@vertz/codegen/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
@@ -3085,19 +3106,27 @@
 
     "@vertz/core/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "@vertz/create-vertz-app/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@vertz/db/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/dev-orchestrator/oxlint": ["oxlint@1.59.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.59.0", "@oxlint/binding-android-arm64": "1.59.0", "@oxlint/binding-darwin-arm64": "1.59.0", "@oxlint/binding-darwin-x64": "1.59.0", "@oxlint/binding-freebsd-x64": "1.59.0", "@oxlint/binding-linux-arm-gnueabihf": "1.59.0", "@oxlint/binding-linux-arm-musleabihf": "1.59.0", "@oxlint/binding-linux-arm64-gnu": "1.59.0", "@oxlint/binding-linux-arm64-musl": "1.59.0", "@oxlint/binding-linux-ppc64-gnu": "1.59.0", "@oxlint/binding-linux-riscv64-gnu": "1.59.0", "@oxlint/binding-linux-riscv64-musl": "1.59.0", "@oxlint/binding-linux-s390x-gnu": "1.59.0", "@oxlint/binding-linux-x64-gnu": "1.59.0", "@oxlint/binding-linux-x64-musl": "1.59.0", "@oxlint/binding-openharmony-arm64": "1.59.0", "@oxlint/binding-win32-arm64-msvc": "1.59.0", "@oxlint/binding-win32-ia32-msvc": "1.59.0", "@oxlint/binding-win32-x64-msvc": "1.59.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-0xBLeGGjP4vD9pygRo8iuOkOzEU1MqOnfiOl7KYezL/QvWL8NUg6n03zXc7ZVqltiOpUxBk2zgHI3PnRIEdAvw=="],
 
+    "@vertz/docs/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@vertz/errors/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/icons/lucide-static": ["lucide-static@0.575.0", "", {}, "sha512-XbHfIufz9ZDW6iLjUphffUmcEWg6gLjufIQOb6heDjYZCRk+ePRbkp8Ax/Rq3Ek4OkT8tyBO/gTCOPDvFMuC4w=="],
+
+    "@vertz/integration-tests/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/landing/wrangler": ["wrangler@4.81.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260405.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260405.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260405.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-9fLPDuDcb8Nu6iXrl5E3HGYt3TVhQr/UvqtTvWr9Nl1X7PlQrmWMwQCfSioqN8VHYyQCyESV5jQsoKg8Sx+sEA=="],
 
     "@vertz/landing-nextjs/wrangler": ["wrangler@4.72.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260310.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260310.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260310.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg=="],
 
     "@vertz/landing-nextjs-vercel/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+
+    "@vertz/mdx/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/runtime/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -3106,6 +3135,10 @@
     "@vertz/server/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/test/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@vertz/testing/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@vertz/tui/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/ui-server/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 

--- a/ci.config.ts
+++ b/ci.config.ts
@@ -23,6 +23,7 @@ const CI_PACKAGES = [
   '@vertz/openapi',
   '@vertz/schema',
   '@vertz/server',
+  '@vertz/sqlite',
   '@vertz/test',
   '@vertz/testing',
   '@vertz/theme-shadcn',

--- a/examples/entity-todo/src/api/db-d1.ts
+++ b/examples/entity-todo/src/api/db-d1.ts
@@ -3,7 +3,7 @@
  *
  * Uses createDb from @vertz/db with Cloudflare D1 binding.
  * This is used in the Cloudflare Worker (worker.ts).
- * For local development with bun:sqlite, see db.ts instead.
+ * For local development with @vertz/sqlite, see db.ts instead.
  */
 
 import type { D1Database } from '@vertz/db';

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6237,7 +6237,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "napi",
  "napi-build",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6269,7 +6269,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -929,7 +929,8 @@ export default { describe, it, test, expect, beforeEach, afterEach, beforeAll, a
 /// URL used for the synthetic test module.
 const VERTZ_TEST_SPECIFIER: &str = "vertz:test";
 
-/// Synthetic module for `vertz:sqlite` (canonical) and `bun:sqlite` (compat alias).
+/// Synthetic module for `vertz:sqlite` (canonical), `@vertz/sqlite` (npm package),
+/// and `bun:sqlite` (compat alias).
 const VERTZ_SQLITE_SPECIFIER: &str = "vertz:sqlite";
 const VERTZ_SQLITE_MODULE: &str = r#"
 const _registry = new FinalizationRegistry((id) => {
@@ -976,6 +977,21 @@ class Database {
   run(sql, ...params) {
     this.#assertOpen();
     return Deno.core.ops.op_sqlite_query_run(this.#id, sql, params);
+  }
+  transaction(fn) {
+    this.#assertOpen();
+    const self = this;
+    return function transactionWrapper() {
+      self.exec('BEGIN');
+      try {
+        const result = fn();
+        self.exec('COMMIT');
+        return result;
+      } catch (e) {
+        self.exec('ROLLBACK');
+        throw e;
+      }
+    };
   }
   close() {
     if (this.#closed) return;
@@ -1781,8 +1797,10 @@ impl ModuleLoader for VertzModuleLoader {
             return Ok(ModuleSpecifier::parse(VERTZ_TEST_SPECIFIER)?);
         }
 
-        // Intercept vertz:sqlite (canonical) and bun:sqlite (compat) → synthetic SQLite module
-        if specifier == "vertz:sqlite" || specifier == "bun:sqlite" {
+        // Intercept vertz:sqlite (canonical), @vertz/sqlite (npm), and bun:sqlite (compat)
+        // → synthetic SQLite module
+        if specifier == "vertz:sqlite" || specifier == "@vertz/sqlite" || specifier == "bun:sqlite"
+        {
             return Ok(ModuleSpecifier::parse(VERTZ_SQLITE_SPECIFIER)?);
         }
 

--- a/native/vtz/tests/fixtures/sqlite-test/package-import-test.js
+++ b/native/vtz/tests/fixtures/sqlite-test/package-import-test.js
@@ -1,0 +1,19 @@
+// Test the @vertz/sqlite npm package import (intercepted by runtime)
+import { Database, Statement } from '@vertz/sqlite';
+
+const db = new Database(':memory:');
+db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+db.run('INSERT INTO t (id, v) VALUES (?, ?)', 1, 'works');
+
+const rows = db.prepare('SELECT * FROM t').all();
+if (rows.length !== 1 || rows[0].v !== 'works') {
+  throw new Error(`@vertz/sqlite import failed: ${JSON.stringify(rows)}`);
+}
+
+// Verify Statement is exported
+if (typeof Statement !== 'function') {
+  throw new Error('Statement is not exported as a function');
+}
+
+db.close();
+console.log('@vertz/sqlite package import test passed');

--- a/native/vtz/tests/fixtures/sqlite-test/transaction-test.js
+++ b/native/vtz/tests/fixtures/sqlite-test/transaction-test.js
@@ -1,0 +1,60 @@
+// Test db.transaction() — commit on success, rollback on error
+import { Database } from '@vertz/sqlite';
+
+const db = new Database(':memory:');
+db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');
+
+// Test 1: Successful transaction commits
+const insertTwo = db.transaction(() => {
+  db.run('INSERT INTO t (id, name) VALUES (?, ?)', 1, 'Alice');
+  db.run('INSERT INTO t (id, name) VALUES (?, ?)', 2, 'Bob');
+});
+insertTwo();
+
+let rows = db.prepare('SELECT * FROM t ORDER BY id').all();
+if (rows.length !== 2) {
+  throw new Error(`Expected 2 rows after commit, got ${rows.length}`);
+}
+if (rows[0].name !== 'Alice' || rows[1].name !== 'Bob') {
+  throw new Error(`Wrong data: ${JSON.stringify(rows)}`);
+}
+console.log('transaction commit test passed');
+
+// Test 2: Failing transaction rolls back
+const failingTx = db.transaction(() => {
+  db.run('INSERT INTO t (id, name) VALUES (?, ?)', 3, 'Carol');
+  throw new Error('deliberate failure');
+});
+
+try {
+  failingTx();
+  throw new Error('Should have thrown');
+} catch (e) {
+  if (e.message !== 'deliberate failure') {
+    throw new Error(`Wrong error: ${e.message}`);
+  }
+}
+
+rows = db.prepare('SELECT * FROM t ORDER BY id').all();
+if (rows.length !== 2) {
+  throw new Error(`Expected 2 rows after rollback, got ${rows.length}`);
+}
+console.log('transaction rollback test passed');
+
+// Test 3: Transaction returns callback result
+db.exec('CREATE TABLE counter (n INTEGER)');
+db.run('INSERT INTO counter (n) VALUES (?)', 0);
+
+const getCount = db.transaction(() => {
+  db.run('UPDATE counter SET n = n + 1');
+  return db.prepare('SELECT n FROM counter').get().n;
+});
+
+const result = getCount();
+if (result !== 1) {
+  throw new Error(`Expected return value 1, got ${result}`);
+}
+console.log('transaction return value test passed');
+
+db.close();
+console.log('all transaction tests passed');

--- a/native/vtz/tests/sqlite_integration.rs
+++ b/native/vtz/tests/sqlite_integration.rs
@@ -101,7 +101,7 @@ async fn test_bun_sqlite_file_based_db() {
     assert!(db_path.exists(), "SQLite file should exist on disk");
 }
 
-/// Module resolution: vertz:sqlite is canonical, bun:sqlite is compat alias
+/// Module resolution: vertz:sqlite is canonical, @vertz/sqlite is npm, bun:sqlite is compat
 #[test]
 fn test_sqlite_module_resolution() {
     use deno_core::{ModuleLoader, ResolutionKind};
@@ -115,6 +115,11 @@ fn test_sqlite_module_resolution() {
     // Canonical: vertz:sqlite
     let result = loader.resolve("vertz:sqlite", "file:///test.js", ResolutionKind::Import);
     assert!(result.is_ok(), "vertz:sqlite should resolve");
+    assert_eq!(result.unwrap().as_str(), "vertz:sqlite");
+
+    // NPM package: @vertz/sqlite
+    let result = loader.resolve("@vertz/sqlite", "file:///test.js", ResolutionKind::Import);
+    assert!(result.is_ok(), "@vertz/sqlite should resolve");
     assert_eq!(result.unwrap().as_str(), "vertz:sqlite");
 
     // Compat alias: bun:sqlite
@@ -142,6 +147,55 @@ async fn test_vertz_sqlite_canonical_import() {
         output.stdout,
         output.stderr
     );
+}
+
+/// `@vertz/sqlite` npm package import resolves to synthetic module
+#[tokio::test]
+async fn test_vertz_sqlite_package_import() {
+    let mut rt = create_runtime();
+    let entry = fixtures_dir().join("package-import-test.js");
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert!(
+        output
+            .stdout
+            .iter()
+            .any(|s| s.contains("@vertz/sqlite package import test passed")),
+        "@vertz/sqlite import test did not pass. stdout: {:?}, stderr: {:?}",
+        output.stdout,
+        output.stderr
+    );
+}
+
+/// db.transaction() �� commit on success, rollback on error, return values
+#[tokio::test]
+async fn test_sqlite_transaction() {
+    let mut rt = create_runtime();
+    let entry = fixtures_dir().join("transaction-test.js");
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    let expected_messages = [
+        "transaction commit test passed",
+        "transaction rollback test passed",
+        "transaction return value test passed",
+        "all transaction tests passed",
+    ];
+
+    for msg in &expected_messages {
+        assert!(
+            output.stdout.iter().any(|s| s.contains(msg)),
+            "Missing '{}'. stdout: {:?}, stderr: {:?}",
+            msg,
+            output.stdout,
+            output.stderr
+        );
+    }
 }
 
 /// Phase 3: @vertz/db integration patterns — queryFn bridge, transactions,

--- a/packages/agents/bunup.config.ts
+++ b/packages/agents/bunup.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
   format: ['esm'],
   dts: { inferTypes: true },
   clean: true,
+  external: ['@vertz/sqlite'],
 });

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@vertz/errors": "workspace:^",
-    "@vertz/schema": "workspace:^"
+    "@vertz/schema": "workspace:^",
+    "@vertz/sqlite": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.3.1",

--- a/packages/agents/src/stores/d1-store.test.ts
+++ b/packages/agents/src/stores/d1-store.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { describe, expect, it } from '@vertz/test';
 import type { Message } from '../loop/react-loop';
 import { d1Store } from './d1-store';
@@ -6,11 +6,11 @@ import type { D1Binding } from './d1-store';
 import type { AgentSession } from './types';
 
 // ---------------------------------------------------------------------------
-// Mock D1 binding using bun:sqlite
+// Mock D1 binding using @vertz/sqlite
 // ---------------------------------------------------------------------------
 
 /**
- * Creates a mock D1 binding backed by bun:sqlite in-memory.
+ * Creates a mock D1 binding backed by @vertz/sqlite in-memory.
  * This mimics the D1 API surface used by d1Store.
  */
 function mockD1Binding(): D1Binding {

--- a/packages/agents/src/stores/sqlite-store.ts
+++ b/packages/agents/src/stores/sqlite-store.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import type { Message } from '../loop/react-loop';
 import type { AgentSession, AgentStore, ListSessionsFilter } from './types';
 
@@ -99,7 +99,7 @@ function rowToMessage(row: MessageRow): Message {
 
 /**
  * SQLite-backed store for agent sessions and messages.
- * Uses bun:sqlite for persistence. Supports both file-based and :memory: databases.
+ * Uses @vertz/sqlite for persistence. Supports both file-based and :memory: databases.
  */
 export function sqliteStore(options: SqliteStoreOptions): AgentStore {
   const db = new Database(options.path);

--- a/packages/cli/bunup.config.ts
+++ b/packages/cli/bunup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig([
     external: [
       '@vertz/compiler',
       '@vertz/tui',
-      'bun:sqlite',
+      '@vertz/sqlite',
       'commander',
       'esbuild',
       'jiti',
@@ -24,7 +24,7 @@ export default defineConfig([
     external: [
       '@vertz/compiler',
       '@vertz/tui',
-      'bun:sqlite',
+      '@vertz/sqlite',
       'commander',
       'esbuild',
       'jiti',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@vertz/db": "workspace:^",
     "@vertz/docs": "workspace:^",
     "@vertz/errors": "workspace:^",
+    "@vertz/sqlite": "workspace:*",
     "@vertz/tui": "workspace:^",
     "@vertz/ui-server": "workspace:^",
     "commander": "^14.0.0",

--- a/packages/cli/src/commands/__tests__/load-db-context.test.ts
+++ b/packages/cli/src/commands/__tests__/load-db-context.test.ts
@@ -610,7 +610,7 @@ export const db = {
 });
 
 // ---------------------------------------------------------------------------
-// createConnection — sqlite (bun:sqlite is available in bun test)
+// createConnection — sqlite (@vertz/sqlite is available in vtz test)
 // ---------------------------------------------------------------------------
 
 describe('createConnection', () => {

--- a/packages/cli/src/commands/load-db-context.ts
+++ b/packages/cli/src/commands/load-db-context.ts
@@ -40,7 +40,7 @@ export interface DbConfig {
 
 const DEFAULT_SQLITE_PATH = './app.db';
 
-/** Adapter contract for bun:sqlite Database (runtime-only module). */
+/** Adapter contract for @vertz/sqlite Database (runtime-only module). */
 interface SqliteDatabase {
   prepare: (sql: string) => { all: (...params: unknown[]) => unknown[] };
   close: () => void;
@@ -239,12 +239,12 @@ export async function createConnection(config: DbConfig): Promise<DbConnection> 
     const dbPath = parseSqliteUrl(config.url);
     let db: SqliteDatabase;
     try {
-      const { Database } = await import('bun:sqlite');
+      const { Database } = await import('@vertz/sqlite');
       db = new Database(dbPath) as SqliteDatabase;
     } catch (err) {
       throw new Error(
-        'Failed to load bun:sqlite. The vertz CLI requires the Bun runtime for SQLite support.\n' +
-          'Run your command with: bun vertz db <command>',
+        'Failed to load @vertz/sqlite. The vertz CLI requires the vtz runtime for SQLite support.\n' +
+          'Run your command with: vtz vertz db <command>',
         { cause: err },
       );
     }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -58,6 +58,7 @@
     "@paralleldrive/cuid2": "^3.3.0",
     "@vertz/errors": "workspace:^",
     "@vertz/schema": "workspace:^",
+    "@vertz/sqlite": "workspace:*",
     "nanoid": "^5.1.5",
     "uuid": "^13.0.0"
   },

--- a/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
+++ b/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
@@ -161,21 +161,21 @@ describe('createLocalSqliteDriver', () => {
 // ---------------------------------------------------------------------------
 
 describe('resolveLocalSqliteDatabase', () => {
-  describe('Given both bun:sqlite and better-sqlite3 are unavailable', () => {
+  describe('Given both @vertz/sqlite and better-sqlite3 are unavailable', () => {
     describe('When resolving the database', () => {
       it('Then throws an error mentioning both backends and the db path', async () => {
-        const bunError = new Error('bun:sqlite not available');
+        const bunError = new Error('@vertz/sqlite not available');
         const betterError = new Error('Could not locate the bindings file');
 
         const failingImport = (_mod: string) => {
-          throw _mod === 'bun:sqlite' ? bunError : betterError;
+          throw _mod === '@vertz/sqlite' ? bunError : betterError;
         };
 
         await expect(resolveLocalSqliteDatabase(':memory:', failingImport)).rejects.toThrow(
           /Failed to initialize SQLite/,
         );
         await expect(resolveLocalSqliteDatabase(':memory:', failingImport)).rejects.toThrow(
-          /bun:sqlite/,
+          /@vertz/sqlite/,
         );
         await expect(resolveLocalSqliteDatabase(':memory:', failingImport)).rejects.toThrow(
           /better-sqlite3/,
@@ -194,15 +194,15 @@ describe('resolveLocalSqliteDatabase', () => {
     });
   });
 
-  describe('Given bun:sqlite succeeds', () => {
+  describe('Given @vertz/sqlite succeeds', () => {
     describe('When resolving the database', () => {
-      it('Then returns the database from bun:sqlite', async () => {
+      it('Then returns the database from @vertz/sqlite', async () => {
         const mockDb = { prepare: () => {}, exec: () => {}, close: () => {} };
         function MockDatabase() {
           return mockDb;
         }
         const mockImport = (mod: string) => {
-          if (mod === 'bun:sqlite') return { Database: MockDatabase };
+          if (mod === '@vertz/sqlite') return { Database: MockDatabase };
           throw new Error('should not reach better-sqlite3');
         };
 
@@ -212,7 +212,7 @@ describe('resolveLocalSqliteDatabase', () => {
     });
   });
 
-  describe('Given bun:sqlite fails but better-sqlite3 succeeds', () => {
+  describe('Given @vertz/sqlite fails but better-sqlite3 succeeds', () => {
     describe('When resolving the database', () => {
       it('Then returns the database from better-sqlite3', async () => {
         const mockDb = { prepare: () => {}, exec: () => {}, close: () => {} };
@@ -220,7 +220,7 @@ describe('resolveLocalSqliteDatabase', () => {
           return mockDb;
         }
         const mockImport = (mod: string) => {
-          if (mod === 'bun:sqlite') throw new Error('not available');
+          if (mod === '@vertz/sqlite') throw new Error('not available');
           return { default: MockDatabase };
         };
 

--- a/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
+++ b/packages/db/src/client/__tests__/local-sqlite-driver.test.ts
@@ -175,7 +175,7 @@ describe('resolveLocalSqliteDatabase', () => {
           /Failed to initialize SQLite/,
         );
         await expect(resolveLocalSqliteDatabase(':memory:', failingImport)).rejects.toThrow(
-          /@vertz/sqlite/,
+          /@vertz\/sqlite/,
         );
         await expect(resolveLocalSqliteDatabase(':memory:', failingImport)).rejects.toThrow(
           /better-sqlite3/,

--- a/packages/db/src/client/__tests__/transaction.test.ts
+++ b/packages/db/src/client/__tests__/transaction.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { describe, expect, it } from '@vertz/test';
 import { d } from '../../d';
 import { sql } from '../../sql/tagged';

--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -182,7 +182,7 @@ export function createSqliteDriver(
 }
 
 // ---------------------------------------------------------------------------
-// Local SQLite database interface (bun:sqlite / better-sqlite3)
+// Local SQLite database interface (@vertz/sqlite / better-sqlite3)
 // ---------------------------------------------------------------------------
 
 interface LocalSqliteDatabase {
@@ -195,13 +195,13 @@ interface LocalSqliteDatabase {
 }
 
 // ---------------------------------------------------------------------------
-// resolveLocalSqliteDatabase — resolve bun:sqlite or better-sqlite3
+// resolveLocalSqliteDatabase — resolve @vertz/sqlite or better-sqlite3
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a local SQLite database using bun:sqlite or better-sqlite3.
+ * Resolve a local SQLite database using @vertz/sqlite or better-sqlite3.
  *
- * Tries bun:sqlite first (Bun/Vertz runtime), then falls back to better-sqlite3 (Node.js).
+ * Tries @vertz/sqlite first (vtz/Bun runtime), then falls back to better-sqlite3 (Node.js).
  * If both fail, throws a descriptive error with both failure reasons.
  *
  * @param dbPath - Path to SQLite file, or ':memory:' for in-memory
@@ -218,14 +218,14 @@ export async function resolveLocalSqliteDatabase(
   const loadModule = importFn ?? ((mod: string) => import(mod));
 
   try {
-    // Try bun:sqlite first (Bun/Vertz runtime)
-    const mod = (await loadModule('bun:sqlite')) as {
+    // Try @vertz/sqlite first (vtz/Bun runtime)
+    const mod = (await loadModule('@vertz/sqlite')) as {
       Database: new (path: string) => LocalSqliteDatabase;
       default?: { Database: new (path: string) => LocalSqliteDatabase };
     };
     // Handle ESM interop: import() may return { default: { Database } } or { Database }
     const Database = mod.Database ?? mod.default?.Database;
-    if (!Database) throw new Error('bun:sqlite module has no Database export');
+    if (!Database) throw new Error('@vertz/sqlite module has no Database export');
     return new Database(dbPath);
   } catch (e) {
     bunSqliteError = e;
@@ -247,7 +247,7 @@ export async function resolveLocalSqliteDatabase(
 
     throw new Error(
       `Failed to initialize SQLite database at "${dbPath}".\n` +
-        `  bun:sqlite error: ${bunMsg}\n` +
+        `  @vertz/sqlite error: ${bunMsg}\n` +
         `  better-sqlite3 error: ${betterMsg}\n\n` +
         'To fix this, either:\n' +
         '  1. Run your script with vtz (e.g. vtz run <script> or vtz dev) — the Vertz\n' +
@@ -258,11 +258,11 @@ export async function resolveLocalSqliteDatabase(
 }
 
 // ---------------------------------------------------------------------------
-// createLocalSqliteDriver — factory for bun:sqlite / better-sqlite3
+// createLocalSqliteDriver — factory for @vertz/sqlite / better-sqlite3
 // ---------------------------------------------------------------------------
 
 /**
- * Create a SQLite driver from a local file path using bun:sqlite or better-sqlite3.
+ * Create a SQLite driver from a local file path using @vertz/sqlite or better-sqlite3.
  *
  * @param dbPath - Path to SQLite file, or ':memory:' for in-memory
  * @param tableSchema - Optional table schema registry for value conversion

--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -212,7 +212,7 @@ export async function resolveLocalSqliteDatabase(
   dbPath: string,
   importFn?: (mod: string) => unknown,
 ): Promise<LocalSqliteDatabase> {
-  let bunSqliteError: unknown;
+  let sqliteError: unknown;
 
   // Use provided import function (for testing) or dynamic import
   const loadModule = importFn ?? ((mod: string) => import(mod));
@@ -228,7 +228,7 @@ export async function resolveLocalSqliteDatabase(
     if (!Database) throw new Error('@vertz/sqlite module has no Database export');
     return new Database(dbPath);
   } catch (e) {
-    bunSqliteError = e;
+    sqliteError = e;
   }
 
   try {
@@ -240,14 +240,14 @@ export async function resolveLocalSqliteDatabase(
     ) => LocalSqliteDatabase;
     return new Database(dbPath);
   } catch (betterSqliteError) {
-    const bunMsg =
-      bunSqliteError instanceof Error ? bunSqliteError.message : String(bunSqliteError);
+    const sqliteMsg =
+      sqliteError instanceof Error ? sqliteError.message : String(sqliteError);
     const betterMsg =
       betterSqliteError instanceof Error ? betterSqliteError.message : String(betterSqliteError);
 
     throw new Error(
       `Failed to initialize SQLite database at "${dbPath}".\n` +
-        `  @vertz/sqlite error: ${bunMsg}\n` +
+        `  @vertz/sqlite error: ${sqliteMsg}\n` +
         `  better-sqlite3 error: ${betterMsg}\n\n` +
         'To fix this, either:\n' +
         '  1. Run your script with vtz (e.g. vtz run <script> or vtz dev) — the Vertz\n' +

--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -240,8 +240,7 @@ export async function resolveLocalSqliteDatabase(
     ) => LocalSqliteDatabase;
     return new Database(dbPath);
   } catch (betterSqliteError) {
-    const sqliteMsg =
-      sqliteError instanceof Error ? sqliteError.message : String(sqliteError);
+    const sqliteMsg = sqliteError instanceof Error ? sqliteError.message : String(sqliteError);
     const betterMsg =
       betterSqliteError instanceof Error ? betterSqliteError.message : String(betterSqliteError);
 

--- a/packages/db/src/migration/__tests__/introspect.test.ts
+++ b/packages/db/src/migration/__tests__/introspect.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@vertz/test';
 import { PGlite } from '@electric-sql/pglite';
 import { introspectPostgres, introspectSqlite, validateIdentifier } from '../introspect';

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -27,6 +27,7 @@
     "@vertz/fetch": "workspace:^",
     "@vertz/schema": "workspace:^",
     "@vertz/server": "workspace:^",
+    "@vertz/sqlite": "workspace:*",
     "@vertz/test": "workspace:*",
     "@vertz/theme-shadcn": "workspace:^",
     "@vertz/ui": "workspace:^",

--- a/packages/integration-tests/src/__tests__/auth-db-stores.test.ts
+++ b/packages/integration-tests/src/__tests__/auth-db-stores.test.ts
@@ -13,7 +13,7 @@
  *
  * Uses public package imports only (@vertz/server, @vertz/db).
  */
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
 import { createDb, type DatabaseClient, type ModelEntry } from '@vertz/db';
 import {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.3.1",
+    "@vertz/sqlite": "workspace:*",
     "@vertz/test": "workspace:*",
     "bun-types": "^1.3.10",
     "bunup": "^0.16.31",

--- a/packages/server/src/auth/__tests__/auth-entity-session.test.ts
+++ b/packages/server/src/auth/__tests__/auth-entity-session.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
 import { createDb, d } from '@vertz/db';
 import { createServer, type ServerInstance } from '../../create-server';

--- a/packages/server/src/auth/__tests__/auth-initialize.test.ts
+++ b/packages/server/src/auth/__tests__/auth-initialize.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { afterEach, describe, expect, it } from '@vertz/test';
 import type { D1Database } from '@vertz/db';
 import { createDb } from '@vertz/db';

--- a/packages/server/src/auth/__tests__/auth-model-validation.test.ts
+++ b/packages/server/src/auth/__tests__/auth-model-validation.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { describe, expect, it } from '@vertz/test';
 import type { D1Database } from '@vertz/db';
 import { createDb } from '@vertz/db';

--- a/packages/server/src/auth/__tests__/server-instance.test.ts
+++ b/packages/server/src/auth/__tests__/server-instance.test.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { afterEach, describe, expect, it } from '@vertz/test';
 import { createDb } from '@vertz/db';
 import { createServer } from '../../create-server';

--- a/packages/server/src/auth/__tests__/test-db-helper.ts
+++ b/packages/server/src/auth/__tests__/test-db-helper.ts
@@ -1,11 +1,11 @@
 /**
  * Test helper — creates an in-memory SQLite database with auth tables.
  *
- * Uses bun:sqlite directly with a _queryFn bridge so the DatabaseClient
+ * Uses @vertz/sqlite directly with a _queryFn bridge so the DatabaseClient
  * can execute raw SQL (including DDL) against a real SQLite instance.
  */
 
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import type { DatabaseClient, ModelEntry } from '@vertz/db';
 import { createDb } from '@vertz/db';
 import { authModels } from '../auth-models';
@@ -32,7 +32,7 @@ function dummyD1() {
 export async function createTestDb(): Promise<TestDb> {
   const rawDb = new Database(':memory:');
 
-  // Bridge: convert $N parameter placeholders to ? for bun:sqlite
+  // Bridge: convert $N parameter placeholders to ? for @vertz/sqlite
   const queryFn = async <T>(sqlStr: string, params: readonly unknown[]) => {
     const sqliteSql = sqlStr.replace(/\$\d+/g, '?');
 

--- a/packages/site/pages/guides/testing.mdx
+++ b/packages/site/pages/guides/testing.mdx
@@ -55,7 +55,7 @@ For E2E tests, use a **file-based SQLite** database. Each dev server run creates
 
 ```ts
 // src/api/db.ts
-import { Database } from 'bun:sqlite';
+import { Database } from '@vertz/sqlite';
 import { createDb } from '@vertz/db';
 import { authModels } from '@vertz/server';
 

--- a/packages/sqlite/bunup.config.ts
+++ b/packages/sqlite/bunup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'bunup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { inferTypes: true },
+  clean: true,
+});

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@vertz/sqlite",
+  "version": "0.2.58",
+  "description": "Type declarations and runtime stubs for the Vertz SQLite driver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "packages/sqlite"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "vtzx bunup",
+    "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.1",
+    "bunup": "^0.16.31",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -1,0 +1,79 @@
+// @vertz/sqlite — Type declarations and runtime stubs for the Vertz SQLite driver.
+//
+// Resolution order:
+//   1. `vtz` runtime — the synthetic module loader intercepts this import
+//      and provides the real SQLite implementation. This file is never reached.
+//   2. Any other context — stubs that throw a helpful error.
+
+const STUB_ERROR =
+  '@vertz/sqlite: this module requires the vtz runtime. ' +
+  'Run your app with `vtz dev` or `vtz run <script>` to use the built-in SQLite driver. ' +
+  'For Node.js, use better-sqlite3 instead.';
+
+function stub(): never {
+  throw new Error(STUB_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// Statement
+// ---------------------------------------------------------------------------
+
+/** Use `db.prepare()` to create statements. Exported for type annotations only. */
+export class Statement<
+  TRow = Record<string, unknown>,
+  TParams extends unknown[] = unknown[],
+> {
+  all(..._params: TParams): TRow[] {
+    return stub();
+  }
+
+  get(..._params: TParams): TRow | null {
+    return stub();
+  }
+
+  run(..._params: TParams): { changes: number } {
+    return stub();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Database
+// ---------------------------------------------------------------------------
+
+export class Database {
+  constructor(_path: string) {
+    stub();
+  }
+
+  exec(_sql: string): void {
+    stub();
+  }
+
+  run(_sql: string, ..._params: unknown[]): { changes: number } {
+    return stub();
+  }
+
+  prepare<TRow = Record<string, unknown>, TParams extends unknown[] = unknown[]>(
+    _sql: string,
+  ): Statement<TRow, TParams> {
+    return stub();
+  }
+
+  /**
+   * Wraps `fn` in BEGIN/COMMIT. If `fn` throws, issues ROLLBACK and re-throws.
+   * Returns a callable that executes the transaction when invoked.
+   *
+   * Note: argument forwarding is not supported — the returned function takes
+   * no arguments. This covers all current codebase usage. bun:sqlite's
+   * `.deferred()`, `.immediate()`, `.exclusive()` modifiers are also omitted.
+   */
+  transaction<T>(_fn: () => T): () => T {
+    return stub();
+  }
+
+  close(): void {
+    stub();
+  }
+}
+
+export default Database;

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -19,10 +19,7 @@ function stub(): never {
 // ---------------------------------------------------------------------------
 
 /** Use `db.prepare()` to create statements. Exported for type annotations only. */
-export class Statement<
-  TRow = Record<string, unknown>,
-  TParams extends unknown[] = unknown[],
-> {
+export class Statement<TRow = Record<string, unknown>, TParams extends unknown[] = unknown[]> {
   all(..._params: TParams): TRow[] {
     return stub();
   }

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -64,7 +64,7 @@ export class Database {
    * Returns a callable that executes the transaction when invoked.
    *
    * Note: argument forwarding is not supported — the returned function takes
-   * no arguments. This covers all current codebase usage. bun:sqlite's
+   * no arguments. This covers all current codebase usage. The upstream
    * `.deferred()`, `.immediate()`, `.exclusive()` modifiers are also omitted.
    */
   transaction<T>(_fn: () => T): () => T {

--- a/packages/sqlite/tsconfig.json
+++ b/packages/sqlite/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "isolatedDeclarations": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": []
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"],
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/sqlite/tsconfig.typecheck.json
+++ b/packages/sqlite/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/plans/2496-replace-bun-sqlite.md
+++ b/plans/2496-replace-bun-sqlite.md
@@ -1,0 +1,527 @@
+# Replace `bun:sqlite` with `@vertz/sqlite`
+
+**Issue:** #2496
+**Status:** Reviewed — awaiting human sign-off
+**Date:** 2026-04-11
+
+## API Surface
+
+The `@vertz/sqlite` package provides TypeScript type declarations and runtime stubs for the vtz native SQLite bindings. It follows the same pattern as `@vertz/test` — types come from the npm package, runtime implementation comes from the vtz synthetic module.
+
+### Developer-facing API
+
+```typescript
+import { Database } from '@vertz/sqlite';
+
+// Constructor — file path or :memory:
+const db = new Database(':memory:');
+const fileDb = new Database('./data/app.db');
+
+// DDL / PRAGMA — exec() runs raw SQL (supports multi-statement)
+db.exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
+db.exec('PRAGMA journal_mode = WAL');
+
+// Shorthand run — prepare + run, returns { changes }
+// Note: db.run() is a Vertz convenience method (not in bun:sqlite's official API)
+const info = db.run('INSERT INTO users (id, name) VALUES (?, ?)', 1, 'Alice');
+// info = { changes: 1 }
+
+// Prepared statements with type generics
+const stmt = db.prepare<{ id: number; name: string }, [number]>(
+  'SELECT * FROM users WHERE id = ?',
+);
+const rows = stmt.all(1);          // => [{ id: 1, name: 'Alice' }]
+const row = stmt.get(1);           // => { id: 1, name: 'Alice' } | null
+const result = stmt.run(2, 'Bob'); // => { changes: 1 }
+
+// Transactions — wraps callback in BEGIN/COMMIT, ROLLBACK on error
+const insertMany = db.transaction(() => {
+  stmt.run(3, 'Carol');
+  stmt.run(4, 'Dave');
+});
+insertMany(); // Atomic
+
+// Cleanup
+db.close();
+```
+
+### Type Declarations
+
+```typescript
+declare module '@vertz/sqlite' {
+  export class Database {
+    constructor(path: string);
+    exec(sql: string): void;
+    run(sql: string, ...params: unknown[]): { changes: number };
+    prepare<TRow = Record<string, unknown>, TParams extends unknown[] = unknown[]>(
+      sql: string,
+    ): Statement<TRow, TParams>;
+    /**
+     * Wraps `fn` in BEGIN/COMMIT. If `fn` throws, issues ROLLBACK and re-throws.
+     * Returns a callable that executes the transaction when invoked.
+     *
+     * Note: argument forwarding is not supported — the returned function takes
+     * no arguments. This covers all current codebase usage. bun:sqlite's
+     * `.deferred()`, `.immediate()`, `.exclusive()` modifiers are also omitted.
+     */
+    transaction<T>(fn: () => T): () => T;
+    close(): void;
+  }
+
+  /** Use `db.prepare()` to create statements. Exported for type annotations only. */
+  export class Statement<TRow = Record<string, unknown>, TParams extends unknown[] = unknown[]> {
+    all(...params: TParams): TRow[];
+    get(...params: TParams): TRow | null;
+    run(...params: TParams): { changes: number };
+  }
+
+  export default Database;
+}
+```
+
+### Module Resolution
+
+| Import specifier | Resolves to | Context |
+|-----------------|-------------|---------|
+| `@vertz/sqlite` | `vertz:sqlite` synthetic module | vtz runtime (synthetic intercept runs before node_modules lookup) |
+| `vertz:sqlite` | `vertz:sqlite` synthetic module | vtz runtime (canonical) |
+| `bun:sqlite` | `vertz:sqlite` synthetic module | vtz runtime (compat, unchanged) |
+| `@vertz/sqlite` | Stubs that throw helpful error | Non-vtz runtime (npm package) |
+
+**Safety note:** The synthetic module intercept in `module_loader.rs` runs before filesystem resolution, so the npm package's stubs are never loaded when running under vtz. This is the same mechanism used by `@vertz/test`.
+
+### SQLite → JavaScript Type Mapping
+
+| SQLite type | JS type | Notes |
+|-------------|---------|-------|
+| INTEGER | `number` | Values > 2^53 lose precision |
+| REAL | `number` | |
+| TEXT | `string` | |
+| NULL | `null` | |
+| BLOB | Not supported | No BLOB usage in codebase |
+
+### Stub Error Message
+
+When `@vertz/sqlite` is imported outside the vtz runtime, stubs throw:
+
+```
+@vertz/sqlite: this module requires the vtz runtime. Run your app with `vtz dev` or `vtz run <script>` to use the built-in SQLite driver. For Node.js, use better-sqlite3 instead.
+```
+
+## `transaction()` Implementation
+
+This is **new functionality** added to the synthetic module as part of this work. The original #2070 design listed `transaction()` as a non-goal, but the agents' `sqlite-store.ts` uses it. The implementation is pure JavaScript — no new Rust ops required.
+
+### Pseudocode (added to synthetic module in `module_loader.rs`)
+
+```javascript
+// Added to Database class in the VERTZ_SQLITE_MODULE string
+transaction(fn) {
+  this.#assertOpen();
+  const self = this;
+  return function transactionWrapper() {
+    self.exec('BEGIN');
+    try {
+      const result = fn();
+      self.exec('COMMIT');
+      return result;
+    } catch (e) {
+      self.exec('ROLLBACK');
+      throw e;
+    }
+  };
+}
+```
+
+### Edge cases
+
+- **Nested transactions:** Not supported. Calling `exec('BEGIN')` inside an already-begun transaction triggers SQLite's own error: `"cannot start a transaction within a transaction"`. This matches `bun:sqlite` behavior.
+- **Async callbacks:** Not supported. `transaction()` is synchronous (like all SQLite ops). If the callback returns a Promise, the transaction commits before the Promise resolves. This matches `bun:sqlite`.
+- **Non-Error throws:** The `catch` block catches any thrown value and re-throws after ROLLBACK. Works with non-Error values.
+- **Argument forwarding:** Not supported. `bun:sqlite`'s `transaction()` forwards arguments from the wrapper to the callback; ours does not. The codebase only uses zero-arg callbacks (see `sqlite-store.ts` line 174), so this is acceptable. Documented in the type declaration JSDoc.
+- **`.deferred()` / `.immediate()` / `.exclusive()`:** Omitted. Not used in the codebase. These `bun:sqlite` modifiers change the transaction isolation level.
+
+## Manifesto Alignment
+
+### Principle 2: One way to do things
+Today there are two ways to import SQLite: `bun:sqlite` and `vertz:sqlite`. This migration establishes `@vertz/sqlite` as the single canonical import, eliminating the ambiguity. The `bun:sqlite` compat alias remains in the runtime for gradual migration of external code, but framework code uses one path.
+
+### Principle 3: AI agents are first-class users
+`@vertz/sqlite` is an npm package with standard TypeScript types. LLMs can discover it via `package.json` and get autocomplete. `bun:sqlite` requires knowing about `bun-types` — an extra cognitive step that trips up agents.
+
+### Principle 8: No Ceilings
+Decoupling from Bun's type system removes a ceiling — packages no longer need `bun-types` just for SQLite, and the API surface is controlled by Vertz.
+
+### Tradeoff: `bun:sqlite` compat alias stays
+We keep the runtime compat alias (`bun:sqlite` → `vertz:sqlite`) to avoid breaking external code or examples that haven't migrated. The alias is zero-cost (a string comparison in module resolution). Framework code migrates fully; the alias can be deprecated later.
+
+## Non-Goals
+
+- **Removing `bun-types` globally** — Many packages use `bun-types` for APIs beyond `bun:sqlite` (`Bun.serve()`, `Bun.file()`, etc.). Phase 2 includes an audit of the 5 affected packages to determine if any can drop `bun-types` now that `bun:sqlite` types come from `@vertz/sqlite`. Even if the answer is "none can be removed," the audit will be documented.
+- **New Rust ops** — `transaction()` is implemented purely in JavaScript (BEGIN/COMMIT/ROLLBACK via existing `exec()` op). No new native ops needed.
+- **Full `bun:sqlite` API parity** — We implement only what the codebase uses. Same decision as #2070. Specifically omitted: `transaction()` argument forwarding, `.deferred()`/`.immediate()`/`.exclusive()`, `db.query()`, `stmt.first()`, `stmt.values()`, named parameters.
+- **BLOB support** — No BLOB usage in the codebase.
+
+## Unknowns
+
+- **`transaction()` is new runtime behavior** — While the import migration is purely a TypeScript-side change, `transaction()` adds ~15 lines of JavaScript to the synthetic module. The implementation is straightforward (BEGIN/COMMIT/ROLLBACK wrapper), but it requires testing as new functionality, not just a migration. This is covered in Phase 1 acceptance criteria.
+
+## Type Flow Map
+
+```
+@vertz/sqlite package (types)
+  └─ Database class
+       ├─ prepare<TRow, TParams>(sql) → Statement<TRow, TParams>
+       │    ├─ .all(...params: TParams) → TRow[]
+       │    ├─ .get(...params: TParams) → TRow | null
+       │    └─ .run(...params: TParams) → { changes: number }
+       ├─ exec(sql) → void
+       ├─ run(sql, ...params) → { changes: number }
+       ├─ transaction<T>(fn: () => T) → () => T
+       └─ close() → void
+
+Consumer flow (agents sqlite-store):
+  import { Database } from '@vertz/sqlite'
+    → const db = new Database(path)
+    → db.prepare<SessionRow, [string]>(sql)  // TRow = SessionRow, TParams = [string]
+    → stmt.get(sessionId)                     // returns SessionRow | null ✓
+    → stmt.all(sessionId)                     // returns SessionRow[] ✓
+    → db.transaction(() => { ... })           // returns () => void ✓
+
+Consumer flow (db sqlite-driver):
+  import('@vertz/sqlite')
+    → const db = new Database(path)
+    → db.prepare(sql).all(...params)          // returns Record<string, unknown>[] ✓
+    → db.prepare(sql).run(...params)          // returns { changes: number } ✓
+    → db.exec(sql)                            // void ✓
+    → db.close()                              // void ✓
+  Note: resolveLocalSqliteDatabase error flow changes — import('@vertz/sqlite')
+  succeeds (npm stubs exist) but new Database() throws. The catch block handles
+  both "module not found" and "stub threw" errors identically.
+
+Consumer flow (cli load-db-context):
+  await import('@vertz/sqlite')
+    → const db = new Database(path)
+    → db.prepare(sql).all(...params)          // returns Record<string, unknown>[] ✓
+    → db.close()                              // void ✓
+```
+
+## E2E Acceptance Test
+
+```typescript
+import { describe, expect, it } from '@vertz/test';
+import { Database, Statement } from '@vertz/sqlite';
+
+describe('Feature: @vertz/sqlite replaces bun:sqlite', () => {
+  describe('Given the @vertz/sqlite package', () => {
+    describe('When importing Database and Statement', () => {
+      it('Then both are available as named exports', () => {
+        expect(Database).toBeDefined();
+        expect(Statement).toBeDefined();
+      });
+    });
+  });
+
+  describe('Given a new Database(":memory:")', () => {
+    describe('When using the full CRUD cycle', () => {
+      it('Then exec, prepare, all, get, run, and close all work', () => {
+        const db = new Database(':memory:');
+        db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');
+
+        const insert = db.prepare('INSERT INTO t (id, name) VALUES (?, ?)');
+        insert.run(1, 'Alice');
+        insert.run(2, 'Bob');
+
+        const all = db.prepare('SELECT * FROM t ORDER BY id').all();
+        expect(all).toEqual([
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ]);
+
+        const one = db.prepare('SELECT * FROM t WHERE id = ?').get(1);
+        expect(one).toEqual({ id: 1, name: 'Alice' });
+
+        const missing = db.prepare('SELECT * FROM t WHERE id = ?').get(999);
+        expect(missing).toBeNull();
+
+        db.close();
+      });
+    });
+  });
+
+  describe('Given db.transaction()', () => {
+    describe('When the callback succeeds', () => {
+      it('Then all operations are committed atomically', () => {
+        const db = new Database(':memory:');
+        db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');
+
+        const tx = db.transaction(() => {
+          db.run('INSERT INTO t (id, name) VALUES (?, ?)', 1, 'A');
+          db.run('INSERT INTO t (id, name) VALUES (?, ?)', 2, 'B');
+        });
+        tx();
+
+        const rows = db.prepare('SELECT * FROM t ORDER BY id').all();
+        expect(rows.length).toBe(2);
+        db.close();
+      });
+    });
+
+    describe('When the callback throws', () => {
+      it('Then all operations are rolled back', () => {
+        const db = new Database(':memory:');
+        db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)');
+
+        const tx = db.transaction(() => {
+          db.run('INSERT INTO t (id, name) VALUES (?, ?)', 1, 'A');
+          throw new Error('fail');
+        });
+
+        expect(() => tx()).toThrow('fail');
+
+        const rows = db.prepare('SELECT * FROM t ORDER BY id').all();
+        expect(rows.length).toBe(0);
+        db.close();
+      });
+    });
+  });
+
+  describe('Given the agents sqlite-store', () => {
+    describe('When importing from @vertz/sqlite instead of bun:sqlite', () => {
+      it('Then all store operations work identically', () => {
+        // Validated by existing sqlite-store.test.ts passing after migration
+      });
+    });
+  });
+
+  describe('Given invalid constructor arguments', () => {
+    describe('When passing a non-string to Database()', () => {
+      // @ts-expect-error — Database requires a string path
+      it('Then TypeScript rejects the call', () => { new Database(123); });
+    });
+  });
+
+  describe('Given direct Statement construction', () => {
+    describe('When trying to construct Statement without db.prepare()', () => {
+      // @ts-expect-error — Statement constructor is not public in type declarations
+      it('Then TypeScript rejects the call', () => { new Statement(); });
+    });
+  });
+});
+```
+
+## Files Affected
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `packages/sqlite/package.json` | Package manifest |
+| `packages/sqlite/tsconfig.json` | TypeScript config |
+| `packages/sqlite/tsconfig.typecheck.json` | Typecheck config |
+| `packages/sqlite/bunup.config.ts` | Build config |
+| `packages/sqlite/src/index.ts` | Type declarations + runtime stubs |
+
+### Source files migrating `bun:sqlite` → `@vertz/sqlite`
+
+| File | Change |
+|------|--------|
+| `packages/agents/src/stores/sqlite-store.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/cli/src/commands/load-db-context.ts` | `await import('bun:sqlite')` → `await import('@vertz/sqlite')`, update error message |
+| `packages/db/src/client/sqlite-driver.ts` | `import('bun:sqlite')` → `import('@vertz/sqlite')` in `resolveLocalSqliteDatabase()`, update error messages |
+
+### Test files migrating `bun:sqlite` → `@vertz/sqlite`
+
+| File | Change |
+|------|--------|
+| `packages/agents/src/stores/d1-store.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/server/src/auth/__tests__/test-db-helper.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/server/src/auth/__tests__/server-instance.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/server/src/auth/__tests__/auth-model-validation.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/server/src/auth/__tests__/auth-initialize.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/server/src/auth/__tests__/auth-entity-session.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/integration-tests/src/__tests__/auth-db-stores.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/db/src/client/__tests__/transaction.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/db/src/migration/__tests__/introspect.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+| `packages/db/src/client/__tests__/local-sqlite-driver.test.ts` | Update mock to use `@vertz/sqlite` |
+| `packages/cli/src/commands/__tests__/load-db-context.test.ts` | `bun:sqlite` → `@vertz/sqlite` |
+
+### Package dependencies (add `@vertz/sqlite` as `dependency`)
+
+| File | Change |
+|------|--------|
+| `packages/agents/package.json` | Add `"@vertz/sqlite": "workspace:*"` to `dependencies` |
+| `packages/cli/package.json` | Add `"@vertz/sqlite": "workspace:*"` to `dependencies` |
+| `packages/db/package.json` | Add `"@vertz/sqlite": "workspace:*"` to `dependencies` |
+| `packages/server/package.json` | Add `"@vertz/sqlite": "workspace:*"` to `devDependencies` (test-only usage) |
+| `packages/integration-tests/package.json` | Add `"@vertz/sqlite": "workspace:*"` to `devDependencies` (test-only usage) |
+
+Note: `@vertz/sqlite` must be in `dependencies` (not `devDependencies`) for packages that import it in production source files, because the types need to resolve during typecheck and the package needs to be available for non-vtz runtimes' fallback stubs.
+
+### Build configs (add `@vertz/sqlite` as external)
+
+Unlike `bun:sqlite` (protocol-prefixed, auto-externalized by bundlers), `@vertz/sqlite` is a standard scoped package that bundlers will try to inline. It MUST be marked as external to prevent the stubs from being bundled into dist.
+
+| File | Change |
+|------|--------|
+| `packages/cli/bunup.config.ts` | Replace `bun:sqlite` with `@vertz/sqlite` in externals |
+| `packages/agents/bunup.config.ts` | Add `@vertz/sqlite` to externals (currently has no explicit externals — `bun:sqlite` was auto-externalized as a protocol import) |
+
+Note: `packages/db/bunup.config.ts` uses dynamic `import()` for SQLite (not static import), so bundlers should leave it alone. Verify during implementation.
+
+### Native runtime
+
+| File | Change |
+|------|--------|
+| `native/vtz/src/runtime/module_loader.rs` | Add `@vertz/sqlite` to the specifier intercept at line 1784 (alongside `vertz:sqlite` and `bun:sqlite`); add `transaction()` to the VERTZ_SQLITE_MODULE string |
+| `native/vtz/tests/fixtures/sqlite-test/` | Add test fixture for `@vertz/sqlite` import; update integration test to cover all three import paths |
+| `native/vtz/src/compiler/import_rewriter.rs` | Ensure `@vertz/sqlite` is treated as a runtime builtin for import rewriting (test at line 1165) |
+| `native/vtz/src/server/module_server.rs` | Consider adding `@vertz/sqlite` to `is_runtime_builtin()`. However, since SQLite is server-only and the npm stubs would correctly throw in browser context, this is acceptable as-is. Document the decision. |
+
+### Documentation and comments
+
+| File | Change |
+|------|--------|
+| `examples/entity-todo/src/api/db-d1.ts` | Update comment referencing `bun:sqlite` |
+| `packages/mint-docs/` | Update any code examples showing `bun:sqlite` to use `@vertz/sqlite` |
+
+### `bun-types` audit
+
+After migration, audit these 5 packages to check if `bun-types` can be removed:
+- `packages/agents/` — check if any non-SQLite `bun:*` APIs are used
+- `packages/cli/` — check if any non-SQLite `bun:*` APIs are used
+- `packages/db/` — check if any non-SQLite `bun:*` APIs are used
+- `packages/server/` — check if any non-SQLite `bun:*` APIs are used
+- `packages/integration-tests/` — check if any non-SQLite `bun:*` APIs are used
+
+Document results. Remove `bun-types` from any package that no longer needs it.
+
+## Implementation Plan
+
+### Phase 1: `@vertz/sqlite` type package + runtime changes
+
+**Goal:** Create the npm package with types and stubs, add `@vertz/sqlite` module resolution to the runtime, add `transaction()` to the synthetic module. No import migration yet.
+
+**Acceptance Criteria:**
+```typescript
+describe('Phase 1: @vertz/sqlite package and runtime', () => {
+  describe('Given the @vertz/sqlite package', () => {
+    describe('When importing Database and Statement', () => {
+      it('Then TypeScript resolves types correctly', () => {});
+      it('Then prepare<TRow, TParams> generic flows to all/get/run', () => {});
+      it('Then default export is Database', () => {});
+    });
+    describe('When running outside vtz', () => {
+      it('Then stubs throw with message mentioning vtz and better-sqlite3', () => {});
+    });
+  });
+
+  describe('Given the vtz runtime', () => {
+    describe('When importing from @vertz/sqlite', () => {
+      it('Then resolves to the vertz:sqlite synthetic module', () => {});
+    });
+    describe('When importing from vertz:sqlite', () => {
+      it('Then resolves to the vertz:sqlite synthetic module', () => {});
+    });
+    describe('When importing from bun:sqlite', () => {
+      it('Then still resolves to the vertz:sqlite synthetic module', () => {});
+    });
+    describe('When using db.transaction()', () => {
+      it('Then successful callbacks are committed', () => {});
+      it('Then throwing callbacks are rolled back', () => {});
+      it('Then nested transactions throw SQLite error', () => {});
+    });
+  });
+});
+```
+
+### Phase 2: Migrate all imports + build configs + bun-types audit
+
+**Goal:** Migrate ALL files (source + test) from `bun:sqlite` to `@vertz/sqlite`. Update build configs, package dependencies, error messages, comments, and docs. Audit `bun-types`. Zero `bun:sqlite` imports remain in framework packages.
+
+**Acceptance Criteria:**
+```typescript
+describe('Phase 2: Full migration', () => {
+  describe('Given @vertz/agents sqlite-store', () => {
+    describe('When importing from @vertz/sqlite', () => {
+      it('Then all existing sqlite-store tests pass', () => {});
+      it('Then transaction-based appendMessages works', () => {});
+    });
+  });
+
+  describe('Given @vertz/cli load-db-context', () => {
+    describe('When dynamically importing @vertz/sqlite', () => {
+      it('Then SQLite connections work for migrations', () => {});
+      it('Then error message references @vertz/sqlite', () => {});
+    });
+  });
+
+  describe('Given @vertz/db sqlite-driver', () => {
+    describe('When resolveLocalSqliteDatabase tries @vertz/sqlite first', () => {
+      it('Then local SQLite driver tests pass', () => {});
+      it('Then error message lists @vertz/sqlite and better-sqlite3', () => {});
+    });
+  });
+
+  describe('Given all test files', () => {
+    describe('When importing from @vertz/sqlite', () => {
+      it('Then all auth tests pass', () => {});
+      it('Then all db tests pass', () => {});
+      it('Then all integration tests pass', () => {});
+      it('Then all agent tests pass', () => {});
+      it('Then all CLI tests pass', () => {});
+    });
+  });
+
+  describe('Given build configs', () => {
+    describe('When @vertz/sqlite is listed as external', () => {
+      it('Then CLI build succeeds', () => {});
+      it('Then agents build succeeds', () => {});
+    });
+  });
+
+  describe('Given the entire packages/ directory', () => {
+    describe('When searching for bun:sqlite imports in .ts files', () => {
+      it('Then zero matches remain', () => {});
+    });
+  });
+
+  describe('Given the native test fixtures', () => {
+    describe('When a @vertz/sqlite import fixture exists', () => {
+      it('Then the integration test passes', () => {});
+    });
+  });
+
+  describe('Given the bun-types audit', () => {
+    describe('When checking each migrated package for non-SQLite bun:* usage', () => {
+      it('Then audit results are documented', () => {});
+      it('Then bun-types is removed from packages that no longer need it', () => {});
+    });
+  });
+});
+```
+
+## Review History
+
+### Rev 1 → Rev 2 (2026-04-11)
+
+Addressed feedback from DX, Product/Scope, and Technical reviews:
+
+| Finding | Source | Resolution |
+|---------|--------|-----------|
+| Missing files: docs, import_rewriter, module_server, test fixtures | Product (Blocker) | Added to Files Affected: mint-docs, import_rewriter.rs, module_server.rs, existing test fixtures |
+| Missing `@vertz/sqlite` in agents bunup.config.ts externals | Technical (Blocker) | Added Build Configs section explaining auto-externalization difference between protocol imports and scoped packages |
+| Missing `@vertz/sqlite` as dependency in consumer packages | Technical (Blocker) | Added Package Dependencies section with `dependencies` vs `devDependencies` guidance |
+| `transaction()` is new functionality, not acknowledged | Product (Should-Fix) | Added dedicated "transaction() Implementation" section with pseudocode and edge cases; updated Unknowns section |
+| Import rewriter + dev server need `@vertz/sqlite` handling | Product (Should-Fix) | Added import_rewriter.rs and module_server.rs to Files Affected with analysis |
+| `bun-types` audit dismissed without investigation | Product (Should-Fix) | Updated Non-Goals; added `bun-types` audit as Phase 2 deliverable |
+| `transaction()` return type doesn't forward arguments | DX (Should-Fix) | Documented as intentional limitation in JSDoc and edge cases section |
+| `resolveLocalSqliteDatabase` error flow change | Technical (Should-Fix) | Added note in Type Flow Map about behavioral difference |
+| `transaction()` JS implementation needs pseudocode | Technical (Should-Fix) | Added full pseudocode to new section |
+| Dev server import rewriter consideration | Technical (Should-Fix) | Documented reasoning: stubs package serves correct browser behavior |
+| Missing `export default Database` in type declarations | DX (Nit) | Added to type declarations |
+| JSDoc on Statement class | DX (Nit) | Added JSDoc noting it's for type annotations only |
+| Error message should mention better-sqlite3 | DX (Nit) | Added exact error message text in Stub Error Message section |
+| Phases 2+3 could merge | Product (Nit) | Merged into single Phase 2 — mechanical migration doesn't warrant separate phases |
+| BDD format inconsistency in E2E test | Product (Nit) | Wrapped `@ts-expect-error` tests in Given/When/Then describes |
+| Statement constructor intentionally omitted from types | Technical (Nit) | Covered by JSDoc on Statement class |

--- a/plans/2496-replace-bun-sqlite/phase-01-sqlite-package-and-runtime.md
+++ b/plans/2496-replace-bun-sqlite/phase-01-sqlite-package-and-runtime.md
@@ -1,0 +1,111 @@
+# Phase 1: `@vertz/sqlite` Package + Runtime Changes
+
+## Context
+
+Issue #2496 replaces `bun:sqlite` imports with `@vertz/sqlite` across the Vertz framework. This phase creates the npm package and updates the vtz runtime. Phase 2 handles the actual import migration.
+
+Design doc: `plans/2496-replace-bun-sqlite.md`
+
+## Tasks
+
+### Task 1: Create `@vertz/sqlite` package with types and stubs
+
+**Files:** (5)
+- `packages/sqlite/package.json` (new)
+- `packages/sqlite/tsconfig.json` (new)
+- `packages/sqlite/tsconfig.typecheck.json` (new)
+- `packages/sqlite/bunup.config.ts` (new)
+- `packages/sqlite/src/index.ts` (new)
+
+**What to implement:**
+
+Create a package following the `@vertz/test` pattern (`packages/test/`):
+
+**`package.json`:**
+- Name: `@vertz/sqlite`, same version as other packages (`0.2.58`)
+- Entry: `dist/index.js`, types: `dist/index.d.ts`
+- Exports: `{ ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }`
+- Build: `vtzx bunup`, typecheck: `tsgo --noEmit -p tsconfig.typecheck.json`
+- No runtime dependencies
+
+**`tsconfig.json`:** Extends `../../tsconfig.json`, `isolatedDeclarations: true`, `outDir: "dist"`, `rootDir: "src"`
+
+**`tsconfig.typecheck.json`:** Extends `../../tsconfig.json`, `noEmit: true`, types: `["node"]`
+
+**`bunup.config.ts`:** Single entry `src/index.ts`, format `esm`, dts with inferTypes
+
+**`src/index.ts`:**
+- Stub error message: `'@vertz/sqlite: this module requires the vtz runtime. Run your app with \`vtz dev\` or \`vtz run <script>\` to use the built-in SQLite driver. For Node.js, use better-sqlite3 instead.'`
+- `Database` class with typed method signatures and stub bodies that throw
+- `Statement` class with typed method signatures and stub bodies that throw
+- `export default Database`
+- Type generics: `prepare<TRow, TParams>()` → `Statement<TRow, TParams>`
+- JSDoc on `Statement`: "Use db.prepare() to create statements. Exported for type annotations only."
+- JSDoc on `transaction()`: documents no argument forwarding, no `.deferred()`/`.immediate()`/`.exclusive()`
+
+**Acceptance criteria:**
+- [ ] `packages/sqlite/` builds without errors
+- [ ] TypeScript resolves `import { Database, Statement } from '@vertz/sqlite'`
+- [ ] `prepare<TRow, TParams>()` generic flows to `Statement.all()`, `.get()`, `.run()`
+- [ ] `export default Database` works for default imports
+- [ ] Stubs throw with helpful message mentioning vtz and better-sqlite3
+
+---
+
+### Task 2: Add `@vertz/sqlite` resolution + `transaction()` to vtz runtime
+
+**Files:** (3)
+- `native/vtz/src/runtime/module_loader.rs` (modified)
+- `native/vtz/tests/fixtures/sqlite-test/vertz-sqlite-import-test.js` (new)
+- `native/vtz/tests/sqlite_integration.rs` (modified)
+
+**What to implement:**
+
+**Module resolution (`module_loader.rs`):**
+Add `@vertz/sqlite` to the specifier intercept alongside `vertz:sqlite` and `bun:sqlite` (around line 1784):
+```rust
+if specifier == "vertz:sqlite" || specifier == "bun:sqlite" || specifier == "@vertz/sqlite" {
+    return Ok(ModuleSpecifier::parse(VERTZ_SQLITE_SPECIFIER)?);
+}
+```
+
+**`transaction()` in synthetic module (`module_loader.rs`):**
+Add to the `Database` class in the `VERTZ_SQLITE_MODULE` string:
+```javascript
+transaction(fn) {
+  this.#assertOpen();
+  const self = this;
+  return function transactionWrapper() {
+    self.exec('BEGIN');
+    try {
+      const result = fn();
+      self.exec('COMMIT');
+      return result;
+    } catch (e) {
+      self.exec('ROLLBACK');
+      throw e;
+    }
+  };
+}
+```
+
+**Test fixture (`vertz-sqlite-import-test.js`):**
+```javascript
+import { Database } from '@vertz/sqlite';
+// Test basic CRUD + transaction
+```
+
+**Integration test (`sqlite_integration.rs`):**
+Add test case for `@vertz/sqlite` import specifier.
+Add test case for `transaction()` commit and rollback.
+
+**Acceptance criteria:**
+- [ ] `import { Database } from '@vertz/sqlite'` resolves to synthetic module in vtz runtime
+- [ ] `import { Database } from 'vertz:sqlite'` still works
+- [ ] `import { Database } from 'bun:sqlite'` still works
+- [ ] `db.transaction(() => { ... })()` commits on success
+- [ ] `db.transaction(() => { throw ... })()` rolls back on error
+- [ ] Nested `transaction()` throws SQLite error
+- [ ] `cargo test --all` passes
+- [ ] `cargo clippy --all-targets --release -- -D warnings` passes
+- [ ] `cargo fmt --all -- --check` passes

--- a/plans/2496-replace-bun-sqlite/phase-02-migrate-imports.md
+++ b/plans/2496-replace-bun-sqlite/phase-02-migrate-imports.md
@@ -1,0 +1,121 @@
+# Phase 2: Migrate All Imports + Build Configs
+
+## Context
+
+Issue #2496 replaces `bun:sqlite` imports with `@vertz/sqlite`. Phase 1 created the package and runtime support. This phase performs the actual migration across all TypeScript files, updates build configs, package dependencies, error messages, and audits `bun-types`.
+
+Design doc: `plans/2496-replace-bun-sqlite.md`
+
+## Tasks
+
+### Task 1: Add `@vertz/sqlite` dependency to consumer packages + update build configs
+
+**Files:** (5)
+- `packages/agents/package.json` (modified — add `@vertz/sqlite` to dependencies)
+- `packages/agents/bunup.config.ts` (modified — add `@vertz/sqlite` to externals)
+- `packages/cli/package.json` (modified — add `@vertz/sqlite` to dependencies)
+- `packages/cli/bunup.config.ts` (modified — replace `bun:sqlite` with `@vertz/sqlite` in externals)
+- `packages/db/package.json` (modified — add `@vertz/sqlite` to dependencies)
+
+**What to implement:**
+
+Add `"@vertz/sqlite": "workspace:*"` to `dependencies` in agents, cli, db package.json files.
+Add `"@vertz/sqlite": "workspace:*"` to `devDependencies` in server, integration-tests package.json files.
+
+Update `packages/cli/bunup.config.ts`: replace `'bun:sqlite'` with `'@vertz/sqlite'` in both external arrays.
+
+Update `packages/agents/bunup.config.ts`: add `external: ['@vertz/sqlite']` — currently has no externals because `bun:sqlite` was auto-externalized as a protocol import.
+
+**Acceptance criteria:**
+- [ ] `vtz install` succeeds with new workspace dependency
+- [ ] `packages/agents` build succeeds with `@vertz/sqlite` externalized
+- [ ] `packages/cli` build succeeds with `@vertz/sqlite` externalized
+
+---
+
+### Task 2: Migrate source file imports
+
+**Files:** (3)
+- `packages/agents/src/stores/sqlite-store.ts` (modified)
+- `packages/cli/src/commands/load-db-context.ts` (modified)
+- `packages/db/src/client/sqlite-driver.ts` (modified)
+
+**What to implement:**
+
+**`sqlite-store.ts`:** Change `import { Database } from 'bun:sqlite'` → `import { Database } from '@vertz/sqlite'`
+
+**`load-db-context.ts`:** Change `await import('bun:sqlite')` → `await import('@vertz/sqlite')`. Update error message from "Failed to load bun:sqlite" to reference `@vertz/sqlite`.
+
+**`sqlite-driver.ts`:** In `resolveLocalSqliteDatabase()`, change `await loadModule('bun:sqlite')` → `await loadModule('@vertz/sqlite')`. Update error messages to reference `@vertz/sqlite` instead of `bun:sqlite`. Update the fallback error text to mention `@vertz/sqlite` and `better-sqlite3`. Update comments referencing `bun:sqlite`.
+
+**Acceptance criteria:**
+- [ ] All existing tests for agents, cli, db pass unchanged
+- [ ] `grep -r "from 'bun:sqlite'" packages/*/src/` returns zero matches (excluding test files)
+- [ ] Error messages reference `@vertz/sqlite`
+
+---
+
+### Task 3: Migrate test file imports
+
+**Files:** (5 — batch 1)
+- `packages/agents/src/stores/d1-store.test.ts` (modified)
+- `packages/server/src/auth/__tests__/test-db-helper.ts` (modified)
+- `packages/server/src/auth/__tests__/server-instance.test.ts` (modified)
+- `packages/server/src/auth/__tests__/auth-model-validation.test.ts` (modified)
+- `packages/server/src/auth/__tests__/auth-initialize.test.ts` (modified)
+
+**What to implement:**
+
+Change all `import { Database } from 'bun:sqlite'` → `import { Database } from '@vertz/sqlite'` in each file.
+
+Add `"@vertz/sqlite": "workspace:*"` to `devDependencies` in `packages/server/package.json` and `packages/integration-tests/package.json`.
+
+**Acceptance criteria:**
+- [ ] All auth tests pass
+- [ ] Agent d1-store tests pass
+
+---
+
+### Task 4: Migrate remaining test file imports + comments + docs
+
+**Files:** (5 — batch 2)
+- `packages/server/src/auth/__tests__/auth-entity-session.test.ts` (modified)
+- `packages/integration-tests/src/__tests__/auth-db-stores.test.ts` (modified)
+- `packages/db/src/client/__tests__/transaction.test.ts` (modified)
+- `packages/db/src/migration/__tests__/introspect.test.ts` (modified)
+- `packages/cli/src/commands/__tests__/load-db-context.test.ts` (modified)
+
+**What to implement:**
+
+Change all `bun:sqlite` imports → `@vertz/sqlite` in each file.
+For `local-sqlite-driver.test.ts` in db, update any mocks that reference `bun:sqlite`.
+Update comment in `examples/entity-todo/src/api/db-d1.ts`.
+
+**Acceptance criteria:**
+- [ ] All db tests pass
+- [ ] All integration tests pass
+- [ ] All CLI tests pass
+- [ ] `grep -r "bun:sqlite" packages/*/src/` returns zero matches
+
+---
+
+### Task 5: Native runtime cleanup + `bun-types` audit
+
+**Files:** (3)
+- `native/vtz/src/compiler/import_rewriter.rs` (modified — verify `@vertz/sqlite` handling)
+- `native/vtz/src/server/module_server.rs` (verify — document decision)
+- Audit results documented in commit message
+
+**What to implement:**
+
+**Import rewriter:** Verify that `@vertz/sqlite` is correctly handled. Since it's a scoped package (not a protocol import like `bun:`), the import rewriter should already route it through the standard dependency resolution path to `/@deps/@vertz/sqlite`. In SSR, the module loader intercepts it. In browser, the stubs package correctly throws. Add/update tests if needed.
+
+**Module server:** Verify behavior. `@vertz/sqlite` will be served from node_modules as the stubs package in browser context — this is correct (SQLite is server-only). Document in commit message that this was verified.
+
+**`bun-types` audit:** Check each migrated package (`agents`, `cli`, `db`, `server`, `integration-tests`) for remaining `bun:*` API usage beyond `bun:sqlite`. If a package no longer uses any `bun:*` APIs, remove `bun-types` from its tsconfig. Document audit results.
+
+**Acceptance criteria:**
+- [ ] Full quality gates pass: `vtz test && vtz run typecheck && vtz run lint`
+- [ ] `cargo test --all` passes (if native changes)
+- [ ] `bun-types` audit documented
+- [ ] Zero `bun:sqlite` imports remain in `packages/` TypeScript files


### PR DESCRIPTION
## Summary

Replaces all `bun:sqlite` imports across the monorepo with the new `@vertz/sqlite` package, completing the migration to vtz-native SQLite bindings.

- **New `@vertz/sqlite` package** — type declarations + runtime stubs (follows `@vertz/test` pattern). Under vtz, the synthetic module loader intercepts the import and provides the real implementation; outside vtz, stubs throw a helpful error
- **Runtime `transaction()` support** — pure JS BEGIN/COMMIT/ROLLBACK wrapper added to the vtz synthetic SQLite module
- **Module resolution** — `vertz:sqlite` (canonical), `@vertz/sqlite` (npm), and `bun:sqlite` (compat alias) all resolve to the same synthetic module
- **8 Rust integration tests** — static/dynamic import, file-based DB, module resolution, `@vertz/sqlite` package import, transactions, `@vertz/db` integration patterns

## Public API Changes

### New: `@vertz/sqlite`
```ts
import { Database, Statement } from '@vertz/sqlite';
```
- `Database` class: `exec()`, `run()`, `prepare()`, `transaction()`, `close()`
- `Statement` class: `all()`, `get()`, `run()`
- `bun:sqlite` still works as a compat alias (resolves to same module)

### Changed imports (internal)
All `import { Database } from 'bun:sqlite'` → `import { Database } from '@vertz/sqlite'` in:
- [`packages/agents/src/stores/sqlite-store.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-sqlite-bindings/packages/agents/src/stores/sqlite-store.ts)
- [`packages/cli/src/commands/load-db-context.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-sqlite-bindings/packages/cli/src/commands/load-db-context.ts)
- [`packages/db/src/client/sqlite-driver.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-sqlite-bindings/packages/db/src/client/sqlite-driver.ts)
- 11 test files across agents, server, db, cli, integration-tests
- [`packages/site/pages/guides/testing.mdx`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-sqlite-bindings/packages/site/pages/guides/testing.mdx) (docs)

### Build config
`@vertz/sqlite` added as explicit external in bunup configs for agents and cli (scoped packages need explicit externalization unlike protocol-prefixed `bun:*` imports).

## Phase Reviews

- **Phase 1** (package + runtime): `reviews/2496-replace-bun-sqlite/phase-01-sqlite-package-and-runtime.md` — Approved after addressing all findings
- **Phase 2** (migration): `reviews/2496-replace-bun-sqlite/phase-02-migrate-imports.md` — 1 blocker (missed docs import) + 3 should-fix items, all resolved

## Test Plan

- [x] 8 Rust integration tests pass (`cargo test -p vtz --test sqlite_integration`)
- [x] Clippy clean, fmt clean
- [x] Zero remaining `bun:sqlite` imports in packages/ and examples/
- [x] `@vertz/sqlite` properly externalized in agents dist bundle
- [x] Pre-push hooks all pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

Closes #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)