### PR TITLE
fix(ci): fix ConfigBridge child process hang after shutdown

### DIFF
--- a/native/vtz/src/ci/config.rs
+++ b/native/vtz/src/ci/config.rs
@@ -88,10 +88,17 @@ impl ConfigBridge {
             .map_err(|e| format!("serialize shutdown: {e}"))?;
         let _ = self.stdin.write_all(format!("{msg}\n").as_bytes()).await;
         // Close stdin so the child process receives EOF and can exit cleanly.
-        // Without this, the readline interface in the JS loader keeps the
-        // process alive indefinitely, causing `child.wait()` to hang.
         drop(self.stdin);
-        let _ = self.child.wait().await;
+        // Give the process a few seconds to exit gracefully, then force kill.
+        // Bun's readline may not terminate the event loop on break/EOF alone.
+        let wait_timeout = std::time::Duration::from_secs(5);
+        if tokio::time::timeout(wait_timeout, self.child.wait())
+            .await
+            .is_err()
+        {
+            let _ = self.child.kill().await;
+            let _ = self.child.wait().await;
+        }
         Ok(())
     }
 
@@ -169,6 +176,8 @@ for await (const line of rl) {
     }
   }
 }
+rl.close();
+process.exit(0);
 "#;
 
 /// Find the config file in the project root.


### PR DESCRIPTION
## Summary

Follow-up to #2518 — the previous stdin `drop()` fix wasn't sufficient. Bun's readline doesn't terminate the event loop when breaking from a `for await` loop, even after receiving EOF on stdin.

**Two-pronged fix:**
- **JS loader**: Add `rl.close()` + `process.exit(0)` after the shutdown break to guarantee the child process terminates
- **Rust shutdown**: Add 5-second timeout on `child.wait()` with force kill fallback, so `vtz ci` never hangs even if the child misbehaves

This was causing `vtz ci build-typecheck` to hang for 19+ minutes on CI after printing "Done", hitting the 20-minute job timeout.

## Test plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-push hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)