### PR TITLE
feat(runtime): replace Bun-specific APIs with vtz-native equivalents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,7 +170,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
         "typescript": "^5.7.0",
       },
@@ -263,7 +262,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
         "typescript": "^5.7.0",
       },
@@ -282,7 +280,6 @@
         "@types/node": "^25.3.1",
         "@vertz/cli": "workspace:*",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.9",
         "typescript": "^5.8.0",
         "wrangler": "^4.78.0",
       },
@@ -323,7 +320,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "typescript": "^5.9.3",
       },
     },
@@ -519,7 +515,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
         "typescript": "^5.7.0",
       },
@@ -542,7 +537,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "bunup": "^0.16.31",
         "typescript": "^5.7.0",
       },
@@ -688,7 +682,6 @@
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/test": "workspace:*",
-        "bun-types": "^1.3.10",
         "bunup": "^0.16.23",
         "typescript": "^5.9.3",
       },
@@ -3100,13 +3093,9 @@
 
     "@vertz/codegen/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "@vertz/compiler/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
     "@vertz/component-docs/wrangler": ["wrangler@4.81.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260405.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260405.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260405.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-9fLPDuDcb8Nu6iXrl5E3HGYt3TVhQr/UvqtTvWr9Nl1X7PlQrmWMwQCfSioqN8VHYyQCyESV5jQsoKg8Sx+sEA=="],
 
     "@vertz/core/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@vertz/create-vertz-app/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/db/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
@@ -3137,8 +3126,6 @@
     "@vertz/test/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/testing/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@vertz/tui/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/ui-server/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 

--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -22,6 +22,7 @@ use super::ops::encoding;
 use super::ops::env;
 use super::ops::fetch;
 use super::ops::fs;
+use super::ops::http_serve;
 use super::ops::microtask;
 use super::ops::os;
 use super::ops::path;
@@ -113,6 +114,7 @@ impl VertzJsRuntime {
         ops.extend(sqlite::op_decls());
         ops.extend(e2e::op_decls());
         ops.extend(signals::op_decls());
+        ops.extend(http_serve::op_decls());
         ops
     }
 
@@ -120,8 +122,12 @@ impl VertzJsRuntime {
     ///
     /// Single source of truth — used by `new()`, the test snapshot, and
     /// the production snapshot.
+    /// Runtime identity marker — stable contract for runtime detection.
+    const RUNTIME_MARKER_JS: &'static str = "globalThis.__vtz_runtime = true;";
+
     pub(crate) fn bootstrap_js() -> String {
         [
+            Self::RUNTIME_MARKER_JS,
             clone::CLONE_BOOTSTRAP_JS,
             console::CONSOLE_BOOTSTRAP_JS,
             timers::TIMERS_BOOTSTRAP_JS,
@@ -137,6 +143,7 @@ impl VertzJsRuntime {
             streams::STREAMS_BOOTSTRAP_JS,
             os::OS_BOOTSTRAP_JS,
             fs::FS_BOOTSTRAP_JS,
+            http_serve::HTTP_SERVE_BOOTSTRAP_JS,
         ]
         .join("\n")
     }
@@ -163,6 +170,7 @@ impl VertzJsRuntime {
                 state.put(performance::PerformanceState { start_time });
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
+                state.put(http_serve::HttpServeState::default());
             })),
             ..Default::default()
         };
@@ -227,6 +235,7 @@ impl VertzJsRuntime {
                 state.put(performance::PerformanceState { start_time });
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
+                state.put(http_serve::HttpServeState::default());
             })),
             ..Default::default()
         };
@@ -431,6 +440,7 @@ impl VertzJsRuntime {
                 state.put(performance::PerformanceState { start_time });
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
+                state.put(http_serve::HttpServeState::default());
             })),
             ..Default::default()
         };

--- a/native/vtz/src/runtime/ops/http_serve.rs
+++ b/native/vtz/src/runtime/ops/http_serve.rs
@@ -1,0 +1,447 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use deno_core::error::AnyError;
+use deno_core::op2;
+use deno_core::OpDecl;
+use deno_core::OpState;
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
+
+/// Global counter for server IDs.
+static NEXT_SERVER_ID: AtomicU32 = AtomicU32::new(1);
+/// Global counter for request IDs.
+static NEXT_REQUEST_ID: AtomicU32 = AtomicU32::new(1);
+
+/// An incoming HTTP request serialized for JS consumption.
+#[derive(serde::Serialize)]
+struct IncomingRequest {
+    id: u32,
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    #[serde(with = "serde_bytes_option")]
+    body: Option<Vec<u8>>,
+}
+
+/// A response from JS to send back to the HTTP client.
+struct HttpResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+/// Pending response senders, shared between Axum handlers and the respond op.
+type PendingResponses = Arc<TokioMutex<HashMap<u32, oneshot::Sender<HttpResponse>>>>;
+
+/// Per-server state stored in OpState.
+struct ServerInstance {
+    /// Receives incoming requests from the Axum handler.
+    request_rx: Arc<TokioMutex<mpsc::Receiver<IncomingRequest>>>,
+    /// Shared map of request_id → response sender.
+    pending_responses: PendingResponses,
+    /// Handle to abort the server task on close.
+    abort_handle: tokio::task::AbortHandle,
+}
+
+/// Shared state for all HTTP servers, stored in OpState.
+#[derive(Default)]
+pub struct HttpServeState {
+    servers: HashMap<u32, ServerInstance>,
+}
+
+/// Custom serde helper for Option<Vec<u8>> — serialize as base64 string or null.
+mod serde_bytes_option {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(bytes) => serializer.serialize_str(&STANDARD.encode(bytes)),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+/// Start an HTTP server on the given port.
+///
+/// Returns `{ id, port, hostname }` where `port` is the actual bound port
+/// (important when the requested port is 0 for OS-assigned).
+#[op2(async)]
+#[serde]
+pub async fn op_http_serve(
+    state: Rc<RefCell<OpState>>,
+    #[smi] port: u16,
+    #[string] hostname: String,
+) -> Result<serde_json::Value, AnyError> {
+    let addr = format!("{}:{}", hostname, port);
+    let listener = TcpListener::bind(&addr)
+        .await
+        .map_err(|e| deno_core::anyhow::anyhow!("Failed to bind {}: {}", addr, e))?;
+
+    let actual_port = listener.local_addr()?.port();
+    let actual_hostname = hostname.clone();
+
+    let server_id = NEXT_SERVER_ID.fetch_add(1, Ordering::SeqCst);
+
+    // Channel: Axum handler → JS accept loop
+    let (request_tx, request_rx) = mpsc::channel::<IncomingRequest>(64);
+
+    // Shared pending response map
+    let pending: PendingResponses = Arc::new(TokioMutex::new(HashMap::new()));
+    let pending_for_axum = Arc::clone(&pending);
+
+    // Start the Axum server in a background task
+    let join_handle = tokio::spawn(async move {
+        let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+            let tx = request_tx.clone();
+            let pending = Arc::clone(&pending_for_axum);
+            async move {
+                let request_id = NEXT_REQUEST_ID.fetch_add(1, Ordering::SeqCst);
+
+                // Extract request data
+                let method = req.method().to_string();
+                let url = req.uri().to_string();
+                let headers: Vec<(String, String)> = req
+                    .headers()
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                    .collect();
+                let body_bytes = axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024)
+                    .await
+                    .ok()
+                    .filter(|b| !b.is_empty())
+                    .map(|b| b.to_vec());
+
+                // Create oneshot for the response
+                let (response_tx, response_rx) = oneshot::channel();
+                pending.lock().await.insert(request_id, response_tx);
+
+                // Send request to JS
+                let incoming = IncomingRequest {
+                    id: request_id,
+                    method,
+                    url,
+                    headers,
+                    body: body_bytes,
+                };
+
+                if tx.send(incoming).await.is_err() {
+                    // Server was closed, JS isn't listening
+                    return StatusCode::SERVICE_UNAVAILABLE.into_response();
+                }
+
+                // Wait for JS to respond
+                match response_rx.await {
+                    Ok(resp) => {
+                        let mut builder = axum::response::Response::builder().status(resp.status);
+                        for (k, v) in &resp.headers {
+                            builder = builder.header(k.as_str(), v.as_str());
+                        }
+                        builder
+                            .body(Body::from(resp.body))
+                            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+                    }
+                    Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                }
+            }
+        });
+
+        // Ignore the error when the server is aborted
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let abort_handle = join_handle.abort_handle();
+
+    // Store server state
+    {
+        let mut op_state = state.borrow_mut();
+        let http_state = op_state.borrow_mut::<HttpServeState>();
+        http_state.servers.insert(
+            server_id,
+            ServerInstance {
+                request_rx: Arc::new(TokioMutex::new(request_rx)),
+                pending_responses: pending,
+                abort_handle,
+            },
+        );
+    }
+
+    Ok(serde_json::json!({
+        "id": server_id,
+        "port": actual_port,
+        "hostname": actual_hostname,
+    }))
+}
+
+/// Wait for the next incoming request on a server.
+///
+/// Returns `{ id, method, url, headers, body }` or null if the server is closing.
+#[op2(async)]
+#[serde]
+pub async fn op_http_serve_accept(
+    state: Rc<RefCell<OpState>>,
+    #[smi] server_id: u32,
+) -> Result<serde_json::Value, AnyError> {
+    let request_rx = {
+        let op_state = state.borrow();
+        let http_state = op_state.borrow::<HttpServeState>();
+        let server = http_state
+            .servers
+            .get(&server_id)
+            .ok_or_else(|| deno_core::anyhow::anyhow!("Unknown server id: {}", server_id))?;
+        Arc::clone(&server.request_rx)
+    };
+
+    let mut rx = request_rx.lock().await;
+    match rx.recv().await {
+        Some(req) => Ok(serde_json::to_value(req)?),
+        None => Ok(serde_json::Value::Null),
+    }
+}
+
+/// Send a response for a pending request.
+#[op2]
+pub fn op_http_serve_respond(
+    state: &mut OpState,
+    #[smi] server_id: u32,
+    #[smi] request_id: u32,
+    #[smi] status: u16,
+    #[serde] headers: Vec<(String, String)>,
+    #[buffer] body: &[u8],
+) -> Result<(), AnyError> {
+    let http_state = state.borrow_mut::<HttpServeState>();
+    let server = http_state
+        .servers
+        .get(&server_id)
+        .ok_or_else(|| deno_core::anyhow::anyhow!("Unknown server id: {}", server_id))?;
+
+    // We need to get the oneshot sender from the pending map.
+    // Since we're in a sync op but pending_responses uses TokioMutex,
+    // we use try_lock which should succeed since no other holder exists.
+    let mut pending = server
+        .pending_responses
+        .try_lock()
+        .map_err(|_| deno_core::anyhow::anyhow!("Pending responses lock contention"))?;
+
+    if let Some(tx) = pending.remove(&request_id) {
+        let _ = tx.send(HttpResponse {
+            status,
+            headers,
+            body: body.to_vec(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Close an HTTP server.
+#[op2(fast)]
+pub fn op_http_serve_close(state: &mut OpState, #[smi] server_id: u32) -> Result<(), AnyError> {
+    let http_state = state.borrow_mut::<HttpServeState>();
+    if let Some(server) = http_state.servers.remove(&server_id) {
+        server.abort_handle.abort();
+    }
+    Ok(())
+}
+
+/// Get the op declarations for HTTP serve ops.
+pub fn op_decls() -> Vec<OpDecl> {
+    vec![
+        op_http_serve(),
+        op_http_serve_accept(),
+        op_http_serve_respond(),
+        op_http_serve_close(),
+    ]
+}
+
+/// JavaScript bootstrap code for the HTTP serve API.
+pub const HTTP_SERVE_BOOTSTRAP_JS: &str = r#"
+((globalThis) => {
+  const ops = Deno.core.ops;
+
+  globalThis.__vtz_http = {
+    async serve(port, hostname, handler) {
+      const server = await ops.op_http_serve(port, hostname);
+      let stopped = false;
+
+      // Accept loop: runs in the background, dispatching requests to the handler
+      (async () => {
+        while (!stopped) {
+          const req = await ops.op_http_serve_accept(server.id);
+          if (req === null) break; // Server closing
+
+          // Process request without blocking the accept loop
+          (async () => {
+            try {
+              // Build full URL for Request constructor
+              const fullUrl = req.url.startsWith('http')
+                ? req.url
+                : `http://${hostname}:${server.port}${req.url}`;
+
+              // Decode base64 body if present
+              let body = undefined;
+              if (req.body) {
+                const binaryStr = atob(req.body);
+                const bytes = new Uint8Array(binaryStr.length);
+                for (let i = 0; i < binaryStr.length; i++) {
+                  bytes[i] = binaryStr.charCodeAt(i);
+                }
+                body = bytes;
+              }
+
+              const request = new Request(fullUrl, {
+                method: req.method,
+                headers: new Headers(req.headers),
+                body: req.method !== 'GET' && req.method !== 'HEAD' ? body : undefined,
+              });
+
+              const response = await handler(request);
+
+              // Serialize response back
+              const respHeaders = [];
+              response.headers.forEach((v, k) => { respHeaders.push([k, v]); });
+              const respBody = new Uint8Array(await response.arrayBuffer());
+
+              ops.op_http_serve_respond(
+                server.id,
+                req.id,
+                response.status,
+                respHeaders,
+                respBody,
+              );
+            } catch (err) {
+              // Send 500 on handler error
+              const errBody = new TextEncoder().encode(err.message || 'Internal Server Error');
+              ops.op_http_serve_respond(
+                server.id,
+                req.id,
+                500,
+                [['content-type', 'text/plain']],
+                errBody,
+              );
+            }
+          })();
+        }
+      })();
+
+      return {
+        id: server.id,
+        port: server.port,
+        hostname: server.hostname,
+        close() {
+          stopped = true;
+          ops.op_http_serve_close(server.id);
+        },
+      };
+    },
+  };
+})(globalThis);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime::js_runtime::{VertzJsRuntime, VertzRuntimeOptions};
+
+    fn create_runtime() -> VertzJsRuntime {
+        VertzJsRuntime::new(VertzRuntimeOptions {
+            capture_output: true,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    /// Helper: run async JS, store result in globalThis.__result, return it.
+    async fn run_async(rt: &mut VertzJsRuntime, code: &str) -> serde_json::Value {
+        let wrapped = format!(
+            r#"(async () => {{ {} }})().then(v => {{ globalThis.__result = v; }}).catch(e => {{ globalThis.__result = 'ERROR: ' + e.message; }})"#,
+            code
+        );
+        rt.execute_script_void("<test>", &wrapped).unwrap();
+        rt.run_event_loop().await.unwrap();
+        rt.execute_script("<read>", "globalThis.__result").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_http_serve_starts_and_responds() {
+        let mut rt = create_runtime();
+
+        // Start server, fetch from it, close server — all in one async block
+        // so run_event_loop can resolve after close() cancels the accept loop.
+        let result = run_async(
+            &mut rt,
+            r#"
+            const server = await globalThis.__vtz_http.serve(0, '127.0.0.1', async (req) => {
+                return new Response('hello from vtz', {
+                    status: 200,
+                    headers: { 'content-type': 'text/plain' },
+                });
+            });
+
+            const resp = await fetch('http://127.0.0.1:' + server.port + '/test');
+            const body = await resp.text();
+            server.close();
+            return body;
+            "#,
+        )
+        .await;
+
+        assert_eq!(result.as_str().unwrap(), "hello from vtz");
+    }
+
+    #[tokio::test]
+    async fn test_http_serve_port_zero() {
+        let mut rt = create_runtime();
+
+        let result = run_async(
+            &mut rt,
+            r#"
+            const server = await globalThis.__vtz_http.serve(0, '127.0.0.1', async (req) => {
+                return new Response('ok');
+            });
+            const port = server.port;
+            server.close();
+            return port;
+            "#,
+        )
+        .await;
+
+        let port = result.as_u64().unwrap();
+        assert!(port > 0, "OS should assign a port > 0");
+    }
+
+    #[tokio::test]
+    async fn test_http_serve_echoes_request_method() {
+        let mut rt = create_runtime();
+
+        let result = run_async(
+            &mut rt,
+            r#"
+            const server = await globalThis.__vtz_http.serve(0, '127.0.0.1', async (req) => {
+                return new Response(req.method, { status: 200 });
+            });
+
+            const resp = await fetch(
+                'http://127.0.0.1:' + server.port + '/test',
+                { method: 'POST' },
+            );
+            const body = await resp.text();
+            server.close();
+            return body;
+            "#,
+        )
+        .await;
+
+        assert_eq!(result.as_str().unwrap(), "POST");
+    }
+}

--- a/native/vtz/src/runtime/ops/mod.rs
+++ b/native/vtz/src/runtime/ops/mod.rs
@@ -8,6 +8,7 @@ pub mod encoding;
 pub mod env;
 pub mod fetch;
 pub mod fs;
+pub mod http_serve;
 pub mod microtask;
 pub mod os;
 pub mod path;

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -835,3 +835,25 @@ async fn test_node_buffer_import() {
     assert_eq!(output.stdout[1], "hex: 68656c6c6f");
     assert_eq!(output.stdout[2], "isBuffer: true");
 }
+
+// --- __vtz_runtime identity marker ---
+
+#[test]
+fn test_vtz_runtime_identity_marker() {
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    rt.execute_script_void(
+        "<test>",
+        r#"
+        console.log("marker: " + globalThis.__vtz_runtime);
+    "#,
+    )
+    .unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(output.stdout[0], "marker: true");
+}

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "bunup": "^0.16.31",
     "typescript": "^5.7.0"
   },

--- a/packages/ci/tsconfig.json
+++ b/packages/ci/tsconfig.json
@@ -5,7 +5,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"],
   "extends": "../../tsconfig.json",

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -365,16 +365,39 @@ describe('startAction', () => {
   });
 });
 
+/**
+ * Helper: extract the server URL from console.log spy calls.
+ * Looks for a log message containing "running at" and extracts the http://... URL.
+ */
+function extractServerUrl(logSpy: MockFunction<(...args: unknown[]) => unknown>): string {
+  const calls = logSpy.mock.calls as unknown[][];
+  const logArgs = calls.find(
+    (args) => typeof args[0] === 'string' && args[0].includes('running at'),
+  );
+  const match = (logArgs?.[0] as string)?.match(/http:\/\/.+?:\d+/);
+  if (!match) throw new Error('Could not extract server URL from log output');
+  return match[0];
+}
+
+/**
+ * Helper: extract the SIGINT shutdown handler from process.on spy calls
+ * and invoke it to stop the server.
+ */
+function stopServerViaSigint(processOnSpy: MockFunction<(...args: unknown[]) => unknown>): void {
+  const onCalls = processOnSpy.mock.calls as [string, () => void][];
+  const sigintHandler = onCalls.find(([signal]) => signal === 'SIGINT');
+  if (sigintHandler) sigintHandler[1]();
+}
+
 describe('startAction — api-only', () => {
   let tmpDir: string;
   let pathsSpy: MockFunction<(...args: unknown[]) => unknown>;
   let logSpy: MockFunction<(...args: unknown[]) => unknown>;
   let processOnSpy: MockFunction<(...args: unknown[]) => unknown>;
-  let originalServe: typeof Bun.serve;
+  let exitSpy: MockFunction<(...args: unknown[]) => unknown>;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'vertz-start-api-'));
-    originalServe = Bun.serve;
     logSpy = spyOn(console, 'log').mockImplementation(() => {}) as MockFunction<
       (...args: unknown[]) => unknown
     >;
@@ -383,14 +406,19 @@ describe('startAction — api-only', () => {
       .mockImplementation(() => process) as unknown as MockFunction<
       (...args: unknown[]) => unknown
     >;
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never) as MockFunction<
+      (...args: unknown[]) => unknown
+    >;
   });
 
   afterEach(() => {
+    stopServerViaSigint(processOnSpy);
     pathsSpy?.mockRestore();
     logSpy.mockRestore();
     processOnSpy.mockRestore();
-    // Restore Bun.serve
-    Object.defineProperty(Bun, 'serve', { value: originalServe, writable: true });
+    exitSpy.mockRestore();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -413,17 +441,8 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServer = { port: 3000, stop: mock() };
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue(mockServer),
-      writable: true,
-    });
-
-    const result = await startAction({ port: 3000, host: '0.0.0.0' });
+    const result = await startAction({ port: 0, host: '0.0.0.0' });
     expect(result.ok).toBe(true);
-
-    // Verify Bun.serve was called
-    expect(Bun.serve).toHaveBeenCalledTimes(1);
 
     // Verify server startup message was logged
     const calls = logSpy.mock.calls as unknown[][];
@@ -441,13 +460,7 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServer = { port: 3000, stop: mock() };
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue(mockServer),
-      writable: true,
-    });
-
-    await startAction({ port: 3000 });
+    await startAction({ port: 0 });
 
     const onCalls = processOnSpy.mock.calls as unknown[][];
     const signals = onCalls.map((args) => args[0]);
@@ -465,7 +478,7 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('Failed to import API module');
@@ -480,7 +493,7 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain(
@@ -489,7 +502,7 @@ describe('startAction — api-only', () => {
     }
   });
 
-  it('passes handler to Bun.serve as the fetch function', async () => {
+  it('handler responds to HTTP requests', async () => {
     scaffoldApiProject('export default { handler: (req) => new Response("hello") };');
 
     const pathsMod = await import('../../utils/paths');
@@ -497,17 +510,13 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServe = mock().mockReturnValue({ port: 4000, stop: mock() });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 4000, host: '127.0.0.1' });
-
-    const serveCall = mockServe.mock.calls[0] as [
-      { port: number; hostname: string; fetch: unknown },
-    ];
-    expect(serveCall[0].port).toBe(4000);
-    expect(serveCall[0].hostname).toBe('127.0.0.1');
-    expect(typeof serveCall[0].fetch).toBe('function');
+    const url = extractServerUrl(logSpy);
+    const res = await fetch(`${url}/test`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toBe('hello');
   });
 
   it('uses localhost in log when host is 0.0.0.0', async () => {
@@ -518,12 +527,7 @@ describe('startAction — api-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 3000, stop: mock() }),
-      writable: true,
-    });
-
-    await startAction({ port: 3000, host: '0.0.0.0' });
+    await startAction({ port: 0, host: '0.0.0.0' });
 
     const calls = logSpy.mock.calls as unknown[][];
     const found = calls.some(
@@ -538,11 +542,10 @@ describe('startAction — ui-only', () => {
   let pathsSpy: MockFunction<(...args: unknown[]) => unknown>;
   let logSpy: MockFunction<(...args: unknown[]) => unknown>;
   let processOnSpy: MockFunction<(...args: unknown[]) => unknown>;
-  let originalServe: typeof Bun.serve;
+  let exitSpy: MockFunction<(...args: unknown[]) => unknown>;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'vertz-start-ui-'));
-    originalServe = Bun.serve;
     logSpy = spyOn(console, 'log').mockImplementation(() => {}) as MockFunction<
       (...args: unknown[]) => unknown
     >;
@@ -551,13 +554,19 @@ describe('startAction — ui-only', () => {
       .mockImplementation(() => process) as unknown as MockFunction<
       (...args: unknown[]) => unknown
     >;
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never) as MockFunction<
+      (...args: unknown[]) => unknown
+    >;
   });
 
   afterEach(() => {
+    stopServerViaSigint(processOnSpy);
     pathsSpy?.mockRestore();
     logSpy.mockRestore();
     processOnSpy.mockRestore();
-    Object.defineProperty(Bun, 'serve', { value: originalServe, writable: true });
+    exitSpy.mockRestore();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -585,15 +594,8 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServer = { port: 3000, stop: mock() };
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue(mockServer),
-      writable: true,
-    });
-
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(true);
-    expect(Bun.serve).toHaveBeenCalledTimes(1);
 
     // Verify server startup message
     const calls = logSpy.mock.calls as unknown[][];
@@ -616,13 +618,7 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServer = { port: 3000, stop: mock() };
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue(mockServer),
-      writable: true,
-    });
-
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(true);
   });
 
@@ -634,7 +630,7 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('Failed to import SSR module');
@@ -649,12 +645,7 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 3000, stop: mock() }),
-      writable: true,
-    });
-
-    await startAction({ port: 3000 });
+    await startAction({ port: 0 });
 
     const onCalls = processOnSpy.mock.calls as unknown[][];
     const signals = onCalls.map((args) => args[0]);
@@ -662,7 +653,7 @@ describe('startAction — ui-only', () => {
     expect(signals).toContain('SIGTERM');
   });
 
-  it('fetch handler serves SSR for nav pre-fetch requests', async () => {
+  it('serves SSR for nav pre-fetch requests', async () => {
     scaffoldUIProject('export default {};');
 
     const pathsMod = await import('../../utils/paths');
@@ -670,27 +661,16 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    let capturedFetch: ((req: Request) => Response | Promise<Response>) | undefined;
-    const mockServe = vi
-      .fn()
-      .mockImplementation((opts: { fetch: (req: Request) => Response | Promise<Response> }) => {
-        capturedFetch = opts.fetch;
-        return { port: 3000, stop: mock() };
-      });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 3000 });
-
-    expect(capturedFetch).toBeDefined();
-    // Nav pre-fetch request — goes through SSR handler which returns a Response
-    const navReq = new Request('http://localhost:3000/', {
-      headers: { 'x-vertz-nav': '1' },
-    });
-    const response = await capturedFetch?.(navReq);
-    expect(response).toBeInstanceOf(Response);
+    const url = extractServerUrl(logSpy);
+    const response = await fetch(url, { headers: { 'x-vertz-nav': '1' } });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe('ssr-mock');
   });
 
-  it('fetch handler serves static files and falls back to SSR', async () => {
+  it('serves static files and falls back to SSR', async () => {
     scaffoldUIProject('export default {};');
     // Create a static file
     mkdirSync(join(tmpDir, 'dist', 'client', 'assets'), { recursive: true });
@@ -701,28 +681,20 @@ describe('startAction — ui-only', () => {
       (...args: unknown[]) => unknown
     >;
 
-    let capturedFetch: ((req: Request) => Response | Promise<Response>) | undefined;
-    const mockServe = vi
-      .fn()
-      .mockImplementation((opts: { fetch: (req: Request) => Response | Promise<Response> }) => {
-        capturedFetch = opts.fetch;
-        return { port: 3000, stop: mock() };
-      });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 3000 });
+    const url = extractServerUrl(logSpy);
 
     // Request a static asset
-    const staticReq = new Request('http://localhost:3000/assets/app.js');
-    const staticRes = await capturedFetch?.(staticReq);
-    expect(staticRes).toBeDefined();
-    expect(staticRes!.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+    const staticRes = await fetch(`${url}/assets/app.js`);
+    expect(staticRes.status).toBe(200);
+    expect(staticRes.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
 
     // Request a route — falls through to SSR
-    const routeReq = new Request('http://localhost:3000/about');
-    const routeRes = await capturedFetch?.(routeReq);
-    expect(routeRes).toBeDefined();
-    expect(routeRes).toBeInstanceOf(Response);
+    const routeRes = await fetch(`${url}/about`);
+    expect(routeRes.status).toBe(200);
+    const body = await routeRes.text();
+    expect(body).toBe('ssr-mock');
   });
 });
 
@@ -731,11 +703,10 @@ describe('startAction — full-stack', () => {
   let pathsSpy: MockFunction<(...args: unknown[]) => unknown>;
   let logSpy: MockFunction<(...args: unknown[]) => unknown>;
   let processOnSpy: MockFunction<(...args: unknown[]) => unknown>;
-  let originalServe: typeof Bun.serve;
+  let exitSpy: MockFunction<(...args: unknown[]) => unknown>;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'vertz-start-fs-'));
-    originalServe = Bun.serve;
     logSpy = spyOn(console, 'log').mockImplementation(() => {}) as MockFunction<
       (...args: unknown[]) => unknown
     >;
@@ -744,13 +715,19 @@ describe('startAction — full-stack', () => {
       .mockImplementation(() => process) as unknown as MockFunction<
       (...args: unknown[]) => unknown
     >;
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never) as MockFunction<
+      (...args: unknown[]) => unknown
+    >;
   });
 
   afterEach(() => {
+    stopServerViaSigint(processOnSpy);
     pathsSpy?.mockRestore();
     logSpy.mockRestore();
     processOnSpy.mockRestore();
-    Object.defineProperty(Bun, 'serve', { value: originalServe, writable: true });
+    exitSpy.mockRestore();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -780,15 +757,8 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockServer = { port: 3000, stop: mock() };
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue(mockServer),
-      writable: true,
-    });
-
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(true);
-    expect(Bun.serve).toHaveBeenCalledTimes(1);
 
     // Verify full-stack server startup message
     const calls = logSpy.mock.calls as unknown[][];
@@ -807,7 +777,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('Failed to import API module');
@@ -822,7 +792,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain(
@@ -842,7 +812,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('Failed to import SSR module');
@@ -860,12 +830,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 3000, stop: mock() }),
-      writable: true,
-    });
-
-    await startAction({ port: 3000 });
+    await startAction({ port: 0 });
 
     const onCalls = processOnSpy.mock.calls as unknown[][];
     const signals = onCalls.map((args) => args[0]);
@@ -889,12 +854,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 3000, stop: mock() }),
-      writable: true,
-    });
-
-    const result = await startAction({ port: 3000 });
+    const result = await startAction({ port: 0 });
     expect(result.ok).toBe(true);
   });
 
@@ -909,21 +869,16 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 8080, stop: mock() }),
-      writable: true,
-    });
-
-    await startAction({ port: 8080, host: '192.168.1.1' });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
     const calls = logSpy.mock.calls as unknown[][];
     const found = calls.some(
-      (args) => typeof args[0] === 'string' && args[0].includes('192.168.1.1'),
+      (args) => typeof args[0] === 'string' && args[0].includes('127.0.0.1'),
     );
     expect(found).toBe(true);
   });
 
-  it('fetch handler routes /api paths to API handler', async () => {
+  it('routes /api paths to API handler', async () => {
     scaffoldFullStackProject(
       'export default { handler: (req) => new Response("api-response") };',
       'export default {};',
@@ -934,28 +889,16 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    let capturedFetch: ((req: Request) => Response | Promise<Response>) | undefined;
-    const mockServe = vi
-      .fn()
-      .mockImplementation((opts: { fetch: (req: Request) => Response | Promise<Response> }) => {
-        capturedFetch = opts.fetch;
-        return { port: 3000, stop: mock() };
-      });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 3000 });
-
-    expect(capturedFetch).toBeDefined();
-
-    // API request
-    const apiReq = new Request('http://localhost:3000/api/users');
-    const apiRes = await capturedFetch?.(apiReq);
-    expect(apiRes).toBeDefined();
-    const body = await apiRes!.text();
+    const url = extractServerUrl(logSpy);
+    const apiRes = await fetch(`${url}/api/users`);
+    expect(apiRes.status).toBe(200);
+    const body = await apiRes.text();
     expect(body).toBe('api-response');
   });
 
-  it('fetch handler routes nav pre-fetch to SSR handler', async () => {
+  it('routes nav pre-fetch to SSR handler', async () => {
     scaffoldFullStackProject(
       'export default { handler: (req) => new Response("api") };',
       'export default {};',
@@ -966,25 +909,16 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    let capturedFetch: ((req: Request) => Response | Promise<Response>) | undefined;
-    const mockServe = vi
-      .fn()
-      .mockImplementation((opts: { fetch: (req: Request) => Response | Promise<Response> }) => {
-        capturedFetch = opts.fetch;
-        return { port: 3000, stop: mock() };
-      });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 3000 });
-
-    const navReq = new Request('http://localhost:3000/', {
-      headers: { 'x-vertz-nav': '1' },
-    });
-    const response = await capturedFetch?.(navReq);
-    expect(response).toBeInstanceOf(Response);
+    const url = extractServerUrl(logSpy);
+    const response = await fetch(url, { headers: { 'x-vertz-nav': '1' } });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe('ssr-mock');
   });
 
-  it('fetch handler serves static files and falls back to SSR', async () => {
+  it('serves static files and falls back to SSR', async () => {
     scaffoldFullStackProject(
       'export default { handler: (req) => new Response("api") };',
       'export default {};',
@@ -997,28 +931,20 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    let capturedFetch: ((req: Request) => Response | Promise<Response>) | undefined;
-    const mockServe = vi
-      .fn()
-      .mockImplementation((opts: { fetch: (req: Request) => Response | Promise<Response> }) => {
-        capturedFetch = opts.fetch;
-        return { port: 3000, stop: mock() };
-      });
-    Object.defineProperty(Bun, 'serve', { value: mockServe, writable: true });
+    await startAction({ port: 0, host: '127.0.0.1' });
 
-    await startAction({ port: 3000 });
+    const url = extractServerUrl(logSpy);
 
     // Static asset
-    const staticReq = new Request('http://localhost:3000/assets/style.css');
-    const staticRes = await capturedFetch?.(staticReq);
-    expect(staticRes).toBeDefined();
-    expect(staticRes!.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+    const staticRes = await fetch(`${url}/assets/style.css`);
+    expect(staticRes.status).toBe(200);
+    expect(staticRes.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
 
     // Non-API, non-static route falls to SSR
-    const routeReq = new Request('http://localhost:3000/dashboard');
-    const routeRes = await capturedFetch?.(routeReq);
-    expect(routeRes).toBeDefined();
-    expect(routeRes).toBeInstanceOf(Response);
+    const routeRes = await fetch(`${url}/dashboard`);
+    expect(routeRes.status).toBe(200);
+    const body = await routeRes.text();
+    expect(body).toBe('ssr-mock');
   });
 
   it('graceful shutdown callback stops server and exits', async () => {
@@ -1032,19 +958,7 @@ describe('startAction — full-stack', () => {
       (...args: unknown[]) => unknown
     >;
 
-    const mockStop = mock();
-    Object.defineProperty(Bun, 'serve', {
-      value: mock().mockReturnValue({ port: 3000, stop: mockStop }),
-      writable: true,
-    });
-
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation(() => undefined as never) as MockFunction<
-      (...args: unknown[]) => unknown
-    >;
-
-    await startAction({ port: 3000 });
+    await startAction({ port: 0 });
 
     // Find the SIGINT handler from process.on calls
     const onCalls = processOnSpy.mock.calls as [string, () => void][];
@@ -1054,9 +968,6 @@ describe('startAction — full-stack', () => {
     // Call the shutdown handler
     sigintHandler?.[1]();
 
-    expect(mockStop).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    exitSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/serve-shared.ts
+++ b/packages/cli/src/commands/serve-shared.ts
@@ -6,22 +6,41 @@
  * (no signal handlers, no console logging, no process.exit).
  */
 
-// Minimal ambient declaration for Bun APIs used by this module.
-// The CLI runs under Bun at runtime; these declarations let tsc validate
-// without pulling in bun-types (which conflicts with @types/node).
-declare const Bun: {
-  serve(options: {
-    port: number;
-    hostname: string;
-    fetch: (req: Request) => Response | Promise<Response>;
-  }): { port: number; stop(): void };
-  file(path: string): Blob & { size: number; type: string };
-};
-
+import { createServer, type Server } from 'node:http';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { extname, join, resolve } from 'node:path';
 import { err, ok, type Result } from '@vertz/errors';
 import type { AppType } from '../dev-server/app-detector';
+
+/** Simple MIME type lookup for static file serving. */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain',
+  '.xml': 'application/xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.wasm': 'application/wasm',
+  '.map': 'application/json',
+};
+
+function getMimeType(filePath: string): string {
+  return MIME_TYPES[extname(filePath)] ?? 'application/octet-stream';
+}
 
 export interface ServeOptions {
   projectRoot: string;
@@ -129,10 +148,11 @@ export function servePrerenderHTML(clientDir: string, pathname: string): Respons
   // Skip _shell.html — that's the SSR template, not a pre-rendered page
   if (htmlPath.endsWith('/_shell.html')) return null;
 
-  const file = Bun.file(htmlPath);
-  if (!file.size) return null;
+  if (!existsSync(htmlPath) || !statSync(htmlPath).isFile()) return null;
+  const fileSize = statSync(htmlPath).size;
+  if (!fileSize) return null;
 
-  return new Response(file, {
+  return new Response(readFileSync(htmlPath), {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, max-age=0, must-revalidate',
@@ -153,12 +173,11 @@ export function serveStaticFile(clientDir: string, pathname: string): Response |
   // Path traversal guard
   if (!filePath.startsWith(clientDir)) return null;
 
-  // Guard: skip directories (Bun.file on a directory causes "MacOS does not
-  // support sending non-regular files" when used as a Response body).
+  // Guard: skip directories and non-existent files
   if (!existsSync(filePath) || !statSync(filePath).isFile()) return null;
 
-  const file = Bun.file(filePath);
-  if (!file.size) return null;
+  const fileSize = statSync(filePath).size;
+  if (!fileSize) return null;
 
   // Cache headers
   const isHashedAsset = pathname.startsWith('/assets/');
@@ -166,11 +185,78 @@ export function serveStaticFile(clientDir: string, pathname: string): Response |
     ? 'public, max-age=31536000, immutable'
     : 'public, max-age=3600';
 
-  return new Response(file, {
+  return new Response(readFileSync(filePath), {
     headers: {
       'Cache-Control': cacheControl,
-      'Content-Type': file.type,
+      'Content-Type': getMimeType(filePath),
     },
+  });
+}
+
+/**
+ * Create an HTTP server from a web-standard fetch handler.
+ * Converts between node:http IncomingMessage/ServerResponse and Request/Response.
+ */
+function startWebServer(
+  port: number,
+  hostname: string,
+  handler: (req: Request) => Response | Promise<Response>,
+): Promise<{ port: number; stop(): void }> {
+  return new Promise((resolvePromise) => {
+    const server: Server = createServer(async (nodeReq, nodeRes) => {
+      try {
+        const url = `http://${hostname}:${port}${nodeReq.url ?? '/'}`;
+        const headers = new Headers();
+        for (const [key, value] of Object.entries(nodeReq.headers)) {
+          if (value) {
+            if (Array.isArray(value)) {
+              for (const v of value) headers.append(key, v);
+            } else {
+              headers.set(key, value);
+            }
+          }
+        }
+
+        const method = nodeReq.method ?? 'GET';
+        const hasBody = method !== 'GET' && method !== 'HEAD';
+        let bodyArrayBuffer: ArrayBuffer | undefined;
+        if (hasBody) {
+          const chunks: Buffer[] = [];
+          for await (const chunk of nodeReq) {
+            chunks.push(chunk as Buffer);
+          }
+          const buf = Buffer.concat(chunks);
+          bodyArrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+        }
+
+        const request = new Request(url, {
+          method,
+          headers,
+          body: hasBody ? bodyArrayBuffer : undefined,
+        });
+
+        const response = await handler(request);
+
+        nodeRes.writeHead(response.status, Object.fromEntries(response.headers));
+        const respBody = await response.arrayBuffer();
+        nodeRes.end(Buffer.from(respBody));
+      } catch (error) {
+        nodeRes.writeHead(500, { 'Content-Type': 'text/plain' });
+        nodeRes.end(error instanceof Error ? error.message : 'Internal Server Error');
+      }
+    });
+
+    server.listen(port, hostname, () => {
+      const addr = server.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : port;
+
+      resolvePromise({
+        port: actualPort,
+        stop() {
+          server.close();
+        },
+      });
+    });
   });
 }
 
@@ -221,29 +307,25 @@ export async function serveUIOnly(options: ServeOptions): Promise<Result<ServeRe
 
   const clientDir = resolve(projectRoot, 'dist', 'client');
 
-  const server = Bun.serve({
-    port,
-    hostname: host,
-    async fetch(req) {
-      const url = new URL(req.url);
-      const pathname = url.pathname;
+  const server = await startWebServer(port, host, async (req) => {
+    const url = new URL(req.url);
+    const pathname = url.pathname;
 
-      // Nav pre-fetch always goes through SSR (for query discovery)
-      if (req.headers.get('x-vertz-nav') === '1') {
-        return ssrHandler(req);
-      }
-
-      // Serve static assets (JS, CSS, images)
-      const staticResponse = serveStaticFile(clientDir, pathname);
-      if (staticResponse) return staticResponse;
-
-      // Check for pre-rendered HTML
-      const prerenderResponse = servePrerenderHTML(clientDir, pathname);
-      if (prerenderResponse) return prerenderResponse;
-
-      // Fallback: runtime SSR
+    // Nav pre-fetch always goes through SSR (for query discovery)
+    if (req.headers.get('x-vertz-nav') === '1') {
       return ssrHandler(req);
-    },
+    }
+
+    // Serve static assets (JS, CSS, images)
+    const staticResponse = serveStaticFile(clientDir, pathname);
+    if (staticResponse) return staticResponse;
+
+    // Check for pre-rendered HTML
+    const prerenderResponse = servePrerenderHTML(clientDir, pathname);
+    if (prerenderResponse) return prerenderResponse;
+
+    // Fallback: runtime SSR
+    return ssrHandler(req);
   });
 
   const displayHost = host === '0.0.0.0' ? 'localhost' : host;
@@ -274,11 +356,7 @@ export async function serveApiOnly(options: ServeOptions): Promise<Result<ServeR
     return err(new Error('API module must export default with a .handler function.'));
   }
 
-  const server = Bun.serve({
-    port,
-    hostname: host,
-    fetch: handler,
-  });
+  const server = await startWebServer(port, host, handler);
 
   const displayHost = host === '0.0.0.0' ? 'localhost' : host;
   return ok({ server, url: `http://${displayHost}:${server.port}`, aotRouteCount: 0 });
@@ -350,34 +428,30 @@ export async function serveFullStack(options: ServeOptions): Promise<Result<Serv
 
   const clientDir = resolve(projectRoot, 'dist', 'client');
 
-  const server = Bun.serve({
-    port,
-    hostname: host,
-    async fetch(req) {
-      const url = new URL(req.url);
-      const pathname = url.pathname;
+  const server = await startWebServer(port, host, async (req) => {
+    const url = new URL(req.url);
+    const pathname = url.pathname;
 
-      // API routes
-      if (pathname.startsWith('/api')) {
-        return apiHandler(req);
-      }
+    // API routes
+    if (pathname.startsWith('/api')) {
+      return apiHandler(req);
+    }
 
-      // Nav pre-fetch always goes through SSR (for query discovery)
-      if (req.headers.get('x-vertz-nav') === '1') {
-        return ssrHandler(req);
-      }
-
-      // Static assets
-      const staticResponse = serveStaticFile(clientDir, pathname);
-      if (staticResponse) return staticResponse;
-
-      // Pre-rendered HTML
-      const prerenderResponse = servePrerenderHTML(clientDir, pathname);
-      if (prerenderResponse) return prerenderResponse;
-
-      // Runtime SSR fallback
+    // Nav pre-fetch always goes through SSR (for query discovery)
+    if (req.headers.get('x-vertz-nav') === '1') {
       return ssrHandler(req);
-    },
+    }
+
+    // Static assets
+    const staticResponse = serveStaticFile(clientDir, pathname);
+    if (staticResponse) return staticResponse;
+
+    // Pre-rendered HTML
+    const prerenderResponse = servePrerenderHTML(clientDir, pathname);
+    if (prerenderResponse) return prerenderResponse;
+
+    // Runtime SSR fallback
+    return ssrHandler(req);
   });
 
   const displayHost = host === '0.0.0.0' ? 'localhost' : host;

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "bunup": "^0.16.31",
     "typescript": "^5.7.0"
   },

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -5,7 +5,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"],
   "extends": "../../tsconfig.json",

--- a/packages/compiler/tsconfig.typecheck.json
+++ b/packages/compiler/tsconfig.typecheck.json
@@ -6,7 +6,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,
-    "types": ["node", "bun-types"]
+    "types": ["node"]
   },
   "extends": "../../tsconfig.json",
   "include": ["src"]

--- a/packages/component-docs/package.json
+++ b/packages/component-docs/package.json
@@ -21,7 +21,6 @@
     "@types/node": "^25.3.1",
     "@vertz/cli": "workspace:*",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.9",
     "typescript": "^5.8.0",
     "wrangler": "^4.78.0"
   },

--- a/packages/component-docs/tsconfig.json
+++ b/packages/component-docs/tsconfig.json
@@ -9,8 +9,7 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2022",
-    "types": ["bun-types"]
+    "target": "ES2022"
   },
   "include": ["src"]
 }

--- a/packages/core/src/app/__tests__/detect-adapter.test.ts
+++ b/packages/core/src/app/__tests__/detect-adapter.test.ts
@@ -1,21 +1,57 @@
-import { describe, expect, it } from '@vertz/test';
+import { afterEach, describe, expect, it } from '@vertz/test';
 import { detectAdapter } from '../detect-adapter';
 
 const hasBun = 'Bun' in globalThis;
+const hasVtz = '__vtz_runtime' in globalThis;
+
+afterEach(() => {
+  // Clean up vtz runtime mock if set
+  if (!hasVtz) {
+    delete (globalThis as Record<string, unknown>).__vtz_runtime;
+    delete (globalThis as Record<string, unknown>).__vtz_http;
+  }
+});
 
 describe('detectAdapter', () => {
-  it.skipIf(!hasBun)('returns a ServerAdapter with a listen method when Bun is available', () => {
-    const adapter = detectAdapter();
+  it.skipIf(!hasBun)(
+    'returns a ServerAdapter with a listen method when Bun is available',
+    async () => {
+      const adapter = await detectAdapter();
+      expect(adapter.listen).toBeTypeOf('function');
+    },
+  );
+
+  it.skipIf(!hasBun)('returns a ServerAdapter when given hasBun hint', async () => {
+    const adapter = await detectAdapter({ hasBun: true, hasVtz: false });
     expect(adapter.listen).toBeTypeOf('function');
   });
 
-  it('returns a ServerAdapter when given hasBun hint', () => {
-    if (!hasBun) return; // Bun adapter requires Bun runtime to construct
-    const adapter = detectAdapter({ hasBun: true });
+  it('returns a vtz ServerAdapter when given hasVtz hint', async () => {
+    // Mock vtz globals so the adapter module can be constructed
+    (globalThis as Record<string, unknown>).__vtz_runtime = true;
+    (globalThis as Record<string, unknown>).__vtz_http = {
+      serve: async () => ({ id: 1, port: 0, hostname: '0.0.0.0', close() {} }),
+    };
+
+    const adapter = await detectAdapter({ hasVtz: true, hasBun: false });
     expect(adapter.listen).toBeTypeOf('function');
   });
 
-  it('throws when no supported runtime is detected', () => {
-    expect(() => detectAdapter({ hasBun: false })).toThrow('No supported server runtime detected');
+  it('prefers vtz adapter when both runtimes are available', async () => {
+    // Mock vtz globals
+    (globalThis as Record<string, unknown>).__vtz_runtime = true;
+    (globalThis as Record<string, unknown>).__vtz_http = {
+      serve: async () => ({ id: 1, port: 0, hostname: '0.0.0.0', close() {} }),
+    };
+
+    const adapter = await detectAdapter({ hasVtz: true, hasBun: true });
+    // The adapter should be the vtz one — we can verify by checking it uses __vtz_http
+    expect(adapter.listen).toBeTypeOf('function');
+  });
+
+  it('rejects when no supported runtime is detected', async () => {
+    await expect(detectAdapter({ hasBun: false, hasVtz: false })).rejects.toThrow(
+      'No supported server runtime detected',
+    );
   });
 });

--- a/packages/core/src/app/__tests__/vtz-adapter.test.ts
+++ b/packages/core/src/app/__tests__/vtz-adapter.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from '@vertz/test';
+import { createVtzAdapter } from '../vtz-adapter';
+
+// Types matching globalThis.__vtz_http shape from the Rust bootstrap JS
+type VtzServeResult = {
+  id: number;
+  port: number;
+  hostname: string;
+  close(): void;
+};
+
+type VtzHttpServe = (
+  port: number,
+  hostname: string,
+  handler: (request: Request) => Promise<Response>,
+) => Promise<VtzServeResult>;
+
+// Mock server returned by __vtz_http.serve()
+const mockClose = mock<() => void>(() => {});
+const mockServer: VtzServeResult = {
+  id: 1,
+  port: 0,
+  hostname: '',
+  close: mockClose,
+};
+const mockServe = mock<VtzHttpServe>(async () => mockServer);
+
+// Save and restore original
+const originalVtzHttp = (globalThis as Record<string, unknown>).__vtz_http;
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).__vtz_http = { serve: mockServe };
+});
+
+afterEach(() => {
+  mockServe.mockClear();
+  mockClose.mockClear();
+  if (originalVtzHttp !== undefined) {
+    (globalThis as Record<string, unknown>).__vtz_http = originalVtzHttp;
+  } else {
+    delete (globalThis as Record<string, unknown>).__vtz_http;
+  }
+});
+
+describe('createVtzAdapter', () => {
+  describe('listen', () => {
+    it('passes port and handler to __vtz_http.serve', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 4000;
+      mockServer.hostname = '127.0.0.1';
+
+      await adapter.listen(4000, handler);
+
+      expect(mockServe).toHaveBeenCalledTimes(1);
+      const args = mockServe.mock.calls[0];
+      expect(args?.[0]).toBe(4000);
+      expect(args?.[2]).toBe(handler);
+    });
+
+    it('passes hostname from options to __vtz_http.serve', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 3000;
+      mockServer.hostname = '0.0.0.0';
+
+      await adapter.listen(3000, handler, { hostname: '0.0.0.0' });
+
+      const args = mockServe.mock.calls[0];
+      expect(args?.[1]).toBe('0.0.0.0');
+    });
+
+    it('defaults hostname to 0.0.0.0 when no options are provided', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 3000;
+      mockServer.hostname = '0.0.0.0';
+
+      await adapter.listen(3000, handler);
+
+      const args = mockServe.mock.calls[0];
+      expect(args?.[1]).toBe('0.0.0.0');
+    });
+
+    it('defaults hostname to 0.0.0.0 when options exist but hostname is omitted', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 3000;
+      mockServer.hostname = '0.0.0.0';
+
+      await adapter.listen(3000, handler, {});
+
+      const args = mockServe.mock.calls[0];
+      expect(args?.[1]).toBe('0.0.0.0');
+    });
+
+    it('returns a ServerHandle with port and hostname from the server', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 54321;
+      mockServer.hostname = '192.168.1.100';
+
+      const handle = await adapter.listen(0, handler);
+
+      expect(handle.port).toBe(54321);
+      expect(handle.hostname).toBe('192.168.1.100');
+    });
+
+    it('returns a ServerHandle whose close() calls server.close()', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServer.port = 3000;
+      mockServer.hostname = '127.0.0.1';
+
+      const handle = await adapter.listen(3000, handler);
+
+      expect(mockClose).not.toHaveBeenCalled();
+
+      await handle.close();
+
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates errors from __vtz_http.serve to the caller', async () => {
+      const adapter = createVtzAdapter();
+      const handler = mock(async () => new Response());
+
+      mockServe.mockImplementationOnce(async () => {
+        throw new Error('Failed to bind 0.0.0.0:3000');
+      });
+
+      await expect(adapter.listen(3000, handler)).rejects.toThrow('Failed to bind 0.0.0.0:3000');
+    });
+  });
+});

--- a/packages/core/src/app/app-builder.ts
+++ b/packages/core/src/app/app-builder.ts
@@ -51,7 +51,7 @@ export function createApp(config: AppConfig): AppBuilder {
       return { routes: registeredRoutes };
     },
     async listen(port, options) {
-      const adapter = detectAdapter();
+      const adapter = await detectAdapter();
       const serverHandle = await adapter.listen(port ?? DEFAULT_PORT, builder.handler, options);
 
       if (options?.logRoutes !== false) {

--- a/packages/core/src/app/detect-adapter.ts
+++ b/packages/core/src/app/detect-adapter.ts
@@ -1,20 +1,31 @@
 import type { ServerAdapter } from '../types/server-adapter';
-import { createBunAdapter } from './bun-adapter';
 
 export interface RuntimeHints {
   hasBun: boolean;
+  hasVtz: boolean;
 }
 
 function detectRuntime(): RuntimeHints {
-  return { hasBun: 'Bun' in globalThis };
+  return {
+    hasBun: 'Bun' in globalThis,
+    hasVtz: '__vtz_runtime' in globalThis,
+  };
 }
 
-export function detectAdapter(hints?: RuntimeHints): ServerAdapter {
+export async function detectAdapter(hints?: RuntimeHints): Promise<ServerAdapter> {
   const runtime = hints ?? detectRuntime();
 
+  if (runtime.hasVtz) {
+    const { createVtzAdapter } = await import('./vtz-adapter');
+    return createVtzAdapter();
+  }
+
   if (runtime.hasBun) {
+    const { createBunAdapter } = await import('./bun-adapter');
     return createBunAdapter();
   }
 
-  throw new Error('No supported server runtime detected. Vertz requires Bun to use app.listen().');
+  throw new Error(
+    'No supported server runtime detected. Vertz requires Bun or vtz to use app.listen().',
+  );
 }

--- a/packages/core/src/app/vtz-adapter.ts
+++ b/packages/core/src/app/vtz-adapter.ts
@@ -1,20 +1,10 @@
 import type { ServerAdapter } from '../types/server-adapter';
 
-declare const globalThis: {
-  __vtz_http: {
-    serve(
-      port: number,
-      hostname: string,
-      handler: (request: Request) => Promise<Response>,
-    ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
-  };
-};
-
 export function createVtzAdapter(): ServerAdapter {
   return {
     async listen(port, handler, options) {
       const hostname = options?.hostname ?? '0.0.0.0';
-      const server = await globalThis.__vtz_http.serve(port, hostname, handler);
+      const server = await globalThis.__vtz_http!.serve(port, hostname, handler);
 
       return {
         port: server.port,

--- a/packages/core/src/app/vtz-adapter.ts
+++ b/packages/core/src/app/vtz-adapter.ts
@@ -1,0 +1,28 @@
+import type { ServerAdapter } from '../types/server-adapter';
+
+declare const globalThis: {
+  __vtz_http: {
+    serve(
+      port: number,
+      hostname: string,
+      handler: (request: Request) => Promise<Response>,
+    ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
+  };
+};
+
+export function createVtzAdapter(): ServerAdapter {
+  return {
+    async listen(port, handler, options) {
+      const hostname = options?.hostname ?? '0.0.0.0';
+      const server = await globalThis.__vtz_http.serve(port, hostname, handler);
+
+      return {
+        port: server.port,
+        hostname: server.hostname,
+        async close() {
+          server.close();
+        },
+      };
+    },
+  };
+}

--- a/packages/core/src/types/vtz-runtime.ts
+++ b/packages/core/src/types/vtz-runtime.ts
@@ -1,0 +1,23 @@
+/**
+ * Type declarations for the vtz runtime globals.
+ *
+ * These globals are injected by the vtz Rust runtime's bootstrap JS.
+ * They are `undefined` when running on other runtimes (Bun, Node).
+ */
+
+declare global {
+  // eslint-disable-next-line no-var -- globals must use var
+  var __vtz_runtime: boolean | undefined;
+  // eslint-disable-next-line no-var -- globals must use var
+  var __vtz_http:
+    | {
+        serve(
+          port: number,
+          hostname: string,
+          handler: (request: Request) => Promise<Response>,
+        ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
+      }
+    | undefined;
+}
+
+export {};

--- a/packages/create-vertz-app/package.json
+++ b/packages/create-vertz-app/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/packages/create-vertz-app/tsconfig.json
+++ b/packages/create-vertz-app/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
-    "types": ["bun-types"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "**/__tests__"],
   "include": ["src/**/*"]

--- a/packages/docs/src/__tests__/build-pipeline.test.ts
+++ b/packages/docs/src/__tests__/build-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildDocs } from '../generator/build-pipeline';
@@ -54,7 +55,7 @@ Check the guides.
   it('generates llms.txt index', async () => {
     await buildDocs({ projectDir: tempDir, outDir, baseUrl: 'https://docs.example.com' });
     expect(existsSync(join(outDir, 'llms.txt'))).toBe(true);
-    const content = await Bun.file(join(outDir, 'llms.txt')).text();
+    const content = await readFile(join(outDir, 'llms.txt'), 'utf-8');
     expect(content).toContain('# Test Docs');
     expect(content).toContain('home.md');
   });
@@ -62,7 +63,7 @@ Check the guides.
   it('generates llms-full.txt concatenated file', async () => {
     await buildDocs({ projectDir: tempDir, outDir });
     expect(existsSync(join(outDir, 'llms-full.txt'))).toBe(true);
-    const content = await Bun.file(join(outDir, 'llms-full.txt')).text();
+    const content = await readFile(join(outDir, 'llms-full.txt'), 'utf-8');
     expect(content).toContain('# Welcome');
   });
 
@@ -81,7 +82,7 @@ Check the guides.
   it('generates a manifest with route metadata', async () => {
     await buildDocs({ projectDir: tempDir, outDir });
     expect(existsSync(join(outDir, 'manifest.json'))).toBe(true);
-    const manifest = JSON.parse(await Bun.file(join(outDir, 'manifest.json')).text());
+    const manifest = JSON.parse(await readFile(join(outDir, 'manifest.json'), 'utf-8'));
     expect(manifest.routes).toHaveLength(1);
     expect(manifest.routes[0].path).toBe('/');
     expect(manifest.routes[0].headings).toHaveLength(2);
@@ -111,7 +112,7 @@ Content here.
   it('generates HTML files for each page', async () => {
     await buildDocs({ projectDir: tempDir, outDir });
     expect(existsSync(join(outDir, 'index.html'))).toBe(true);
-    const html = await Bun.file(join(outDir, 'index.html')).text();
+    const html = await readFile(join(outDir, 'index.html'), 'utf-8');
     expect(html).toContain('<!DOCTYPE html>');
     expect(html).toContain('Welcome');
   });
@@ -130,7 +131,7 @@ Page content.
 `,
     );
     await buildDocs({ projectDir: tempDir, outDir });
-    const html = await Bun.file(join(outDir, 'index.html')).text();
+    const html = await readFile(join(outDir, 'index.html'), 'utf-8');
     expect(html).toContain('<title>Custom Title - Test Docs</title>');
     expect(html).toContain('A custom description for SEO.');
   });
@@ -138,7 +139,7 @@ Page content.
   it('generates sitemap.xml listing all pages', async () => {
     await buildDocs({ projectDir: tempDir, outDir, baseUrl: 'https://docs.example.com' });
     expect(existsSync(join(outDir, 'sitemap.xml'))).toBe(true);
-    const sitemap = await Bun.file(join(outDir, 'sitemap.xml')).text();
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
     expect(sitemap).toContain('<?xml');
     expect(sitemap).toContain('https://docs.example.com/');
   });
@@ -146,7 +147,7 @@ Page content.
   it('generates robots.txt', async () => {
     await buildDocs({ projectDir: tempDir, outDir, baseUrl: 'https://docs.example.com' });
     expect(existsSync(join(outDir, 'robots.txt'))).toBe(true);
-    const robots = await Bun.file(join(outDir, 'robots.txt')).text();
+    const robots = await readFile(join(outDir, 'robots.txt'), 'utf-8');
     expect(robots).toContain('Sitemap: https://docs.example.com/sitemap.xml');
   });
 
@@ -161,7 +162,7 @@ Page content.
     );
     await buildDocs({ projectDir: tempDir, outDir });
     expect(existsSync(join(outDir, 'old-page', 'index.html'))).toBe(true);
-    const html = await Bun.file(join(outDir, 'old-page', 'index.html')).text();
+    const html = await readFile(join(outDir, 'old-page', 'index.html'), 'utf-8');
     expect(html).toContain('/new-page');
     expect(html).toContain('http-equiv="refresh"');
   });
@@ -183,7 +184,7 @@ Page content.
     // But HTML should still be generated
     expect(existsSync(join(outDir, 'internal/debug.html'))).toBe(true);
     // llms.txt should not list excluded page
-    const llmsTxt = await Bun.file(join(outDir, 'llms.txt')).text();
+    const llmsTxt = await readFile(join(outDir, 'llms.txt'), 'utf-8');
     expect(llmsTxt).not.toContain('debug');
   });
 
@@ -201,7 +202,7 @@ Content here.
 `,
     );
     await buildDocs({ projectDir: tempDir, outDir, baseUrl: 'https://docs.example.com' });
-    const llmMd = await Bun.file(join(outDir, 'llms', 'home.md')).text();
+    const llmMd = await readFile(join(outDir, 'llms', 'home.md'), 'utf-8');
     // Enriched frontmatter includes title, description, category, and url
     expect(llmMd).toContain('title: Getting Started');
     expect(llmMd).toContain('description: Learn how to get started with Vertz.');
@@ -211,7 +212,7 @@ Content here.
 
   it('enriches LLM frontmatter even when source has no frontmatter', async () => {
     await buildDocs({ projectDir: tempDir, outDir, baseUrl: 'https://docs.example.com' });
-    const llmMd = await Bun.file(join(outDir, 'llms', 'home.md')).text();
+    const llmMd = await readFile(join(outDir, 'llms', 'home.md'), 'utf-8');
     // Even without source frontmatter, the build injects category and url
     expect(llmMd).toContain('category: Start');
     expect(llmMd).toContain('url: https://docs.example.com/');
@@ -228,7 +229,7 @@ Content here.
     await buildDocs({ projectDir: tempDir, outDir });
     expect(existsSync(join(outDir, 'favicon.svg'))).toBe(true);
     expect(existsSync(join(outDir, 'logo', 'dark.svg'))).toBe(true);
-    const content = await Bun.file(join(outDir, 'favicon.svg')).text();
+    const content = await readFile(join(outDir, 'favicon.svg'), 'utf-8');
     expect(content).toBe('<svg>icon</svg>');
   });
 

--- a/packages/docs/src/__tests__/docs-cli-actions.test.ts
+++ b/packages/docs/src/__tests__/docs-cli-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@vertz/test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -37,7 +38,7 @@ describe('createDocsDevServer — static files', () => {
   let testDir: string;
   let server: { port: number; hostname: string; stop(): void } | null = null;
 
-  // Bun.serve() requires native Response — unregister happy-dom for these tests
+  // HTTP server requires native Response — unregister happy-dom for these tests
   beforeAll(() => {
     GlobalRegistrator.unregister();
   });
@@ -175,7 +176,7 @@ describe('docsBuildAction', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(existsSync(join(testDir, 'dist', 'llms.txt'))).toBe(true);
-      const llmsTxt = await Bun.file(join(testDir, 'dist', 'llms.txt')).text();
+      const llmsTxt = await readFile(join(testDir, 'dist', 'llms.txt'), 'utf-8');
       expect(llmsTxt).toContain('https://docs.example.com');
     }
   });

--- a/packages/docs/src/__tests__/init.test.ts
+++ b/packages/docs/src/__tests__/init.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initDocs } from '../cli/init';
@@ -33,15 +34,15 @@ describe('initDocs', () => {
 
   it('does not overwrite existing config', async () => {
     const configPath = join(tempDir, 'vertz.config.ts');
-    await Bun.write(configPath, 'export default { name: "Existing" }');
+    writeFileSync(configPath, 'export default { name: "Existing" }');
     await initDocs(tempDir);
-    const content = await Bun.file(configPath).text();
+    const content = await readFile(configPath, 'utf-8');
     expect(content).toContain('Existing');
   });
 
   it('config contains defineDocsConfig import', async () => {
     await initDocs(tempDir);
-    const content = await Bun.file(join(tempDir, 'vertz.config.ts')).text();
+    const content = await readFile(join(tempDir, 'vertz.config.ts'), 'utf-8');
     expect(content).toContain('defineDocsConfig');
   });
 });

--- a/packages/docs/src/cli/init.ts
+++ b/packages/docs/src/cli/init.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const CONFIG_TEMPLATE = `import { defineDocsConfig } from '@vertz/docs';
@@ -78,16 +79,16 @@ export async function initDocs(projectDir: string): Promise<void> {
 
   const configPath = join(projectDir, 'vertz.config.ts');
   if (!existsSync(configPath)) {
-    await Bun.write(configPath, CONFIG_TEMPLATE);
+    await writeFile(configPath, CONFIG_TEMPLATE);
   }
 
   const indexPath = join(pagesDir, 'index.mdx');
   if (!existsSync(indexPath)) {
-    await Bun.write(indexPath, INDEX_TEMPLATE);
+    await writeFile(indexPath, INDEX_TEMPLATE);
   }
 
   const quickstartPath = join(pagesDir, 'quickstart.mdx');
   if (!existsSync(quickstartPath)) {
-    await Bun.write(quickstartPath, QUICKSTART_TEMPLATE);
+    await writeFile(quickstartPath, QUICKSTART_TEMPLATE);
   }
 }

--- a/packages/docs/src/dev/docs-dev-server.ts
+++ b/packages/docs/src/dev/docs-dev-server.ts
@@ -1,5 +1,6 @@
+import { createServer, type Server } from 'node:http';
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { extname, resolve } from 'node:path';
 import { loadDocsConfig } from '../config/load';
 import { extractHeadings } from '../mdx/extract-headings';
 import { parseFrontmatter } from '../mdx/frontmatter';
@@ -19,6 +20,26 @@ export interface DocsDevServer {
   hostname: string;
   stop(): void;
 }
+
+/** Simple MIME type lookup for static file serving. */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain',
+  '.xml': 'application/xml',
+  '.webp': 'image/webp',
+};
 
 /**
  * Read frontmatter from all page MDX files and return a map of
@@ -61,6 +82,7 @@ function readPageFrontmatter(
  */
 export async function createDocsDevServer(options: DocsDevServerOptions): Promise<DocsDevServer> {
   const { projectDir, host = 'localhost' } = options;
+  const port = options.port ?? 3001;
   const pagesDir = resolve(projectDir, 'pages');
 
   const config = await loadDocsConfig(projectDir);
@@ -74,106 +96,105 @@ export async function createDocsDevServer(options: DocsDevServerOptions): Promis
   // Read frontmatter from all pages at startup
   const { pageTitles, pageDescriptions } = readPageFrontmatter(pagesDir, routes);
 
-  const sseClients = new Set<ReadableStreamController<Uint8Array>>();
+  const sseClients = new Set<import('node:http').ServerResponse>();
 
-  const server = Bun.serve({
-    port: options.port ?? 3001,
-    hostname: host,
-    async fetch(req) {
-      const url = new URL(req.url);
-      const pathname = url.pathname;
+  const server: Server = createServer(async (req, res) => {
+    const pathname = new URL(req.url ?? '/', `http://${host}:${port}`).pathname;
 
-      // SSE endpoint for live reload
-      if (pathname === '/__docs_reload') {
-        let streamController: ReadableStreamDefaultController<Uint8Array>;
-        const stream = new ReadableStream<Uint8Array>({
-          start(controller) {
-            streamController = controller;
-            sseClients.add(controller);
-          },
-          cancel() {
-            sseClients.delete(streamController);
-          },
-        });
-        return new Response(stream, {
-          headers: {
-            'content-type': 'text/event-stream',
-            'cache-control': 'no-cache',
-            connection: 'keep-alive',
-          },
-        });
+    // SSE endpoint for live reload
+    if (pathname === '/__docs_reload') {
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+      sseClients.add(res);
+      req.on('close', () => {
+        sseClients.delete(res);
+      });
+      return;
+    }
+
+    // Find matching route
+    const route = routeMap.get(pathname);
+    if (!route) {
+      // Try serving from public/ directory
+      const publicPath = resolve(projectDir, 'public', pathname.slice(1));
+      if (
+        publicPath.startsWith(resolve(projectDir, 'public')) &&
+        existsSync(publicPath) &&
+        statSync(publicPath).isFile()
+      ) {
+        const content = readFileSync(publicPath);
+        const mime = MIME_TYPES[extname(publicPath)] ?? 'application/octet-stream';
+        res.writeHead(200, { 'content-type': mime });
+        res.end(content);
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end('Not Found');
+      return;
+    }
+
+    try {
+      const normalizedFilePath = route.filePath.endsWith('.mdx')
+        ? route.filePath
+        : `${route.filePath}.mdx`;
+      const mdxPath = resolve(pagesDir, normalizedFilePath);
+
+      // Guard against path traversal
+      if (!mdxPath.startsWith(pagesDir)) {
+        res.writeHead(403, { 'content-type': 'text/plain' });
+        res.end('Forbidden');
+        return;
       }
 
-      // Find matching route
-      const route = routeMap.get(pathname);
-      if (!route) {
-        // Try serving from public/ directory
-        const publicPath = resolve(projectDir, 'public', pathname.slice(1));
-        if (
-          publicPath.startsWith(resolve(projectDir, 'public')) &&
-          existsSync(publicPath) &&
-          statSync(publicPath).isFile()
-        ) {
-          const file = Bun.file(publicPath);
-          return new Response(file);
-        }
-        return new Response('Not Found', { status: 404 });
-      }
+      const source = readFileSync(mdxPath, 'utf-8');
+      const contentHtml = await compileMdxToHtml(source);
+      const headings = extractHeadings(source);
 
-      try {
-        const normalizedFilePath = route.filePath.endsWith('.mdx')
-          ? route.filePath
-          : `${route.filePath}.mdx`;
-        const mdxPath = resolve(pagesDir, normalizedFilePath);
+      // Get frontmatter title and description for this page
+      const pageTitle = pageTitles[route.filePath];
+      const description = pageDescriptions[route.filePath];
 
-        // Guard against path traversal
-        if (!mdxPath.startsWith(pagesDir)) {
-          return new Response('Forbidden', { status: 403 });
-        }
-
-        const source = readFileSync(mdxPath, 'utf-8');
-        const contentHtml = await compileMdxToHtml(source);
-        const headings = extractHeadings(source);
-
-        // Get frontmatter title and description for this page
-        const pageTitle = pageTitles[route.filePath];
-        const description = pageDescriptions[route.filePath];
-
-        const html = renderPageHtml({
-          config,
-          route,
-          contentHtml,
-          headings,
-          pageTitle,
-          description,
-          pageTitles,
-        });
-        return new Response(html, {
-          headers: { 'content-type': 'text/html; charset=utf-8' },
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return new Response(`<h1>Error</h1><pre>${escapeHtml(message)}</pre>`, {
-          status: 500,
-          headers: { 'content-type': 'text/html' },
-        });
-      }
-    },
+      const html = renderPageHtml({
+        config,
+        route,
+        contentHtml,
+        headings,
+        pageTitle,
+        description,
+        pageTitles,
+      });
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(html);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.writeHead(500, { 'content-type': 'text/html' });
+      res.end(`<h1>Error</h1><pre>${escapeHtml(message)}</pre>`);
+    }
   });
 
-  return {
-    port: server.port ?? options.port ?? 3001,
-    hostname: server.hostname ?? host,
-    stop() {
-      for (const client of sseClients) {
-        try {
-          client.close();
-        } catch {
-          // Client already closed
-        }
-      }
-      sseClients.clear();
-      server.stop();
-    },
-  };
+  return new Promise((resolvePromise) => {
+    server.listen(port, host, () => {
+      const addr = server.address();
+      const actualPort = typeof addr === 'object' && addr ? addr.port : port;
+
+      resolvePromise({
+        port: actualPort,
+        hostname: host,
+        stop() {
+          for (const client of sseClients) {
+            try {
+              client.end();
+            } catch {
+              // Client already closed
+            }
+          }
+          sseClients.clear();
+          server.close();
+        },
+      });
+    });
+  });
 }

--- a/packages/docs/src/generator/build-pipeline.ts
+++ b/packages/docs/src/generator/build-pipeline.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { loadDocsConfig } from '../config/load';
 import { compileMdxToHtml } from '../dev/compile-mdx-html';
@@ -63,7 +64,7 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
     const filePath = join(pagesDir, normalizedFilePath);
     if (!existsSync(filePath)) continue;
 
-    const rawContent = await Bun.file(filePath).text();
+    const rawContent = await readFile(filePath, 'utf-8');
     const { data: frontmatter, content: bodyContent } = parseFrontmatter(rawContent);
     const headings = extractHeadings(bodyContent);
     const title = frontmatter.title ?? route.title;
@@ -94,7 +95,7 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
 
     const htmlPath = toHtmlOutputPath(route.path, outDir);
     mkdirSync(dirname(htmlPath), { recursive: true });
-    await Bun.write(htmlPath, seoHtml);
+    await writeFile(htmlPath, seoHtml);
 
     // Generate LLM markdown with enriched frontmatter
     if (config.llm?.enabled && !isLlmExcluded(route.filePath, config.llm.exclude)) {
@@ -109,7 +110,7 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
 
       const llmFilePath = toLlmOutputPath(route.path, outDir);
       mkdirSync(dirname(llmFilePath), { recursive: true });
-      await Bun.write(llmFilePath, markdown);
+      await writeFile(llmFilePath, markdown);
     }
   }
 
@@ -118,19 +119,19 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
     const llmConfig = config.llm;
     const includedRoutes = routes.filter((r) => !isLlmExcluded(r.filePath, llmConfig.exclude));
     const llmsTxt = generateLlmsTxt(includedRoutes, llmConfig, baseUrl);
-    await Bun.write(join(outDir, 'llms.txt'), llmsTxt);
+    await writeFile(join(outDir, 'llms.txt'), llmsTxt);
 
     const llmsFullTxt = generateLlmsFullTxt(llmPages, llmConfig);
-    await Bun.write(join(outDir, 'llms-full.txt'), llmsFullTxt);
+    await writeFile(join(outDir, 'llms-full.txt'), llmsFullTxt);
   }
 
   // Generate sitemap.xml
   if (baseUrl) {
     const sitemap = generateSitemap(manifestRoutes, baseUrl);
-    await Bun.write(join(outDir, 'sitemap.xml'), sitemap);
+    await writeFile(join(outDir, 'sitemap.xml'), sitemap);
 
     const robots = generateRobotsTxt(baseUrl);
-    await Bun.write(join(outDir, 'robots.txt'), robots);
+    await writeFile(join(outDir, 'robots.txt'), robots);
   }
 
   // Generate redirect pages
@@ -139,7 +140,7 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
       const redirectHtml = generateRedirectHtml(redirect.destination);
       const redirectPath = join(outDir, redirect.source, 'index.html');
       mkdirSync(dirname(redirectPath), { recursive: true });
-      await Bun.write(redirectPath, redirectHtml);
+      await writeFile(redirectPath, redirectHtml);
     }
   }
 
@@ -159,7 +160,7 @@ export async function buildDocs(options: BuildDocsOptions): Promise<BuildManifes
     name: config.name,
     routes: manifestRoutes,
   };
-  await Bun.write(join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 
   return manifest;
 }

--- a/packages/og/package.json
+++ b/packages/og/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "bunup": "^0.16.31",
     "typescript": "^5.7.0"
   },

--- a/packages/og/tsconfig.json
+++ b/packages/og/tsconfig.json
@@ -6,8 +6,7 @@
     "jsxFactory": "h",
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "types": ["bun-types"]
+    "rootDir": "src"
   },
   "exclude": [
     "node_modules",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "bunup": "^0.16.31",
     "typescript": "^5.7.0"
   },

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -4,7 +4,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"],
   "extends": "../../tsconfig.json",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/test": "workspace:*",
-    "bun-types": "^1.3.10",
     "bunup": "^0.16.23",
     "typescript": "^5.9.3"
   },

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -7,7 +7,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts", "**/*.test.tsx"],
   "extends": "../../tsconfig.json",

--- a/packages/ui-server/src/google-fonts-resolver.ts
+++ b/packages/ui-server/src/google-fonts-resolver.ts
@@ -5,7 +5,7 @@
  * and returns new FontDescriptor objects with local `src` paths.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, relative } from 'node:path';
 import type { FontDescriptor, GoogleFontMeta } from '@vertz/ui/css';
@@ -160,8 +160,8 @@ function isCacheValid(cacheDir: string, entry: ManifestEntry): boolean {
   for (let i = 0; i < entry.files.length; i++) {
     const filePath = join(cacheDir, entry.files[i]!);
     if (!existsSync(filePath)) return false;
-    const stat = Bun.file(filePath).size;
-    if (stat < MIN_WOFF2_SIZE) return false;
+    const fileSize = statSync(filePath).size;
+    if (fileSize < MIN_WOFF2_SIZE) return false;
   }
   return true;
 }

--- a/plans/2497-replace-bun-apis.md
+++ b/plans/2497-replace-bun-apis.md
@@ -1,0 +1,314 @@
+# Replace Bun.serve/Bun.file/Bun.write with vtz-native APIs
+
+**Issue:** #2497
+**Status:** Draft (Rev 2 — addressing DX, Product, and Technical review feedback)
+**Author:** viniciusdacal
+
+## Problem
+
+Several framework packages use Bun-specific runtime APIs (`Bun.serve()`, `Bun.file()`, `Bun.write()`, `import.meta.hot`). These are the core coupling points preventing full decoupling from Bun. The vtz runtime already provides equivalent low-level capabilities — file I/O ops, synthetic `node:fs` / `node:fs/promises` modules, an internal Axum HTTP server — but framework packages still call Bun APIs directly.
+
+## API Surface
+
+### File I/O — Replace `Bun.file()` / `Bun.write()` with `node:fs`
+
+The vtz runtime already provides `node:fs` and `node:fs/promises` synthetic modules with full async + sync APIs. These are the standard replacement:
+
+```ts
+// BEFORE — Bun.file()
+const content = await Bun.file(path).text();
+const size = Bun.file(path).size;
+return new Response(Bun.file(path));
+
+// AFTER — node:fs/promises (works on both Bun and vtz)
+import { readFile, stat } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+
+const content = await readFile(path, 'utf-8');
+const { size } = await stat(path);
+// Note: reads entire file into memory. Fine for small files (HTML, JSON, fonts).
+// For large static files, use createReadStream wrapped in ReadableStream.
+return new Response(readFileSync(path));
+```
+
+```ts
+// BEFORE �� Bun.write()
+await Bun.write(filePath, content);
+
+// AFTER �� node:fs/promises
+import { writeFile } from 'node:fs/promises';
+await writeFile(filePath, content);
+```
+
+### HTTP Server — Add `createVtzAdapter()` with a native fetch-handler op
+
+The `ServerAdapter` interface in `@vertz/core` already abstracts the HTTP server layer. We add a vtz-native adapter backed by a new Rust op.
+
+**Why not `node:http`?** The vtz runtime's `node:http` synthetic module calls `Deno.serve()`, but the vtz runtime only includes `deno_core` (which provides `Deno.core`), not the full Deno runtime. `Deno.serve` does not exist. The `node:http` module is effectively dead code for HTTP serving.
+
+**Approach:** Implement a new native op (`op_http_serve`) that binds a port and dispatches incoming requests to a JS fetch handler. This is architecturally clean — the vtz runtime already has an Axum HTTP server; we're extending it to support user-created servers.
+
+```ts
+// packages/core/src/app/vtz-adapter.ts
+import type { ServerAdapter } from '../types/server-adapter';
+
+export function createVtzAdapter(): ServerAdapter {
+  return {
+    async listen(port, handler, options) {
+      // op_http_serve is a native vtz op that:
+      // 1. Binds an Axum server on the given port
+      // 2. Converts each incoming HTTP request to a Web Request
+      // 3. Calls the handler function
+      // 4. Converts the Web Response back to an HTTP response
+      // 5. Returns { port, hostname } (actual bound port for port=0 support)
+      const server = await Deno.core.ops.op_http_serve(
+        port,
+        options?.hostname ?? '0.0.0.0',
+        handler,
+      );
+
+      return {
+        port: server.port,
+        hostname: server.hostname,
+        async close() {
+          await Deno.core.ops.op_http_serve_close(server.id);
+        },
+      };
+    },
+  };
+}
+```
+
+The op accepts a standard `(request: Request) => Promise<Response>` fetch handler — no `node:http` compatibility layer needed, no string-only `ServerResponse`, no binary data corruption. This matches the `ServerAdapter` interface perfectly and supports:
+- Arbitrary port binding (including port 0 for OS-assigned ports)
+- Both text and binary response bodies (via Web Response)
+- Proper port discovery (returns actual bound port)
+
+### Runtime Detection — Update `detectAdapter()`
+
+```ts
+// packages/core/src/app/detect-adapter.ts
+import type { ServerAdapter } from '../types/server-adapter';
+
+export interface RuntimeHints {
+  hasBun: boolean;
+  hasVtz: boolean;
+}
+
+function detectRuntime(): RuntimeHints {
+  return {
+    hasBun: 'Bun' in globalThis,
+    // Explicit runtime identity marker set in vtz bootstrap JS.
+    // Not an implementation side-effect — intentional stable contract.
+    hasVtz: '__vtz_runtime' in globalThis,
+  };
+}
+
+export async function detectAdapter(hints?: RuntimeHints): Promise<ServerAdapter> {
+  const runtime = hints ?? detectRuntime();
+
+  if (runtime.hasVtz) {
+    const { createVtzAdapter } = await import('./vtz-adapter');
+    return createVtzAdapter();
+  }
+
+  if (runtime.hasBun) {
+    const { createBunAdapter } = await import('./bun-adapter');
+    return createBunAdapter();
+  }
+
+  throw new Error(
+    'No supported server runtime detected. Vertz requires Bun or vtz to use app.listen().',
+  );
+}
+```
+
+**Changes from v1:**
+- Uses `await import()` instead of `require()` (ESM-first, strict TypeScript compatible)
+- Uses `__vtz_runtime` instead of `__vertz_fs` (explicit runtime identity marker, not implementation side-effect)
+
+### Runtime Identity Marker (Rust)
+
+Add a single line to the vtz runtime bootstrap JS:
+
+```js
+// In native/vtz/src/runtime/js_runtime.rs bootstrap
+globalThis.__vtz_runtime = true;
+```
+
+This is a deliberate, stable contract for runtime detection. Not tied to any specific op module.
+
+### HMR — No changes needed
+
+The vtz compiler already strips `import.meta.hot` lines during post-processing (`strip_import_meta_hot` in `pipeline.rs`). The vtz dev server handles HMR via its own WebSocket protocol (`HmrMessage::Update`, `HmrMessage::FullReload`, `HmrMessage::CssUpdate`). Client entry files that call `import.meta.hot.accept()` are safe — the compiler removes these lines when building for vtz.
+
+The Bun plugin (`packages/ui-server/src/bun-plugin/`) that injects `import.meta.hot.accept()` is Bun-specific by design. When running on vtz, the vtz dev server handles module HMR through its own pipeline, not through the Bun plugin. No migration needed.
+
+**Audit:** Reviewed all `import.meta.hot` usage in framework packages. All occurrences are either:
+1. Client entry files (`import.meta.hot.accept()`) — stripped by vtz compiler
+2. Bun plugin code (`packages/ui-server/src/bun-plugin/`) �� Bun-specific by design
+3. Template strings in `create-vertz-app` — generates client entry files with the same pattern
+
+No conditional runtime checks on `import.meta.hot` that would affect non-HMR behavior.
+
+### `bun-types` Removal
+
+Remove `"types": ["bun-types"]` from tsconfig.json in all framework packages that no longer use any Bun-specific APIs after migration. Packages that still legitimately use Bun APIs (e.g., the Bun adapter, Bun plugins) retain `bun-types`.
+
+For packages that need both Bun and vtz compatibility, Bun APIs are accessed via dynamic `import()` or conditional `typeof Bun !== 'undefined'` checks, keeping the static type surface clean.
+
+## Manifesto Alignment
+
+- **"If it builds, it works"** — Replacing runtime-specific APIs with cross-runtime Node.js APIs means the same code builds and runs on both Bun and vtz. No runtime surprises.
+- **"One way to do things"** — `node:fs` is the single file I/O convention. No `Bun.file()` vs `readFile()` ambiguity.
+- **"No ceilings"** — This is literally the "if a dependency limits us, we replace it" principle. Removing Bun coupling enables the vtz runtime to be the primary runtime.
+- **"AI agents are first-class users"** — LLMs know `node:fs`. They don't know `Bun.file()` as reliably. Standard APIs reduce hallucination.
+
+## Non-Goals
+
+- **Removing Bun support entirely.** The `createBunAdapter()` stays. Vertz supports both runtimes.
+- **Implementing `vtz start` (production server command).** That's a separate runtime feature. This issue is about removing Bun-specific calls from framework packages.
+- **Migrating test-only files.** Test-only `Bun.file()` / `Bun.write()` / `Bun.spawn()` calls are lower priority and can remain as-is since tests run on Bun. If a test file is touched during migration, we'll migrate it too. Note: the GitHub issue acceptance criteria should be updated to "No `Bun.*` API calls remain in framework package **source files** (excluding test files and example/app packages)."
+- **Migrating `Bun.spawn()`.** The vtz runtime's `node:child_process` `spawn()` throws "not yet supported." `Bun.spawn()` migration is blocked until the runtime implements it.
+- **Migrating example/app packages** (`packages/landing`, `packages/component-docs`). Focus is framework packages.
+- **Migrating intentionally Bun-specific code.** The following use Bun APIs by design and stay Bun-specific:
+  - `@vertz/ui-server/src/bun-plugin/` — Bun's plugin system, `import.meta.hot`, `Bun.file().text()`, `Bun.hash()`. The vtz dev server has its own compilation pipeline.
+  - `@vertz/mdx/src/plugin.ts` — Bun plugin using `Bun.file().text()` in `build.onLoad`. Vtz has its own MDX handling via the module loader.
+  - `@vertz/ui-server/src/compiler/native-compiler.ts` — `Bun.Transpiler` fallback for when native compiler binary is unavailable. On vtz, the native compiler is always available (same binary).
+  - `@vertz/ui-server/src/compiler/library-plugin.ts` — `Bun.Transpiler` for excluded files in Bun library builds.
+  - `@vertz/core/src/app/bun-adapter.ts` — The Bun adapter itself.
+  - `@vertz/integration-tests/src/runtime-adapters/bun.ts` — Bun-specific integration test adapter.
+  - `@vertz/cli/src/production-build/ui-build-pipeline.ts` — Uses `Bun.build()` for production bundling. Vtz will have its own build pipeline.
+- **WebSocket server abstraction.** The `ServerAdapter` interface doesn't include WebSocket support. `@vertz/server`'s access-event-broadcaster uses Bun-specific WebSocket types. This is a separate concern for a future issue.
+
+## Unknowns
+
+1. ~~**Does `Deno.serve` work in the vtz runtime?**~~ **Resolved: No.** The vtz runtime only includes `deno_core`, not `deno_http`/`deno_net`. `Deno.serve` does not exist. The `node:http` synthetic module's `createServer` is dead code for HTTP serving. Phase 1 implements `op_http_serve` as a native op.
+
+2. **`Bun.file()` as a Response body.** Some code does `return new Response(Bun.file(path))` which streams the file efficiently. The `node:fs` equivalent (`readFileSync`) reads the entire file into memory. **Resolution: Acceptable for framework packages which serve small files (HTML, JSON, fonts). For `@vertz/cli` `serve-shared.ts` which serves arbitrary static files, consider `createReadStream` wrapped in `ReadableStream` to avoid loading large files into memory.**
+
+## Type Flow Map
+
+No new generics introduced. The `ServerAdapter` interface is unchanged. `createVtzAdapter()` returns `ServerAdapter` — same type contract as `createBunAdapter()`.
+
+Note: `detectAdapter()` changes from sync to async (returns `Promise<ServerAdapter>`) due to `await import()`. The `app.listen()` caller is already async so this is a compatible change.
+
+## E2E Acceptance Test
+
+```ts
+// After migration, this works on vtz runtime:
+import { readFile, writeFile, stat } from 'node:fs/promises';
+
+// File I/O — no Bun APIs
+const content = await readFile('test.txt', 'utf-8');
+await writeFile('out.txt', content);
+const { size } = await stat('out.txt');
+expect(size).toBeGreaterThan(0);
+
+// HTTP server — adapter auto-detects runtime
+import { createApp } from '@vertz/core';
+const app = createApp({ entities: [] });
+const handle = await app.listen(0); // port 0 = OS-assigned
+expect(handle.port).toBeGreaterThan(0);
+await handle.close();
+
+// @ts-expect-error — Bun.file is not available when bun-types is removed
+Bun.file('test.txt');
+```
+
+## Affected Packages & Migration Map
+
+### In-scope: Replace with cross-runtime APIs
+
+| Package | File | Bun API | Replacement | Phase |
+|---------|------|---------|-------------|-------|
+| `@vertz/core` | `src/app/bun-adapter.ts` | `Bun.serve()` | Keep; add `vtz-adapter.ts`; update `detect-adapter.ts` | 1 |
+| `@vertz/core` | `src/app/detect-adapter.ts` | `Bun` in globalThis | Add vtz detection, dynamic imports | 1 |
+| `@vertz/docs` | `src/generator/build-pipeline.ts` | `Bun.file().text()`, `Bun.write()` | `readFile()`, `writeFile()` from `node:fs/promises` | 2 |
+| `@vertz/docs` | `src/dev/docs-dev-server.ts` | `Bun.serve()`, `Bun.file()` | `node:http` + `readFileSync()` (or vtz adapter) | 2 |
+| `@vertz/docs` | `src/cli/init.ts` | `Bun.write()` x3 | `writeFile()` from `node:fs/promises` | 2 |
+| `@vertz/ui-server` | `src/google-fonts-resolver.ts` | `Bun.file().size` | `stat().size` from `node:fs/promises` | 2 |
+| `@vertz/cli` | `src/commands/serve-shared.ts` | `Bun.serve()` x3, `Bun.file()` x2 | vtz adapter for serve; `readFile`/`readFileSync` for files | 2 |
+| Various | `tsconfig.json` | `bun-types` | Remove from migrated packages | 3 |
+
+### Intentionally Bun-specific (no migration)
+
+| Package | File | Bun API | Why it stays |
+|---------|------|---------|-------------|
+| `@vertz/core` | `src/app/bun-adapter.ts` | `Bun.serve()` | The Bun adapter itself |
+| `@vertz/ui-server` | `src/bun-plugin/*.ts` | `import.meta.hot`, `Bun.file()`, `Bun.hash()` | Bun plugin system; vtz has own pipeline |
+| `@vertz/ui-server` | `src/compiler/native-compiler.ts` | `Bun.Transpiler` | Fallback only; vtz has native compiler |
+| `@vertz/ui-server` | `src/compiler/library-plugin.ts` | `Bun.Transpiler` | Bun library build path |
+| `@vertz/mdx` | `src/plugin.ts` | `Bun.file().text()` | Bun plugin; vtz has own MDX handling |
+| `@vertz/cli` | `src/production-build/ui-build-pipeline.ts` | `Bun.build()` x3 | Production bundler; vtz will have own |
+| `@vertz/server` | `src/auth/access-event-broadcaster.ts` | Bun WebSocket types | WebSocket abstraction is a separate issue |
+| `@vertz/integration-tests` | `src/runtime-adapters/bun.ts` | `Bun.serve()` | Bun-specific test adapter |
+| Various test files | `*.test.ts`, `test-compiler-plugin.ts` | `Bun.file()`, `Bun.write()` | Tests run on Bun |
+
+### Out of scope (blocked)
+
+| Package | File | Bun API | Blocker |
+|---------|------|---------|---------|
+| `@vertz/docs` | `src/generator/build-pipeline.ts` | `Bun.spawn()` (pagefind) | Runtime `spawn()` not implemented |
+| `@vertz/landing` | `scripts/dev-all.ts` | `Bun.spawn()` | Runtime `spawn()` not implemented |
+
+## Implementation Phases
+
+### Phase 1: vtz HTTP Serve Op + Server Adapter + Runtime Marker (Rust + TS)
+
+**Rust work:**
+1. Add `globalThis.__vtz_runtime = true` to bootstrap JS in `js_runtime.rs`
+2. Implement `op_http_serve(port, hostname, handler)` in `native/vtz/src/runtime/ops/`:
+   - Spawns an Axum HTTP server on the given port
+   - Converts incoming HTTP requests to Web `Request` objects
+   - Calls the JS fetch handler
+   - Converts the Web `Response` back to HTTP
+   - Returns `{ port, hostname }` (actual bound port for port=0)
+3. Implement `op_http_serve_close(server_id)` to shut down the server
+4. Tests: Rust integration tests for the ops
+
+**TypeScript work:**
+5. Create `packages/core/src/app/vtz-adapter.ts` using the new ops
+6. Update `packages/core/src/app/detect-adapter.ts` with vtz detection + dynamic imports
+7. Tests: adapter creates server, handles request/response, auto-detects runtime
+
+### Phase 2: File I/O + Server Migration (TS only)
+
+1. `packages/docs/src/generator/build-pipeline.ts` — replace `Bun.file()`, `Bun.write()`
+2. `packages/docs/src/cli/init.ts` — replace `Bun.write()` x3
+3. `packages/docs/src/dev/docs-dev-server.ts` — replace `Bun.serve()`, `Bun.file()`
+4. `packages/ui-server/src/google-fonts-resolver.ts` — replace `Bun.file().size`
+5. `packages/cli/src/commands/serve-shared.ts` — replace `Bun.serve()`, `Bun.file()` (use `readFileSync` for small assets; consider `createReadStream` for arbitrary static files)
+6. Tests: verify build pipeline, fonts resolver, docs dev server, CLI serve still work
+
+### Phase 3: bun-types Cleanup (TS only)
+
+1. Remove `"types": ["bun-types"]` from tsconfigs of migrated packages
+2. Verify typecheck passes without bun-types
+3. Add vtz runtime type declarations if needed (for `__vtz_runtime`, ops types)
+4. Run full quality gates across all packages
+
+## Review Sign-offs
+
+### DX Review — Approved
+- Finding 1 (should-fix): Migration map incomplete — **addressed** in Rev 2 (expanded table)
+- Finding 2 (nit): readFileSync in Response body — **addressed** (added note about streaming)
+- Finding 3 (nit): require() vs import() — **addressed** (changed to `await import()`)
+- Finding 4 (nit): __vertz_fs fragile marker — **addressed** (changed to `__vtz_runtime`)
+
+### Product/Scope Review — Changes Requested
+- Finding 1 (should-fix): @vertz/cli missing from map — **addressed** (added to Phase 2)
+- Finding 2 (should-fix): Issue criteria vs non-goals — **addressed** (noted in Non-Goals)
+- Recommendation: streaming for @vertz/cli — **addressed** (noted in Phase 2 and Unknown #2)
+- Recommendation: import.meta.hot audit — **addressed** (added audit results in HMR section)
+
+### Technical Review — Changes Requested
+- Finding 1 (blocker): Deno.serve doesn't exist — **addressed** (Phase 1 redesigned around native op)
+- Finding 2: Adapter code won't work — **addressed** (new adapter uses op_http_serve)
+- Finding 3: Migration map incomplete — **addressed** (expanded both tables)
+- Finding 4: node:fs is solid — confirmed, no changes needed
+- Finding 5: Binary response corruption — **addressed** (fetch-handler op avoids node:http entirely)
+- Finding 6: Runtime marker fragile — **addressed** (explicit `__vtz_runtime` marker)
+- Finding 7: No WebSocket support — acknowledged in Non-Goals
+- Finding 8: address() returns port 0 — **addressed** (op returns actual bound port)
+- Finding 9: Bun.Transpiler undocumented — **addressed** (added to intentionally-Bun table)

--- a/plans/2497-replace-bun-apis/phase-01-vtz-http-serve-op.md
+++ b/plans/2497-replace-bun-apis/phase-01-vtz-http-serve-op.md
@@ -1,0 +1,108 @@
+# Phase 1: vtz HTTP Serve Op + Server Adapter + Runtime Marker
+
+## Context
+
+Issue #2497 — replace Bun-specific APIs with vtz-native equivalents. This phase implements the HTTP server foundation: a native Rust op that lets JavaScript code create HTTP servers, a TypeScript adapter for `@vertz/core`'s `ServerAdapter` interface, and a runtime identity marker for auto-detection.
+
+Design doc: `plans/2497-replace-bun-apis.md`
+
+## Tasks
+
+### Task 1: Runtime Identity Marker
+
+**Files:** (2)
+- `native/vtz/src/runtime/js_runtime.rs` (modified)
+- `native/vtz/tests/v8_integration.rs` (modified)
+
+**What to implement:**
+Add `globalThis.__vtz_runtime = true` to the bootstrap JS in `VertzJsRuntime::bootstrap_js()`. This is a deliberate, stable contract for runtime detection — not tied to any specific op module.
+
+**Acceptance criteria:**
+- [ ] `globalThis.__vtz_runtime === true` in any JS executed by the vtz runtime
+- [ ] Rust integration test verifies the marker exists
+- [ ] Marker is present in both `new()` and `new_for_test()` paths (via bootstrap JS)
+
+---
+
+### Task 2: `op_http_serve` Native Op (Rust)
+
+**Files:** (4)
+- `native/vtz/src/runtime/ops/http_serve.rs` (new)
+- `native/vtz/src/runtime/ops/mod.rs` (modified)
+- `native/vtz/src/runtime/js_runtime.rs` (modified)
+- `native/vtz/tests/v8_integration.rs` (modified)
+
+**What to implement:**
+
+Create a new op module `http_serve` that exposes two ops:
+
+1. `op_http_serve(port: u16, hostname: String)` — async op that:
+   - Spawns a Tokio task running an Axum HTTP server on the given port/hostname
+   - Binds to the port (supports port 0 for OS-assigned)
+   - Returns `{ id: u32, port: u16, hostname: String }` (actual bound port)
+   - The server stores incoming requests in a channel/queue
+
+2. `op_http_serve_accept(server_id: u32)` — async op that:
+   - Waits for the next incoming request on the server
+   - Converts the Axum request to a serialized form: `{ id: u32, method: String, url: String, headers: Vec<(String, String)>, body: Option<Vec<u8>> }`
+   - Returns the request to JS
+
+3. `op_http_serve_respond(request_id: u32, status: u16, headers: Vec<(String, String)>, body: Vec<u8>)` — sync op that:
+   - Sends the response back to the waiting Axum handler
+   - Uses a oneshot channel per request
+
+4. `op_http_serve_close(server_id: u32)` — sync op that shuts down the server
+
+**Architecture:** Use a request/response channel pattern:
+- Server spawns Axum, each incoming request gets a `oneshot::Sender<Response>`
+- `op_http_serve_accept` polls a `mpsc::Receiver<(Request, oneshot::Sender<Response>)>`
+- JS receives the request, processes it, calls `op_http_serve_respond` to send back the response
+- This avoids passing JS functions into Rust ops (which deno_core doesn't support for async ops)
+
+**Bootstrap JS:** Expose a high-level `__vtz_http.serve(port, hostname, handler)` that:
+- Calls `op_http_serve` to create the server
+- Runs an accept loop: `while (true) { const req = await accept(); const res = await handler(new Request(...)); respond(req.id, res); }`
+- Returns `{ port, hostname, close() }`
+
+**Acceptance criteria:**
+- [ ] `op_http_serve` binds a port and returns actual port number (including port 0)
+- [ ] `op_http_serve_accept` receives incoming HTTP requests
+- [ ] `op_http_serve_respond` sends response back to client
+- [ ] `op_http_serve_close` shuts down the server cleanly
+- [ ] Bootstrap JS exposes `__vtz_http.serve(port, hostname, handler)`
+- [ ] Rust integration test: create server, send fetch request, verify response
+- [ ] Supports both text and binary response bodies
+
+---
+
+### Task 3: `createVtzAdapter` + `detectAdapter` Update (TypeScript)
+
+**Files:** (5)
+- `packages/core/src/app/vtz-adapter.ts` (new)
+- `packages/core/src/app/detect-adapter.ts` (modified)
+- `packages/core/src/app/vtz-adapter.test.ts` (new)
+- `packages/core/src/app/detect-adapter.test.ts` (modified or new)
+- `packages/core/src/types/server-adapter.ts` (check — may need no changes)
+
+**What to implement:**
+
+1. `vtz-adapter.ts` — `createVtzAdapter(): ServerAdapter` that:
+   - Calls `globalThis.__vtz_http.serve(port, hostname, handler)` inside `listen()`
+   - Returns `{ port, hostname, close() }` matching `ServerHandle`
+   - Handler is the standard `(request: Request) => Promise<Response>` fetch handler
+
+2. `detect-adapter.ts` — Update to:
+   - Add `hasVtz: '__vtz_runtime' in globalThis` to `RuntimeHints`
+   - Make `detectAdapter` async (returns `Promise<ServerAdapter>`)
+   - Use `await import('./vtz-adapter')` for vtz, `await import('./bun-adapter')` for Bun
+   - Prefer vtz over Bun when both are present (vtz is more specific)
+
+3. Update `app-builder.ts` if needed — `listen()` already returns `Promise<ServerHandle>`, but `detectAdapter()` changing to async may require a small update.
+
+**Acceptance criteria:**
+- [ ] `createVtzAdapter()` returns a valid `ServerAdapter`
+- [ ] `detectAdapter()` returns vtz adapter when `__vtz_runtime` is present
+- [ ] `detectAdapter()` returns Bun adapter when only Bun is present
+- [ ] `detectAdapter()` throws when neither runtime is detected
+- [ ] `app.listen(0)` works with vtz adapter (OS-assigned port)
+- [ ] Typecheck passes: `vtz run typecheck` on `packages/core`

--- a/plans/2497-replace-bun-apis/phase-02-file-io-migration.md
+++ b/plans/2497-replace-bun-apis/phase-02-file-io-migration.md
@@ -1,0 +1,118 @@
+# Phase 2: File I/O + Server Migration
+
+## Context
+
+Issue #2497 — replace Bun-specific APIs with vtz-native equivalents. This phase migrates all `Bun.file()`, `Bun.write()`, and `Bun.serve()` calls in framework source files to cross-runtime equivalents (`node:fs/promises` and the new vtz/Bun adapter pattern).
+
+Design doc: `plans/2497-replace-bun-apis.md`
+Depends on: Phase 1 (vtz adapter available for `Bun.serve()` replacements)
+
+## Tasks
+
+### Task 1: Migrate `@vertz/docs` build pipeline
+
+**Files:** (2)
+- `packages/docs/src/generator/build-pipeline.ts` (modified)
+- `packages/docs/src/generator/__tests__/build-pipeline.test.ts` (modified if exists, or verify existing tests pass)
+
+**What to implement:**
+
+Replace all `Bun.file()` and `Bun.write()` calls:
+- `await Bun.file(filePath).text()` → `await readFile(filePath, 'utf-8')` from `node:fs/promises`
+- `await Bun.write(path, content)` → `await writeFile(path, content)` from `node:fs/promises`
+- Keep `Bun.spawn()` (pagefind) as-is — out of scope (runtime `spawn()` not implemented)
+
+Add `import { readFile, writeFile } from 'node:fs/promises'` at the top.
+
+**Acceptance criteria:**
+- [ ] No `Bun.file()` or `Bun.write()` calls in `build-pipeline.ts` (except `Bun.spawn`)
+- [ ] Existing tests still pass
+- [ ] `vtz run typecheck` passes on `packages/docs`
+
+---
+
+### Task 2: Migrate `@vertz/docs` init CLI
+
+**Files:** (2)
+- `packages/docs/src/cli/init.ts` (modified)
+- `packages/docs/src/__tests__/init.test.ts` (modified if it uses Bun.write)
+
+**What to implement:**
+
+Replace 3x `Bun.write()` calls with `writeFile()` from `node:fs/promises`:
+- `await Bun.write(configPath, configContent)` → `await writeFile(configPath, configContent)`
+- Same for the two starter page files
+
+Add `import { writeFile } from 'node:fs/promises'` at the top.
+
+**Acceptance criteria:**
+- [ ] No `Bun.write()` calls in `init.ts`
+- [ ] Existing tests still pass
+- [ ] `vtz run typecheck` passes on `packages/docs`
+
+---
+
+### Task 3: Migrate `@vertz/docs` dev server
+
+**Files:** (2)
+- `packages/docs/src/dev/docs-dev-server.ts` (modified)
+- `packages/docs/src/dev/__tests__/docs-dev-server.test.ts` (modified if exists)
+
+**What to implement:**
+
+Replace `Bun.serve()` and `Bun.file()`:
+- `Bun.serve({ port, fetch })` → Use `node:http` `createServer` (works on Bun + can be replaced with vtz op later). The docs dev server is a simple HTTP server, not using the `ServerAdapter` pattern since it's internal tooling.
+- `Bun.file(publicPath)` for static file serving → `readFileSync(publicPath)` from `node:fs`
+- Or use `await readFile(publicPath)` from `node:fs/promises` since the handler is async
+
+Add `import { createServer } from 'node:http'` and `import { readFile } from 'node:fs/promises'`.
+
+Note: `node:http` `createServer` works on Bun natively (Bun has full Node.js compat). On vtz, this module's `createServer` currently uses `Deno.serve` which doesn't exist, but the docs dev server is only used in development with Bun for now. If vtz support is needed later, the server can be migrated to use `__vtz_http.serve`.
+
+**Acceptance criteria:**
+- [ ] No `Bun.serve()` or `Bun.file()` calls in `docs-dev-server.ts`
+- [ ] Dev server still starts and serves content correctly
+- [ ] `vtz run typecheck` passes on `packages/docs`
+
+---
+
+### Task 4: Migrate `@vertz/ui-server` google fonts resolver
+
+**Files:** (2)
+- `packages/ui-server/src/google-fonts-resolver.ts` (modified)
+- `packages/ui-server/src/__tests__/google-fonts-resolver.test.ts` (verify existing tests pass)
+
+**What to implement:**
+
+Replace `Bun.file(filePath).size`:
+- `const stat = Bun.file(filePath).size` → `const { size } = await stat(filePath)` from `node:fs/promises`
+- Or use `statSync(filePath).size` from `node:fs` if the call site is synchronous
+
+Add `import { stat } from 'node:fs/promises'` (or `statSync` from `node:fs`).
+
+**Acceptance criteria:**
+- [ ] No `Bun.file()` calls in `google-fonts-resolver.ts`
+- [ ] Existing tests still pass
+- [ ] `vtz run typecheck` passes on `packages/ui-server`
+
+---
+
+### Task 5: Migrate `@vertz/cli` serve command
+
+**Files:** (2)
+- `packages/cli/src/commands/serve-shared.ts` (modified)
+- `packages/cli/src/commands/__tests__/serve-shared.test.ts` (verify existing tests pass)
+
+**What to implement:**
+
+Replace 3x `Bun.serve()` and 2x `Bun.file()`:
+- `Bun.serve({ port, fetch })` → Use `createServer` from `node:http` (Bun has full compat)
+- `Bun.file(htmlPath)` for serving pre-rendered HTML → `readFileSync(htmlPath)` from `node:fs`
+- Remove the ambient `declare const Bun` block at the top of the file
+- For static file serving of arbitrary files (images, fonts), consider using `readFileSync` wrapped in a `Buffer` for proper binary support. For very large files, `createReadStream` would be better but adds complexity — acceptable to defer.
+
+**Acceptance criteria:**
+- [ ] No `Bun.serve()` or `Bun.file()` calls in `serve-shared.ts`
+- [ ] No `declare const Bun` ambient declaration
+- [ ] CLI serve command still works for UI-only, API-only, and full-stack apps
+- [ ] `vtz run typecheck` passes on `packages/cli`

--- a/plans/2497-replace-bun-apis/phase-03-bun-types-cleanup.md
+++ b/plans/2497-replace-bun-apis/phase-03-bun-types-cleanup.md
@@ -1,0 +1,99 @@
+# Phase 3: bun-types Cleanup
+
+## Context
+
+Issue #2497 — replace Bun-specific APIs with vtz-native equivalents. This phase removes `bun-types` from tsconfig.json in packages that no longer use any Bun-specific APIs after the Phase 2 migration, and adds vtz runtime type declarations.
+
+Design doc: `plans/2497-replace-bun-apis.md`
+Depends on: Phase 2 (all Bun API calls migrated)
+
+## Tasks
+
+### Task 1: Identify packages for bun-types removal
+
+**Files:** (1)
+- Analysis task — no file changes, produce a list
+
+**What to implement:**
+
+For each of the 18 packages with `"types": ["bun-types"]` in their tsconfig.json, check whether the package still has any `Bun.*` API calls in source files (not test files). Categorize into:
+- **Remove bun-types** — no remaining Bun API usage in source
+- **Keep bun-types** — still uses Bun APIs (e.g., Bun adapter, Bun plugins)
+
+**Acceptance criteria:**
+- [ ] Complete list of packages and their bun-types disposition
+- [ ] Each "keep" decision has a documented reason
+
+---
+
+### Task 2: Remove bun-types from migrated packages
+
+**Files:** (up to 5 tsconfig.json files per batch)
+- Various `packages/*/tsconfig.json` (modified)
+
+**What to implement:**
+
+For each package identified in Task 1 as "remove":
+- Remove `"bun-types"` from the `"types"` array in `tsconfig.json`
+- If the `"types"` array becomes empty, remove the entire `"types"` field
+- Run `vtz run typecheck` to verify no type errors
+
+If any typecheck failures occur, they indicate remaining Bun API usage that wasn't caught in Phase 2. Fix the usage or keep bun-types for that package.
+
+**Acceptance criteria:**
+- [ ] `bun-types` removed from all packages that no longer use Bun APIs
+- [ ] `vtz run typecheck` passes across all packages
+- [ ] No new type errors introduced
+
+---
+
+### Task 3: Add vtz runtime type declarations
+
+**Files:** (2)
+- `packages/core/src/types/vtz-runtime.d.ts` (new)
+- `packages/core/tsconfig.json` (modified if needed)
+
+**What to implement:**
+
+Add type declarations for vtz runtime globals used by the adapter:
+
+```ts
+declare global {
+  var __vtz_runtime: boolean | undefined;
+  var __vtz_http: {
+    serve(
+      port: number,
+      hostname: string,
+      handler: (request: Request) => Promise<Response>,
+    ): Promise<{ id: number; port: number; hostname: string; close(): Promise<void> }>;
+  } | undefined;
+}
+```
+
+These types ensure TypeScript doesn't complain about accessing `globalThis.__vtz_runtime` and `globalThis.__vtz_http` in the adapter code.
+
+**Acceptance criteria:**
+- [ ] No `@ts-expect-error` or `as any` needed for vtz runtime globals
+- [ ] Type declarations are minimal — only what's actually used
+- [ ] `vtz run typecheck` passes
+
+---
+
+### Task 4: Final quality gates
+
+**Files:** (0 — validation only)
+
+**What to implement:**
+
+Run full quality gates across the entire monorepo:
+```bash
+vtz test && vtz run typecheck && vtz run lint
+```
+
+Verify no regressions from the full migration.
+
+**Acceptance criteria:**
+- [ ] All tests pass
+- [ ] Typecheck clean
+- [ ] Lint clean
+- [ ] No `Bun.*` calls in migrated source files (grep verification)


### PR DESCRIPTION
## Summary

Closes #2497

- **Phase 1**: Add native HTTP serve ops to the vtz Rust runtime (`op_http_serve`, `op_http_accept`, `op_http_respond`, `op_http_close`) and create a `ServerAdapter` for the vtz runtime in `@vertz/core`
- **Phase 2**: Migrate `Bun.file()`, `Bun.write()`, and `Bun.serve()` to `node:fs` and `node:http` in `@vertz/docs`, `@vertz/cli`, and `@vertz/ui-server`
- **Phase 3**: Remove `bun-types` from 7 packages that don't use Bun-specific APIs, replacing with `@types/node` where needed. Add `vtz-runtime.ts` global type declarations.

## Public API Changes

- `detectAdapter()` in `@vertz/core` is now **async** (returns `Promise<ServerAdapter>` instead of `ServerAdapter`). Only internal consumer is `app-builder.ts` which was already async.
- New `createVtzAdapter()` export in `@vertz/core` for vtz runtime HTTP serving.
- New global type declarations: `__vtz_runtime` and `__vtz_http` in `packages/core/src/types/vtz-runtime.ts`.

## Key Files

- [`native/vtz/src/runtime/ops/http_serve.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/replace-bun-apis/native/vtz/src/runtime/ops/http_serve.rs) — Rust HTTP serve ops
- [`packages/core/src/app/vtz-adapter.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/replace-bun-apis/packages/core/src/app/vtz-adapter.ts) — vtz ServerAdapter
- [`packages/core/src/app/detect-adapter.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/replace-bun-apis/packages/core/src/app/detect-adapter.ts) — Async adapter detection (vtz-first)
- [`packages/cli/src/commands/serve-shared.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/replace-bun-apis/packages/cli/src/commands/serve-shared.ts) — node:http server for `vertz start`/`vertz preview`
- [`packages/docs/src/dev/docs-dev-server.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/replace-bun-apis/packages/docs/src/dev/docs-dev-server.ts) — node:http docs dev server

## Test plan

- [x] `@vertz/core` adapter tests: 104/104 pass (vtz-adapter: 7 tests, detect-adapter: 5 tests)
- [x] `@vertz/cli` start tests: 54/54 pass (real servers on port 0)
- [x] Build + typecheck: 62/62 turbo tasks pass
- [x] Lint: 0 errors
- [x] Rust tests: `cargo test --all` passes (http_serve ops + v8 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)