### PR TITLE
fix(runtime): process.stdout.write must not append newline

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1337,8 +1337,8 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
         if (!p.versions) p.versions = {};
         if (!p.versions.node) p.versions.node = '20.0.0';
         if (!p.nextTick) p.nextTick = (fn, ...args) => queueMicrotask(() => fn(...args));
-        if (!p.stdout) p.stdout = { write: (s) => { console.log(s); } };
-        if (!p.stderr) p.stderr = { write: (s) => { console.error(s); } };
+        if (!p.stdout) p.stdout = { write: (s) => Deno.core.ops.op_stdout_write(String(s)) };
+        if (!p.stderr) p.stderr = { write: (s) => Deno.core.ops.op_stderr_write(String(s)) };
         globalThis.process = p;
         return p;
       }
@@ -2321,8 +2321,8 @@ if (!proc.versions) proc.versions = {};
 if (!proc.versions.node) proc.versions.node = '20.0.0';
 if (!proc.exit) proc.exit = (code) => { throw new Error('process.exit(' + (code !== undefined ? code : '') + ') is not supported in the Vertz runtime'); };
 if (!proc.nextTick) proc.nextTick = (fn, ...args) => queueMicrotask(() => fn(...args));
-if (!proc.stdout) proc.stdout = { write: (s) => { console.log(s); } };
-if (!proc.stderr) proc.stderr = { write: (s) => { console.error(s); } };
+if (!proc.stdout) proc.stdout = { write: (s) => Deno.core.ops.op_stdout_write(String(s)) };
+if (!proc.stderr) proc.stderr = { write: (s) => Deno.core.ops.op_stderr_write(String(s)) };
 globalThis.process = proc;
 
 export default proc;

--- a/native/vtz/src/runtime/ops/console.rs
+++ b/native/vtz/src/runtime/ops/console.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -63,6 +64,34 @@ pub fn op_console_info(state: &mut OpState, #[string] msg: String) {
     }
 }
 
+/// Write raw string to stdout without a trailing newline.
+/// Matches Node.js `process.stdout.write()` semantics.
+#[op2(fast)]
+pub fn op_stdout_write(state: &mut OpState, #[string] msg: String) -> bool {
+    let console_state = state.borrow::<ConsoleState>();
+    if console_state.capture {
+        console_state.captured.lock().unwrap().stdout.push(msg);
+    } else {
+        let _ = std::io::stdout().write_all(msg.as_bytes());
+        let _ = std::io::stdout().flush();
+    }
+    true
+}
+
+/// Write raw string to stderr without a trailing newline.
+/// Matches Node.js `process.stderr.write()` semantics.
+#[op2(fast)]
+pub fn op_stderr_write(state: &mut OpState, #[string] msg: String) -> bool {
+    let console_state = state.borrow::<ConsoleState>();
+    if console_state.capture {
+        console_state.captured.lock().unwrap().stderr.push(msg);
+    } else {
+        let _ = std::io::stderr().write_all(msg.as_bytes());
+        let _ = std::io::stderr().flush();
+    }
+    true
+}
+
 /// Get the op declarations for console ops.
 pub fn op_decls() -> Vec<OpDecl> {
     vec![
@@ -70,6 +99,8 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_console_warn(),
         op_console_error(),
         op_console_info(),
+        op_stdout_write(),
+        op_stderr_write(),
     ]
 }
 
@@ -196,5 +227,80 @@ mod tests {
         let output = rt.captured_output();
         assert_eq!(output.stdout, vec!["first", "second"]);
         assert_eq!(output.stderr.len(), 1);
+    }
+
+    #[test]
+    fn test_stdout_write_no_newline() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void("<test>", "Deno.core.ops.op_stdout_write('hello');")
+            .unwrap();
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["hello"]);
+    }
+
+    #[test]
+    fn test_stderr_write_no_newline() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void("<test>", "Deno.core.ops.op_stderr_write('hello');")
+            .unwrap();
+        let output = rt.captured_output();
+        // stderr.write should NOT add ANSI color codes (unlike console.error)
+        assert_eq!(output.stderr, vec!["hello"]);
+    }
+
+    #[test]
+    fn test_stdout_write_returns_true() {
+        let mut rt = create_capturing_runtime();
+        let result = rt
+            .execute_script("<test>", "Deno.core.ops.op_stdout_write('test')")
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_stderr_write_returns_true() {
+        let mut rt = create_capturing_runtime();
+        let result = rt
+            .execute_script("<test>", "Deno.core.ops.op_stderr_write('test')")
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_process_stdout_write_uses_raw_op() {
+        let mut rt = create_capturing_runtime();
+        // Set up process.stdout the same way the CJS bootstrap does
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            if (!globalThis.process) globalThis.process = {};
+            globalThis.process.stdout = { write: (s) => Deno.core.ops.op_stdout_write(String(s)) };
+            process.stdout.write('a');
+            process.stdout.write('b');
+        "#,
+        )
+        .unwrap();
+        let output = rt.captured_output();
+        // Each write should be captured separately, without newlines
+        assert_eq!(output.stdout, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_process_stderr_write_uses_raw_op() {
+        let mut rt = create_capturing_runtime();
+        // Set up process.stderr the same way the CJS bootstrap does
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            if (!globalThis.process) globalThis.process = {};
+            globalThis.process.stderr = { write: (s) => Deno.core.ops.op_stderr_write(String(s)) };
+            process.stderr.write('err1');
+            process.stderr.write('err2');
+        "#,
+        )
+        .unwrap();
+        let output = rt.captured_output();
+        // stderr.write should NOT add ANSI color codes (unlike console.error)
+        assert_eq!(output.stderr, vec!["err1", "err2"]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2582 — `process.stdout.write` and `process.stderr.write` stubs in the vtz runtime were delegating to `console.log`/`console.error`, which append a newline via `println!`/`eprintln!`. Node.js's `process.stdout.write` does NOT append a newline.

- Added dedicated `op_stdout_write` and `op_stderr_write` Rust ops that use `write_all`/`flush` (no trailing newline)
- Updated both CJS bootstrap and ESM `NODE_PROCESS_MODULE` stubs to use the new ops
- 6 new tests covering the ops directly and via `process.stdout/stderr.write`

## Public API Changes

None — internal runtime fix. `process.stdout.write` and `process.stderr.write` now match Node.js semantics (no trailing newline).

## Files Changed

- [`native/vtz/src/runtime/ops/console.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-stdout-write-newline/native/vtz/src/runtime/ops/console.rs) — new `op_stdout_write`/`op_stderr_write` ops + 6 tests
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-stdout-write-newline/native/vtz/src/runtime/module_loader.rs) — updated CJS and ESM process stubs

## Test plan

- [x] `op_stdout_write` captures without newline
- [x] `op_stderr_write` captures without ANSI codes
- [x] Both ops return `true` (Node.js semantics)
- [x] `process.stdout.write` integration via CJS bootstrap
- [x] `process.stderr.write` integration via CJS bootstrap
- [x] All existing console tests pass (no regression)
- [x] All module_loader tests pass (no regression)
- [x] Full `cargo test -p vtz` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)