### PR TITLE
fix(runtime): ESM preload loading + remove CI exit-code workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,44 +307,10 @@ jobs:
         run: cd packages/ci && vtz run build
 
       - name: Build & typecheck
-        run: |
-          # TODO: Remove timeout wrapper after next runtime release that
-          # includes the std::process::exit(0) fix (see #2474).
-          # The pre-built vtz binary from npm doesn't have the fix yet.
-          set +eo pipefail
-          timeout --kill-after=10 120 vtz ci build-typecheck --concurrency 2 2>&1 | tee /tmp/build-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -eo pipefail
-          if [ $EXIT_CODE -eq 0 ]; then exit 0; fi
-          if [ $EXIT_CODE -eq 124 ] || [ $EXIT_CODE -eq 137 ]; then
-            if grep -q '\[pipe\] Done in' /tmp/build-output.log && grep -q '0 failed' /tmp/build-output.log; then
-              echo "::warning::vtz ci completed but process did not exit cleanly (pending runtime release with #2474 fix)"
-              exit 0
-            fi
-          fi
-          echo "::error::Build/typecheck failed with exit code $EXIT_CODE"
-          exit 1
+        run: vtz ci build-typecheck --concurrency 2
 
       - name: Test
-        run: |
-          # TODO: Remove timeout wrapper after next runtime release that
-          # includes the std::process::exit(0) fix (see #2474).
-          set +eo pipefail
-          timeout --kill-after=10 600 vtz ci test --concurrency 2 2>&1 | tee /tmp/test-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -eo pipefail
-          if [ $EXIT_CODE -eq 0 ]; then exit 0; fi
-          # Check if any vtz test reported actual failures (N fail where N > 0)
-          FAIL_LINES=$(grep -cE '^\s*[1-9][0-9]*\s+fail' /tmp/test-output.log || true)
-          if [ "$FAIL_LINES" -gt 0 ]; then
-            echo "::error::Tests failed"
-            exit 1
-          fi
-          # Exit 124/137 = timeout, or vtz ci exited non-zero due to
-          # task timeouts (hung processes). If no actual vtz test failures
-          # were detected, treat as success — matching old CI behavior.
-          echo "::warning::Test processes did not exit cleanly (pending runtime release with #2474 fix)"
-          exit 0
+        run: vtz ci test --concurrency 2
 
   # ---------------------------------------------------------------------------
   # Rust checks — runs in parallel with TS jobs.

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -219,43 +219,24 @@ fn execute_test_file_inner(
     // NOTE: async context + test harness are pre-baked in the V8 snapshot,
     // so we skip load_async_context() and TEST_HARNESS_JS injection.
 
-    // 1. Set filter if provided
+    // 2. Set filter if provided
     if let Some(ref filter) = options.filter {
         let escaped = filter.replace('\\', "\\\\").replace('\'', "\\'");
         let set_filter = format!("globalThis.__vertz_test_filter = '{}'", escaped);
         runtime.execute_script_void("[vertz:set-filter]", &set_filter)?;
     }
 
-    // 4. Execute preload scripts (run as classic scripts, not modules — no import support)
+    // 3. Create tokio runtime (needed for async module loading of preloads and test file)
+    let tokio_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    // 4. Load preload scripts as ES modules (supports import statements)
     for preload_path in &options.preload {
-        let preload_source = std::fs::read_to_string(preload_path).map_err(|e| {
-            deno_core::anyhow::anyhow!(
-                "Cannot read preload script '{}': {}",
-                preload_path.display(),
-                e
-            )
+        let specifier = ModuleSpecifier::from_file_path(preload_path).map_err(|_| {
+            deno_core::anyhow::anyhow!("Invalid preload path: {}", preload_path.display())
         })?;
-        let ext = preload_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
-
-        let code = if ext == "ts" || ext == "tsx" {
-            let root_path = std::path::Path::new(root_dir);
-            let src_dir = root_path.join("src");
-            let ctx = crate::plugin::CompileContext {
-                file_path: preload_path,
-                root_dir: root_path,
-                src_dir: &src_dir,
-                target: "ssr",
-            };
-            let output = plugin.compile(&preload_source, &ctx);
-            output.code
-        } else {
-            preload_source
-        };
-
-        runtime.execute_script_void("[vertz:preload]", &code)?;
+        tokio_rt.block_on(async { runtime.load_side_module(&specifier).await })?;
     }
 
     // 5. Pre-compile test file for mock extraction (transitive mocking support)
@@ -287,11 +268,7 @@ fn execute_test_file_inner(
     let specifier = ModuleSpecifier::from_file_path(file_path)
         .map_err(|_| deno_core::anyhow::anyhow!("Invalid file path: {}", file_path.display()))?;
 
-    let tokio_rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
-
-    // 4. Create inspector session for coverage if enabled
+    // 7. Create inspector session for coverage if enabled
     let mut session = if options.coverage {
         let inspector = runtime.inner_mut().inspector();
         let session = inspector.borrow().create_local_session();
@@ -300,7 +277,7 @@ fn execute_test_file_inner(
         None
     };
 
-    // 5. Start coverage collection (before module load)
+    // 8. Start coverage collection (before module load)
     if let Some(ref mut session) = session {
         inspector_post_message_sync(session, &mut runtime, "Profiler.enable", None::<()>)?;
         inspector_post_message_sync(
@@ -314,10 +291,10 @@ fn execute_test_file_inner(
         )?;
     }
 
-    // 6. Load module
+    // 9. Load module
     tokio_rt.block_on(async { runtime.load_main_module(&specifier).await })?;
 
-    // 7. Run all registered tests with timeout
+    // 10. Run all registered tests with timeout
     let timeout_duration = if options.timeout_ms > 0 {
         Some(std::time::Duration::from_millis(options.timeout_ms))
     } else {
@@ -783,11 +760,11 @@ mod tests {
         );
 
         assert!(result.file_error.is_some());
-        assert!(result
-            .file_error
-            .as_ref()
-            .unwrap()
-            .contains("Cannot read preload script"));
+        let err = result.file_error.as_ref().unwrap();
+        assert!(
+            err.contains("Cannot read module") || err.contains("nonexistent-setup.ts"),
+            "Expected error about missing preload file, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2507 (Replace Bun APIs). Two fixes that were committed after the PR was merged:

- **Fix preload scripts in vtz test runner**: Preload scripts were loaded via `execute_script_void()` (classic V8 script context) where `import` is illegal. All test files using ESM imports in preload scripts failed with "Cannot use import statement outside a module". Switched to `load_side_module()` which goes through the module loader, supporting ES module syntax and automatic TS compilation.

- **Remove #2474 exit-code workaround from CI**: The timeout+pattern-matching workaround for #2474 (process hang) was swallowing non-zero exit codes from `vtz ci test`, causing CI to report green even when test packages had load errors. Issue #2474 is CLOSED — remove the workaround so failures are properly reported.

**Note:** The preload fix is in the Rust runtime binary. CI uses the published npm version of vtz (via `setup-vtz`), which won't have this fix until the next runtime release. CI tests may still fail with ESM errors — but now they'll be properly reported instead of hidden.

## Test plan

- [x] `cargo test --all` — all 19 tests pass
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI properly reports test failures (no more silent green)
- [ ] After next vtz runtime release, ESM preload errors should be eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)