### PR TITLE
fix(desktop): add Windows platform handling for app.dataDir/cacheDir

### DIFF
--- a/.changeset/fix-windows-app-dirs.md
+++ b/.changeset/fix-windows-app-dirs.md
@@ -1,0 +1,5 @@
+---
+'@vertz/desktop': patch
+---
+
+Add Windows platform handling for `app.dataDir()` and `app.cacheDir()` using `APPDATA` and `LOCALAPPDATA` environment variables. Error messages now include the specific missing environment variable name.

--- a/native/vtz/src/webview/ipc_handlers/app.rs
+++ b/native/vtz/src/webview/ipc_handlers/app.rs
@@ -17,6 +17,7 @@ fn current_platform() -> Platform {
     } else if cfg!(target_os = "windows") {
         Platform::Windows
     } else {
+        // Treat all Unix-like OSes (Linux, FreeBSD, etc.) as Linux/XDG.
         Platform::Linux
     }
 }

--- a/native/vtz/src/webview/ipc_handlers/app.rs
+++ b/native/vtz/src/webview/ipc_handlers/app.rs
@@ -4,51 +4,88 @@ use std::path::Path;
 
 use crate::webview::ipc_dispatcher::IpcError;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Platform {
+    MacOs,
+    Windows,
+    Linux,
+}
+
+fn current_platform() -> Platform {
+    if cfg!(target_os = "macos") {
+        Platform::MacOs
+    } else if cfg!(target_os = "windows") {
+        Platform::Windows
+    } else {
+        Platform::Linux
+    }
+}
+
+/// Resolve the data directory for the given platform using the provided env lookup.
+fn resolve_data_dir(
+    platform: Platform,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<String, &'static str> {
+    match platform {
+        Platform::MacOs => env("HOME")
+            .map(|h| format!("{}/Library/Application Support", h))
+            .ok_or("HOME environment variable is not set"),
+        Platform::Windows => env("APPDATA").ok_or("APPDATA environment variable is not set"),
+        Platform::Linux => env("XDG_DATA_HOME")
+            .or_else(|| env("HOME").map(|h| format!("{}/.local/share", h)))
+            .ok_or("HOME environment variable is not set"),
+    }
+}
+
+/// Resolve the cache directory for the given platform using the provided env lookup.
+fn resolve_cache_dir(
+    platform: Platform,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<String, &'static str> {
+    match platform {
+        Platform::MacOs => env("HOME")
+            .map(|h| format!("{}/Library/Caches", h))
+            .ok_or("HOME environment variable is not set"),
+        Platform::Windows => {
+            env("LOCALAPPDATA").ok_or("LOCALAPPDATA environment variable is not set")
+        }
+        Platform::Linux => env("XDG_CACHE_HOME")
+            .or_else(|| env("HOME").map(|h| format!("{}/.cache", h)))
+            .ok_or("HOME environment variable is not set"),
+    }
+}
+
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
 /// Return the platform-appropriate application data directory.
 ///
 /// - macOS: `~/Library/Application Support`
+/// - Windows: `%APPDATA%`
 /// - Linux: `$XDG_DATA_HOME` or `~/.local/share`
 pub async fn data_dir() -> Result<serde_json::Value, IpcError> {
-    let dir = if cfg!(target_os = "macos") {
-        std::env::var("HOME")
-            .map(|h| format!("{}/Library/Application Support", h))
-            .ok()
-    } else {
-        std::env::var("XDG_DATA_HOME").ok().or_else(|| {
-            std::env::var("HOME")
-                .map(|h| format!("{}/.local/share", h))
-                .ok()
-        })
-    };
-
-    match dir {
-        Some(d) => Ok(serde_json::Value::String(d)),
-        None => Err(IpcError::io_error(
-            "Could not determine application data directory",
-        )),
+    match resolve_data_dir(current_platform(), env_var) {
+        Ok(d) => Ok(serde_json::Value::String(d)),
+        Err(hint) => Err(IpcError::io_error(format!(
+            "Could not determine application data directory: {}",
+            hint
+        ))),
     }
 }
 
 /// Return the platform-appropriate application cache directory.
 ///
 /// - macOS: `~/Library/Caches`
+/// - Windows: `%LOCALAPPDATA%`
 /// - Linux: `$XDG_CACHE_HOME` or `~/.cache`
 pub async fn cache_dir() -> Result<serde_json::Value, IpcError> {
-    let dir = if cfg!(target_os = "macos") {
-        std::env::var("HOME")
-            .map(|h| format!("{}/Library/Caches", h))
-            .ok()
-    } else {
-        std::env::var("XDG_CACHE_HOME")
-            .ok()
-            .or_else(|| std::env::var("HOME").map(|h| format!("{}/.cache", h)).ok())
-    };
-
-    match dir {
-        Some(d) => Ok(serde_json::Value::String(d)),
-        None => Err(IpcError::io_error(
-            "Could not determine application cache directory",
-        )),
+    match resolve_cache_dir(current_platform(), env_var) {
+        Ok(d) => Ok(serde_json::Value::String(d)),
+        Err(hint) => Err(IpcError::io_error(format!(
+            "Could not determine application cache directory: {}",
+            hint
+        ))),
     }
 }
 
@@ -94,6 +131,16 @@ async fn version_from_dir(start_dir: &Path) -> Result<serde_json::Value, IpcErro
 mod tests {
     use super::*;
 
+    fn mock_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name: &str| {
+            vars.iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    // --- data_dir integration tests (current platform) ---
+
     #[tokio::test]
     async fn data_dir_returns_string() {
         let result = data_dir().await.unwrap();
@@ -102,12 +149,116 @@ mod tests {
         assert!(!path.is_empty());
     }
 
+    // --- cache_dir integration tests (current platform) ---
+
     #[tokio::test]
     async fn cache_dir_returns_string() {
         let result = cache_dir().await.unwrap();
         assert!(result.is_string());
         let path = result.as_str().unwrap();
         assert!(!path.is_empty());
+    }
+
+    // --- resolve_data_dir unit tests ---
+
+    #[test]
+    fn resolve_data_dir_macos_uses_home() {
+        let env = mock_env(&[("HOME", "/Users/alice")]);
+        let result = resolve_data_dir(Platform::MacOs, env).unwrap();
+        assert_eq!(result, "/Users/alice/Library/Application Support");
+    }
+
+    #[test]
+    fn resolve_data_dir_macos_missing_home_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_data_dir(Platform::MacOs, env).unwrap_err();
+        assert!(err.contains("HOME"));
+    }
+
+    #[test]
+    fn resolve_data_dir_windows_uses_appdata() {
+        let env = mock_env(&[("APPDATA", r"C:\Users\alice\AppData\Roaming")]);
+        let result = resolve_data_dir(Platform::Windows, env).unwrap();
+        assert_eq!(result, r"C:\Users\alice\AppData\Roaming");
+    }
+
+    #[test]
+    fn resolve_data_dir_windows_missing_appdata_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_data_dir(Platform::Windows, env).unwrap_err();
+        assert!(err.contains("APPDATA"));
+    }
+
+    #[test]
+    fn resolve_data_dir_linux_prefers_xdg() {
+        let env = mock_env(&[("XDG_DATA_HOME", "/custom/data"), ("HOME", "/home/alice")]);
+        let result = resolve_data_dir(Platform::Linux, env).unwrap();
+        assert_eq!(result, "/custom/data");
+    }
+
+    #[test]
+    fn resolve_data_dir_linux_falls_back_to_home() {
+        let env = mock_env(&[("HOME", "/home/alice")]);
+        let result = resolve_data_dir(Platform::Linux, env).unwrap();
+        assert_eq!(result, "/home/alice/.local/share");
+    }
+
+    #[test]
+    fn resolve_data_dir_linux_missing_home_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_data_dir(Platform::Linux, env).unwrap_err();
+        assert!(err.contains("HOME"));
+    }
+
+    // --- resolve_cache_dir unit tests ---
+
+    #[test]
+    fn resolve_cache_dir_macos_uses_home() {
+        let env = mock_env(&[("HOME", "/Users/alice")]);
+        let result = resolve_cache_dir(Platform::MacOs, env).unwrap();
+        assert_eq!(result, "/Users/alice/Library/Caches");
+    }
+
+    #[test]
+    fn resolve_cache_dir_macos_missing_home_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_cache_dir(Platform::MacOs, env).unwrap_err();
+        assert!(err.contains("HOME"));
+    }
+
+    #[test]
+    fn resolve_cache_dir_windows_uses_localappdata() {
+        let env = mock_env(&[("LOCALAPPDATA", r"C:\Users\alice\AppData\Local")]);
+        let result = resolve_cache_dir(Platform::Windows, env).unwrap();
+        assert_eq!(result, r"C:\Users\alice\AppData\Local");
+    }
+
+    #[test]
+    fn resolve_cache_dir_windows_missing_localappdata_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_cache_dir(Platform::Windows, env).unwrap_err();
+        assert!(err.contains("LOCALAPPDATA"));
+    }
+
+    #[test]
+    fn resolve_cache_dir_linux_prefers_xdg() {
+        let env = mock_env(&[("XDG_CACHE_HOME", "/custom/cache"), ("HOME", "/home/alice")]);
+        let result = resolve_cache_dir(Platform::Linux, env).unwrap();
+        assert_eq!(result, "/custom/cache");
+    }
+
+    #[test]
+    fn resolve_cache_dir_linux_falls_back_to_home() {
+        let env = mock_env(&[("HOME", "/home/alice")]);
+        let result = resolve_cache_dir(Platform::Linux, env).unwrap();
+        assert_eq!(result, "/home/alice/.cache");
+    }
+
+    #[test]
+    fn resolve_cache_dir_linux_missing_home_returns_error() {
+        let env = mock_env(&[]);
+        let err = resolve_cache_dir(Platform::Linux, env).unwrap_err();
+        assert!(err.contains("HOME"));
     }
 
     #[tokio::test]

--- a/packages/desktop/src/app.ts
+++ b/packages/desktop/src/app.ts
@@ -6,6 +6,7 @@ import type { DesktopError, IpcCallOptions } from './types.js';
  * Get the platform-appropriate application data directory.
  *
  * - macOS: `~/Library/Application Support`
+ * - Windows: `%APPDATA%`
  * - Linux: `$XDG_DATA_HOME` or `~/.local/share`
  */
 export function dataDir(options?: IpcCallOptions): Promise<Result<string, DesktopError>> {
@@ -16,6 +17,7 @@ export function dataDir(options?: IpcCallOptions): Promise<Result<string, Deskto
  * Get the platform-appropriate application cache directory.
  *
  * - macOS: `~/Library/Caches`
+ * - Windows: `%LOCALAPPDATA%`
  * - Linux: `$XDG_CACHE_HOME` or `~/.cache`
  */
 export function cacheDir(options?: IpcCallOptions): Promise<Result<string, DesktopError>> {


### PR DESCRIPTION
## Summary

- Adds explicit Windows support for `app.dataDir()` (uses `%APPDATA%`) and `app.cacheDir()` (uses `%LOCALAPPDATA%`)
- Refactors platform resolution into testable pure functions with injectable env lookup
- Error messages now include the specific missing env var name as a hint
- 14 new unit tests covering all 3 platforms (macOS, Windows, Linux) for both functions, including error cases

## Public API Changes

None — the TypeScript API is unchanged. JSDoc comments updated to document Windows paths.

Fixes #2486

## Test plan

- [x] `cargo test -p vtz --lib --features desktop -- ipc_handlers::app` — 20/20 passing
- [x] `cargo clippy -p vtz --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt -p vtz -- --check` — clean
- [x] Pre-push hooks all passed (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)