### PR TITLE
fix(desktop): shell.spawn kills process group on kill()

### DIFF
--- a/.changeset/spawn-pgkill.md
+++ b/.changeset/spawn-pgkill.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(desktop): shell.spawn now kills entire process group on kill(), preventing orphaned subprocesses

--- a/native/vtz/src/webview/ipc_handlers/shell.rs
+++ b/native/vtz/src/webview/ipc_handlers/shell.rs
@@ -153,6 +153,10 @@ pub async fn spawn(
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
+    // Put the child in its own process group so kill() can terminate the entire tree.
+    #[cfg(unix)]
+    cmd.process_group(0);
+
     let mut child = cmd.spawn().map_err(|e| IpcError {
         code: IpcErrorCode::ExecutionFailed,
         message: format!("Failed to spawn '{}': {}", params.command, e),

--- a/native/vtz/src/webview/process_map.rs
+++ b/native/vtz/src/webview/process_map.rs
@@ -53,22 +53,31 @@ impl ProcessMap {
             None => return Ok(false),
         };
 
-        // SAFETY: We are sending SIGKILL to a process group we spawned.
-        // The pid is a valid u32 from Child::id(). With process_group(0),
-        // PID == PGID. Negating targets the entire group. If the process
-        // group already exited, kill returns ESRCH which we treat as success.
-        let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+        #[cfg(unix)]
+        {
+            // SAFETY: We are sending SIGKILL to a process group we spawned.
+            // The pid is a valid u32 from Child::id(). With process_group(0),
+            // PID == PGID. Negating targets the entire group. If the process
+            // group already exited, kill returns ESRCH which we treat as success.
+            let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
 
-        if ret == 0 {
-            Ok(true)
-        } else {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::ESRCH) {
-                // Process already exited — treat as success
-                Ok(false)
+            if ret == 0 {
+                Ok(true)
             } else {
-                Err(err)
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ESRCH) {
+                    // Process already exited — treat as success
+                    Ok(false)
+                } else {
+                    Err(err)
+                }
             }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = pid;
+            Ok(false)
         }
     }
 
@@ -84,11 +93,16 @@ impl ProcessMap {
 
         let mut killed = 0;
         for (_sub_id, pid) in entries {
-            // SAFETY: Same as kill() above — sending SIGKILL to process groups we spawned.
-            let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
-            if ret == 0 {
-                killed += 1;
+            #[cfg(unix)]
+            {
+                // SAFETY: Same as kill() above — sending SIGKILL to process groups we spawned.
+                let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+                if ret == 0 {
+                    killed += 1;
+                }
             }
+            #[cfg(not(unix))]
+            let _ = pid;
         }
         killed
     }

--- a/native/vtz/src/webview/process_map.rs
+++ b/native/vtz/src/webview/process_map.rs
@@ -38,7 +38,11 @@ impl ProcessMap {
         self.inner.lock().unwrap().remove(&sub_id)
     }
 
-    /// Kill a process by subscription ID using SIGKILL.
+    /// Kill a process group by subscription ID using SIGKILL.
+    ///
+    /// Processes are spawned with `process_group(0)`, so their PID is also
+    /// their PGID. Negating the PID targets the entire process group,
+    /// ensuring subprocesses are killed too.
     ///
     /// Idempotent: returns `Ok(true)` if signal was sent,
     /// `Ok(false)` if the process was already removed.
@@ -49,10 +53,11 @@ impl ProcessMap {
             None => return Ok(false),
         };
 
-        // SAFETY: We are sending SIGKILL to a PID we spawned.
-        // The pid is a valid u32 from Child::id(). If the process
-        // already exited, kill returns ESRCH which we treat as success.
-        let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        // SAFETY: We are sending SIGKILL to a process group we spawned.
+        // The pid is a valid u32 from Child::id(). With process_group(0),
+        // PID == PGID. Negating targets the entire group. If the process
+        // group already exited, kill returns ESRCH which we treat as success.
+        let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
 
         if ret == 0 {
             Ok(true)
@@ -67,9 +72,9 @@ impl ProcessMap {
         }
     }
 
-    /// Kill all tracked processes. Used on webview close for cleanup.
+    /// Kill all tracked process groups. Used on webview close for cleanup.
     ///
-    /// Returns the number of processes that were signaled.
+    /// Returns the number of process groups that were signaled.
     pub fn kill_all(&self) -> usize {
         let entries: Vec<(u64, u32)> = {
             let mut map = self.inner.lock().unwrap();
@@ -79,8 +84,8 @@ impl ProcessMap {
 
         let mut killed = 0;
         for (_sub_id, pid) in entries {
-            // SAFETY: Same as kill() above — sending SIGKILL to PIDs we spawned.
-            let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+            // SAFETY: Same as kill() above — sending SIGKILL to process groups we spawned.
+            let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
             if ret == 0 {
                 killed += 1;
             }
@@ -169,5 +174,57 @@ mod tests {
         map.insert(2, 200);
         map.insert(3, 300);
         assert_eq!(map.len(), 3);
+    }
+
+    // ── #2515: Process group kill for spawned processes ──
+
+    #[tokio::test]
+    async fn kill_terminates_entire_process_group() {
+        use std::time::Duration;
+        use tokio::process::Command;
+
+        let marker =
+            std::env::temp_dir().join(format!("vtz_test_spawn_pgkill_{}", std::process::id()));
+        // Clean up from any previous failed run
+        let _ = std::fs::remove_file(&marker);
+
+        let marker_path = marker.display().to_string();
+
+        // Spawn a process in its own process group (simulates what spawn() does).
+        // The process starts a background subprocess that writes a marker file after 2s.
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            &format!("(sleep 2 && echo alive > {}) & wait", marker_path),
+        ]);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        #[cfg(unix)]
+        cmd.process_group(0);
+
+        let child = cmd.spawn().expect("failed to spawn test process");
+        let pid = child.id().expect("failed to get PID");
+
+        let map = ProcessMap::new();
+        map.insert(1, pid);
+
+        // Give the subprocess time to start
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Kill via ProcessMap — should kill the entire process group
+        let result = map.kill(1).unwrap();
+        assert!(result, "expected kill to signal the process");
+
+        // Wait long enough for the subprocess to write the marker (if it survived)
+        tokio::time::sleep(Duration::from_secs(4)).await;
+
+        assert!(
+            !marker.exists(),
+            "marker file exists — subprocess was NOT killed (process group kill failed)"
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_file(&marker);
     }
 }

--- a/reviews/spawn-process-group-kill/phase-01-fix.md
+++ b/reviews/spawn-process-group-kill/phase-01-fix.md
@@ -1,0 +1,40 @@
+# Phase 1: Process Group Kill Fix
+
+- **Author:** Claude Opus 4.6
+- **Reviewer:** Claude Opus 4.6 (adversarial)
+- **Commits:** 4cd65e06b..5d2b27f6c
+- **Date:** 2026-04-12
+
+## Changes
+
+- `native/vtz/src/webview/ipc_handlers/shell.rs` (modified) -- added `process_group(0)` to `spawn()`
+- `native/vtz/src/webview/process_map.rs` (modified) -- changed `kill()` and `kill_all()` to use negative PID for process group kill, added `#[cfg(unix)]` guards, added integration test
+
+## CI Status
+
+- [x] Quality gates passed at 5d2b27f6c
+- [x] All 9 process_map tests pass
+- [x] All 21 shell handler tests pass
+- [x] Full vtz test suite (3286+ tests) passes with desktop feature
+- [x] clippy clean (--release -D warnings)
+- [x] rustfmt clean
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (failing test written first, then fix applied)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Mirrors existing pattern from execute() (#2509)
+
+## Findings
+
+### Approved with one should-fix
+
+**SHOULD-FIX (addressed):** `process_map.rs` called `libc::kill()` without `#[cfg(unix)]` guards. Pre-existing issue but cheap to fix while touching the code. Fixed in commit 5d2b27f6c.
+
+**Noted (no action needed):** PID 0 edge case -- `ProcessMap` doesn't guard against PID 0 being inserted, which would cause `kill(0, SIGKILL)` targeting the caller's own process group. Mitigated by `spawn()` validating PID via `.ok_or_else()`. Internal API, acceptable risk.
+
+## Resolution
+
+Should-fix finding addressed in follow-up commit. No remaining blockers.


### PR DESCRIPTION
## Summary

- `shell.spawn()` now creates child processes in their own process group via `process_group(0)`, mirroring the fix applied to `shell.execute()` in #2509
- `ProcessMap::kill()` and `kill_all()` now use `kill(-pgid, SIGKILL)` to terminate the entire process group, preventing orphaned subprocesses
- Added `#[cfg(unix)]` platform guards to `libc::kill()` calls for portability

## Public API Changes

None — internal runtime behavior fix only.

## Test Plan

- [x] New integration test `kill_terminates_entire_process_group` — spawns a process with a background subprocess, verifies `ProcessMap::kill()` terminates both
- [x] All 9 process_map tests pass
- [x] All 21 shell handler tests pass
- [x] Full vtz test suite (3286+ tests) passes with desktop feature
- [x] clippy clean, rustfmt clean

Fixes #2515

🤖 Generated with [Claude Code](https://claude.com/claude-code)