### PR TITLE
fix(runtime): correct SSR Fast Refresh import path for @vertz/ui/internals

### DIFF
--- a/native/vtz/src/assets/fast-refresh-helpers.js
+++ b/native/vtz/src/assets/fast-refresh-helpers.js
@@ -15,7 +15,7 @@ import {
   stopSignalCollection,
   _tryOnCleanup,
   runCleanups,
-} from '/@deps/@vertz/ui/dist/src/internals.js';
+} from '/@deps/@vertz/ui/dist/internals.js';
 
 var fr = globalThis[Symbol.for('vertz:fast-refresh')];
 if (fr && typeof fr.registerHelpers === 'function') {

--- a/native/vtz/src/compiler/import_rewriter.rs
+++ b/native/vtz/src/compiler/import_rewriter.rs
@@ -390,7 +390,7 @@ fn rewrite_specifier_inner(
 
     // Bare specifiers: resolve via package.json exports to get full file path,
     // so that relative imports within packages resolve correctly in the browser.
-    // e.g., `@vertz/ui/internals` → `/@deps/@vertz/ui/dist/src/internals.js`
+    // e.g., `@vertz/ui/internals` → `/@deps/@vertz/ui/dist/internals.js`
     //
     // Use the file's parent directory as the resolution starting point — this matches
     // Node.js resolution behavior and is critical for monorepos where transitive deps

--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 /// Returns the fully-resolved file path within node_modules.
 ///
 /// Handles:
-/// - `@vertz/ui` → node_modules/@vertz/ui/dist/src/index.js (via "." export)
-/// - `@vertz/ui/internals` → node_modules/@vertz/ui/dist/src/internals.js (via "./internals" export)
+/// - `@vertz/ui` → node_modules/@vertz/ui/dist/index.js (via "." export)
+/// - `@vertz/ui/internals` → node_modules/@vertz/ui/dist/internals.js (via "./internals" export)
 /// - `zod` → node_modules/zod/lib/index.mjs (via "." export)
 pub fn resolve_from_node_modules(specifier: &str, root_dir: &Path) -> Option<PathBuf> {
     let (pkg_name, subpath) = split_package_specifier(specifier);
@@ -69,7 +69,7 @@ fn resolve_package_entry(pkg_dir: &Path, subpath: &str) -> Option<PathBuf> {
 /// Convert a resolved file path back to a `/@deps/` URL that preserves
 /// the file tree structure within node_modules.
 ///
-/// This is critical: by using the full file path (e.g., `/@deps/@vertz/ui/dist/src/internals.js`)
+/// This is critical: by using the full file path (e.g., `/@deps/@vertz/ui/dist/internals.js`)
 /// instead of just the specifier (e.g., `/@deps/@vertz/ui/internals`), relative imports
 /// within the package (like `../shared/chunk-xyz.js`) resolve correctly in the browser.
 pub fn resolve_to_deps_url(specifier: &str, root_dir: &Path) -> String {
@@ -291,28 +291,28 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
 
-        // Create @vertz/ui package with exports
+        // Create @vertz/ui package with exports (matching real package structure)
         let pkg_dir = root.join("node_modules/@vertz/ui");
-        std::fs::create_dir_all(pkg_dir.join("dist/src")).unwrap();
-        std::fs::write(pkg_dir.join("dist/src/index.js"), "export {}").unwrap();
-        std::fs::write(pkg_dir.join("dist/src/internals.js"), "export {}").unwrap();
+        std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+        std::fs::write(pkg_dir.join("dist/index.js"), "export {}").unwrap();
+        std::fs::write(pkg_dir.join("dist/internals.js"), "export {}").unwrap();
         std::fs::write(
             pkg_dir.join("package.json"),
             r#"{
                 "name": "@vertz/ui",
                 "exports": {
-                    ".": "./dist/src/index.js",
-                    "./internals": "./dist/src/internals.js"
+                    ".": "./dist/index.js",
+                    "./internals": "./dist/internals.js"
                 }
             }"#,
         )
         .unwrap();
 
         let resolved = resolve_from_node_modules("@vertz/ui", root);
-        assert_eq!(resolved, Some(pkg_dir.join("dist/src/index.js")));
+        assert_eq!(resolved, Some(pkg_dir.join("dist/index.js")));
 
         let resolved = resolve_from_node_modules("@vertz/ui/internals", root);
-        assert_eq!(resolved, Some(pkg_dir.join("dist/src/internals.js")));
+        assert_eq!(resolved, Some(pkg_dir.join("dist/internals.js")));
     }
 
     #[test]
@@ -321,21 +321,21 @@ mod tests {
         let root = tmp.path();
 
         let pkg_dir = root.join("node_modules/@vertz/ui");
-        std::fs::create_dir_all(pkg_dir.join("dist/src")).unwrap();
-        std::fs::write(pkg_dir.join("dist/src/internals.js"), "export {}").unwrap();
+        std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+        std::fs::write(pkg_dir.join("dist/internals.js"), "export {}").unwrap();
         std::fs::write(
             pkg_dir.join("package.json"),
             r#"{
                 "name": "@vertz/ui",
                 "exports": {
-                    "./internals": "./dist/src/internals.js"
+                    "./internals": "./dist/internals.js"
                 }
             }"#,
         )
         .unwrap();
 
         let url = resolve_to_deps_url("@vertz/ui/internals", root);
-        assert_eq!(url, "/@deps/@vertz/ui/dist/src/internals.js");
+        assert_eq!(url, "/@deps/@vertz/ui/dist/internals.js");
     }
 
     #[test]

--- a/native/vtz/src/server/module_server.rs
+++ b/native/vtz/src/server/module_server.rs
@@ -457,8 +457,8 @@ pub async fn handle_deps_request(
 
     // 2. Fallback: serve directly from node_modules/ using the full path.
     //
-    // URLs like `/@deps/@vertz/ui/dist/src/internals.js` map directly to
-    // `node_modules/@vertz/ui/dist/src/internals.js`. This preserves the
+    // URLs like `/@deps/@vertz/ui/dist/internals.js` map directly to
+    // `node_modules/@vertz/ui/dist/internals.js`. This preserves the
     // file tree structure so relative imports within packages just work.
     //
     // Also handles bare specifier lookups like `/@deps/@vertz/ui/internals`

--- a/native/vtz/src/ssr/html_document.rs
+++ b/native/vtz/src/ssr/html_document.rs
@@ -461,6 +461,40 @@ mod tests {
     }
 
     #[test]
+    fn test_fast_refresh_helpers_import_path() {
+        // The fast-refresh-helpers.js asset imports from @vertz/ui/internals.
+        // The @vertz/ui package exports "./internals" → "./dist/internals.js" (no /src/).
+        // The inline script must use the correct resolved path.
+        assert!(
+            FAST_REFRESH_HELPERS_JS.contains("/@deps/@vertz/ui/dist/internals.js"),
+            "Fast Refresh helpers should import from /@deps/@vertz/ui/dist/internals.js (without /src/)"
+        );
+        assert!(
+            !FAST_REFRESH_HELPERS_JS.contains("dist/src/internals.js"),
+            "Fast Refresh helpers must NOT contain the wrong path dist/src/internals.js"
+        );
+    }
+
+    #[test]
+    fn test_hmr_output_uses_correct_internals_path() {
+        // When HMR is enabled, the SSR document embeds the fast-refresh helpers
+        // inline. Verify the rendered HTML has the correct import path.
+        let opts = SsrHtmlOptions {
+            enable_hmr: true,
+            ..default_options()
+        };
+        let html = assemble_ssr_document(&opts);
+        assert!(
+            html.contains("/@deps/@vertz/ui/dist/internals.js"),
+            "SSR HTML should contain the correct internals import path"
+        );
+        assert!(
+            !html.contains("dist/src/internals.js"),
+            "SSR HTML must NOT contain the wrong path dist/src/internals.js"
+        );
+    }
+
+    #[test]
     fn test_html_document_omits_ssr_data_when_none() {
         let opts = SsrHtmlOptions {
             ssr_data: None,

--- a/tests/tree-shaking/tree-shaking.test.ts
+++ b/tests/tree-shaking/tree-shaking.test.ts
@@ -66,7 +66,7 @@ const PACKAGES: { name: string; singleImport: string; distEntry: string }[] = [
   {
     name: '@vertz/ui-primitives',
     singleImport: `import { Button } from '@vertz/ui-primitives'; console.log(Button);`,
-    distEntry: 'packages/ui-primitives/dist/src/index.js',
+    distEntry: 'packages/ui-primitives/dist/index.js',
   },
   {
     name: '@vertz/fetch',
@@ -76,7 +76,7 @@ const PACKAGES: { name: string; singleImport: string; distEntry: string }[] = [
   {
     name: '@vertz/ui',
     singleImport: `import { ref } from '@vertz/ui'; console.log(ref);`,
-    distEntry: 'packages/ui/dist/src/index.js',
+    distEntry: 'packages/ui/dist/index.js',
   },
   {
     name: '@vertz/icons',
@@ -91,7 +91,7 @@ const PACKAGES: { name: string; singleImport: string; distEntry: string }[] = [
   {
     name: '@vertz/ui/components',
     singleImport: `import { Button } from '@vertz/ui/components'; console.log(Button);`,
-    distEntry: 'packages/ui/dist/src/components/index.js',
+    distEntry: 'packages/ui/dist/components/index.js',
   },
 ];
 
@@ -103,11 +103,11 @@ const MAX_RATIO = 0.5;
 
 /** Subpath aliases for packages that use conditional exports (e.g. @vertz/ui/internals). */
 const SUBPATH_ALIASES: Record<string, string> = {
-  '@vertz/ui/internals': 'packages/ui/dist/src/internals.js',
+  '@vertz/ui/internals': 'packages/ui/dist/internals.js',
   '@vertz/core/internals': 'packages/core/dist/internals.js',
   '@vertz/db/sql': 'packages/db/dist/sql/index.js',
   '@vertz/theme-shadcn/base': 'packages/theme-shadcn/dist/base.js',
-  '@vertz/ui/components': 'packages/ui/dist/src/components/index.js',
+  '@vertz/ui/components': 'packages/ui/dist/components/index.js',
 };
 
 const aliases: Record<string, string> = {


### PR DESCRIPTION
## Summary

Fixes #2579

- Fix the hardcoded import path in `fast-refresh-helpers.js` from `/@deps/@vertz/ui/dist/src/internals.js` to `/@deps/@vertz/ui/dist/internals.js` — the `/src/` segment was wrong, causing a 404 on every page load and breaking Fast Refresh context helpers (pushScope, popScope, etc.)
- Fix stale `dist/src/` paths in the tree-shaking test that referenced the old `@vertz/ui` and `@vertz/ui-primitives` build output layout
- Fix incorrect test mock data in `resolve.rs` that asserted the wrong path structure
- Fix stale comments in `resolve.rs`, `module_server.rs`, and `import_rewriter.rs`

## Public API Changes

None — internal bug fix only.

## Test plan

- [x] New regression test `test_fast_refresh_helpers_import_path` verifies the asset has the correct import path
- [x] New regression test `test_hmr_output_uses_correct_internals_path` verifies the assembled SSR HTML uses the correct path when HMR is enabled
- [x] All existing Rust tests pass (`cargo test --all`)
- [x] Clippy clean (`cargo clippy --all-targets --release -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [ ] Manual verification: `vtz dev` on a todo-app template, check DevTools console for no 404 on `internals.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)