### PR TITLE
fix(runtime): mutable dynamic import wrappers for spyOn (#2535)

### DIFF
--- a/native/vertz-compiler-core/src/mock_hoisting.rs
+++ b/native/vertz-compiler-core/src/mock_hoisting.rs
@@ -126,6 +126,9 @@ pub fn transform_mock_hoisting(
         // Scan for vi.importActual() replacements
         replace_import_actual(ms, program, source);
 
+        // Wrap dynamic import() for mutable module namespaces
+        wrap_dynamic_imports(ms, program);
+
         return MockHoistingResult {
             mocked_specifiers,
             mock_preamble: None,
@@ -302,6 +305,9 @@ pub fn transform_mock_hoisting(
     // Replace vi.importActual() calls everywhere
     replace_import_actual(ms, program, source);
 
+    // Wrap dynamic import() for mutable module namespaces
+    wrap_dynamic_imports(ms, program);
+
     MockHoistingResult {
         mocked_specifiers,
         mock_preamble,
@@ -309,7 +315,7 @@ pub fn transform_mock_hoisting(
     }
 }
 
-// ── Helper functions ─────────────────────────────────────────────────────
+// ── Helper functions ───────────────���─────────────────────────��───────────
 
 /// Extract the specifier string from a top-level `vi.mock('spec', ...)` or
 /// `mock.module('spec', ...)` call, if the statement matches.
@@ -627,6 +633,32 @@ impl<'a, 'b> Visit<'_> for ImportActualVisitor<'a, 'b> {
 /// Thin wrapper to avoid borrow issues.
 fn ms_overwrite(ms: &mut MagicString, start: u32, end: u32, text: &str) {
     ms.overwrite(start, end, text);
+}
+
+/// Wrap dynamic `import()` expressions with `.then(globalThis.__vertz_unwrap_module)`
+/// so the returned module namespace is mutable (enabling `spyOn` on ES modules).
+fn wrap_dynamic_imports(ms: &mut MagicString, program: &Program) {
+    let mut visitor = DynamicImportVisitor {
+        insert_positions: Vec::new(),
+    };
+    visitor.visit_program(program);
+
+    // Insert in reverse order to preserve positions
+    visitor.insert_positions.sort_unstable();
+    for pos in visitor.insert_positions.into_iter().rev() {
+        ms.append_right(pos, ".then(globalThis.__vertz_unwrap_module)");
+    }
+}
+
+struct DynamicImportVisitor {
+    insert_positions: Vec<u32>,
+}
+
+impl Visit<'_> for DynamicImportVisitor {
+    fn visit_import_expression(&mut self, import: &ImportExpression<'_>) {
+        self.insert_positions.push(import.span.end);
+        walk::walk_import_expression(self, import);
+    }
 }
 
 /// Find `vi.mock()` / `mock.module()` calls inside function bodies (nested).
@@ -1037,5 +1069,81 @@ function App() {
         // (query is a signal API, so tasks.data would get .value in JSX)
         // The mocked import (add from ./math) should NOT get signal transforms
         assert!(!code.contains("add.value"));
+    }
+
+    // ── Dynamic import() wrapping for mutable modules ───────────────────
+
+    #[test]
+    fn wraps_dynamic_import_with_mutable_helper() {
+        let source = r#"const mod = await import('./utils');
+"#;
+        let (output, _) = parse_and_transform(source);
+        assert!(
+            output.contains("import('./utils').then(globalThis.__vertz_unwrap_module)"),
+            "Dynamic import() should be wrapped with .then(globalThis.__vertz_unwrap_module), got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn wraps_dynamic_import_inside_function_body() {
+        let source = r#"async function setup() {
+  const mod = await import('../../production-build');
+  spyOn(mod, 'BuildOrchestrator');
+}
+"#;
+        let (output, _) = parse_and_transform(source);
+        assert!(
+            output.contains(
+                "import('../../production-build').then(globalThis.__vertz_unwrap_module)"
+            ),
+            "Dynamic import inside function should be wrapped, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn wraps_multiple_dynamic_imports() {
+        let source = r#"const a = await import('./a');
+const b = await import('./b');
+"#;
+        let (output, _) = parse_and_transform(source);
+        assert!(
+            output.contains("import('./a').then(globalThis.__vertz_unwrap_module)"),
+            "First import should be wrapped, got: {}",
+            output
+        );
+        assert!(
+            output.contains("import('./b').then(globalThis.__vertz_unwrap_module)"),
+            "Second import should be wrapped, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn wraps_dynamic_import_with_existing_then_chain() {
+        let source = r#"const { buildAction } = await import('./build').then(m => m);
+"#;
+        let (output, _) = parse_and_transform(source);
+        // Should insert .then() between import() and the existing .then()
+        assert!(
+            output.contains("import('./build').then(globalThis.__vertz_unwrap_module)"),
+            "Import with existing .then should still get wrapped, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn does_not_wrap_import_declaration() {
+        let source = r#"import { add } from './math';
+const x = add(1, 2);
+"#;
+        let (output, _) = parse_and_transform(source);
+        // Static import declarations should NOT be wrapped
+        assert!(
+            !output.contains("__vertz_unwrap_module"),
+            "Static import declarations should not be wrapped, got: {}",
+            output
+        );
     }
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1427,6 +1427,10 @@ fn extract_export_names(source: &str) -> Vec<String> {
 /// The proxy reads from `globalThis.__vertz_mocked_modules[specifier]` and
 /// re-exports each named export as `const` bindings. Mock behavior changes
 /// via object mutation (e.g. `.mockImplementation()`), not reference replacement.
+///
+/// For test files that need mutable module namespaces (e.g. `spyOn` on
+/// dynamic imports), the mock_hoisting compiler transform wraps `import()`
+/// with `.then(globalThis.__vertz_unwrap_module)` to create mutable wrappers.
 fn generate_mock_proxy_module(specifier: &str, export_names: &[String]) -> String {
     let mut code = format!(
         "const __m = globalThis.__vertz_mocked_modules?.['{}'] ?? {{}};\n",
@@ -1437,7 +1441,7 @@ fn generate_mock_proxy_module(specifier: &str, export_names: &[String]) -> Strin
         if name == "default" {
             code.push_str("export default ('default' in __m ? __m.default : __m);\n");
         } else {
-            // Use getter-based re-export for late binding
+            // Capture mock reference at load time — object mutations (.mockImplementation) propagate
             code.push_str(&format!("export const {} = __m['{}'];\n", name, name));
         }
     }

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -1181,6 +1181,32 @@ if (typeof globalThis.HTMLElement === 'undefined') {
   };
   function expectTypeOf() { return new Proxy({}, expectTypeOfHandler); }
 
+  // __vertz_unwrap_module — creates a mutable wrapper around ES module namespaces.
+  // Dynamic `import()` returns frozen Module namespace objects. spyOn() needs to
+  // replace properties on them, which fails. This wrapper delegates reads to the
+  // original module (preserving live bindings) while allowing property writes.
+  globalThis.__vertz_unwrap_module = (mod) => {
+    if (!mod || typeof mod !== 'object') return mod;
+    // Fast path: if already mutable, return as-is
+    const keys = Object.getOwnPropertyNames(mod);
+    if (keys.length > 0) {
+      const desc = Object.getOwnPropertyDescriptor(mod, keys[0]);
+      if (desc && desc.writable && desc.configurable) return mod;
+    }
+    // Create mutable wrapper — reads delegate to original, writes stored locally
+    const overrides = Object.create(null);
+    const wrapper = Object.create(null);
+    for (const key of keys) {
+      Object.defineProperty(wrapper, key, {
+        get() { return key in overrides ? overrides[key] : mod[key]; },
+        set(v) { overrides[key] = v; },
+        configurable: true,
+        enumerable: true,
+      });
+    }
+    return wrapper;
+  };
+
   // Exports object — module loader will intercept
   // `import { describe, it, expect } from '@vertz/test'` and return these.
   globalThis.__vertz_test_exports = {
@@ -3458,6 +3484,75 @@ mod tests {
                 item["status"], "pass",
                 "DOM prototype chain test {} failed: {:?}",
                 i, item["error"]
+            );
+        }
+    }
+
+    #[test]
+    fn test_unwrap_module_makes_frozen_object_mutable() {
+        let mut rt = create_test_runtime();
+        let results = run_test_code(
+            &mut rt,
+            r#"
+            describe('__vertz_unwrap_module', () => {
+                it('makes frozen object properties writable', () => {
+                    const frozen = Object.freeze({ greet: () => 'original' });
+                    const mutable = globalThis.__vertz_unwrap_module(frozen);
+                    // Should be able to assign without throwing
+                    mutable.greet = () => 'replaced';
+                    expect(mutable.greet()).toBe('replaced');
+                });
+
+                it('delegates reads to original when not overridden', () => {
+                    const original = Object.freeze({ value: 42, name: 'test' });
+                    const mutable = globalThis.__vertz_unwrap_module(original);
+                    expect(mutable.value).toBe(42);
+                    expect(mutable.name).toBe('test');
+                });
+
+                it('returns already-mutable objects as-is', () => {
+                    const obj = { greet: () => 'hello' };
+                    const result = globalThis.__vertz_unwrap_module(obj);
+                    expect(result).toBe(obj);
+                });
+
+                it('supports spyOn pattern on frozen objects', () => {
+                    const mod = Object.freeze({
+                        findProjectRoot: () => '/real/path',
+                        otherFn: () => 'other',
+                    });
+                    const mutable = globalThis.__vertz_unwrap_module(mod);
+
+                    // Simulate spyOn: read original, replace with spy
+                    const original = mutable.findProjectRoot;
+                    const spy = mock(() => '/mocked/path');
+                    mutable.findProjectRoot = spy;
+                    expect(mutable.findProjectRoot()).toBe('/mocked/path');
+
+                    // Restore
+                    mutable.findProjectRoot = original;
+                    expect(mutable.findProjectRoot()).toBe('/real/path');
+
+                    // Other properties still delegate to original
+                    expect(mutable.otherFn()).toBe('other');
+                });
+
+                it('returns null/undefined/primitives as-is', () => {
+                    expect(globalThis.__vertz_unwrap_module(null)).toBe(null);
+                    expect(globalThis.__vertz_unwrap_module(undefined)).toBe(undefined);
+                    expect(globalThis.__vertz_unwrap_module(42)).toBe(42);
+                });
+            });
+            "#,
+        );
+
+        let arr = results.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        for (i, item) in arr.iter().enumerate() {
+            assert_eq!(
+                item["status"], "pass",
+                "__vertz_unwrap_module test {} ({}) failed: {:?}",
+                i, item["name"], item["error"]
             );
         }
     }

--- a/native/vtz/tests/test_runner.rs
+++ b/native/vtz/tests/test_runner.rs
@@ -1231,3 +1231,66 @@ fn e2e_mock_transitive() {
     );
     assert_eq!(result.total_passed, 1);
 }
+
+// --- E2E: spyOn on dynamically imported module ---
+
+#[test]
+fn e2e_spy_on_dynamic_import() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_project(tmp.path());
+
+    // A simple module with exported functions
+    write_file(
+        tmp.path(),
+        "src/utils/paths.ts",
+        r#"
+        export function findProjectRoot(): string {
+            return '/real/root';
+        }
+
+        export function resolvePath(p: string): string {
+            return '/resolved/' + p;
+        }
+        "#,
+    );
+
+    // Test file that uses spyOn on a dynamically imported module
+    write_file(
+        tmp.path(),
+        "src/__tests__/spy-dynamic.test.ts",
+        r#"
+        describe('spyOn dynamic import', () => {
+            it('can spy on dynamically imported module functions', async () => {
+                const pathsMod = await import('../utils/paths');
+                const spy = spyOn(pathsMod, 'findProjectRoot').mockReturnValue('/mocked/root');
+
+                expect(pathsMod.findProjectRoot()).toBe('/mocked/root');
+
+                spy.mockRestore();
+                expect(pathsMod.findProjectRoot()).toBe('/real/root');
+            });
+
+            it('can spy on multiple functions from same module', async () => {
+                const pathsMod = await import('../utils/paths');
+                const spy1 = spyOn(pathsMod, 'findProjectRoot').mockReturnValue('/mock1');
+                const spy2 = spyOn(pathsMod, 'resolvePath').mockReturnValue('/mock2');
+
+                expect(pathsMod.findProjectRoot()).toBe('/mock1');
+                expect(pathsMod.resolvePath('test')).toBe('/mock2');
+
+                spy1.mockRestore();
+                spy2.mockRestore();
+            });
+        });
+        "#,
+    );
+
+    let (result, output) = run_tests(make_config(tmp.path()));
+
+    assert!(
+        result.success(),
+        "spyOn on dynamic import should work: output={output}, results={:?}",
+        result.results
+    );
+    assert_eq!(result.total_passed, 2);
+}


### PR DESCRIPTION
## Summary

- Fixes `Cannot assign to read only property 'X' of object '[object Module]'` when using `spyOn()` on dynamically imported modules in the vtz test runner
- The mock_hoisting compiler transform now wraps all `import()` expressions in test files with `.then(globalThis.__vertz_unwrap_module)` to create mutable wrappers
- The `__vertz_unwrap_module` runtime global creates a wrapper that delegates reads to the original module (preserving live bindings) while allowing property writes for `spyOn`/mock patterns

## Public API Changes

None — internal runtime change only. No changes to `@vertz/test` API surface.

## How it works

1. **Compiler transform** (`mock_hoisting.rs`): A new `DynamicImportVisitor` finds all `import()` expressions in test files and appends `.then(globalThis.__vertz_unwrap_module)` after each
2. **Runtime global** (`globals.rs`): `__vertz_unwrap_module` creates a mutable wrapper object with getter/setter property descriptors that delegate to the original frozen Module namespace

## Test plan

- [x] 5 compiler unit tests for dynamic import wrapping (various positions, multiple imports, existing `.then()` chains)
- [x] 1 runtime unit test for `__vertz_unwrap_module` (frozen objects, already-mutable objects, spyOn pattern, primitives)
- [x] 1 E2E integration test: creates a real module + test file using `spyOn` on dynamic import, verifies full pipeline
- [x] All 1142 compiler-core tests pass
- [x] All vtz runtime tests pass (including 23 test_runner E2E tests)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Notes

- The `build.test.ts` acceptance criterion from #2535 is partially met: the "read only property" error is eliminated (0 occurrences). However, a pre-existing `AbstractableNode` duplicate identifier error from ts-morph CJS interop now surfaces (it was previously masked). That's a separate issue.
- The cloudflare handler tests have a separate mock hoisting scoping issue (mock factory references variables not yet defined in preamble scope) — also pre-existing, not related to this fix.

Closes #2535

🤖 Generated with [Claude Code](https://claude.com/claude-code)