### PR TITLE
fix(runtime): CJS interop, readdir withFileTypes, cpSync for docs tests (#2545)

### DIFF
--- a/.changeset/fix-docs-test-runtime.md
+++ b/.changeset/fix-docs-test-runtime.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix docs test failures: add CJS-to-ESM interop, readdir withFileTypes/recursive, cpSync, workspace source fallback, and pkg_type_cache for module loader

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6237,7 +6237,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "napi",
  "napi-build",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6269,7 +6269,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -11,7 +11,7 @@ use deno_core::ModuleSpecifier;
 use deno_core::PollEventLoopOptions;
 use deno_core::RuntimeOptions;
 
-use super::module_loader::VertzModuleLoader;
+use super::module_loader::{VertzModuleLoader, CJS_BOOTSTRAP_JS};
 use super::ops::async_context;
 use super::ops::clone;
 use super::ops::console;
@@ -143,6 +143,7 @@ impl VertzJsRuntime {
             streams::STREAMS_BOOTSTRAP_JS,
             os::OS_BOOTSTRAP_JS,
             fs::FS_BOOTSTRAP_JS,
+            CJS_BOOTSTRAP_JS,
             http_serve::HTTP_SERVE_BOOTSTRAP_JS,
         ]
         .join("\n")

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -68,6 +68,10 @@ pub struct VertzModuleLoader {
     shared_source_cache: Option<std::sync::Arc<SharedSourceCache>>,
     v8_code_cache: Option<std::sync::Arc<V8CodeCache>>,
     resolution_cache: Option<std::sync::Arc<SharedResolutionCache>>,
+    /// Cache for package.json "type" field lookups.
+    /// Key: directory path, Value: `true` if the directory has a package.json with `"type": "module"`.
+    /// Missing key means "not yet checked".
+    pkg_type_cache: RefCell<HashMap<PathBuf, Option<bool>>>,
 }
 
 impl VertzModuleLoader {
@@ -83,6 +87,7 @@ impl VertzModuleLoader {
             shared_source_cache: None,
             v8_code_cache: None,
             resolution_cache: None,
+            pkg_type_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -103,6 +108,7 @@ impl VertzModuleLoader {
             shared_source_cache: None,
             v8_code_cache: None,
             resolution_cache: None,
+            pkg_type_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -127,6 +133,7 @@ impl VertzModuleLoader {
             shared_source_cache,
             v8_code_cache,
             resolution_cache,
+            pkg_type_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -773,7 +780,16 @@ impl VertzModuleLoader {
 ///
 /// Additionally, if no `package.json` is found (e.g. temp directories), falls
 /// back to source-level heuristic: files with ESM syntax are treated as ESM.
-fn is_cjs_module(path: &Path, source: &str) -> bool {
+/// Determine whether the given file is a CommonJS module.
+///
+/// When `cache` is provided, the result of package.json "type" field lookups is
+/// memoized per directory so repeated loads from the same package avoid redundant
+/// filesystem reads.
+fn is_cjs_module_cached(
+    path: &Path,
+    source: &str,
+    cache: Option<&RefCell<HashMap<PathBuf, Option<bool>>>>,
+) -> bool {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
     match ext {
         "cjs" => true,
@@ -781,15 +797,42 @@ fn is_cjs_module(path: &Path, source: &str) -> bool {
         "js" => {
             let mut dir = path.parent();
             while let Some(d) = dir {
-                let pkg_json = d.join("package.json");
-                if pkg_json.is_file() {
-                    if let Ok(content) = std::fs::read_to_string(&pkg_json) {
-                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                            return json.get("type").and_then(|v| v.as_str()) != Some("module");
+                // Check cache first
+                if let Some(c) = cache {
+                    if let Some(cached) = c.borrow().get(d).copied() {
+                        // cached == Some(true) means "type":"module", Some(false) means CJS,
+                        // None means "no package.json here, keep walking up"
+                        match cached {
+                            Some(is_esm) => return !is_esm,
+                            None => {
+                                dir = d.parent();
+                                continue;
+                            }
                         }
                     }
-                    // Unreadable/unparseable package.json → default to CJS
-                    return true;
+                }
+
+                let pkg_json = d.join("package.json");
+                if pkg_json.is_file() {
+                    let is_esm = if let Ok(content) = std::fs::read_to_string(&pkg_json) {
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                            json.get("type").and_then(|v| v.as_str()) == Some("module")
+                        } else {
+                            false // Unparseable → default CJS
+                        }
+                    } else {
+                        false // Unreadable → default CJS
+                    };
+
+                    if let Some(c) = cache {
+                        c.borrow_mut().insert(d.to_path_buf(), Some(is_esm));
+                    }
+                    return !is_esm;
+                }
+
+                // No package.json in this directory
+                if let Some(c) = cache {
+                    c.borrow_mut().insert(d.to_path_buf(), None);
                 }
                 dir = d.parent();
             }
@@ -803,21 +846,59 @@ fn is_cjs_module(path: &Path, source: &str) -> bool {
 /// Quick heuristic: check if source contains ESM export/import syntax.
 ///
 /// Looks for `export ` or `import ` at the start of a line (after optional
-/// whitespace). This is intentionally simple — it doesn't parse comments or
-/// strings, but it's enough to avoid wrapping obvious ESM files.
+/// whitespace), skipping block comments. This is intentionally simple — it
+/// doesn't parse strings, but it's enough to avoid wrapping obvious ESM files.
 fn has_esm_syntax(source: &str) -> bool {
+    let mut in_block_comment = false;
     for line in source.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("export ")
-            || trimmed.starts_with("export{")
-            || trimmed.starts_with("import ")
-            || trimmed.starts_with("import{")
-            || trimmed.starts_with("import(")
-        {
+
+        // Track block comment state
+        if in_block_comment {
+            if let Some(pos) = trimmed.find("*/") {
+                // Block comment ends — check the rest of this line
+                let rest = trimmed[pos + 2..].trim();
+                in_block_comment = false;
+                if is_esm_line(rest) {
+                    return true;
+                }
+            }
+            continue;
+        }
+
+        // Skip single-line comments
+        if trimmed.starts_with("//") {
+            continue;
+        }
+
+        // Check for block comment start
+        if trimmed.starts_with("/*") {
+            if let Some(end_pos) = trimmed.find("*/") {
+                // Inline block comment — check the rest of the line
+                let rest = trimmed[end_pos + 2..].trim();
+                if is_esm_line(rest) {
+                    return true;
+                }
+            } else {
+                in_block_comment = true;
+            }
+            continue;
+        }
+
+        if is_esm_line(trimmed) {
             return true;
         }
     }
     false
+}
+
+/// Check if a trimmed line starts with ESM syntax.
+fn is_esm_line(trimmed: &str) -> bool {
+    trimmed.starts_with("export ")
+        || trimmed.starts_with("export{")
+        || trimmed.starts_with("import ")
+        || trimmed.starts_with("import{")
+        || trimmed.starts_with("import(")
 }
 
 /// Wrap CommonJS source code into an ESM module.
@@ -2187,7 +2268,8 @@ impl ModuleLoader for VertzModuleLoader {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
             // Determine if we need to compile or wrap
-            let is_cjs = matches!(ext, "js" | "cjs" | "") && is_cjs_module(&path, &source);
+            let is_cjs = matches!(ext, "js" | "cjs" | "")
+                && is_cjs_module_cached(&path, &source, Some(&self.pkg_type_cache));
             let (code, module_type) = match ext {
                 "ts" | "tsx" | "jsx" => {
                     let compiled = self.compile_source(&source, &filename)?;
@@ -3296,5 +3378,178 @@ export function Hello() {
             result
         );
         assert_eq!(result.unwrap().to_file_path().unwrap(), canon(&src_entry));
+    }
+
+    // ---------------------------------------------------------------
+    // has_esm_syntax tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_has_esm_syntax_export_default() {
+        assert!(has_esm_syntax("export default function foo() {}"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_named_export() {
+        assert!(has_esm_syntax("export { foo };"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_import_statement() {
+        assert!(has_esm_syntax("import { bar } from 'baz';"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_import_brace() {
+        assert!(has_esm_syntax("import{bar} from 'baz';"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_no_esm() {
+        assert!(!has_esm_syntax("const x = 1;\nmodule.exports = x;\n"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_skips_single_line_comment() {
+        assert!(!has_esm_syntax("// export default 42\nconst x = 1;"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_skips_block_comment() {
+        assert!(!has_esm_syntax(
+            "/* export default 42\nexport { foo } */\nconst x = 1;"
+        ));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_after_block_comment() {
+        assert!(has_esm_syntax("/* comment */\nexport default 42;"));
+    }
+
+    #[test]
+    fn test_has_esm_syntax_inline_block_comment_then_esm() {
+        // Block comment ends on same line, ESM follows
+        assert!(has_esm_syntax("/* comment */ export default 42;"));
+    }
+
+    // ---------------------------------------------------------------
+    // is_cjs_module_cached tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_cjs_detection_cjs_extension() {
+        let path = Path::new("/tmp/foo.cjs");
+        assert!(is_cjs_module_cached(path, "", None));
+    }
+
+    #[test]
+    fn test_cjs_detection_mjs_extension() {
+        let path = Path::new("/tmp/foo.mjs");
+        assert!(!is_cjs_module_cached(path, "", None));
+    }
+
+    #[test]
+    fn test_cjs_detection_js_with_type_module() {
+        let tmp = create_temp_dir();
+        std::fs::write(tmp.path().join("package.json"), r#"{ "type": "module" }"#).unwrap();
+        let js_path = tmp.path().join("index.js");
+        std::fs::write(&js_path, "module.exports = 1;").unwrap();
+        assert!(!is_cjs_module_cached(&js_path, "module.exports = 1;", None));
+    }
+
+    #[test]
+    fn test_cjs_detection_js_with_type_commonjs() {
+        let tmp = create_temp_dir();
+        std::fs::write(tmp.path().join("package.json"), r#"{ "type": "commonjs" }"#).unwrap();
+        let js_path = tmp.path().join("index.js");
+        std::fs::write(&js_path, "export default 1;").unwrap();
+        assert!(is_cjs_module_cached(&js_path, "export default 1;", None));
+    }
+
+    #[test]
+    fn test_cjs_detection_js_no_package_json_cjs_source() {
+        let tmp = create_temp_dir();
+        let js_path = tmp.path().join("index.js");
+        std::fs::write(&js_path, "module.exports = { foo: 1 };").unwrap();
+        // No package.json → falls back to source heuristic
+        assert!(is_cjs_module_cached(
+            &js_path,
+            "module.exports = { foo: 1 };",
+            None
+        ));
+    }
+
+    #[test]
+    fn test_cjs_detection_js_no_package_json_esm_source() {
+        let tmp = create_temp_dir();
+        let js_path = tmp.path().join("index.js");
+        std::fs::write(&js_path, "export default 1;").unwrap();
+        // No package.json → source has ESM syntax → not CJS
+        assert!(!is_cjs_module_cached(&js_path, "export default 1;", None));
+    }
+
+    #[test]
+    fn test_cjs_detection_uses_cache() {
+        let tmp = create_temp_dir();
+        std::fs::write(tmp.path().join("package.json"), r#"{ "type": "module" }"#).unwrap();
+        let js_path = tmp.path().join("index.js");
+        std::fs::write(&js_path, "").unwrap();
+
+        let cache: RefCell<HashMap<PathBuf, Option<bool>>> = RefCell::new(HashMap::new());
+        // First call populates cache
+        assert!(!is_cjs_module_cached(&js_path, "", Some(&cache)));
+        assert!(!cache.borrow().is_empty());
+
+        // Cache should contain the directory with Some(true) = ESM
+        let has_entry = cache.borrow().values().any(|v| *v == Some(true));
+        assert!(has_entry, "Cache should contain ESM entry");
+
+        // Second call uses cache (even if we delete the package.json)
+        std::fs::remove_file(tmp.path().join("package.json")).unwrap();
+        // Reset the file for a clean re-read (source has no ESM syntax, so without
+        // cache it would think CJS because package.json is gone)
+        assert!(!is_cjs_module_cached(&js_path, "", Some(&cache)));
+    }
+
+    // ---------------------------------------------------------------
+    // wrap_cjs_module tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_wrap_cjs_module_has_default_export() {
+        let path = Path::new("/tmp/test/foo.js");
+        let result = wrap_cjs_module("module.exports = 42;", path);
+        assert!(result.contains("export default __cjs_exports;"));
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_provides_filename() {
+        let path = Path::new("/tmp/test/foo.js");
+        let result = wrap_cjs_module("", path);
+        assert!(result.contains("__filename"));
+        assert!(result.contains("/tmp/test/foo.js"));
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_provides_dirname() {
+        let path = Path::new("/tmp/test/foo.js");
+        let result = wrap_cjs_module("", path);
+        assert!(result.contains("__dirname"));
+        assert!(result.contains("/tmp/test"));
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_provides_require() {
+        let path = Path::new("/tmp/test/foo.js");
+        let result = wrap_cjs_module("", path);
+        assert!(result.contains("var require = globalThis.__vtz_cjs_require("));
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_preserves_source() {
+        let path = Path::new("/tmp/test/foo.js");
+        let src = "const x = 1;\nmodule.exports = x;";
+        let result = wrap_cjs_module(src, path);
+        assert!(result.contains(src));
     }
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -361,7 +361,35 @@ impl VertzModuleLoader {
                 // Follow symlinks (Bun creates symlinks in workspace packages)
                 match nm_dir.canonicalize() {
                     Ok(canonical) => {
-                        return self.resolve_package_entry(&canonical, subpath.as_deref());
+                        match self.resolve_package_entry(&canonical, subpath.as_deref()) {
+                            Ok(resolved) => return Ok(resolved),
+                            Err(_) => {
+                                // Dist not built — try source fallback for workspace packages
+                                let pkg_json_path = canonical.join("package.json");
+                                if pkg_json_path.is_file() {
+                                    if let Ok(content) = std::fs::read_to_string(&pkg_json_path) {
+                                        if let Ok(pkg) =
+                                            serde_json::from_str::<serde_json::Value>(&content)
+                                        {
+                                            if let Ok(resolved) = self
+                                                .resolve_self_reference_source(
+                                                    &canonical,
+                                                    &pkg,
+                                                    subpath.as_deref(),
+                                                )
+                                            {
+                                                return Ok(resolved);
+                                            }
+                                        }
+                                    }
+                                }
+                                // Continue searching up the tree
+                                if !search_dir.pop() {
+                                    break;
+                                }
+                                continue;
+                            }
+                        }
                     }
                     Err(_) => {
                         // Broken symlink — continue searching up the tree
@@ -735,6 +763,214 @@ impl VertzModuleLoader {
         Ok(final_code)
     }
 }
+
+/// Check whether a `.js` file should be loaded as CommonJS.
+///
+/// Follows Node.js semantics:
+/// - `.cjs` → always CJS
+/// - `.mjs` → always ESM
+/// - `.js` → CJS unless the nearest `package.json` has `"type": "module"`
+///
+/// Additionally, if no `package.json` is found (e.g. temp directories), falls
+/// back to source-level heuristic: files with ESM syntax are treated as ESM.
+fn is_cjs_module(path: &Path, source: &str) -> bool {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    match ext {
+        "cjs" => true,
+        "mjs" => false,
+        "js" => {
+            let mut dir = path.parent();
+            while let Some(d) = dir {
+                let pkg_json = d.join("package.json");
+                if pkg_json.is_file() {
+                    if let Ok(content) = std::fs::read_to_string(&pkg_json) {
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                            return json.get("type").and_then(|v| v.as_str()) != Some("module");
+                        }
+                    }
+                    // Unreadable/unparseable package.json → default to CJS
+                    return true;
+                }
+                dir = d.parent();
+            }
+            // No package.json found — use source-level heuristic
+            !has_esm_syntax(source)
+        }
+        _ => false,
+    }
+}
+
+/// Quick heuristic: check if source contains ESM export/import syntax.
+///
+/// Looks for `export ` or `import ` at the start of a line (after optional
+/// whitespace). This is intentionally simple — it doesn't parse comments or
+/// strings, but it's enough to avoid wrapping obvious ESM files.
+fn has_esm_syntax(source: &str) -> bool {
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("export ")
+            || trimmed.starts_with("export{")
+            || trimmed.starts_with("import ")
+            || trimmed.starts_with("import{")
+            || trimmed.starts_with("import(")
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Wrap CommonJS source code into an ESM module.
+///
+/// The wrapper provides `module`, `exports`, `require`, `__filename`, `__dirname`
+/// bindings and exports `module.exports` as the default export.
+fn wrap_cjs_module(source: &str, path: &Path) -> String {
+    let filename = path.to_string_lossy();
+    let dirname = path
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let filename_json = serde_json::to_string(&*filename).unwrap_or_else(|_| "\"\"".to_string());
+    let dirname_json = serde_json::to_string(&*dirname).unwrap_or_else(|_| "\"\"".to_string());
+
+    format!(
+        "var __filename = {f};\n\
+         var __dirname = {d};\n\
+         var module = {{ exports: {{}} }};\n\
+         var exports = module.exports;\n\
+         var require = globalThis.__vtz_cjs_require({d});\n\n\
+         {src}\n\n\
+         var __cjs_exports = module.exports;\n\
+         export default __cjs_exports;\n",
+        f = filename_json,
+        d = dirname_json,
+        src = source,
+    )
+}
+
+/// JavaScript bootstrap for CJS `require()` support.
+///
+/// Installs `globalThis.__vtz_cjs_require(fromDir)` which returns a `require`
+/// function that resolves relative paths, reads files synchronously, and evaluates
+/// them as CommonJS modules with `module`, `exports`, `require`, `__filename`,
+/// `__dirname` bindings.
+pub const CJS_BOOTSTRAP_JS: &str = r#"
+((globalThis) => {
+  const _cjsCache = Object.create(null);
+
+  function _resolveCjsPath(specifier, fromDir) {
+    if (specifier.startsWith('./') || specifier.startsWith('../')) {
+      const parts = (fromDir + '/' + specifier).split('/');
+      const resolved = [];
+      for (const part of parts) {
+        if (part === '' && resolved.length > 0) continue;
+        if (part === '.') continue;
+        if (part === '..') { resolved.pop(); continue; }
+        resolved.push(part);
+      }
+      let path = '/' + resolved.join('/');
+
+      if (Deno.core.ops.op_fs_exists_sync(path)) {
+        try {
+          const stat = Deno.core.ops.op_fs_stat_sync(path);
+          if (stat.isDirectory) {
+            // Check package.json main
+            const pkgPath = path + '/package.json';
+            if (Deno.core.ops.op_fs_exists_sync(pkgPath)) {
+              try {
+                const pkg = JSON.parse(Deno.core.ops.op_fs_read_file_sync(pkgPath));
+                if (pkg.main) {
+                  const mainPath = path + '/' + pkg.main;
+                  if (Deno.core.ops.op_fs_exists_sync(mainPath)) return mainPath;
+                }
+              } catch (_) { /* ignore parse errors */ }
+            }
+            if (Deno.core.ops.op_fs_exists_sync(path + '/index.js')) return path + '/index.js';
+            if (Deno.core.ops.op_fs_exists_sync(path + '/index.json')) return path + '/index.json';
+            throw new Error("Cannot find module '" + specifier + "' from '" + fromDir + "'");
+          }
+        } catch (_) { /* stat error — treat as file */ }
+        return path;
+      }
+      if (Deno.core.ops.op_fs_exists_sync(path + '.js')) return path + '.js';
+      if (Deno.core.ops.op_fs_exists_sync(path + '.json')) return path + '.json';
+      if (Deno.core.ops.op_fs_exists_sync(path + '/index.js')) return path + '/index.js';
+
+      throw new Error("Cannot find module '" + specifier + "' from '" + fromDir + "'");
+    }
+
+    // Bare specifiers — walk up node_modules
+    let dir = fromDir;
+    while (dir && dir !== '/') {
+      const candidate = dir + '/node_modules/' + specifier;
+      if (Deno.core.ops.op_fs_exists_sync(candidate)) {
+        try {
+          const stat = Deno.core.ops.op_fs_stat_sync(candidate);
+          if (stat.isDirectory) {
+            const pkgPath = candidate + '/package.json';
+            if (Deno.core.ops.op_fs_exists_sync(pkgPath)) {
+              try {
+                const pkg = JSON.parse(Deno.core.ops.op_fs_read_file_sync(pkgPath));
+                if (pkg.main) {
+                  const mainPath = candidate + '/' + pkg.main;
+                  if (Deno.core.ops.op_fs_exists_sync(mainPath)) return mainPath;
+                }
+              } catch (_) { /* ignore parse errors */ }
+            }
+            if (Deno.core.ops.op_fs_exists_sync(candidate + '/index.js')) return candidate + '/index.js';
+          } else {
+            return candidate;
+          }
+        } catch (_) { return candidate; }
+      }
+      if (Deno.core.ops.op_fs_exists_sync(candidate + '.js')) return candidate + '.js';
+      const lastSlash = dir.lastIndexOf('/');
+      dir = lastSlash > 0 ? dir.substring(0, lastSlash) : '';
+    }
+
+    throw new Error(
+      "require('" + specifier + "') could not be resolved from '" + fromDir + "'. " +
+      "Use ESM imports for complex module resolution."
+    );
+  }
+
+  function _loadCjsModule(filename, dirname) {
+    if (filename in _cjsCache) return _cjsCache[filename].exports;
+
+    if (filename.endsWith('.json')) {
+      const source = Deno.core.ops.op_fs_read_file_sync(filename);
+      const parsed = JSON.parse(source);
+      _cjsCache[filename] = { exports: parsed };
+      return parsed;
+    }
+
+    const source = Deno.core.ops.op_fs_read_file_sync(filename);
+    const mod = { exports: {} };
+    _cjsCache[filename] = mod;
+
+    const requireFn = _createRequire(dirname);
+    requireFn.resolve = function(specifier) {
+      return _resolveCjsPath(specifier, dirname);
+    };
+
+    const fn = new Function('module', 'exports', 'require', '__filename', '__dirname', source);
+    fn(mod, mod.exports, requireFn, filename, dirname);
+
+    return mod.exports;
+  }
+
+  function _createRequire(fromDir) {
+    return function require(specifier) {
+      const resolved = _resolveCjsPath(specifier, fromDir);
+      const lastSlash = resolved.lastIndexOf('/');
+      const dirname = lastSlash >= 0 ? resolved.substring(0, lastSlash) : '.';
+      return _loadCjsModule(resolved, dirname);
+    };
+  }
+
+  globalThis.__vtz_cjs_require = _createRequire;
+})(globalThis);
+"#;
 
 /// Prefix for mocked module synthetic specifiers.
 const VERTZ_MOCK_PREFIX: &str = "vertz:mock:";
@@ -1251,6 +1487,7 @@ export const renameSync = fs.renameSync;
 export const realpathSync = fs.realpathSync;
 export const mkdtempSync = fs.mkdtempSync;
 export const copyFileSync = fs.copyFileSync;
+export const cpSync = fs.cpSync;
 export const chmodSync = fs.chmodSync;
 export const readFile = fs.readFile;
 export const writeFile = fs.writeFile;
@@ -1949,14 +2186,21 @@ impl ModuleLoader for VertzModuleLoader {
             let filename = path.to_string_lossy().to_string();
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-            // Determine if we need to compile
+            // Determine if we need to compile or wrap
+            let is_cjs = matches!(ext, "js" | "cjs" | "") && is_cjs_module(&path, &source);
             let (code, module_type) = match ext {
                 "ts" | "tsx" | "jsx" => {
                     let compiled = self.compile_source(&source, &filename)?;
                     (compiled, ModuleType::JavaScript)
                 }
                 "json" => (source, ModuleType::Json),
-                _ => (source, ModuleType::JavaScript),
+                _ => {
+                    if is_cjs {
+                        (wrap_cjs_module(&source, &path), ModuleType::JavaScript)
+                    } else {
+                        (source, ModuleType::JavaScript)
+                    }
+                }
             };
 
             let code_cache = self

--- a/native/vtz/src/runtime/ops/fs.rs
+++ b/native/vtz/src/runtime/ops/fs.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use deno_core::error::AnyError;
 use deno_core::op2;
@@ -19,6 +19,17 @@ fn io_error_code(e: &std::io::Error) -> &'static str {
         std::io::ErrorKind::IsADirectory => "EISDIR",
         _ => "EIO",
     }
+}
+
+/// Directory entry result returned to JavaScript for readdir with withFileTypes.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirentResult {
+    pub name: String,
+    pub parent_path: String,
+    pub is_file: bool,
+    pub is_directory: bool,
+    pub is_symlink: bool,
 }
 
 /// Stat result returned to JavaScript.
@@ -166,6 +177,126 @@ pub fn op_fs_readdir_sync(#[string] path: String) -> Result<Vec<String>, AnyErro
     Ok(names)
 }
 
+/// Read directory entries with file type info (sync), optionally recursive.
+#[op2]
+#[serde]
+pub fn op_fs_readdir_with_types_sync(
+    #[string] path: String,
+    recursive: bool,
+) -> Result<Vec<DirentResult>, AnyError> {
+    let root = PathBuf::from(&path);
+    let mut results = Vec::new();
+    readdir_with_types_impl(&root, recursive, &mut results)?;
+    Ok(results)
+}
+
+/// Internal recursive helper for readdir with types.
+fn readdir_with_types_impl(
+    dir: &Path,
+    recursive: bool,
+    results: &mut Vec<DirentResult>,
+) -> Result<(), AnyError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        deno_core::anyhow::anyhow!("{}: {}: '{}'", io_error_code(&e), e, dir.display())
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| deno_core::anyhow::anyhow!("{}", e))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| deno_core::anyhow::anyhow!("{}", e))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let parent_path = dir.to_string_lossy().to_string();
+
+        results.push(DirentResult {
+            name: name.clone(),
+            parent_path,
+            is_file: file_type.is_file(),
+            is_directory: file_type.is_dir(),
+            is_symlink: file_type.is_symlink(),
+        });
+
+        if recursive && file_type.is_dir() {
+            let child_dir = dir.join(&name);
+            readdir_with_types_impl(&child_dir, true, results)?;
+        }
+    }
+    Ok(())
+}
+
+/// Read directory entries (sync), optionally recursive (names only).
+#[op2]
+#[serde]
+pub fn op_fs_readdir_recursive_sync(#[string] path: String) -> Result<Vec<String>, AnyError> {
+    let root = PathBuf::from(&path);
+    let mut results = Vec::new();
+    readdir_recursive_impl(&root, &root, &mut results)?;
+    Ok(results)
+}
+
+/// Internal recursive helper for readdir (names only).
+fn readdir_recursive_impl(
+    root: &Path,
+    dir: &Path,
+    results: &mut Vec<String>,
+) -> Result<(), AnyError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        deno_core::anyhow::anyhow!("{}: {}: '{}'", io_error_code(&e), e, dir.display())
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| deno_core::anyhow::anyhow!("{}", e))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| deno_core::anyhow::anyhow!("{}", e))?;
+        let rel_path = entry
+            .path()
+            .strip_prefix(root)
+            .unwrap_or(&entry.path())
+            .to_string_lossy()
+            .to_string();
+
+        results.push(rel_path.clone());
+
+        if file_type.is_dir() {
+            readdir_recursive_impl(root, &entry.path(), results)?;
+        }
+    }
+    Ok(())
+}
+
+/// Read directory entries with file type info (async), optionally recursive.
+#[op2(async)]
+#[serde]
+pub async fn op_fs_readdir_with_types(
+    #[string] path: String,
+    recursive: bool,
+) -> Result<Vec<DirentResult>, AnyError> {
+    // Run the blocking I/O on a thread pool
+    let path_clone = path.clone();
+    tokio::task::spawn_blocking(move || {
+        let root = PathBuf::from(&path_clone);
+        let mut results = Vec::new();
+        readdir_with_types_impl(&root, recursive, &mut results)?;
+        Ok(results)
+    })
+    .await
+    .map_err(|e| deno_core::anyhow::anyhow!("readdir join error: {}", e))?
+}
+
+/// Read directory entries (async), optionally recursive (names only).
+#[op2(async)]
+#[serde]
+pub async fn op_fs_readdir_recursive(#[string] path: String) -> Result<Vec<String>, AnyError> {
+    let path_clone = path.clone();
+    tokio::task::spawn_blocking(move || {
+        let root = PathBuf::from(&path_clone);
+        let mut results = Vec::new();
+        readdir_recursive_impl(&root, &root, &mut results)?;
+        Ok(results)
+    })
+    .await
+    .map_err(|e| deno_core::anyhow::anyhow!("readdir join error: {}", e))?
+}
+
 /// Get file/directory metadata.
 #[op2]
 #[serde]
@@ -253,6 +384,70 @@ pub fn op_fs_copy_file_sync(#[string] src: String, #[string] dest: String) -> Re
     std::fs::copy(&src, &dest)
         .map(|_| ())
         .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}' -> '{}'", e, src, dest))
+}
+
+/// Copy a file or directory recursively (like `cp -r`).
+#[op2(fast)]
+pub fn op_fs_cp_sync(
+    #[string] src: String,
+    #[string] dest: String,
+    recursive: bool,
+) -> Result<(), AnyError> {
+    let src_path = PathBuf::from(&src);
+    if !src_path.exists() {
+        return Err(deno_core::anyhow::anyhow!(
+            "ENOENT: no such file or directory: '{}'",
+            src
+        ));
+    }
+    if src_path.is_dir() {
+        if !recursive {
+            return Err(deno_core::anyhow::anyhow!(
+                "ERR_FS_EISDIR: path is a directory, set recursive to true: '{}'",
+                src
+            ));
+        }
+        cp_dir_recursive(&src_path, &PathBuf::from(&dest))
+    } else {
+        // Single file copy
+        if let Some(parent) = PathBuf::from(&dest).parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, parent.display()))?;
+            }
+        }
+        std::fs::copy(&src, &dest)
+            .map(|_| ())
+            .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}' -> '{}'", e, src, dest))
+    }
+}
+
+/// Internal helper for recursive directory copy.
+fn cp_dir_recursive(src: &Path, dest: &Path) -> Result<(), AnyError> {
+    if !dest.exists() {
+        std::fs::create_dir_all(dest)
+            .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, dest.display()))?;
+    }
+    for entry in std::fs::read_dir(src)
+        .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, src.display()))?
+    {
+        let entry = entry.map_err(|e| deno_core::anyhow::anyhow!("{}", e))?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if src_path.is_dir() {
+            cp_dir_recursive(&src_path, &dest_path)?;
+        } else {
+            std::fs::copy(&src_path, &dest_path).map_err(|e| {
+                deno_core::anyhow::anyhow!(
+                    "{}: '{}' -> '{}'",
+                    e,
+                    src_path.display(),
+                    dest_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 /// Change file permissions (chmod).
@@ -424,6 +619,8 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_fs_exists_sync(),
         op_fs_mkdir_sync(),
         op_fs_readdir_sync(),
+        op_fs_readdir_with_types_sync(),
+        op_fs_readdir_recursive_sync(),
         op_fs_stat_sync(),
         op_fs_lstat_sync(),
         op_fs_rm_sync(),
@@ -432,6 +629,7 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_fs_realpath_sync(),
         op_fs_mkdtemp_sync(),
         op_fs_copy_file_sync(),
+        op_fs_cp_sync(),
         op_fs_chmod_sync(),
         // Async
         op_fs_read_file(),
@@ -440,6 +638,8 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_fs_write_file_bytes(),
         op_fs_mkdir(),
         op_fs_readdir(),
+        op_fs_readdir_with_types(),
+        op_fs_readdir_recursive(),
         op_fs_stat(),
         op_fs_rm(),
         op_fs_unlink(),
@@ -584,7 +784,26 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     Deno.core.ops.op_fs_mkdir_sync(String(path), recursive);
   }
 
-  function readdirSync(path) {
+  function createDirentObject(raw) {
+    return {
+      name: raw.name,
+      parentPath: raw.parentPath,
+      isFile: () => raw.isFile,
+      isDirectory: () => raw.isDirectory,
+      isSymbolicLink: () => raw.isSymlink,
+    };
+  }
+
+  function readdirSync(path, options) {
+    const withFileTypes = options && options.withFileTypes;
+    const recursive = options && options.recursive;
+    if (withFileTypes) {
+      const raw = Deno.core.ops.op_fs_readdir_with_types_sync(String(path), !!recursive);
+      return raw.map(createDirentObject);
+    }
+    if (recursive) {
+      return Deno.core.ops.op_fs_readdir_recursive_sync(String(path));
+    }
     return Deno.core.ops.op_fs_readdir_sync(String(path));
   }
 
@@ -622,6 +841,11 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     Deno.core.ops.op_fs_copy_file_sync(String(src), String(dest));
   }
 
+  function cpSync(src, dest, options) {
+    const recursive = options && options.recursive ? true : false;
+    Deno.core.ops.op_fs_cp_sync(String(src), String(dest), recursive);
+  }
+
   function chmodSync(path, mode) {
     Deno.core.ops.op_fs_chmod_sync(String(path), mode);
   }
@@ -653,7 +877,16 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     await Deno.core.ops.op_fs_mkdir(String(path), recursive);
   }
 
-  async function readdir(path) {
+  async function readdir(path, options) {
+    const withFileTypes = options && options.withFileTypes;
+    const recursive = options && options.recursive;
+    if (withFileTypes) {
+      const raw = await Deno.core.ops.op_fs_readdir_with_types(String(path), !!recursive);
+      return raw.map(createDirentObject);
+    }
+    if (recursive) {
+      return Deno.core.ops.op_fs_readdir_recursive(String(path));
+    }
     return Deno.core.ops.op_fs_readdir(String(path));
   }
 
@@ -685,7 +918,7 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     readFileSync, writeFileSync, appendFileSync, existsSync,
     mkdirSync, readdirSync, statSync, lstatSync,
     rmSync, unlinkSync, renameSync, realpathSync,
-    mkdtempSync, copyFileSync, chmodSync,
+    mkdtempSync, copyFileSync, cpSync, chmodSync,
     // Async wrappers (node:fs also has callback-style but we provide promise-based)
     readFile, writeFile, mkdir, readdir, stat, rm, unlink, rename, realpath,
     // Promises sub-object


### PR DESCRIPTION
## Summary

Fixes #2545 — all 6 `@vertz/docs` test files now pass under `vtz test` (90 tests total).

### Root causes
- **CJS modules not loadable in V8 ESM runtime** — Node.js CJS packages (unified, remark, rehype ecosystem) use `module.exports`/`require` which V8's ESM loader rejects
- **`readdir` missing `withFileTypes` + `recursive` support** — `discover.ts` uses `readdir(dir, { recursive: true, withFileTypes: true })` returning `Dirent` objects
- **`cpSync` missing from `node:fs`** — `build-pipeline.ts` imports `{ cpSync } from 'node:fs'`
- **Workspace source fallback missing** — symlinked workspace packages without `dist/` couldn't resolve to source files

### Changes

**`native/vtz/src/runtime/module_loader.rs`**
- [`is_cjs_module_cached()`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/richmond-v8/native/vtz/src/runtime/module_loader.rs) — detects CJS via package.json `type` field + ESM syntax heuristic, with per-directory caching
- [`has_esm_syntax()`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/richmond-v8/native/vtz/src/runtime/module_loader.rs) — scans for `export`/`import` keywords, properly skipping block and inline comments
- [`wrap_cjs_module()`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/richmond-v8/native/vtz/src/runtime/module_loader.rs) — wraps CJS source with `module`/`exports`/`require`/`__filename`/`__dirname` bindings + `export default`
- `CJS_BOOTSTRAP_JS` — JS bootstrap providing `globalThis.__vtz_cjs_require()` with path resolution, file reading, `new Function()` evaluation, and circular dependency support
- `pkg_type_cache` field on `VertzModuleLoader` for memoizing package.json lookups
- Workspace source fallback in `resolve_node_module()`
- 21 unit tests for CJS detection, ESM syntax heuristic, and CJS wrapping

**`native/vtz/src/runtime/ops/fs.rs`**
- `op_fs_readdir_with_types_sync/async` — returns `DirentResult` structs with `is_file`/`is_directory`/`is_symlink`
- `op_fs_readdir_recursive_sync/async` — returns flat list of relative paths
- `op_fs_cp_sync` + `cp_dir_recursive` — recursive directory copy
- JS shims: `readdirSync`/`readdir` updated with `withFileTypes`/`recursive` options, `createDirentObject()`, `cpSync()`

**`native/vtz/src/runtime/js_runtime.rs`**
- Bootstrap includes `CJS_BOOTSTRAP_JS` after FS module

## Public API Changes

None — these are internal runtime capabilities.

## Follow-up issues created

- #2565 — Named CJS export extraction for better interop
- #2566 — `cpSync` symlink loop detection
- #2567 — `readdir` recursive symlink loop detection

## Test plan

- [x] All 90 docs tests pass across 6 test files (`vtz test`)
- [x] All 3180 Rust tests pass (`cargo test --all`)
- [x] Clippy clean (`cargo clippy --all-targets --release -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [x] Pre-push hooks pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)