### PR TITLE
fix(ci): add @vertz/build bootstrap to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,13 @@ jobs:
           cp native/target/release/libvertz_compiler.so native/vertz-compiler/vertz-compiler.linux-x64.node
           echo "Native compiler binary ready: $(ls -la native/vertz-compiler/vertz-compiler.linux-x64.node)"
 
+      - name: Build @vertz/build
+        run: |
+          cd packages/build && tsc --outDir dist --declaration
+          cd $GITHUB_WORKSPACE
+          ln -sf ../../packages/build/dist/cli.js node_modules/.bin/vertz-build
+          chmod +x node_modules/.bin/vertz-build
+
       - name: Build TS packages
         run: turbo run build --filter='!@vertz-examples/*' --filter='!entity-todo-example' --filter='!@vertz/landing-nextjs' --filter='!@vertz/landing-nextjs-vercel' --filter='!@vertz/landing' --filter='!@vertz/component-docs' --filter='!@vertz/site' --filter='!@vertz/og' --filter='!@vertz/mint-docs' --filter='!@vertz-benchmarks/*' --filter='!contacts-api-example' --filter='!create-vertz'
 


### PR DESCRIPTION
## Summary

- PR #2512 replaced `bunup` with `@vertz/build` (esbuild + tsc) but only added the bootstrap step to the CI workflow
- The Release workflow was missing the `Build @vertz/build` step, causing `vertz-build: not found` (exit 127) for `@vertz/compiler`, `@vertz/errors`, `@vertz/icons`, `@vertz/ci`, and other packages
- Added the same bootstrap step (tsc build + bin symlink) that already exists in `ci.yml`

## Test plan

- [ ] Merge to main and verify the Release workflow passes
- [ ] Verify `turbo run build` succeeds without `vertz-build: not found` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)