### PR TITLE
fix(vtz): support file:// URLs in fetch for PGlite WASM loading

### DIFF
--- a/.changeset/fix-file-url-fetch.md
+++ b/.changeset/fix-file-url-fetch.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): support file:// URLs in fetch for PGlite WASM loading

--- a/native/vtz/src/runtime/ops/fetch.rs
+++ b/native/vtz/src/runtime/ops/fetch.rs
@@ -360,6 +360,105 @@ mod tests {
         assert_eq!(result, serde_json::json!("correct-error"));
     }
 
+    // --- file:// URL support ---
+
+    #[tokio::test]
+    async fn test_fetch_file_url_returns_text_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("hello.txt");
+        std::fs::write(&file_path, "file content here").unwrap();
+        let file_url = url::Url::from_file_path(&file_path).unwrap();
+
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}');
+                return [resp.status, await resp.text()];
+            "#,
+                file_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_u64().unwrap(), 200);
+        assert_eq!(arr[1].as_str().unwrap(), "file content here");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_file_url_returns_binary_via_array_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("data.bin");
+        // Write known binary bytes (including non-UTF-8)
+        std::fs::write(&file_path, [0x00, 0x61, 0x73, 0x6D, 0x01, 0xFF]).unwrap();
+        let file_url = url::Url::from_file_path(&file_path).unwrap();
+
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}');
+                const buf = await resp.arrayBuffer();
+                const bytes = new Uint8Array(buf);
+                return Array.from(bytes);
+            "#,
+                file_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        let bytes: Vec<u8> = arr.iter().map(|v| v.as_u64().unwrap() as u8).collect();
+        assert_eq!(bytes, vec![0x00, 0x61, 0x73, 0x6D, 0x01, 0xFF]);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_file_url_response_ok_and_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, "ok").unwrap();
+        let file_url = url::Url::from_file_path(&file_path).unwrap();
+
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}');
+                return [resp.ok, resp.status, resp.statusText, resp.url];
+            "#,
+                file_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0], serde_json::json!(true));
+        assert_eq!(arr[1].as_u64().unwrap(), 200);
+        assert_eq!(arr[2].as_str().unwrap(), "OK");
+        assert!(arr[3].as_str().unwrap().starts_with("file://"));
+    }
+
+    // --- file:// URL: nonexistent file throws ---
+
+    #[tokio::test]
+    async fn test_fetch_file_url_nonexistent_throws() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await fetch('file:///nonexistent/path/does-not-exist.txt');
+                return 'no-throw';
+            } catch (e) {
+                return 'threw';
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("threw"));
+    }
+
     // --- Error: invalid HTTP method ---
 
     #[tokio::test]

--- a/native/vtz/src/runtime/ops/fetch.rs
+++ b/native/vtz/src/runtime/ops/fetch.rs
@@ -439,6 +439,50 @@ mod tests {
         assert!(arr[3].as_str().unwrap().starts_with("file://"));
     }
 
+    #[tokio::test]
+    async fn test_fetch_file_url_sets_content_type_for_wasm() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("module.wasm");
+        std::fs::write(&file_path, [0x00, 0x61, 0x73, 0x6D]).unwrap();
+        let file_url = url::Url::from_file_path(&file_path).unwrap();
+
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}');
+                return resp.headers.get('content-type');
+            "#,
+                file_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "application/wasm");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_file_url_sets_content_type_for_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("data.json");
+        std::fs::write(&file_path, r#"{"key":"value"}"#).unwrap();
+        let file_url = url::Url::from_file_path(&file_path).unwrap();
+
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}');
+                return resp.headers.get('content-type');
+            "#,
+                file_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "application/json");
+    }
+
     // --- file:// URL: nonexistent file throws ---
 
     #[tokio::test]

--- a/native/vtz/src/runtime/ops/web_api.rs
+++ b/native/vtz/src/runtime/ops/web_api.rs
@@ -484,6 +484,17 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
       throw signal.reason || new DOMException_('The operation was aborted.', 'AbortError');
     }
 
+    // Handle file:// URLs by reading from the filesystem
+    if (req.url.startsWith('file://')) {
+      const filePath = Deno.core.ops.op_file_url_to_path(req.url);
+      const bytes = await Deno.core.ops.op_fs_read_file_bytes(filePath);
+      return new Response(new Uint8Array(bytes), {
+        status: 200,
+        statusText: 'OK',
+        url: req.url,
+      });
+    }
+
     // Build options for Rust op
     const options = {
       method: req.method,

--- a/native/vtz/src/runtime/ops/web_api.rs
+++ b/native/vtz/src/runtime/ops/web_api.rs
@@ -488,9 +488,29 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
     if (req.url.startsWith('file://')) {
       const filePath = Deno.core.ops.op_file_url_to_path(req.url);
       const bytes = await Deno.core.ops.op_fs_read_file_bytes(filePath);
+      const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
+      const mimeTypes = {
+        '.wasm': 'application/wasm',
+        '.json': 'application/json',
+        '.js': 'application/javascript',
+        '.mjs': 'application/javascript',
+        '.html': 'text/html',
+        '.htm': 'text/html',
+        '.css': 'text/css',
+        '.txt': 'text/plain',
+        '.xml': 'application/xml',
+        '.svg': 'image/svg+xml',
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif',
+        '.webp': 'image/webp',
+      };
+      const contentType = mimeTypes[ext] || 'application/octet-stream';
       return new Response(new Uint8Array(bytes), {
         status: 200,
         statusText: 'OK',
+        headers: { 'content-type': contentType },
         url: req.url,
       });
     }


### PR DESCRIPTION
## Summary

- Intercepts `file://` URLs in the JS-side `fetch()` bootstrap before reaching `op_fetch` (which only supports HTTP/HTTPS via reqwest)
- Reads files as binary using existing `op_file_url_to_path` + `op_fs_read_file_bytes` ops, preserving correct `.arrayBuffer()` behavior for WASM module instantiation
- Adds extension-based MIME type detection (critical: `WebAssembly.compileStreaming()` requires `application/wasm` content-type)

Fixes #2522

## Public API Changes

None — this is a runtime bug fix. `fetch('file://...')` now works as expected instead of throwing.

## Key Files

- [`native/vtz/src/runtime/ops/web_api.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-file-url-fetch/native/vtz/src/runtime/ops/web_api.rs) — file:// interception + MIME type detection in JS fetch bootstrap
- [`native/vtz/src/runtime/ops/fetch.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-file-url-fetch/native/vtz/src/runtime/ops/fetch.rs) — 6 new tests

## Test Plan

- [x] `fetch('file:///path/to/file.txt')` returns text content with status 200
- [x] `fetch('file:///path/to/file.wasm')` returns binary content via `.arrayBuffer()`
- [x] Response has correct `ok`, `status`, `statusText`, `url` properties
- [x] Content-Type set correctly for `.wasm` (application/wasm) and `.json` (application/json)
- [x] `fetch('file:///nonexistent')` throws (not silent failure)
- [x] All 11 existing HTTP fetch tests pass (no regression)
- [x] All 28 web_api tests pass (no regression)
- [x] Clippy clean, fmt clean

## Review

Adversarial review completed. 1 SHOULD-FIX (Content-Type header) addressed in second commit. Review at `reviews/fix-file-url-fetch/phase-01-file-url-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)