### PR TITLE
fix(agents): react-loop toolContext undefined (#2548)

### DIFF
--- a/packages/agents/src/loop/react-loop.test.ts
+++ b/packages/agents/src/loop/react-loop.test.ts
@@ -1060,20 +1060,20 @@ describe('reactLoop()', () => {
           { text: 'Done' },
         ]);
 
-        await expect(
-          reactLoop({
-            llm,
-            tools: { noop },
-            systemPrompt: 'You are helpful.',
-            userMessage: 'Do stuff',
-            maxIterations: 10,
-            toolContext: TEST_TOOL_CONTEXT,
-            contextCompression: {
-              maxMessages: 5,
-              compress: () => [],
-            },
-          }),
-        ).rejects.toThrow('Context compression returned empty message array');
+        const promise = reactLoop({
+          llm,
+          tools: { noop },
+          systemPrompt: 'You are helpful.',
+          userMessage: 'Do stuff',
+          maxIterations: 10,
+          toolContext: TEST_TOOL_CONTEXT,
+          contextCompression: {
+            maxMessages: 5,
+            compress: () => [],
+          },
+        });
+
+        await expect(promise).rejects.toThrow('Context compression returned empty message array');
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fixes the failing test in `react-loop.test.ts` where `toolContext is not defined` was thrown
- Root cause: vtz test runner scoping bug when complex async calls are inlined inside `expect().rejects.toThrow()` — extracting the promise to a `const` before passing to `expect()` works around it
- Filed [#2576](https://github.com/vertz-dev/vertz/issues/2576) for the underlying vtz runtime bug

## Public API Changes

None — test-only change.

## Test plan

- [x] All 36 tests in `react-loop.test.ts` pass (was 35 pass / 1 fail)
- [x] Full agents package tests pass (192 passed, 2 skipped)
- [x] Lint and format clean

Fixes #2548

🤖 Generated with [Claude Code](https://claude.com/claude-code)