### PR TITLE
fix(runtime): cpSync symlink loops + CJS named exports

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -912,18 +912,20 @@ fn is_esm_line(trimmed: &str) -> bool {
 fn extract_cjs_named_exports(source: &str) -> Vec<String> {
     let mut names: Vec<String> = Vec::new();
 
-    // Count how many times `module.exports =` appears at the top level.
-    // If more than one, it's dynamic — bail out.
+    // Count how many times `module.exports = <value>` appears.
+    // Excludes `module.exports.prop = ...` (property assignment)
+    // and `module.exports === ...` / `module.exports == ...` (comparisons).
+    // If more than one reassignment, it's dynamic — bail out.
     let me_assignments: Vec<&str> = source
         .lines()
         .map(|l| l.trim())
-        .filter(|l| l.starts_with("module.exports") && l.contains('='))
+        .filter(|l| is_module_exports_assignment(l))
         .collect();
 
     if me_assignments.len() == 1 {
         let line = me_assignments[0];
         // Find the `= { ... }` part — may span multiple lines.
-        if let Some(eq_idx) = line.find('=') {
+        if let Some(eq_idx) = find_assignment_eq(line) {
             let rhs = line[eq_idx + 1..].trim();
             if rhs.starts_with('{') {
                 // Single-line: module.exports = { foo, bar: val };
@@ -936,10 +938,14 @@ fn extract_cjs_named_exports(source: &str) -> Vec<String> {
             // Non-object RHS (e.g., `module.exports = 42;`) → empty
         }
     } else if me_assignments.is_empty() {
-        // Check for `exports.name = ...` pattern
+        // Check for `exports.name = ...` or `module.exports.name = ...` patterns
         for line in source.lines() {
             let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("exports.") {
+            // `exports.name = ...`
+            let rest = trimmed
+                .strip_prefix("exports.")
+                .or_else(|| trimmed.strip_prefix("module.exports."));
+            if let Some(rest) = rest {
                 if let Some(name) = rest.split(&['=', ' ', '('][..]).next() {
                     let name = name.trim();
                     if !name.is_empty() && name != "default" && is_valid_js_ident(name) {
@@ -956,10 +962,54 @@ fn extract_cjs_named_exports(source: &str) -> Vec<String> {
     names
 }
 
+/// Check if a line is a `module.exports = <value>` assignment (not a comparison
+/// or property assignment like `module.exports.foo = ...`).
+fn is_module_exports_assignment(line: &str) -> bool {
+    // Must start with exactly `module.exports` followed by optional whitespace then `=`
+    let rest = match line.strip_prefix("module.exports") {
+        Some(r) => r,
+        None => return false,
+    };
+    // Exclude `module.exports.prop = ...`
+    if rest.starts_with('.') {
+        return false;
+    }
+    // Find the `=` sign
+    let rest = rest.trim_start();
+    if !rest.starts_with('=') {
+        return false;
+    }
+    // Exclude `==` and `===`
+    let after_eq = &rest[1..];
+    !after_eq.starts_with('=')
+}
+
+/// Find the position of the assignment `=` in a `module.exports = ...` line,
+/// skipping `==` and `===`.
+fn find_assignment_eq(line: &str) -> Option<usize> {
+    let mut i = 0;
+    let bytes = line.as_bytes();
+    while i < bytes.len() {
+        if bytes[i] == b'=' {
+            // Skip `===` and `==`
+            if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
+                i += if i + 2 < bytes.len() && bytes[i + 2] == b'=' {
+                    3
+                } else {
+                    2
+                };
+                continue;
+            }
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Extract the body of the object literal from `module.exports = { ... }`,
 /// handling multi-line cases.
 fn extract_object_body(source: &str) -> Option<String> {
-    let me_prefix = "module.exports";
     let mut collecting = false;
     let mut depth = 0i32;
     let mut body = String::new();
@@ -967,8 +1017,8 @@ fn extract_object_body(source: &str) -> Option<String> {
     for line in source.lines() {
         let trimmed = line.trim();
         if !collecting {
-            if trimmed.starts_with(me_prefix) && trimmed.contains('=') {
-                if let Some(eq_idx) = trimmed.find('=') {
+            if is_module_exports_assignment(trimmed) {
+                if let Some(eq_idx) = find_assignment_eq(trimmed) {
                     let rhs = &trimmed[eq_idx + 1..];
                     collecting = true;
                     // Process this line's content
@@ -1012,23 +1062,77 @@ fn extract_object_body(source: &str) -> Option<String> {
 }
 
 /// Parse object keys from the body between `{ }`.
+///
+/// Only splits on commas at brace depth 0 so nested objects
+/// (e.g., `foo: { a: 1, b: 2 }, bar`) don't produce spurious keys.
 fn parse_object_keys(body: &str, names: &mut Vec<String>) {
-    for part in body.split(',') {
+    // Split on commas respecting brace depth
+    let parts = split_top_level_commas(body);
+    for part in &parts {
         let part = part.trim();
         if part.is_empty() {
             continue;
         }
         // `key: value` or just `key` (shorthand)
-        let key = if let Some((k, _)) = part.split_once(':') {
-            k.trim()
+        // Find the first `:` at depth 0
+        let key = if let Some(colon_idx) = find_top_level_colon(part) {
+            part[..colon_idx].trim()
         } else {
             part.trim_end_matches(';')
         };
-        let key = key.trim();
-        if !key.is_empty() && key != "default" && is_valid_js_ident(key) {
-            names.push(key.to_string());
+        let key = unquote(key.trim());
+        if !key.is_empty() && key != "default" && is_valid_js_ident(&key) {
+            names.push(key.into_owned());
         }
     }
+}
+
+/// Split a string on commas, but only at brace/bracket depth 0.
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        parts.push(&s[start..]);
+    }
+    parts
+}
+
+/// Find the first `:` that is not inside nested braces/brackets.
+fn find_top_level_colon(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            ':' if depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Strip surrounding quotes (`"` or `'`) from a string key.
+fn unquote(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.len() >= 2 {
+        let first = s.as_bytes()[0];
+        let last = s.as_bytes()[s.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return std::borrow::Cow::Borrowed(&s[1..s.len() - 1]);
+        }
+    }
+    std::borrow::Cow::Borrowed(s)
 }
 
 /// Check if a string is a valid JS identifier (simplified).
@@ -3801,5 +3905,48 @@ exports.bar = fn;";
             !result.contains("export const {"),
             "Should not have named re-exports for non-object export"
         );
+    }
+
+    // --- Review-driven edge case tests ---
+
+    #[test]
+    fn test_extract_cjs_named_exports_module_exports_property_assignment() {
+        // module.exports.foo = ... should be treated like exports.foo = ...
+        let src = "\
+module.exports.foo = 1;
+module.exports.bar = fn;";
+        let names = extract_cjs_named_exports(src);
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_nested_object_no_spurious_keys() {
+        // Nested object properties should NOT leak as top-level export names
+        let names = extract_cjs_named_exports("module.exports = { foo: { a: 1, b: 2 }, bar };");
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_string_keys() {
+        // Quoted keys that are valid identifiers should be extracted
+        let names = extract_cjs_named_exports("module.exports = { \"foo\": 1, 'bar': 2 };");
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_comparison_not_counted() {
+        // `module.exports === ...` should not be counted as an assignment
+        let src = "\
+if (module.exports === null) {}
+module.exports = { foo: 1 };";
+        let names = extract_cjs_named_exports(src);
+        assert_eq!(names, vec!["foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_spread_ignored() {
+        // Spread syntax should be silently skipped (can't statically analyze)
+        let names = extract_cjs_named_exports("module.exports = { ...base, foo, bar };");
+        assert_eq!(names, vec!["bar", "foo"]);
     }
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -901,10 +901,152 @@ fn is_esm_line(trimmed: &str) -> bool {
         || trimmed.starts_with("import(")
 }
 
+/// Extract named export identifiers from CJS source code.
+///
+/// Handles two patterns:
+/// 1. `module.exports = { foo, bar: val }` — single top-level object literal assignment
+/// 2. `exports.foo = ...` — individual property assignments
+///
+/// Returns an empty `Vec` when the export shape is dynamic (conditional assignments,
+/// non-object `module.exports`, etc.).
+fn extract_cjs_named_exports(source: &str) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+
+    // Count how many times `module.exports =` appears at the top level.
+    // If more than one, it's dynamic — bail out.
+    let me_assignments: Vec<&str> = source
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| l.starts_with("module.exports") && l.contains('='))
+        .collect();
+
+    if me_assignments.len() == 1 {
+        let line = me_assignments[0];
+        // Find the `= { ... }` part — may span multiple lines.
+        if let Some(eq_idx) = line.find('=') {
+            let rhs = line[eq_idx + 1..].trim();
+            if rhs.starts_with('{') {
+                // Single-line: module.exports = { foo, bar: val };
+                // Extract keys from the object literal.
+                let obj_src = extract_object_body(source);
+                if let Some(body) = obj_src {
+                    parse_object_keys(&body, &mut names);
+                }
+            }
+            // Non-object RHS (e.g., `module.exports = 42;`) → empty
+        }
+    } else if me_assignments.is_empty() {
+        // Check for `exports.name = ...` pattern
+        for line in source.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("exports.") {
+                if let Some(name) = rest.split(&['=', ' ', '('][..]).next() {
+                    let name = name.trim();
+                    if !name.is_empty() && name != "default" && is_valid_js_ident(name) {
+                        names.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    // Multiple `module.exports =` assignments → dynamic, return empty
+
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Extract the body of the object literal from `module.exports = { ... }`,
+/// handling multi-line cases.
+fn extract_object_body(source: &str) -> Option<String> {
+    let me_prefix = "module.exports";
+    let mut collecting = false;
+    let mut depth = 0i32;
+    let mut body = String::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if !collecting {
+            if trimmed.starts_with(me_prefix) && trimmed.contains('=') {
+                if let Some(eq_idx) = trimmed.find('=') {
+                    let rhs = &trimmed[eq_idx + 1..];
+                    collecting = true;
+                    // Process this line's content
+                    for ch in rhs.chars() {
+                        if ch == '{' {
+                            depth += 1;
+                            if depth == 1 {
+                                continue; // skip opening brace
+                            }
+                        } else if ch == '}' {
+                            depth -= 1;
+                            if depth == 0 {
+                                return Some(body);
+                            }
+                        }
+                        if depth >= 1 {
+                            body.push(ch);
+                        }
+                    }
+                }
+            }
+        } else {
+            for ch in trimmed.chars() {
+                if ch == '{' {
+                    depth += 1;
+                } else if ch == '}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(body);
+                    }
+                }
+                if depth >= 1 {
+                    body.push(ch);
+                }
+            }
+            // Add a comma between lines for easier parsing
+            body.push(',');
+        }
+    }
+    None
+}
+
+/// Parse object keys from the body between `{ }`.
+fn parse_object_keys(body: &str, names: &mut Vec<String>) {
+    for part in body.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        // `key: value` or just `key` (shorthand)
+        let key = if let Some((k, _)) = part.split_once(':') {
+            k.trim()
+        } else {
+            part.trim_end_matches(';')
+        };
+        let key = key.trim();
+        if !key.is_empty() && key != "default" && is_valid_js_ident(key) {
+            names.push(key.to_string());
+        }
+    }
+}
+
+/// Check if a string is a valid JS identifier (simplified).
+fn is_valid_js_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
 /// Wrap CommonJS source code into an ESM module.
 ///
 /// The wrapper provides `module`, `exports`, `require`, `__filename`, `__dirname`
 /// bindings and exports `module.exports` as the default export.
+/// When the source has statically-analyzable named exports, they are re-exported
+/// as `export const { name1, name2 } = __cjs_exports;`.
 fn wrap_cjs_module(source: &str, path: &Path) -> String {
     let filename = path.to_string_lossy();
     let dirname = path
@@ -914,6 +1056,16 @@ fn wrap_cjs_module(source: &str, path: &Path) -> String {
     let filename_json = serde_json::to_string(&*filename).unwrap_or_else(|_| "\"\"".to_string());
     let dirname_json = serde_json::to_string(&*dirname).unwrap_or_else(|_| "\"\"".to_string());
 
+    let named_exports = extract_cjs_named_exports(source);
+    let named_line = if named_exports.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "export const {{ {} }} = __cjs_exports;\n",
+            named_exports.join(", ")
+        )
+    };
+
     format!(
         "var __filename = {f};\n\
          var __dirname = {d};\n\
@@ -922,10 +1074,12 @@ fn wrap_cjs_module(source: &str, path: &Path) -> String {
          var require = globalThis.__vtz_cjs_require({d});\n\n\
          {src}\n\n\
          var __cjs_exports = module.exports;\n\
-         export default __cjs_exports;\n",
+         export default __cjs_exports;\n\
+         {named}",
         f = filename_json,
         d = dirname_json,
         src = source,
+        named = named_line,
     )
 }
 
@@ -3551,5 +3705,101 @@ export function Hello() {
         let src = "const x = 1;\nmodule.exports = x;";
         let result = wrap_cjs_module(src, path);
         assert!(result.contains(src));
+    }
+
+    // ---------------------------------------------------------------
+    // Named CJS export extraction
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_extract_cjs_named_exports_object_literal() {
+        let names = extract_cjs_named_exports("module.exports = { foo, bar };");
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_key_value_pairs() {
+        let names = extract_cjs_named_exports("module.exports = { foo: 1, bar: fn };");
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_mixed_shorthand_and_kv() {
+        let names = extract_cjs_named_exports("module.exports = { foo, bar: 2, baz };");
+        assert_eq!(names, vec!["bar", "baz", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_multiline() {
+        let src = "\
+const foo = 1;
+const bar = 2;
+module.exports = {
+  foo,
+  bar,
+};";
+        let names = extract_cjs_named_exports(src);
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_non_object_returns_empty() {
+        // module.exports = someValue (not an object literal)
+        let names = extract_cjs_named_exports("module.exports = 42;");
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_dynamic_assignment_returns_empty() {
+        let src = "\
+if (condition) {
+  module.exports = { a: 1 };
+} else {
+  module.exports = { b: 2 };
+}";
+        let names = extract_cjs_named_exports(src);
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_exports_dot_pattern() {
+        let src = "\
+exports.foo = 1;
+exports.bar = fn;";
+        let names = extract_cjs_named_exports(src);
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_extract_cjs_named_exports_skips_default_keyword() {
+        // "default" is a reserved word, should not be emitted as named export
+        let names = extract_cjs_named_exports("module.exports = { default: main, foo };");
+        assert_eq!(names, vec!["foo"]);
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_emits_named_reexports() {
+        let path = Path::new("/tmp/test/pkg.js");
+        let src = "module.exports = { foo, bar };";
+        let result = wrap_cjs_module(src, path);
+        assert!(result.contains("export default __cjs_exports;"));
+        // Named re-exports destructure from __cjs_exports
+        assert!(
+            result.contains("export const { bar, foo } = __cjs_exports;"),
+            "Expected named re-exports, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_wrap_cjs_module_no_named_exports_for_non_object() {
+        let path = Path::new("/tmp/test/pkg.js");
+        let src = "module.exports = 42;";
+        let result = wrap_cjs_module(src, path);
+        assert!(result.contains("export default __cjs_exports;"));
+        assert!(
+            !result.contains("export const {"),
+            "Should not have named re-exports for non-object export"
+        );
     }
 }

--- a/native/vtz/src/runtime/ops/fs.rs
+++ b/native/vtz/src/runtime/ops/fs.rs
@@ -431,7 +431,10 @@ pub fn op_fs_cp_sync(
 /// Internal helper for recursive directory copy.
 ///
 /// `visited` tracks canonical paths of directories already entered to detect
-/// symlink loops.
+/// symlink loops. Note: this is stricter than Node's `fs.cpSync` — diamond-shaped
+/// symlink structures (two subtrees both linking to the same directory) will error
+/// on the second traversal. This prevents duplicate content and is consistent with
+/// `cp -r` behavior on most Unix systems.
 fn cp_dir_recursive(
     src: &Path,
     dest: &Path,
@@ -1411,6 +1414,36 @@ mod tests {
             err_msg.contains("symlink loop") || err_msg.contains("ELOOP"),
             "Error should mention symlink loop, got: {}",
             err_msg
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_cp_sync_follows_legitimate_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create an external directory that the symlink points to (no loop)
+        let external = tmp.path().join("external");
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::write(external.join("data.txt"), "external data").unwrap();
+
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("local.txt"), "local").unwrap();
+        // Symlink to external dir (not a loop)
+        std::os::unix::fs::symlink(&external, src.join("link")).unwrap();
+
+        let dest = tmp.path().join("dest");
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(src.canonicalize().unwrap());
+        super::cp_dir_recursive(&src, &dest, &mut visited).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dest.join("local.txt")).unwrap(),
+            "local"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("link/data.txt")).unwrap(),
+            "external data"
         );
     }
 }

--- a/native/vtz/src/runtime/ops/fs.rs
+++ b/native/vtz/src/runtime/ops/fs.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use deno_core::error::AnyError;
@@ -407,7 +408,12 @@ pub fn op_fs_cp_sync(
                 src
             ));
         }
-        cp_dir_recursive(&src_path, &PathBuf::from(&dest))
+        let mut visited = HashSet::new();
+        let canonical = src_path
+            .canonicalize()
+            .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, src))?;
+        visited.insert(canonical);
+        cp_dir_recursive(&src_path, &PathBuf::from(&dest), &mut visited)
     } else {
         // Single file copy
         if let Some(parent) = PathBuf::from(&dest).parent() {
@@ -423,7 +429,14 @@ pub fn op_fs_cp_sync(
 }
 
 /// Internal helper for recursive directory copy.
-fn cp_dir_recursive(src: &Path, dest: &Path) -> Result<(), AnyError> {
+///
+/// `visited` tracks canonical paths of directories already entered to detect
+/// symlink loops.
+fn cp_dir_recursive(
+    src: &Path,
+    dest: &Path,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<(), AnyError> {
     if !dest.exists() {
         std::fs::create_dir_all(dest)
             .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, dest.display()))?;
@@ -435,7 +448,16 @@ fn cp_dir_recursive(src: &Path, dest: &Path) -> Result<(), AnyError> {
         let src_path = entry.path();
         let dest_path = dest.join(entry.file_name());
         if src_path.is_dir() {
-            cp_dir_recursive(&src_path, &dest_path)?;
+            let canonical = src_path
+                .canonicalize()
+                .map_err(|e| deno_core::anyhow::anyhow!("{}: '{}'", e, src_path.display()))?;
+            if !visited.insert(canonical) {
+                return Err(deno_core::anyhow::anyhow!(
+                    "ELOOP: symlink loop detected copying '{}'",
+                    src_path.display()
+                ));
+            }
+            cp_dir_recursive(&src_path, &dest_path, visited)?;
         } else {
             std::fs::copy(&src_path, &dest_path).map_err(|e| {
                 deno_core::anyhow::anyhow!(
@@ -1344,5 +1366,51 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result, serde_json::json!([true, false]));
+    }
+
+    // --- cpSync tests ---
+
+    #[test]
+    fn test_cp_sync_recursive_copies_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        std::fs::create_dir_all(src.join("sub")).unwrap();
+        std::fs::write(src.join("a.txt"), "a").unwrap();
+        std::fs::write(src.join("sub/b.txt"), "b").unwrap();
+
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(src.canonicalize().unwrap());
+        super::cp_dir_recursive(&src, &dest, &mut visited).unwrap();
+
+        assert_eq!(std::fs::read_to_string(dest.join("a.txt")).unwrap(), "a");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("sub/b.txt")).unwrap(),
+            "b"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_cp_sync_detects_symlink_loop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(src.join("child")).unwrap();
+        std::fs::write(src.join("file.txt"), "hello").unwrap();
+
+        // Create a symlink loop: src/child/loop -> src
+        std::os::unix::fs::symlink(&src, src.join("child/loop")).unwrap();
+
+        let dest = tmp.path().join("dest");
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(src.canonicalize().unwrap());
+        let result = super::cp_dir_recursive(&src, &dest, &mut visited);
+        assert!(result.is_err(), "Expected error for symlink loop");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("symlink loop") || err_msg.contains("ELOOP"),
+            "Error should mention symlink loop, got: {}",
+            err_msg
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#2566** — `cpSync` now detects symlink loops by tracking visited canonical paths in a `HashSet`. Returns `ELOOP` error instead of recursing until stack overflow.
- **#2565** — CJS wrapper (`wrap_cjs_module`) now statically extracts named exports from `module.exports = { foo, bar }` and `exports.foo = ...` patterns, emitting `export const { foo, bar } = __cjs_exports;` alongside `export default`.

Fixes #2565
Fixes #2566

## Public API Changes

None — these are internal runtime improvements. No changes to user-facing APIs.

## Changes

### cpSync symlink loop detection (`native/vtz/src/runtime/ops/fs.rs`)
- `cp_dir_recursive` now accepts a `visited: &mut HashSet<PathBuf>` parameter
- Each directory's canonical path is checked against the set before recursing
- Diamond-shaped symlink structures are also rejected (intentionally stricter than Node.js, documented)

### CJS named export extraction (`native/vtz/src/runtime/module_loader.rs`)
- New `extract_cjs_named_exports()` function with two extraction strategies:
  - `module.exports = { foo, bar: val }` — single object literal assignment
  - `exports.foo = ...` / `module.exports.foo = ...` — individual property assignments
- Robust parsing: respects brace depth for nested objects, strips quoted keys, skips `==`/`===` comparisons, ignores spread syntax
- Dynamic `module.exports` (conditional assignments) correctly falls back to default-only
- `wrap_cjs_module()` appends named re-exports when static analysis succeeds

## Test Plan

- [x] 3 cpSync tests: normal recursive copy, symlink loop detection, legitimate symlink following
- [x] 13 CJS extraction tests: object literal, key-value pairs, multiline, non-object fallback, dynamic assignment, exports.foo pattern, module.exports.foo pattern, nested objects, string keys, comparison skipping, spread syntax, default keyword skipping
- [x] 7 wrap_cjs_module tests: existing tests + named re-export emission + non-object suppression
- [x] Full `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Review

Adversarial review completed — 2 blockers found and fixed:
1. `module.exports` detection false-positives on `===`/`==`/property assignments
2. Nested objects producing spurious export names from naive comma splitting

Review file: [`reviews/runtime-fixes-2565-2566/phase-01-review.md`](reviews/runtime-fixes-2565-2566/phase-01-review.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)