### PR TITLE
fix(vtz): generate bin stubs for workspace packages

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6237,7 +6237,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "napi",
  "napi-build",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6269,7 +6269,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/pm/bin.rs
+++ b/native/vtz/src/pm/bin.rs
@@ -1,49 +1,76 @@
 use crate::pm::resolver::ResolvedGraph;
+use crate::pm::workspace::WorkspacePackage;
 use std::path::Path;
 
-/// Generate .bin/ stubs for all packages with bin entries
+/// Write a single bin stub shell script to `bin_dir/<bin_name>`.
+fn write_bin_stub(
+    bin_dir: &Path,
+    bin_name: &str,
+    target: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stub_path = bin_dir.join(bin_name);
+
+    // Ensure parent directory exists (scoped bin names like @babel/parser
+    // require creating .bin/@babel/)
+    if let Some(parent) = stub_path.parent() {
+        if parent != bin_dir {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let stub_content = format!(
+        "#!/bin/sh\nexec node \"$(dirname \"$0\")/{}\" \"$@\"\n",
+        target
+    );
+
+    std::fs::write(&stub_path, stub_content)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&stub_path, perms)?;
+    }
+
+    Ok(())
+}
+
+/// Generate .bin/ stubs for all packages with bin entries.
+/// Handles both npm registry packages (from the resolved graph) and
+/// workspace packages (symlinked into node_modules/).
+///
+/// Workspace stubs are generated after npm stubs, so workspace packages
+/// take precedence when both define the same bin name (matches npm/yarn/pnpm).
 pub fn generate_bin_stubs(
     root_dir: &Path,
     graph: &ResolvedGraph,
+    workspaces: &[WorkspacePackage],
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let bin_dir = root_dir.join("node_modules").join(".bin");
     std::fs::create_dir_all(&bin_dir)?;
 
     let mut count = 0;
 
+    // npm registry packages
     for pkg in graph.packages.values() {
-        // Only generate stubs for root-level packages (not nested)
         if !pkg.nest_path.is_empty() {
             continue;
         }
 
         for (bin_name, bin_path) in &pkg.bin {
-            let stub_path = bin_dir.join(bin_name);
             let target = format!("../{}/{}", pkg.name, bin_path.trim_start_matches("./"));
+            write_bin_stub(&bin_dir, bin_name, &target)?;
+            count += 1;
+        }
+    }
 
-            // Ensure parent directory exists (scoped bin names like @babel/parser
-            // require creating .bin/@babel/)
-            if let Some(parent) = stub_path.parent() {
-                if parent != bin_dir {
-                    std::fs::create_dir_all(parent)?;
-                }
-            }
+    // Workspace packages — generated after npm stubs so they take precedence
+    for ws in workspaces {
+        let bin_map = ws.pkg.bin.to_map(&ws.name);
 
-            let stub_content = format!(
-                "#!/bin/sh\nexec node \"$(dirname \"$0\")/{}\" \"$@\"\n",
-                target
-            );
-
-            std::fs::write(&stub_path, stub_content)?;
-
-            // Make executable
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let perms = std::fs::Permissions::from_mode(0o755);
-                std::fs::set_permissions(&stub_path, perms)?;
-            }
-
+        for (bin_name, bin_path) in &bin_map {
+            let target = format!("../{}/{}", ws.name, bin_path.trim_start_matches("./"));
+            write_bin_stub(&bin_dir, bin_name, &target)?;
             count += 1;
         }
     }
@@ -54,8 +81,26 @@ pub fn generate_bin_stubs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pm::types::ResolvedPackage;
+    use crate::pm::types::{BinField, PackageJson, ResolvedPackage};
     use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn make_pkg_json(name: &str, bin: BinField) -> PackageJson {
+        PackageJson {
+            name: Some(name.to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: BTreeMap::new(),
+            dev_dependencies: BTreeMap::new(),
+            peer_dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            bundled_dependencies: vec![],
+            bin,
+            scripts: BTreeMap::new(),
+            workspaces: None,
+            overrides: BTreeMap::new(),
+            files: None,
+        }
+    }
 
     #[test]
     fn test_generate_bin_stubs() {
@@ -80,7 +125,7 @@ mod tests {
             },
         );
 
-        let count = generate_bin_stubs(root, &graph).unwrap();
+        let count = generate_bin_stubs(root, &graph, &[]).unwrap();
         assert_eq!(count, 1);
 
         let stub_path = root.join("node_modules/.bin/esbuild");
@@ -115,7 +160,7 @@ mod tests {
             },
         );
 
-        let count = generate_bin_stubs(root, &graph).unwrap();
+        let count = generate_bin_stubs(root, &graph, &[]).unwrap();
         assert_eq!(count, 2);
         assert!(root.join("node_modules/.bin/tsc").exists());
         assert!(root.join("node_modules/.bin/tsserver").exists());
@@ -144,7 +189,7 @@ mod tests {
             },
         );
 
-        let count = generate_bin_stubs(root, &graph).unwrap();
+        let count = generate_bin_stubs(root, &graph, &[]).unwrap();
         assert_eq!(count, 0);
         assert!(!root.join("node_modules/.bin/cmd").exists());
     }
@@ -169,7 +214,7 @@ mod tests {
             },
         );
 
-        let count = generate_bin_stubs(root, &graph).unwrap();
+        let count = generate_bin_stubs(root, &graph, &[]).unwrap();
         assert_eq!(count, 0);
     }
 
@@ -199,11 +244,246 @@ mod tests {
             },
         );
 
-        generate_bin_stubs(root, &graph).unwrap();
+        generate_bin_stubs(root, &graph, &[]).unwrap();
 
         let perms = std::fs::metadata(root.join("node_modules/.bin/cmd"))
             .unwrap()
             .permissions();
         assert_eq!(perms.mode() & 0o111, 0o111); // executable bits set
+    }
+
+    // ─── Workspace bin stub tests ───
+
+    #[test]
+    fn test_workspace_bin_stubs_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        let graph = ResolvedGraph::default();
+
+        let mut bin_map = BTreeMap::new();
+        bin_map.insert("vertz-build".to_string(), "./dist/cli.js".to_string());
+
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/build".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/build"),
+            pkg: make_pkg_json("@vertz/build", BinField::Map(bin_map)),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        assert_eq!(count, 1);
+
+        let stub_path = root.join("node_modules/.bin/vertz-build");
+        assert!(stub_path.exists(), "workspace bin stub should be created");
+
+        let content = std::fs::read_to_string(&stub_path).unwrap();
+        assert!(content.starts_with("#!/bin/sh"));
+        assert!(
+            content.contains("@vertz/build/dist/cli.js"),
+            "stub should point to workspace package: {}",
+            content
+        );
+    }
+
+    #[test]
+    fn test_workspace_bin_stubs_single() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        let graph = ResolvedGraph::default();
+
+        let workspaces = vec![WorkspacePackage {
+            name: "my-cli".to_string(),
+            version: "1.0.0".to_string(),
+            path: PathBuf::from("packages/cli"),
+            pkg: make_pkg_json("my-cli", BinField::Single("./bin/cli.js".to_string())),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        assert_eq!(count, 1);
+
+        let stub_path = root.join("node_modules/.bin/my-cli");
+        assert!(
+            stub_path.exists(),
+            "workspace bin stub (single) should be created"
+        );
+
+        let content = std::fs::read_to_string(&stub_path).unwrap();
+        assert!(content.contains("my-cli/bin/cli.js"));
+    }
+
+    #[test]
+    fn test_workspace_no_bins_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        let graph = ResolvedGraph::default();
+
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/core".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/core"),
+            pkg: make_pkg_json("@vertz/core", BinField::default()),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_workspace_and_npm_bins_combined() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        // npm package with bin
+        let mut graph = ResolvedGraph::default();
+        let mut npm_bin = BTreeMap::new();
+        npm_bin.insert("esbuild".to_string(), "./bin/esbuild".to_string());
+        graph.packages.insert(
+            "esbuild@0.24.0".to_string(),
+            ResolvedPackage {
+                name: "esbuild".to_string(),
+                version: "0.24.0".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                bin: npm_bin,
+                nest_path: vec![],
+            },
+        );
+
+        // workspace package with bin
+        let mut ws_bin = BTreeMap::new();
+        ws_bin.insert("vertz-build".to_string(), "./dist/cli.js".to_string());
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/build".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/build"),
+            pkg: make_pkg_json("@vertz/build", BinField::Map(ws_bin)),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        assert_eq!(count, 2);
+
+        assert!(root.join("node_modules/.bin/esbuild").exists());
+        assert!(root.join("node_modules/.bin/vertz-build").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_workspace_bin_stub_is_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        let graph = ResolvedGraph::default();
+
+        let mut bin_map = BTreeMap::new();
+        bin_map.insert("vertz-build".to_string(), "./dist/cli.js".to_string());
+
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/build".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/build"),
+            pkg: make_pkg_json("@vertz/build", BinField::Map(bin_map)),
+        }];
+
+        generate_bin_stubs(root, &graph, &workspaces).unwrap();
+
+        let perms = std::fs::metadata(root.join("node_modules/.bin/vertz-build"))
+            .unwrap()
+            .permissions();
+        assert_eq!(perms.mode() & 0o111, 0o111);
+    }
+
+    #[test]
+    fn test_workspace_scoped_single_bin_strips_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        let graph = ResolvedGraph::default();
+
+        // Scoped package with BinField::Single — bin name should be "build", not "@vertz/build"
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/build".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/build"),
+            pkg: make_pkg_json(
+                "@vertz/build",
+                BinField::Single("./dist/cli.js".to_string()),
+            ),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        assert_eq!(count, 1);
+
+        // Bin name should be "build" (scope stripped), not "@vertz/build"
+        let stub_path = root.join("node_modules/.bin/build");
+        assert!(stub_path.exists(), "scoped single bin should strip scope");
+        assert!(
+            !root.join("node_modules/.bin/@vertz").exists(),
+            "should not create nested scope directory"
+        );
+
+        let content = std::fs::read_to_string(&stub_path).unwrap();
+        assert!(
+            content.contains("@vertz/build/dist/cli.js"),
+            "target should use full scoped name: {}",
+            content
+        );
+    }
+
+    #[test]
+    fn test_workspace_bin_takes_precedence_over_npm() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+
+        // npm package with bin "cli"
+        let mut graph = ResolvedGraph::default();
+        let mut npm_bin = BTreeMap::new();
+        npm_bin.insert("cli".to_string(), "./bin/cli.js".to_string());
+        graph.packages.insert(
+            "some-cli@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "some-cli".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                bin: npm_bin,
+                nest_path: vec![],
+            },
+        );
+
+        // workspace package also defining bin "cli" — should win
+        let mut ws_bin = BTreeMap::new();
+        ws_bin.insert("cli".to_string(), "./dist/main.js".to_string());
+        let workspaces = vec![WorkspacePackage {
+            name: "@vertz/cli".to_string(),
+            version: "0.2.58".to_string(),
+            path: PathBuf::from("packages/cli"),
+            pkg: make_pkg_json("@vertz/cli", BinField::Map(ws_bin)),
+        }];
+
+        let count = generate_bin_stubs(root, &graph, &workspaces).unwrap();
+        // Both counted (2 writes), even though one overwrites the other
+        assert_eq!(count, 2);
+
+        // Workspace stub should be the one that exists (wrote last)
+        let content = std::fs::read_to_string(root.join("node_modules/.bin/cli")).unwrap();
+        assert!(
+            content.contains("@vertz/cli/dist/main.js"),
+            "workspace bin should take precedence: {}",
+            content
+        );
     }
 }

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -371,8 +371,8 @@ pub async fn install(
         }
     }
 
-    // Generate .bin/ stubs
-    let bin_count = bin::generate_bin_stubs(root_dir, &graph)?;
+    // Generate .bin/ stubs (npm + workspace packages)
+    let bin_count = bin::generate_bin_stubs(root_dir, &graph, &workspaces)?;
     output.bin_stubs_created(bin_count);
 
     // Run postinstall scripts based on policy

--- a/native/vtz/src/pm/types.rs
+++ b/native/vtz/src/pm/types.rs
@@ -46,11 +46,16 @@ impl Default for BinField {
 
 impl BinField {
     /// Normalize to a map. For single-string bin, uses the package name as key.
+    /// Scoped names like `@scope/pkg` are reduced to `pkg` (matches npm behavior).
     pub fn to_map(&self, package_name: &str) -> BTreeMap<String, String> {
         match self {
             BinField::Single(path) => {
+                let bin_name = package_name
+                    .strip_prefix('@')
+                    .and_then(|s| s.split('/').nth(1))
+                    .unwrap_or(package_name);
                 let mut map = BTreeMap::new();
-                map.insert(package_name.to_string(), path.clone());
+                map.insert(bin_name.to_string(), path.clone());
                 map
             }
             BinField::Map(map) => map.clone(),


### PR DESCRIPTION
## Summary

Fixes #2520 (workspace bin stubs).

- `generate_bin_stubs` only iterated `graph.packages` (npm registry packages) but never created stubs for workspace packages
- Workspace packages with `bin` entries (like `@vertz/build` → `vertz-build`) were symlinked into `node_modules/` by the linker, but their bin stubs were never written to `node_modules/.bin/`
- Also fixes `BinField::to_map` to strip scope from scoped package names (e.g. `@vertz/build` → bin name `build`), matching npm/yarn/pnpm behavior

## Changes

- [`native/vtz/src/pm/bin.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-vtz-ci/native/vtz/src/pm/bin.rs): Add `workspaces` param to `generate_bin_stubs`, extract `write_bin_stub` helper, add 4 new tests (scoped single bin, collision precedence, combined npm+ws, executable perms)
- [`native/vtz/src/pm/mod.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-vtz-ci/native/vtz/src/pm/mod.rs): Pass `&workspaces` at call site
- [`native/vtz/src/pm/types.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-vtz-ci/native/vtz/src/pm/types.rs): Fix `BinField::to_map` scope stripping

## Public API Changes

None — internal Rust API only. The `generate_bin_stubs` signature changed (added `workspaces` param), but it has a single internal call site.

## Test plan

- [x] 12 bin stub tests pass (6 existing + 6 new workspace tests)
- [x] All cargo tests pass (`cargo test --all`)
- [x] Clippy clean (`cargo clippy --all-targets --release -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [x] Pre-push hooks pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

## Note on CI workflow

The CI workflow (`ci.yml`) still uses `bun install` and `timeout` workarounds. These can only be removed after the next `vtz` binary release (0.2.59) ships to npm, since CI downloads the published binary via `setup-vtz`. A follow-up PR will clean up CI once the release is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)