### PR TITLE
fix(vtz,codegen): child_process ops and tsc type compatibility

### DIFF
--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -27,6 +27,7 @@ use super::ops::microtask;
 use super::ops::os;
 use super::ops::path;
 use super::ops::performance;
+use super::ops::process;
 use super::ops::signals;
 use super::ops::sqlite;
 use super::ops::streams;
@@ -115,6 +116,7 @@ impl VertzJsRuntime {
         ops.extend(e2e::op_decls());
         ops.extend(signals::op_decls());
         ops.extend(http_serve::op_decls());
+        ops.extend(process::op_decls());
         ops
     }
 

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1832,73 +1832,55 @@ export default { AsyncLocalStorage, AsyncResource };
 "#;
 
 /// Synthetic module for `node:child_process`.
-/// Provides spawn, execFile, execSync stubs that delegate to Deno.Command.
+/// Provides execSync, execFile, execFileSync, spawn via native op.
 const NODE_CHILD_PROCESS_SPECIFIER: &str = "vertz:node_child_process";
 const NODE_CHILD_PROCESS_MODULE: &str = r#"
 function execSync(cmd, opts) {
-  const parts = cmd.split(' ');
-  const command = new Deno.Command(parts[0], {
-    args: parts.slice(1),
-    cwd: opts?.cwd,
-    env: opts?.env,
-    stdout: opts?.encoding ? 'piped' : 'piped',
-    stderr: 'piped',
-  });
-  const result = command.outputSync();
-  if (result.code !== 0) {
+  // Node.js runs execSync through a shell (/bin/sh -c "...")
+  const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+    '/bin/sh', ['-c', cmd], opts?.cwd ?? null, opts?.env ?? null,
+  );
+  if (code !== 0) {
     const err = new Error(`Command failed: ${cmd}`);
-    err.status = result.code;
-    err.stderr = new TextDecoder().decode(result.stderr);
+    err.status = code;
+    err.stderr = stderr;
     throw err;
   }
-  const out = new TextDecoder().decode(result.stdout);
-  return opts?.encoding ? out : new TextEncoder().encode(out);
+  return opts?.encoding ? stdout : new TextEncoder().encode(stdout);
 }
 
 function execFile(file, args, opts, cb) {
   if (typeof opts === 'function') { cb = opts; opts = {}; }
+  let code, stdout, stderr;
   try {
-    const command = new Deno.Command(file, {
-      args: args || [],
-      cwd: opts?.cwd,
-      env: opts?.env,
-      stdout: 'piped',
-      stderr: 'piped',
-    });
-    const result = command.outputSync();
-    const stdout = new TextDecoder().decode(result.stdout);
-    const stderr = new TextDecoder().decode(result.stderr);
-    if (result.code !== 0) {
-      const err = new Error(`Command failed: ${file}`);
-      err.code = result.code;
-      err.stderr = stderr;
-      if (cb) cb(err, stdout, stderr); else throw err;
-      return;
-    }
-    if (cb) cb(null, stdout, stderr);
+    [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+      file, args || [], opts?.cwd ?? null, opts?.env ?? null,
+    );
   } catch (e) {
-    if (cb) cb(e, '', '');
-    else throw e;
+    if (cb) { cb(e, '', ''); return; }
+    throw e;
   }
+  if (code !== 0) {
+    const err = new Error(`Command failed: ${file}`);
+    err.status = code;
+    err.stderr = stderr;
+    if (cb) cb(err, stdout, stderr); else throw err;
+    return;
+  }
+  if (cb) cb(null, stdout, stderr);
 }
 
 function execFileSync(file, args, opts) {
-  const command = new Deno.Command(file, {
-    args: args || [],
-    cwd: opts?.cwd,
-    env: opts?.env,
-    stdout: 'piped',
-    stderr: 'piped',
-  });
-  const result = command.outputSync();
-  if (result.code !== 0) {
+  const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+    file, args || [], opts?.cwd ?? null, opts?.env ?? null,
+  );
+  if (code !== 0) {
     const err = new Error(`Command failed: ${file}`);
-    err.status = result.code;
-    err.stderr = new TextDecoder().decode(result.stderr);
+    err.status = code;
+    err.stderr = stderr;
     throw err;
   }
-  const out = new TextDecoder().decode(result.stdout);
-  return opts?.encoding ? out : new TextEncoder().encode(out);
+  return opts?.encoding ? stdout : new TextEncoder().encode(stdout);
 }
 
 function spawn(_cmd, _args, _opts) {

--- a/native/vtz/src/runtime/ops/mod.rs
+++ b/native/vtz/src/runtime/ops/mod.rs
@@ -13,6 +13,7 @@ pub mod microtask;
 pub mod os;
 pub mod path;
 pub mod performance;
+pub mod process;
 pub mod signals;
 pub mod sqlite;
 pub mod streams;

--- a/native/vtz/src/runtime/ops/process.rs
+++ b/native/vtz/src/runtime/ops/process.rs
@@ -1,0 +1,149 @@
+use deno_core::op2;
+use deno_core::OpDecl;
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Synchronously spawn a child process and capture its output.
+///
+/// Returns a tuple of (exit_code, stdout, stderr).
+/// The `cwd` and `env` parameters are optional.
+#[op2]
+#[serde]
+pub fn op_command_output_sync(
+    #[string] file: String,
+    #[serde] args: Vec<String>,
+    #[string] cwd: Option<String>,
+    #[serde] env: Option<HashMap<String, String>>,
+) -> Result<(i32, String, String), deno_core::error::AnyError> {
+    let mut cmd = Command::new(&file);
+    cmd.args(&args);
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    if let Some(env_map) = env {
+        // Node.js replaces the entire environment when opts.env is set.
+        cmd.env_clear();
+        for (key, value) in env_map {
+            cmd.env(key, value);
+        }
+    }
+
+    let output = cmd.output().map_err(|e| {
+        deno_core::error::type_error(format!("Failed to execute command '{file}': {e}"))
+    })?;
+
+    let code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    Ok((code, stdout, stderr))
+}
+
+/// Get the op declarations for process ops.
+pub fn op_decls() -> Vec<OpDecl> {
+    vec![op_command_output_sync()]
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime::js_runtime::{VertzJsRuntime, VertzRuntimeOptions};
+
+    #[test]
+    fn test_op_command_output_sync_echo() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+                    "echo", ["hello"], null, null
+                );
+                ({ code, stdout: stdout.trim(), stderr })
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result["code"], 0);
+        assert_eq!(result["stdout"], "hello");
+    }
+
+    #[test]
+    fn test_op_command_output_sync_nonzero_exit() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+                    "false", [], null, null
+                );
+                code
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, 1);
+    }
+
+    #[test]
+    fn test_op_command_output_sync_with_cwd() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+                    "pwd", [], "/tmp", null
+                );
+                ({ code, stdout: stdout.trim() })
+                "#,
+            )
+            .unwrap();
+        // On macOS, /tmp is a symlink to /private/tmp
+        let stdout = result["stdout"].as_str().unwrap();
+        assert_eq!(result["code"], 0);
+        assert!(stdout == "/tmp" || stdout == "/private/tmp");
+    }
+
+    #[test]
+    fn test_op_command_output_sync_env_replaces_parent() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        // When env is provided, parent env should be cleared (Node.js semantics).
+        // We set a custom var and verify HOME is not inherited.
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+                    "/usr/bin/env", [], null, { "CUSTOM_VAR": "hello" }
+                );
+                // `env` should only list CUSTOM_VAR, not inherited vars
+                const hasHome = stdout.includes('HOME=');
+                const hasCustom = stdout.includes('CUSTOM_VAR=hello');
+                ({ hasHome, hasCustom })
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result["hasHome"], false);
+        assert_eq!(result["hasCustom"], true);
+    }
+
+    #[test]
+    fn test_op_command_output_sync_invalid_command() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script(
+            "<test>",
+            r#"
+            try {
+                Deno.core.ops.op_command_output_sync(
+                    "nonexistent_command_xyz_123", [], null, null
+                );
+                "no_error"
+            } catch (e) {
+                "error"
+            }
+            "#,
+        );
+        assert_eq!(result.unwrap(), "error");
+    }
+}

--- a/packages/codegen/src/__tests__/entity-types-query.test.ts
+++ b/packages/codegen/src/__tests__/entity-types-query.test.ts
@@ -479,5 +479,40 @@ describe('Entity Types Generator - Query Types', () => {
         'select?: { id?: true; title?: true; status?: true; priority?: true; createdAt?: true }',
       );
     });
+
+    it('generates ListQuery with index signature for Record<string, unknown> compatibility (#2561)', () => {
+      const entity = createEntityWithExpose();
+      const ir = createCodegenIR([entity]);
+      const files = generator.generate(ir, { outputDir: '', options: {} });
+      const typesFile = files.find((f) => f.path === 'types/task.ts');
+
+      const listQueryMatch = typesFile?.content.match(
+        /export interface TaskListQuery \{[\s\S]*?\n\}/,
+      );
+      const listQueryBlock = listQueryMatch?.[0] ?? '';
+      expect(listQueryBlock).toContain('[key: string]: unknown');
+    });
+
+    it('generates GetQuery with index signature for Record<string, unknown> compatibility (#2561)', () => {
+      const entity = createEntityWithExpose({
+        exposeInclude: [
+          {
+            name: 'assignee',
+            entity: 'user',
+            type: 'one',
+            resolvedFields: [{ name: 'id', tsType: 'string', optional: false }],
+          },
+        ],
+      });
+      const ir = createCodegenIR([entity]);
+      const files = generator.generate(ir, { outputDir: '', options: {} });
+      const typesFile = files.find((f) => f.path === 'types/task.ts');
+
+      const getQueryMatch = typesFile?.content.match(
+        /export interface TaskGetQuery \{[\s\S]*?\n\}/,
+      );
+      const getQueryBlock = getQueryMatch?.[0] ?? '';
+      expect(getQueryBlock).toContain('[key: string]: unknown');
+    });
   });
 });

--- a/packages/codegen/src/generators/entity-types-generator.ts
+++ b/packages/codegen/src/generators/entity-types-generator.ts
@@ -320,7 +320,7 @@ export class EntityTypesGenerator implements Generator {
     hasOrderBy: boolean,
     hasInclude: boolean,
   ): string {
-    const props: string[] = [`  select?: ${selectType}`];
+    const props: string[] = ['  [key: string]: unknown', `  select?: ${selectType}`];
     if (hasWhere) props.push(`  where?: ${entityPascal}WhereInput`);
     if (hasOrderBy) props.push(`  orderBy?: ${entityPascal}OrderByInput`);
     if (hasInclude) props.push(`  include?: ${entityPascal}IncludeInput`);
@@ -330,7 +330,7 @@ export class EntityTypesGenerator implements Generator {
   }
 
   private emitGetQuery(entityPascal: string, selectType: string, hasInclude: boolean): string {
-    const props: string[] = [`  select?: ${selectType}`];
+    const props: string[] = ['  [key: string]: unknown', `  select?: ${selectType}`];
     if (hasInclude) props.push(`  include?: ${entityPascal}IncludeInput`);
     return `export interface ${entityPascal}GetQuery {\n${props.join(';\n')};\n}`;
   }

--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -138,10 +138,10 @@ describe('templates', () => {
       expect(tsconfig.compilerOptions.jsxImportSource).toBe('@vertz/ui');
     });
 
-    it('has empty types array (no bun-types)', () => {
+    it('includes vertz/env in types for ImportMeta augmentations (#2561)', () => {
       const result = tsconfigTemplate();
       const tsconfig = JSON.parse(result);
-      expect(tsconfig.compilerOptions.types).toEqual([]);
+      expect(tsconfig.compilerOptions.types).toEqual(['vertz/env']);
     });
   });
 

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -638,7 +638,7 @@ export function tsconfigTemplate(): string {
       skipLibCheck: true,
       strict: true,
       target: 'ES2022',
-      types: [],
+      types: ['vertz/env'],
     },
     include: ['src', '.vertz/generated'],
   };

--- a/packages/fetch/src/vertzql.test-d.ts
+++ b/packages/fetch/src/vertzql.test-d.ts
@@ -1,0 +1,28 @@
+/**
+ * Type-level tests for VertzQL types.
+ *
+ * Validates that VertzQLParams is assignable to Record<string, unknown>,
+ * which is the parameter type of resolveVertzQL(). Generated entity SDK
+ * code passes VertzQLParams to resolveVertzQL — this must not produce
+ * a TS2345 error (#2561).
+ *
+ * Checked by `tsc --noEmit -p tsconfig.typecheck.json`.
+ */
+
+import type { VertzQLParams } from './vertzql';
+import { resolveVertzQL } from './vertzql';
+
+// ─── VertzQLParams is passable to resolveVertzQL ─────────────────
+
+declare const params: VertzQLParams;
+resolveVertzQL(params);
+
+// ─── VertzQLParams is assignable to Record<string, unknown> ──────
+
+const _record: Record<string, unknown> = params;
+void _record;
+
+// ─── Optional VertzQLParams works (the generated code pattern) ───
+
+declare const optionalParams: VertzQLParams | undefined;
+resolveVertzQL(optionalParams);

--- a/packages/fetch/src/vertzql.ts
+++ b/packages/fetch/src/vertzql.ts
@@ -8,6 +8,7 @@ export interface VertzQLIncludeEntry {
 }
 
 export interface VertzQLParams {
+  [key: string]: unknown;
   select?: Record<string, true>;
   include?: Record<string, true | VertzQLIncludeEntry>;
   where?: Record<string, unknown>;

--- a/packages/vertz/__tests__/subpath-exports.test.ts
+++ b/packages/vertz/__tests__/subpath-exports.test.ts
@@ -92,8 +92,10 @@ describe('exports point to built artifacts', () => {
     const pkgPath = path.resolve(import.meta.dirname, '..', 'package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
 
-    for (const [, entry] of Object.entries(pkg.exports)) {
-      const { import: importPath } = entry as { import: string };
+    for (const [subpath, entry] of Object.entries(pkg.exports)) {
+      const { import: importPath } = entry as { import?: string };
+      // Types-only exports (e.g., ./env) have no import field
+      if (!importPath) continue;
       expect(importPath.startsWith('./dist/')).toBe(true);
       expect(importPath.endsWith('.js')).toBe(true);
       // The built file must actually exist
@@ -102,7 +104,7 @@ describe('exports point to built artifacts', () => {
     }
   });
 
-  it('all subpath types resolve to dist/*.d.ts', async () => {
+  it('all subpath types resolve to .d.ts files', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');
     const pkgPath = path.resolve(import.meta.dirname, '..', 'package.json');
@@ -110,11 +112,25 @@ describe('exports point to built artifacts', () => {
 
     for (const [, entry] of Object.entries(pkg.exports)) {
       const { types: typesPath } = entry as { types: string };
-      expect(typesPath.startsWith('./dist/')).toBe(true);
       expect(typesPath.endsWith('.d.ts')).toBe(true);
       const fullPath = path.resolve(import.meta.dirname, '..', typesPath);
       expect(fs.existsSync(fullPath)).toBe(true);
     }
+  });
+
+  it('vertz/env is a types-only export pointing to env.d.ts', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const pkgPath = path.resolve(import.meta.dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+    const envExport = pkg.exports['./env'];
+    expect(envExport).toBeDefined();
+    expect(envExport.types).toBe('./env.d.ts');
+    expect(envExport.import).toBeUndefined();
+
+    const fullPath = path.resolve(import.meta.dirname, '..', envExport.types);
+    expect(fs.existsSync(fullPath)).toBe(true);
   });
 });
 
@@ -125,8 +141,9 @@ describe('tree-shaking: subpaths are independent modules', () => {
     const pkgPath = path.resolve(import.meta.dirname, '..', 'package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
 
-    const exportPaths = Object.values(pkg.exports) as Array<{ import: string }>;
-    const importPaths = exportPaths.map((e) => e.import);
+    const exportPaths = Object.values(pkg.exports) as Array<{ import?: string }>;
+    // Filter to runtime exports (types-only exports have no import path)
+    const importPaths = exportPaths.map((e) => e.import).filter(Boolean);
 
     // All import paths should be unique (no shared entry point)
     const unique = new Set(importPaths);

--- a/packages/vertz/env.d.ts
+++ b/packages/vertz/env.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Vertz runtime environment type augmentations.
+ *
+ * Include in your tsconfig.json:
+ *   "types": ["vertz/env"]
+ *
+ * Or add a triple-slash reference:
+ *   /// <reference types="vertz/env" />
+ */
+
+interface ImportMetaHot {
+  /** Accept the current module's HMR update. */
+  accept(): void;
+  /** Accept updates for specific dependencies. */
+  accept(deps: string | string[], cb?: (modules: unknown[]) => void): void;
+  /** Dispose callback — runs before module is replaced. */
+  dispose(cb: (data: Record<string, unknown>) => void): void;
+  /** Persistent data across HMR updates. */
+  data: Record<string, unknown>;
+}
+
+interface ImportMeta {
+  /** Whether this module is the entry point. Available in the vtz runtime. */
+  readonly main: boolean;
+  /** Hot Module Replacement API. Only available in dev mode; undefined in production. */
+  readonly hot: ImportMetaHot | undefined;
+}

--- a/packages/vertz/package.json
+++ b/packages/vertz/package.json
@@ -29,7 +29,8 @@
     "directory": "packages/vertz"
   },
   "files": [
-    "dist"
+    "dist",
+    "env.d.ts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -93,6 +94,9 @@
     "./ui-auth": {
       "import": "./dist/ui-auth.js",
       "types": "./dist/ui-auth.d.ts"
+    },
+    "./env": {
+      "types": "./env.d.ts"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

Fixes two open issues:

- **#2555** — DTS generation tests fail because `node:child_process.execFile` uses `Deno.Command` which doesn't exist in the vtz runtime
- **#2561** — `tsc --noEmit` on scaffolded projects produces errors for `VertzQLParams`, `import.meta.hot`, and `import.meta.main`

### Changes

**Runtime (`native/vtz/`)**
- New `op_command_output_sync` Rust op in [`native/vtz/src/runtime/ops/process.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-test-failures/native/vtz/src/runtime/ops/process.rs) — spawns child processes via `std::process::Command`
- Updated `node:child_process` JS shim to use the native op instead of `Deno.Command`
- `execSync` now runs through `/bin/sh -c` (matching Node.js shell semantics)
- `execFile` error handling: consistent `err.status`, no double-callback risk
- Environment replacement: `env_clear()` before setting custom env (Node.js semantics)

**TypeScript types (`packages/`)**
- Added `[key: string]: unknown` index signature to `VertzQLParams` in `@vertz/fetch`
- Added index signatures to generated `ListQuery`/`GetQuery` interfaces in codegen
- New [`packages/vertz/env.d.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-test-failures/packages/vertz/env.d.ts) — `ImportMeta` augmentations for `hot` (as `| undefined`) and `main`
- New `vertz/env` export in `packages/vertz/package.json`
- Scaffolded tsconfig template now includes `"types": ["vertz/env"]`

## Public API Changes

- `VertzQLParams` interface now has an index signature (`[key: string]: unknown`)
- New `vertz/env` subpath export (types-only) for `ImportMeta` augmentations
- Generated `ListQuery`/`GetQuery` types now have index signatures

## Test plan

- [x] 5 Rust unit tests for `op_command_output_sync` (echo, nonzero exit, cwd, env replacement, invalid command)
- [x] DTS generation tests pass with rebuilt vtz binary (5/5)
- [x] Type-level test `vertzql.test-d.ts` verifies `VertzQLParams` assignability
- [x] 2 codegen tests verify index signatures in generated `ListQuery`/`GetQuery`
- [x] Subpath export test verifies `vertz/env` exists and points to `env.d.ts`
- [x] Template test updated for `types: ['vertz/env']`
- [x] Clippy clean, rustfmt clean, oxlint clean
- [x] Adversarial review completed — all blockers and should-fixes addressed

Closes #2555
Closes #2561

🤖 Generated with [Claude Code](https://claude.com/claude-code)