### PR TITLE
fix(test): skip CJS require tests under vtz runtime

### DIFF
--- a/.changeset/fix-test-require-skip.md
+++ b/.changeset/fix-test-require-skip.md
@@ -1,0 +1,5 @@
+---
+'@vertz/test': patch
+---
+
+Skip CJS require-based Bun bridge tests when running under vtz test runner

--- a/packages/test/src/__tests__/exports.test.ts
+++ b/packages/test/src/__tests__/exports.test.ts
@@ -31,24 +31,27 @@ import type {
 // --- Bun runtime bridge ---
 // When running under `bun test`, @vertz/test re-exports from bun:test.
 // These tests verify the bridge works correctly.
+// Tests that use require() are skipped under vtz (no CJS require in ESM modules).
+
+const isBun = typeof Bun !== 'undefined';
 
 describe('@vertz/test Bun bridge', () => {
-  it('describe is a function from bun:test', () => {
+  it.skipIf(!isBun)('describe is a function from bun:test', () => {
     const mod = require('../index');
     expect(typeof mod.describe).toBe('function');
   });
 
-  it('it is a function from bun:test', () => {
+  it.skipIf(!isBun)('it is a function from bun:test', () => {
     const mod = require('../index');
     expect(typeof mod.it).toBe('function');
   });
 
-  it('test is a function from bun:test', () => {
+  it.skipIf(!isBun)('test is a function from bun:test', () => {
     const mod = require('../index');
     expect(typeof mod.test).toBe('function');
   });
 
-  it('expect is a function from bun:test', () => {
+  it.skipIf(!isBun)('expect is a function from bun:test', () => {
     const mod = require('../index');
     expect(typeof mod.expect).toBe('function');
   });
@@ -88,7 +91,7 @@ describe('@vertz/test Bun bridge', () => {
     expect(typeof vi.restoreAllMocks).toBe('function');
   });
 
-  it('describe has skip, each modifiers', () => {
+  it.skipIf(!isBun)('describe has skip, each modifiers', () => {
     const mod = require('../index');
     expect(typeof mod.describe.skip).toBe('function');
     expect(typeof mod.describe.each).toBe('function');
@@ -96,7 +99,7 @@ describe('@vertz/test Bun bridge', () => {
     expect('only' in mod.describe).toBe(true);
   });
 
-  it('it has skip, todo, each modifiers', () => {
+  it.skipIf(!isBun)('it has skip, todo, each modifiers', () => {
     const mod = require('../index');
     expect(typeof mod.it.skip).toBe('function');
     expect(typeof mod.it.todo).toBe('function');
@@ -105,7 +108,7 @@ describe('@vertz/test Bun bridge', () => {
     expect('only' in mod.it).toBe(true);
   });
 
-  it('expect has asymmetric matcher factories', () => {
+  it.skipIf(!isBun)('expect has asymmetric matcher factories', () => {
     const mod = require('../index');
     expect(typeof mod.expect.any).toBe('function');
     expect(typeof mod.expect.anything).toBe('function');


### PR DESCRIPTION
## Summary

- Skips 7 `require()`-based Bun bridge tests in `@vertz/test` when running under the vtz test runner using `it.skipIf(!isBun)`
- These tests verify CJS interop with `bun:test` and are only meaningful under Bun — under vtz, `require()` is not available in ESM modules
- The remaining 10 tests (ESM imports, type exports) continue to run and pass under both runtimes

Fixes #2536

## Public API Changes

None — test-only change.

## Test plan

- [x] `vtz test packages/test` — 9 passed, 7 skipped (16 total)
- [x] Typecheck clean (`tsgo --noEmit`)
- [x] Lint/format clean (`oxlint` + `oxfmt`)
- [x] Adversarial review passed — no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)