### PR TITLE
fix(ui-server): fix aot-manifest-loader and ssr-progressive-response test failures

### DIFF
--- a/packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts
+++ b/packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts
@@ -23,7 +23,7 @@ let srcDir: string;
 let serverDir: string;
 
 beforeEach(() => {
-  tmpDir = join(import.meta.dir, `.tmp-aot-e2e-${Date.now()}`);
+  tmpDir = join(import.meta.dirname, `.tmp-aot-e2e-${Date.now()}`);
   srcDir = join(tmpDir, 'src');
   serverDir = join(tmpDir, 'server');
   mkdirSync(srcDir, { recursive: true });

--- a/packages/ui-server/src/__tests__/aot-manifest-build.test.ts
+++ b/packages/ui-server/src/__tests__/aot-manifest-build.test.ts
@@ -22,7 +22,7 @@ describe.skipIf(!hasNativeCompiler)('generateAotBuildManifest', () => {
   let srcDir: string;
 
   beforeEach(() => {
-    tmpDir = join(import.meta.dir, `.tmp-aot-build-${Date.now()}`);
+    tmpDir = join(import.meta.dirname, `.tmp-aot-build-${Date.now()}`);
     srcDir = join(tmpDir, 'src');
     mkdirSync(srcDir, { recursive: true });
   });

--- a/packages/ui-server/src/__tests__/aot-manifest-loader.test.ts
+++ b/packages/ui-server/src/__tests__/aot-manifest-loader.test.ts
@@ -11,7 +11,7 @@ describe('loadAotManifest', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = join(import.meta.dir, `.tmp-aot-loader-${Date.now()}`);
+    tmpDir = join(import.meta.dirname, `.tmp-aot-loader-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });
   });
 

--- a/packages/ui-server/src/__tests__/font-metrics.test.ts
+++ b/packages/ui-server/src/__tests__/font-metrics.test.ts
@@ -5,7 +5,7 @@ import { font } from '@vertz/ui';
 import { detectFallbackFont, extractFontMetrics } from '../font-metrics';
 
 // Use real font files from the landing site as test fixtures
-const FIXTURES_ROOT = join(import.meta.dir, '../../../../packages/landing');
+const FIXTURES_ROOT = join(import.meta.dirname, '../../../../packages/landing');
 const DM_SANS_PATH = '/public/fonts/dm-sans-latin.woff2';
 const DM_SERIF_PATH = '/public/fonts/dm-serif-display-latin.woff2';
 const JB_MONO_PATH = '/public/fonts/jetbrains-mono-latin.woff2';
@@ -185,7 +185,7 @@ describe('extractFontMetrics()', () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 
     // Create a temporary corrupt font file
-    const tmpDir = join(import.meta.dir, '__tmp_corrupt__');
+    const tmpDir = join(import.meta.dirname, '__tmp_corrupt__');
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(join(tmpDir, 'corrupt.woff2'), Buffer.from([0, 1, 2, 3, 4, 5]));
     afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));

--- a/packages/ui-server/src/__tests__/ssr-progressive-response.test.ts
+++ b/packages/ui-server/src/__tests__/ssr-progressive-response.test.ts
@@ -18,12 +18,14 @@ function stringStream(...parts: string[]): ReadableStream<Uint8Array> {
 /** Helper: create a ReadableStream that errors after emitting some chunks. */
 function errorStream(parts: string[], errorMessage: string): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
+  let index = 0;
   return new ReadableStream({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(encoder.encode(part));
+    pull(controller) {
+      if (index < parts.length) {
+        controller.enqueue(encoder.encode(parts[index++]));
+      } else {
+        throw new Error(errorMessage);
       }
-      controller.error(new Error(errorMessage));
     },
   });
 }

--- a/packages/ui-server/src/bun-plugin/__tests__/image-paths.test.ts
+++ b/packages/ui-server/src/bun-plugin/__tests__/image-paths.test.ts
@@ -8,7 +8,7 @@ import {
   resolveImageSrc,
 } from '../image-paths';
 
-const TMP_DIR = resolve(import.meta.dir, '.tmp-image-paths-test');
+const TMP_DIR = resolve(import.meta.dirname, '.tmp-image-paths-test');
 
 beforeAll(() => {
   mkdirSync(TMP_DIR, { recursive: true });

--- a/packages/ui-server/src/bun-plugin/__tests__/image-processor.test.ts
+++ b/packages/ui-server/src/bun-plugin/__tests__/image-processor.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import sharp from 'sharp';
 import { processImage } from '../image-processor';
 
-const TMP_DIR = resolve(import.meta.dir, '.tmp-image-test');
+const TMP_DIR = resolve(import.meta.dirname, '.tmp-image-test');
 const OUTPUT_DIR = resolve(TMP_DIR, 'output');
 const FIXTURES_DIR = resolve(TMP_DIR, 'fixtures');
 


### PR DESCRIPTION
## Summary

Fixes #2553 — two ui-server test files failing under `vtz test`.

**Root causes:**
- `import.meta.dir` is Bun-specific and returns `undefined` in the vtz runtime, causing `serde_v8 error` when passed to `path.join()`. Fixed by using the standard `import.meta.dirname` across all ui-server test files.
- `controller.error()` called in a ReadableStream `start()` callback doesn't propagate through `reader.read()` in the vtz runtime. Fixed the `errorStream` test helper to use `throw` in `pull()` instead, which correctly rejects the read promise.

## Public API Changes

None — test-only changes.

## Files Changed

- [`packages/ui-server/src/__tests__/aot-manifest-loader.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/__tests__/aot-manifest-loader.test.ts) — `import.meta.dir` → `import.meta.dirname`
- [`packages/ui-server/src/__tests__/ssr-progressive-response.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/__tests__/ssr-progressive-response.test.ts) — `errorStream` helper rewritten to use `pull()`+`throw`
- [`packages/ui-server/src/__tests__/aot-manifest-build.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/__tests__/aot-manifest-build.test.ts) — `import.meta.dir` → `import.meta.dirname`
- [`packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/__tests__/aot-e2e-pipeline.test.ts) — `import.meta.dir` → `import.meta.dirname`
- [`packages/ui-server/src/__tests__/font-metrics.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/__tests__/font-metrics.test.ts) — `import.meta.dir` → `import.meta.dirname`
- [`packages/ui-server/src/bun-plugin/__tests__/image-paths.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/bun-plugin/__tests__/image-paths.test.ts) — `import.meta.dir` → `import.meta.dirname`
- [`packages/ui-server/src/bun-plugin/__tests__/image-processor.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-ui-server-tests/packages/ui-server/src/bun-plugin/__tests__/image-processor.test.ts) — `import.meta.dir` → `import.meta.dirname`

## Test plan

- [x] All 22 tests in both target files pass under `vtz test`
- [x] No regressions in other ui-server tests
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)