### PR TITLE
fix(site): use vertz binary instead of broken vtz run path pattern

### DIFF
--- a/benchmarks/vertz/playwright.config.ts
+++ b/benchmarks/vertz/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command: 'bun node_modules/@vertz/cli/dist/vertz.js dev --port 4201',
+    command: 'vtz dev --port 4201',
     url: 'http://localhost:4201',
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,

--- a/packages/component-docs/package.json
+++ b/packages/component-docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vtz dev",
-    "build": "vtz run node_modules/@vertz/cli/dist/vertz.js build",
+    "build": "vertz build",
     "typecheck": "tsgo --noEmit",
     "deploy": "vtz run build && vtzx wrangler deploy",
     "deploy:preview": "vtz run build && vtzx wrangler deploy --env preview"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Vertz documentation site — built with @vertz/docs",
   "scripts": {
-    "dev": "vtz run node_modules/@vertz/cli/dist/vertz.js docs dev",
-    "build": "vtz run node_modules/@vertz/cli/dist/vertz.js docs build",
-    "check": "vtz run node_modules/@vertz/cli/dist/vertz.js docs check"
+    "dev": "vertz docs dev",
+    "build": "vertz docs build",
+    "check": "vertz docs check"
   },
   "dependencies": {
     "@vertz/cli": "workspace:^",

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -21,7 +21,7 @@ for cargo_toml in "$REPO_ROOT"/native/vtz/Cargo.toml \
                   "$REPO_ROOT"/native/vertz-compiler/Cargo.toml \
                   "$REPO_ROOT"/native/vertz-compiler-core/Cargo.toml; do
   if [ -f "$cargo_toml" ]; then
-    sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$cargo_toml"
+    sed "s/^version = \".*\"/version = \"$VERSION\"/" "$cargo_toml" > "${cargo_toml}.tmp" && mv "${cargo_toml}.tmp" "$cargo_toml"
   fi
 done
 


### PR DESCRIPTION
## Summary

- Fix `@vertz/site` and `@vertz/component-docs` build scripts that used `vtz run node_modules/@vertz/cli/dist/vertz.js` — `vtz run` expects a script name from `package.json`, not a file path
- Fix `benchmarks/vertz/playwright.config.ts` which used `bun node_modules/@vertz/cli/dist/vertz.js dev` — replaced with `vtz dev`
- Fix macOS-incompatible `sed -i` in `scripts/version.sh` using portable temp-file approach

## Public API Changes

None — only build scripts and internal tooling.

Closes #2558

## Test plan

- [ ] `vtz run dev` works in `packages/site/`
- [ ] `vtz run build` works in `packages/site/`
- [ ] `vtz run build` works in `packages/component-docs/`
- [ ] `scripts/version.sh` runs on macOS without sed errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)