### PR TITLE
fix(runtime): fix fetch streaming, env proxy, module resolution, and deepEqual bugs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -62,12 +62,10 @@
     {
       "files": ["packages/ui-primitives/src/**/*.tsx"],
       "rules": {
-        "jsx-a11y/no-noninteractive-element-to-interactive-role": "off",
         "jsx-a11y/no-redundant-roles": "off",
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/role-has-required-aria-props": "off",
         "jsx-a11y/role-supports-aria-props": "off",
-        "jsx-a11y/interactive-supports-focus": "off",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/prefer-tag-over-role": "off"
       }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -359,8 +359,18 @@ impl VertzModuleLoader {
             let nm_dir = search_dir.join("node_modules").join(&package_name);
             if nm_dir.is_symlink() {
                 // Follow symlinks (Bun creates symlinks in workspace packages)
-                let canonical = nm_dir.canonicalize().unwrap_or(nm_dir);
-                return self.resolve_package_entry(&canonical, subpath.as_deref());
+                match nm_dir.canonicalize() {
+                    Ok(canonical) => {
+                        return self.resolve_package_entry(&canonical, subpath.as_deref());
+                    }
+                    Err(_) => {
+                        // Broken symlink — continue searching up the tree
+                        if !search_dir.pop() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
             }
             if nm_dir.is_dir() {
                 return self.resolve_package_entry(&nm_dir, subpath.as_deref());

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -8,6 +8,18 @@ pub fn op_env_get(#[string] key: String) -> Option<String> {
     std::env::var(&key).ok()
 }
 
+/// Set an environment variable.
+#[op2(fast)]
+pub fn op_env_set(#[string] key: String, #[string] value: String) {
+    std::env::set_var(&key, &value);
+}
+
+/// Remove an environment variable.
+#[op2(fast)]
+pub fn op_env_remove(#[string] key: String) {
+    std::env::remove_var(&key);
+}
+
 /// Get the current working directory.
 #[op2]
 #[string]
@@ -19,7 +31,7 @@ pub fn op_cwd() -> Result<String, deno_core::error::AnyError> {
 
 /// Get the op declarations for env ops.
 pub fn op_decls() -> Vec<OpDecl> {
-    vec![op_env_get(), op_cwd()]
+    vec![op_env_get(), op_env_set(), op_env_remove(), op_cwd()]
 }
 
 /// JavaScript bootstrap code for process.env.
@@ -30,6 +42,16 @@ pub const ENV_BOOTSTRAP_JS: &str = r#"
       if (typeof prop !== 'string') return undefined;
       const val = Deno.core.ops.op_env_get(prop);
       return val === null ? undefined : val;
+    },
+    set(_target, prop, value) {
+      if (typeof prop !== 'string') return true;
+      Deno.core.ops.op_env_set(prop, String(value));
+      return true;
+    },
+    deleteProperty(_target, prop) {
+      if (typeof prop !== 'string') return true;
+      Deno.core.ops.op_env_remove(prop);
+      return true;
     },
     has(_target, prop) {
       if (typeof prop !== 'string') return false;
@@ -106,5 +128,31 @@ mod tests {
             .unwrap();
         assert_eq!(result, serde_json::json!("hello_vertz"));
         std::env::remove_var("VERTZ_TEST_ENV_VAR");
+    }
+
+    #[test]
+    fn test_process_env_set_var() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "process.env.VERTZ_SET_TEST = 'set_value'; process.env.VERTZ_SET_TEST",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!("set_value"));
+        std::env::remove_var("VERTZ_SET_TEST");
+    }
+
+    #[test]
+    fn test_process_env_delete_var() {
+        std::env::set_var("VERTZ_DELETE_TEST", "to_delete");
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "delete process.env.VERTZ_DELETE_TEST; process.env.VERTZ_DELETE_TEST === undefined",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
     }
 }

--- a/native/vtz/src/runtime/ops/web_api.rs
+++ b/native/vtz/src/runtime/ops/web_api.rs
@@ -286,12 +286,15 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
     let bodyUsed = false;
     let bodyBytes = null;
     let bodyText = null;
+    let bodyStream = null;
 
     if (bodyInit === undefined || bodyInit === null) {
       bodyText = '';
       bodyBytes = new Uint8Array(0);
     } else if (typeof bodyInit === 'string') {
       bodyText = bodyInit;
+    } else if (bodyInit instanceof ReadableStream) {
+      bodyStream = bodyInit;
     } else if (bodyInit instanceof ArrayBuffer) {
       bodyBytes = new Uint8Array(bodyInit);
     } else if (ArrayBuffer.isView(bodyInit)) {
@@ -309,9 +312,30 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
       return new Uint8Array(0);
     }
 
+    async function drainStream() {
+      if (!bodyStream) return new Uint8Array(0);
+      const reader = bodyStream.getReader();
+      const chunks = [];
+      let totalLength = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        totalLength += value.byteLength;
+      }
+      const result = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      return result;
+    }
+
     return {
       get bodyUsed() { return bodyUsed; },
       get body() {
+        if (bodyStream) return bodyStream;
         // Return a ReadableStream that enqueues the body bytes
         const bytes = getBytes();
         return new ReadableStream({
@@ -326,20 +350,41 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
       async text() {
         consumeBody();
         if (bodyText !== null) return bodyText;
+        if (bodyStream) {
+          const bytes = await drainStream();
+          return new TextDecoder().decode(bytes);
+        }
         return new TextDecoder().decode(bodyBytes);
       },
       async json() {
         consumeBody();
-        const text = bodyText !== null ? bodyText : new TextDecoder().decode(bodyBytes);
+        let text;
+        if (bodyText !== null) {
+          text = bodyText;
+        } else if (bodyStream) {
+          const bytes = await drainStream();
+          text = new TextDecoder().decode(bytes);
+        } else {
+          text = new TextDecoder().decode(bodyBytes);
+        }
         return JSON.parse(text);
       },
       async arrayBuffer() {
         consumeBody();
         if (bodyBytes !== null) return bodyBytes.buffer.slice(bodyBytes.byteOffset, bodyBytes.byteOffset + bodyBytes.byteLength);
+        if (bodyStream) {
+          const bytes = await drainStream();
+          return bytes.buffer;
+        }
         return new TextEncoder().encode(bodyText).buffer;
       },
       clone() {
         if (bodyUsed) throw new TypeError('Cannot clone a consumed body');
+        if (bodyStream) {
+          const [s1, s2] = bodyStream.tee();
+          bodyStream = s1;
+          return createBodyMixin(s2);
+        }
         return createBodyMixin(bodyText !== null ? bodyText : bodyBytes ? new Uint8Array(bodyBytes) : null);
       },
     };

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -285,8 +285,8 @@ if (typeof globalThis.HTMLElement === 'undefined') {
       return a.every((v, i) => deepEqual(v, b[i], seen));
     }
 
-    const keysA = Object.keys(a);
-    const keysB = Object.keys(b);
+    const keysA = Object.keys(a).filter(k => a[k] !== undefined);
+    const keysB = Object.keys(b).filter(k => b[k] !== undefined);
     if (keysA.length !== keysB.length) return false;
     return keysA.every(k => deepEqual(a[k], b[k], seen));
   }
@@ -1641,6 +1641,37 @@ mod tests {
                 });
                 it('NaN equals NaN', () => {
                     expect(NaN).toEqual(NaN);
+                });
+            });
+            "#,
+        );
+
+        let arr = results.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        for (i, item) in arr.iter().enumerate() {
+            assert_eq!(
+                item["status"], "pass",
+                "Test {} ({}) failed: {:?}",
+                i, item["name"], item["error"]
+            );
+        }
+    }
+
+    #[test]
+    fn test_deep_equal_undefined_properties() {
+        let mut rt = create_test_runtime();
+        let results = run_test_code(
+            &mut rt,
+            r#"
+            describe('deepEqual undefined properties', () => {
+                it('treats explicit undefined same as missing key', () => {
+                    expect({ a: 1, b: undefined }).toEqual({ a: 1 });
+                });
+                it('treats missing key same as explicit undefined', () => {
+                    expect({ a: 1 }).toEqual({ a: 1, b: undefined });
+                });
+                it('both sides with undefined properties', () => {
+                    expect({ a: 1, b: undefined }).toEqual({ a: 1, b: undefined });
                 });
             });
             "#,


### PR DESCRIPTION
## Summary

Fixes four runtime bugs that caused ~20 test failures across `@vertz/fetch`, `@vertz/core`, `@vertz/openapi`, and `@vertz/server`:

- **Response body ReadableStream not handled in `createBodyMixin`** — streaming parsers in `@vertz/fetch` received empty arrays because ReadableStream bodies were silently dropped. Added ReadableStream detection, stream draining for text/json/arrayBuffer, and tee() support for clone().
- **`process.env` proxy missing set/deleteProperty traps** — `@vertz/core` immutability tests failed because `NODE_ENV` couldn't be set at runtime. Added `op_env_set` and `op_env_remove` Rust ops with corresponding JS proxy traps.
- **Broken symlinks in node_modules halt module resolution** — when a workspace symlink points to a missing Bun cache entry, `canonicalize()` fails and the resolver stops instead of continuing up the tree. Now falls back to searching parent directories.
- **`deepEqual` treats explicit undefined properties as present** — `toEqual` assertions failed when comparing objects with `requestBody: undefined` against objects without the key, diverging from vitest semantics. Fixed by filtering undefined-valued keys in the comparison.
- **oxlint config references non-existent rules** — removed two `jsx-a11y` rules (`interactive-supports-focus`, `no-noninteractive-element-to-interactive-role`) that don't exist in oxlint 1.59.0 and were set to `"off"` anyway.

## Files Changed

- [`native/vtz/src/runtime/ops/web_api.rs`](https://github.com/vertz-dev/vertz/blob/fix/runtime-test-failures-2523/native/vtz/src/runtime/ops/web_api.rs) — ReadableStream body support in createBodyMixin
- [`native/vtz/src/runtime/ops/env.rs`](https://github.com/vertz-dev/vertz/blob/fix/runtime-test-failures-2523/native/vtz/src/runtime/ops/env.rs) — op_env_set, op_env_remove + proxy set/delete traps
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/fix/runtime-test-failures-2523/native/vtz/src/runtime/module_loader.rs) — broken symlink fallback
- [`native/vtz/src/test/globals.rs`](https://github.com/vertz-dev/vertz/blob/fix/runtime-test-failures-2523/native/vtz/src/test/globals.rs) — deepEqual undefined property handling + tests
- [`.oxlintrc.json`](https://github.com/vertz-dev/vertz/blob/fix/runtime-test-failures-2523/.oxlintrc.json) — remove non-existent oxlint rules

## Test plan

- [x] `@vertz/fetch` streaming: 10/10 SSE + NDJSON tests pass
- [x] `@vertz/core` immutability: 13/13 tests pass (dev proxy, freeze, make-immutable)
- [x] `@vertz/openapi` parser: 21/21 tests pass (deepEqual fix)
- [x] `@vertz/testing`: 45/45 tests pass
- [x] Rust quality gates: 4,655+ tests pass, clippy clean, fmt clean
- [x] Pre-push hooks: all 6 checks pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

Closes #2523

🤖 Generated with [Claude Code](https://claude.com/claude-code)