### PR TITLE
fix(runtime): CJS require() resolves exports field, execSync uses shell (#2580, #2581)

### DIFF
--- a/.changeset/fix-cjs-resolve-exec.md
+++ b/.changeset/fix-cjs-resolve-exec.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix CJS require() to resolve package.json exports field and fix execSync to use shell execution instead of splitting on spaces

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1458,7 +1458,7 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
           }
           if (code !== 0) {
             const err = new Error('Command failed: ' + file);
-            err.status = code;
+            err.code = code;
             err.stderr = stderr;
             if (cb) cb(err, stdout, stderr); else throw err;
             return;
@@ -1709,7 +1709,10 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
   }
 
   function _resolveCjsCondition(value) {
-    if (typeof value === 'string') return value;
+    if (typeof value === 'string') {
+      // Exports targets must start with './' to prevent path traversal
+      return value.startsWith('./') ? value : undefined;
+    }
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       // CJS priority: require > node > default
       const keys = ['require', 'node', 'default'];
@@ -1723,7 +1726,8 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
   function _resolveCjsExports(exports, key) {
     // String shorthand: exports = "./dist/main.js" (applies to ".")
     if (typeof exports === 'string') {
-      return key === '.' ? exports : undefined;
+      if (key !== '.') return undefined;
+      return exports.startsWith('./') ? exports : undefined;
     }
     if (typeof exports === 'object' && exports !== null && !Array.isArray(exports)) {
       // Check if key exists directly in the map

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1434,51 +1434,48 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
       }
       case 'child_process': {
         function execSync(cmd, opts) {
-          const parts = cmd.split(' ');
-          const command = new Deno.Command(parts[0], {
-            args: parts.slice(1), cwd: opts?.cwd, env: opts?.env, stdout: 'piped', stderr: 'piped',
-          });
-          const result = command.outputSync();
-          if (result.code !== 0) {
+          const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+            '/bin/sh', ['-c', cmd], opts?.cwd ?? null, opts?.env ?? null,
+          );
+          if (code !== 0) {
             const err = new Error('Command failed: ' + cmd);
-            err.status = result.code;
-            err.stderr = new TextDecoder().decode(result.stderr);
+            err.status = code;
+            err.stderr = stderr;
             throw err;
           }
-          const out = new TextDecoder().decode(result.stdout);
-          return opts?.encoding ? out : new TextEncoder().encode(out);
+          return opts?.encoding ? stdout : new TextEncoder().encode(stdout);
         }
         function execFile(file, args, opts, cb) {
           if (typeof opts === 'function') { cb = opts; opts = {}; }
+          let code, stdout, stderr;
           try {
-            const command = new Deno.Command(file, {
-              args: args || [], cwd: opts?.cwd, env: opts?.env, stdout: 'piped', stderr: 'piped',
-            });
-            const result = command.outputSync();
-            const stdout = new TextDecoder().decode(result.stdout);
-            const stderr = new TextDecoder().decode(result.stderr);
-            if (result.code !== 0) {
-              const err = new Error('Command failed: ' + file);
-              err.code = result.code; err.stderr = stderr;
-              if (cb) cb(err, stdout, stderr); else throw err;
-              return;
-            }
-            if (cb) cb(null, stdout, stderr);
-          } catch (e) { if (cb) cb(e, '', ''); else throw e; }
+            [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+              file, args || [], opts?.cwd ?? null, opts?.env ?? null,
+            );
+          } catch (e) {
+            if (cb) { cb(e, '', ''); return; }
+            throw e;
+          }
+          if (code !== 0) {
+            const err = new Error('Command failed: ' + file);
+            err.status = code;
+            err.stderr = stderr;
+            if (cb) cb(err, stdout, stderr); else throw err;
+            return;
+          }
+          if (cb) cb(null, stdout, stderr);
         }
         function execFileSync(file, args, opts) {
-          const command = new Deno.Command(file, {
-            args: args || [], cwd: opts?.cwd, env: opts?.env, stdout: 'piped', stderr: 'piped',
-          });
-          const result = command.outputSync();
-          if (result.code !== 0) {
+          const [code, stdout, stderr] = Deno.core.ops.op_command_output_sync(
+            file, args || [], opts?.cwd ?? null, opts?.env ?? null,
+          );
+          if (code !== 0) {
             const err = new Error('Command failed: ' + file);
-            err.status = result.code;
-            err.stderr = new TextDecoder().decode(result.stderr);
+            err.status = code;
+            err.stderr = stderr;
             throw err;
           }
-          const out = new TextDecoder().decode(result.stdout);
-          return opts?.encoding ? out : new TextEncoder().encode(out);
+          return opts?.encoding ? stdout : new TextEncoder().encode(stdout);
         }
         function spawn(_cmd, _args, _opts) {
           throw new Error('node:child_process spawn() is not yet supported in the Vertz runtime.');
@@ -1711,6 +1708,36 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
     }
   }
 
+  function _resolveCjsCondition(value) {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      // CJS priority: require > node > default
+      const keys = ['require', 'node', 'default'];
+      for (const k of keys) {
+        if (k in value) return _resolveCjsCondition(value[k]);
+      }
+    }
+    return undefined;
+  }
+
+  function _resolveCjsExports(exports, key) {
+    // String shorthand: exports = "./dist/main.js" (applies to ".")
+    if (typeof exports === 'string') {
+      return key === '.' ? exports : undefined;
+    }
+    if (typeof exports === 'object' && exports !== null && !Array.isArray(exports)) {
+      // Check if key exists directly in the map
+      if (key in exports) {
+        return _resolveCjsCondition(exports[key]);
+      }
+      // If key is "." and this looks like a conditions map (no subpath keys)
+      if (key === '.') {
+        return _resolveCjsCondition(exports);
+      }
+    }
+    return undefined;
+  }
+
   function _resolveCjsPath(specifier, fromDir) {
     if (specifier.startsWith('./') || specifier.startsWith('../')) {
       const parts = (fromDir + '/' + specifier).split('/');
@@ -1753,30 +1780,65 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
     }
 
     // Bare specifiers — walk up node_modules
+    // Split specifier into package name and subpath
+    let packageName, subpath;
+    if (specifier.startsWith('@')) {
+      const parts = specifier.split('/');
+      packageName = parts[0] + '/' + parts[1];
+      subpath = parts.length > 2 ? parts.slice(2).join('/') : null;
+    } else {
+      const slashIdx = specifier.indexOf('/');
+      if (slashIdx === -1) {
+        packageName = specifier;
+        subpath = null;
+      } else {
+        packageName = specifier.substring(0, slashIdx);
+        subpath = specifier.substring(slashIdx + 1);
+      }
+    }
+
     let dir = fromDir;
     while (dir && dir !== '/') {
-      const candidate = dir + '/node_modules/' + specifier;
-      if (Deno.core.ops.op_fs_exists_sync(candidate)) {
+      const pkgDir = dir + '/node_modules/' + packageName;
+      if (Deno.core.ops.op_fs_exists_sync(pkgDir)) {
         try {
-          const stat = Deno.core.ops.op_fs_stat_sync(candidate);
+          const stat = Deno.core.ops.op_fs_stat_sync(pkgDir);
           if (stat.isDirectory) {
-            const pkgPath = candidate + '/package.json';
+            const pkgPath = pkgDir + '/package.json';
             if (Deno.core.ops.op_fs_exists_sync(pkgPath)) {
               try {
                 const pkg = JSON.parse(Deno.core.ops.op_fs_read_file_sync(pkgPath));
-                if (pkg.main) {
-                  const mainPath = candidate + '/' + pkg.main;
+                // Try exports field first
+                if (pkg.exports !== undefined) {
+                  const exportKey = subpath ? './' + subpath : '.';
+                  const resolved = _resolveCjsExports(pkg.exports, exportKey);
+                  if (resolved) {
+                    const full = pkgDir + '/' + resolved;
+                    if (Deno.core.ops.op_fs_exists_sync(full)) return full;
+                  }
+                }
+                // Fall back to main (only for root entry)
+                if (!subpath && pkg.main) {
+                  const mainPath = pkgDir + '/' + pkg.main;
                   if (Deno.core.ops.op_fs_exists_sync(mainPath)) return mainPath;
                 }
               } catch (_) { /* ignore parse errors */ }
             }
-            if (Deno.core.ops.op_fs_exists_sync(candidate + '/index.js')) return candidate + '/index.js';
+            // Subpath without exports: try direct file
+            if (subpath) {
+              const direct = pkgDir + '/' + subpath;
+              if (Deno.core.ops.op_fs_exists_sync(direct)) return direct;
+              if (Deno.core.ops.op_fs_exists_sync(direct + '.js')) return direct + '.js';
+              if (Deno.core.ops.op_fs_exists_sync(direct + '/index.js')) return direct + '/index.js';
+            } else {
+              if (Deno.core.ops.op_fs_exists_sync(pkgDir + '/index.js')) return pkgDir + '/index.js';
+            }
           } else {
-            return candidate;
+            return pkgDir;
           }
-        } catch (_) { return candidate; }
+        } catch (_) { return pkgDir; }
       }
-      if (Deno.core.ops.op_fs_exists_sync(candidate + '.js')) return candidate + '.js';
+      if (!subpath && Deno.core.ops.op_fs_exists_sync(pkgDir + '.js')) return pkgDir + '.js';
       const lastSlash = dir.lastIndexOf('/');
       dir = lastSlash > 0 ? dir.substring(0, lastSlash) : '';
     }

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -1100,3 +1100,237 @@ async fn test_cjs_require_exports_string_shorthand() {
         output.stdout
     );
 }
+
+#[tokio::test]
+async fn test_cjs_exec_sync_shell_pipes() {
+    // Shell operators like pipes must work (proves shell execution, not just space handling)
+    let tmp = tempfile::tempdir().unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const { execSync } = require('child_process');
+        const result = execSync('echo "abc def" | tr " " "_"', { encoding: 'utf8' });
+        console.log("piped: " + result.trim());
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "piped: abc_def",
+        "execSync should support shell pipes. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_exec_file_sync() {
+    // execFileSync must work through the native op
+    let tmp = tempfile::tempdir().unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const { execFileSync } = require('child_process');
+        const result = execFileSync('/bin/echo', ['hello', 'from', 'execFileSync'], { encoding: 'utf8' });
+        console.log("result: " + result.trim());
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "result: hello from execFileSync",
+        "execFileSync should work. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_scoped_package_exports() {
+    // require('@scope/pkg') with exports field
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp
+        .path()
+        .join("node_modules")
+        .join("@test-scope")
+        .join("my-lib");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "@test-scope/my-lib", "exports": { ".": { "require": "./dist/index.cjs" } } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("index.cjs"),
+        "module.exports = { scoped: true };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('@test-scope/my-lib');
+        console.log("scoped: " + pkg.scoped);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "scoped: true",
+        "require() should resolve scoped package exports. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_exports_path_traversal_blocked() {
+    // exports with path traversal (../../) must NOT resolve
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a secret file outside the package
+    std::fs::write(
+        tmp.path().join("secret.js"),
+        "module.exports = { leaked: true };",
+    )
+    .unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("evil-pkg");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "evil-pkg", "exports": { ".": "../../secret.js" } }"#,
+    )
+    .unwrap();
+    // Also provide a fallback index.js so we can distinguish "blocked" from "not found"
+    std::fs::write(pkg_dir.join("index.js"), "module.exports = { safe: true };").unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('evil-pkg');
+        // Should get index.js fallback, not the traversal target
+        console.log("safe: " + (pkg.safe === true));
+        console.log("leaked: " + (pkg.leaked === true));
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "safe: true",
+        "Path traversal exports should be blocked, falling back to index.js. Got: {:?}",
+        output.stdout
+    );
+    assert_eq!(
+        output.stdout[1], "leaked: false",
+        "Path traversal must not leak files outside package. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_nested_conditions() {
+    // Nested conditions: { ".": { "node": { "require": "./cjs.js" } } }
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("nested-cond-pkg");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "nested-cond-pkg", "exports": { ".": { "node": { "require": "./dist/cjs.js", "import": "./dist/esm.js" } } } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("cjs.js"),
+        "module.exports = { nested: 'cjs' };",
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("esm.js"),
+        "module.exports = { nested: 'esm' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('nested-cond-pkg');
+        console.log("nested: " + pkg.nested);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "nested: cjs",
+        "Nested node.require condition should resolve to CJS. Got: {:?}",
+        output.stdout
+    );
+}

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -857,3 +857,246 @@ fn test_vtz_runtime_identity_marker() {
     let output = rt.captured_output();
     assert_eq!(output.stdout[0], "marker: true");
 }
+
+// --- Bug #2580: CJS execSync must use shell execution, not cmd.split(' ') ---
+
+#[tokio::test]
+async fn test_cjs_exec_sync_shell_execution() {
+    // CJS require('child_process').execSync should run through /bin/sh,
+    // not split on spaces. Quoted args with spaces must work.
+    let tmp = tempfile::tempdir().unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const { execSync } = require('child_process');
+        const result = execSync('echo "hello world"', { encoding: 'utf8' });
+        console.log("result: " + result.trim());
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "result: hello world",
+        "execSync should handle quoted args via shell. Got: {:?}",
+        output.stdout
+    );
+}
+
+// --- Bug #2581: CJS require() must resolve package.json exports field ---
+
+#[tokio::test]
+async fn test_cjs_require_exports_only_package() {
+    // Package with only "exports" field (no "main") must resolve via require()
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create package with exports-only
+    let pkg_dir = tmp.path().join("node_modules").join("exports-pkg");
+    std::fs::create_dir_all(pkg_dir.join("lib")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "exports-pkg", "exports": { ".": { "require": "./lib/main.cjs" } } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("lib").join("main.cjs"),
+        "module.exports = { greeting: 'from exports' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('exports-pkg');
+        console.log("greeting: " + pkg.greeting);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "greeting: from exports",
+        "require() should resolve exports field. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_subpath_exports() {
+    // require('pkg/utils') should resolve via exports["./utils"]
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("subpath-pkg");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "subpath-pkg", "exports": { ".": "./dist/index.js", "./utils": "./dist/utils.js" } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("index.js"),
+        "module.exports = { name: 'main' };",
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("utils.js"),
+        "module.exports = { name: 'utils' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const utils = require('subpath-pkg/utils');
+        console.log("name: " + utils.name);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "name: utils",
+        "require() should resolve subpath exports. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_prefers_require_condition() {
+    // When both "require" and "import" conditions exist, CJS should use "require"
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("dual-pkg");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "dual-pkg", "exports": { ".": { "import": "./dist/esm.js", "require": "./dist/cjs.js" } } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("esm.js"),
+        "module.exports = { format: 'esm' };",
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("cjs.js"),
+        "module.exports = { format: 'cjs' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('dual-pkg');
+        console.log("format: " + pkg.format);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "format: cjs",
+        "require() should prefer 'require' condition over 'import'. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_exports_string_shorthand() {
+    // exports: "./dist/main.js" (string shorthand for ".")
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("string-exports-pkg");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "string-exports-pkg", "exports": "./dist/main.js" }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("main.js"),
+        "module.exports = { source: 'string-exports' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('string-exports-pkg');
+        console.log("source: " + pkg.source);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "source: string-exports",
+        "require() should resolve string exports shorthand. Got: {:?}",
+        output.stdout
+    );
+}


### PR DESCRIPTION
## Summary

- **#2580**: CJS `execSync` used `cmd.split(' ')` instead of shell execution. Now uses `op_command_output_sync('/bin/sh', ['-c', cmd])` matching the ESM synthetic module. Also aligns `execFile`/`execFileSync` to use the native op.
- **#2581**: CJS `_resolveCjsPath` only checked `pkg.main` for bare specifiers. Now resolves the `exports` field with CJS-appropriate condition priority (`require > node > default`), supports string shorthand, subpath exports, and falls back to `main` when exports is absent.
- **Security**: Added path traversal guard — exports targets must start with `./`

## Public API Changes

None — internal runtime CJS bootstrap changes only.

## Files Changed

- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cjs-resolve-exec/native/vtz/src/runtime/module_loader.rs) — CJS bootstrap: new `_resolveCjsExports`/`_resolveCjsCondition` helpers, bare specifier resolution refactored, `execSync`/`execFile`/`execFileSync` rewritten
- [`native/vtz/tests/v8_integration.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cjs-resolve-exec/native/vtz/tests/v8_integration.rs) — 10 new integration tests

## Test Plan

- [x] `test_cjs_exec_sync_shell_execution` — quoted args with spaces
- [x] `test_cjs_exec_sync_shell_pipes` — shell pipe operators
- [x] `test_cjs_exec_file_sync` — execFileSync via native op
- [x] `test_cjs_require_exports_only_package` — package with only exports field
- [x] `test_cjs_require_subpath_exports` — `require('pkg/utils')` via exports
- [x] `test_cjs_require_prefers_require_condition` — CJS picks `require` over `import`
- [x] `test_cjs_require_exports_string_shorthand` — `exports: "./main.js"`
- [x] `test_cjs_require_scoped_package_exports` — `@scope/pkg` with exports
- [x] `test_cjs_require_nested_conditions` — `{ node: { require: ... } }`
- [x] `test_cjs_require_exports_path_traversal_blocked` — `../../` targets rejected
- [x] All existing tests pass (cargo test --all)
- [x] clippy clean, fmt clean

## Pre-existing Issues Found

- #2586 — CJS relative path resolution ignores exports field
- #2587 — CJS/ESM exports resolver does not support array fallbacks

Closes #2580
Closes #2581

🤖 Generated with [Claude Code](https://claude.com/claude-code)