### PR TITLE
fix(runtime): CJS relative path exports + array fallback (#2586, #2587)

### DIFF
--- a/.changeset/fix-cjs-exports-resolve.md
+++ b/.changeset/fix-cjs-exports-resolve.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix CJS relative path resolution to check exports field before main, and add array fallback support to both CJS and ESM exports resolvers

--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -137,6 +137,14 @@ fn resolve_export_entry(exports: &serde_json::Value, key: &str) -> Option<String
                 None
             }
         }
+        // Top-level array fallback: "exports": [{ "import": "./esm.js" }, "./fallback.js"]
+        serde_json::Value::Array(_) => {
+            if key == "." {
+                resolve_condition_value_from_entry(exports)
+            } else {
+                None
+            }
+        }
         serde_json::Value::Object(map) => {
             if let Some(entry) = map.get(key) {
                 resolve_condition_value_from_entry(entry)
@@ -387,5 +395,17 @@ mod tests {
             resolve_export_entry(&exports, "."),
             Some("./dist/esm.js".to_string())
         );
+    }
+
+    #[test]
+    fn test_resolve_export_entry_top_level_array() {
+        // Top-level array: "exports": [{ "import": "./esm.js" }, "./fallback.js"]
+        let exports = serde_json::json!([{ "import": "./dist/esm.js" }, "./dist/fallback.js"]);
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/esm.js".to_string())
+        );
+        // Subpath on top-level array should return None
+        assert_eq!(resolve_export_entry(&exports, "./utils"), None);
     }
 }

--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -139,18 +139,29 @@ fn resolve_export_entry(exports: &serde_json::Value, key: &str) -> Option<String
         }
         serde_json::Value::Object(map) => {
             if let Some(entry) = map.get(key) {
-                // Entry can be a string or a conditions object
-                match entry {
-                    serde_json::Value::String(s) => Some(s.clone()),
-                    serde_json::Value::Object(conditions) => {
-                        // Try: import > module > default
-                        resolve_condition_value(conditions)
-                    }
-                    _ => None,
-                }
+                resolve_condition_value_from_entry(entry)
             } else {
                 None
             }
+        }
+        _ => None,
+    }
+}
+
+/// Resolve a condition value from an exports entry.
+/// Handles strings, condition objects, and array fallbacks.
+fn resolve_condition_value_from_entry(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Object(conditions) => resolve_condition_value(conditions),
+        serde_json::Value::Array(arr) => {
+            // Array fallback: first matching entry wins
+            for entry in arr {
+                if let Some(resolved) = resolve_condition_value_from_entry(entry) {
+                    return Some(resolved);
+                }
+            }
+            None
         }
         _ => None,
     }
@@ -183,6 +194,14 @@ fn resolve_condition_value(
                             if !s.ends_with(".d.ts") && !s.ends_with(".d.mts") {
                                 return Some(s.to_string());
                             }
+                        }
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    // Array fallback within a condition
+                    for entry in arr {
+                        if let Some(resolved) = resolve_condition_value_from_entry(entry) {
+                            return Some(resolved);
                         }
                     }
                 }
@@ -344,5 +363,29 @@ mod tests {
         // No node_modules — should fall back
         let url = resolve_to_deps_url("unknown-pkg", tmp.path());
         assert_eq!(url, "/@deps/unknown-pkg");
+    }
+
+    #[test]
+    fn test_resolve_export_entry_array_fallback() {
+        // Array fallback: first matching string wins
+        let exports = serde_json::json!({
+            ".": ["./dist/main.js", "./dist/alt.js"]
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/main.js".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_export_entry_array_with_conditions() {
+        // Array fallback with condition objects
+        let exports = serde_json::json!({
+            ".": [{ "import": "./dist/esm.js" }, "./dist/fallback.js"]
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/esm.js".to_string())
+        );
     }
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1737,7 +1737,12 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
       if (key !== '.') return undefined;
       return exports.startsWith('./') ? exports : undefined;
     }
-    if (typeof exports === 'object' && exports !== null && !Array.isArray(exports)) {
+    // Top-level array: exports = [{ "require": "./cjs.js" }, "./fallback.js"]
+    if (Array.isArray(exports)) {
+      if (key !== '.') return undefined;
+      return _resolveCjsCondition(exports);
+    }
+    if (typeof exports === 'object' && exports !== null) {
       // Check if key exists directly in the map
       if (key in exports) {
         return _resolveCjsCondition(exports[key]);
@@ -1772,9 +1777,9 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
                 const pkg = JSON.parse(Deno.core.ops.op_fs_read_file_sync(pkgPath));
                 // Try exports field first (consistent with bare specifier resolution)
                 if (pkg.exports !== undefined) {
-                  const resolved = _resolveCjsExports(pkg.exports, '.');
-                  if (resolved) {
-                    const full = path + '/' + resolved;
+                  const resolvedExport = _resolveCjsExports(pkg.exports, '.');
+                  if (resolvedExport) {
+                    const full = path + '/' + resolvedExport;
                     if (Deno.core.ops.op_fs_exists_sync(full)) return full;
                   }
                 }
@@ -2069,6 +2074,9 @@ fn resolve_exports_entry(exports: &serde_json::Value, key: &str) -> Option<Strin
     match exports {
         // Direct string value (applies to "." entry)
         serde_json::Value::String(s) if key == "." => Some(s.clone()),
+
+        // Top-level array fallback (applies to "." entry)
+        serde_json::Value::Array(_) if key == "." => resolve_condition_value(exports),
 
         // Object with conditions or subpath patterns
         serde_json::Value::Object(map) => {
@@ -3512,6 +3520,18 @@ export function Hello() {
             resolve_condition_value(&value),
             Some("./dist/esm.js".to_string())
         );
+    }
+
+    #[test]
+    fn test_resolve_exports_entry_top_level_array() {
+        // Top-level array: "exports": [{ "import": "./esm.js" }, "./fallback.js"]
+        let exports = serde_json::json!([{ "import": "./dist/esm.js" }, "./dist/fallback.js"]);
+        assert_eq!(
+            resolve_exports_entry(&exports, "."),
+            Some("./dist/esm.js".to_string())
+        );
+        // Subpath on top-level array should return None
+        assert_eq!(resolve_exports_entry(&exports, "./utils"), None);
     }
 
     // --- Phase 5a: node:* synthetic module resolution ---

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1713,7 +1713,15 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
       // Exports targets must start with './' to prevent path traversal
       return value.startsWith('./') ? value : undefined;
     }
-    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    if (Array.isArray(value)) {
+      // Array fallback: first matching entry wins
+      for (const entry of value) {
+        const resolved = _resolveCjsCondition(entry);
+        if (resolved) return resolved;
+      }
+      return undefined;
+    }
+    if (typeof value === 'object' && value !== null) {
       // CJS priority: require > node > default
       const keys = ['require', 'node', 'default'];
       for (const k of keys) {
@@ -1758,11 +1766,19 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
         try {
           const stat = Deno.core.ops.op_fs_stat_sync(path);
           if (stat.isDirectory) {
-            // Check package.json main
             const pkgPath = path + '/package.json';
             if (Deno.core.ops.op_fs_exists_sync(pkgPath)) {
               try {
                 const pkg = JSON.parse(Deno.core.ops.op_fs_read_file_sync(pkgPath));
+                // Try exports field first (consistent with bare specifier resolution)
+                if (pkg.exports !== undefined) {
+                  const resolved = _resolveCjsExports(pkg.exports, '.');
+                  if (resolved) {
+                    const full = path + '/' + resolved;
+                    if (Deno.core.ops.op_fs_exists_sync(full)) return full;
+                  }
+                }
+                // Fall back to main
                 if (pkg.main) {
                   const mainPath = path + '/' + pkg.main;
                   if (Deno.core.ops.op_fs_exists_sync(mainPath)) return mainPath;
@@ -2083,6 +2099,15 @@ fn resolve_condition_value(value: &serde_json::Value) -> Option<String> {
             for key in &["import", "node", "module", "default", "require"] {
                 if let Some(entry) = map.get(*key) {
                     return resolve_condition_value(entry);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(arr) => {
+            // Array fallback: first matching entry wins
+            for entry in arr {
+                if let Some(resolved) = resolve_condition_value(entry) {
+                    return Some(resolved);
                 }
             }
             None
@@ -3464,6 +3489,28 @@ export function Hello() {
         assert_eq!(
             resolve_exports_entry(&exports, "./utils"),
             Some("./dist/utils.js".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_exports_entry_array_fallback() {
+        // Array fallback: first matching entry wins
+        let exports = serde_json::json!({
+            ".": ["./dist/main.js", "./dist/alt.js"]
+        });
+        assert_eq!(
+            resolve_exports_entry(&exports, "."),
+            Some("./dist/main.js".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_condition_value_array_with_conditions() {
+        // Array with condition objects — first matching wins
+        let value = serde_json::json!([{ "import": "./dist/esm.js" }, "./dist/fallback.js"]);
+        assert_eq!(
+            resolve_condition_value(&value),
+            Some("./dist/esm.js".to_string())
         );
     }
 

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -1334,3 +1334,167 @@ async fn test_cjs_require_nested_conditions() {
         output.stdout
     );
 }
+
+// --- Bug #2586: CJS relative path resolution must check exports field ---
+
+#[tokio::test]
+async fn test_cjs_require_relative_path_resolves_exports() {
+    // require('./node_modules/exports-only-pkg') should resolve via exports field,
+    // not just pkg.main. Currently the relative path branch only checks main.
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("rel-exports-pkg");
+    std::fs::create_dir_all(pkg_dir.join("lib")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "rel-exports-pkg", "exports": { ".": { "require": "./lib/entry.cjs" } } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("lib").join("entry.cjs"),
+        "module.exports = { source: 'exports-field' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('./node_modules/rel-exports-pkg');
+        console.log("source: " + pkg.source);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "source: exports-field",
+        "Relative path require() should resolve exports field. Got: {:?}",
+        output.stdout
+    );
+}
+
+// --- Bug #2587: CJS exports resolver must support array fallbacks ---
+
+#[tokio::test]
+async fn test_cjs_require_exports_array_fallback() {
+    // Array fallbacks in exports: first matching entry wins
+    // { ".": [{ "require": "./dist/cjs.js" }, "./dist/fallback.js"] }
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp.path().join("node_modules").join("array-fallback-pkg");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "array-fallback-pkg", "exports": { ".": [{ "require": "./dist/cjs.js" }, "./dist/fallback.js"] } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("cjs.js"),
+        "module.exports = { source: 'cjs-from-array' };",
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("fallback.js"),
+        "module.exports = { source: 'fallback' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('array-fallback-pkg');
+        console.log("source: " + pkg.source);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "source: cjs-from-array",
+        "require() should resolve array fallback in exports. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_cjs_require_exports_array_string_fallback() {
+    // Array with only string entries: ["./dist/main.js", "./dist/alt.js"]
+    // First existing entry should win
+    let tmp = tempfile::tempdir().unwrap();
+
+    let pkg_dir = tmp
+        .path()
+        .join("node_modules")
+        .join("array-string-fallback");
+    std::fs::create_dir_all(pkg_dir.join("dist")).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "array-string-fallback", "exports": { ".": ["./dist/main.js", "./dist/alt.js"] } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("main.js"),
+        "module.exports = { source: 'first-string' };",
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("dist").join("alt.js"),
+        "module.exports = { source: 'alt-string' };",
+    )
+    .unwrap();
+
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import { createRequire } from 'node:module';
+        const require = createRequire(import.meta.url);
+        const pkg = require('array-string-fallback');
+        console.log("source: " + pkg.source);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "source: first-string",
+        "require() should resolve first string in array fallback. Got: {:?}",
+        output.stdout
+    );
+}


### PR DESCRIPTION
## Summary

- **#2586**: CJS `_resolveCjsPath` relative path branch now checks `pkg.exports` before `pkg.main` when resolving into a directory with a `package.json` — consistent with bare specifier resolution
- **#2587**: Array fallback values in exports fields are now resolved (first matching entry wins) in all three resolvers: JS CJS, Rust ESM (module_loader), and Rust deps resolver
- Top-level array exports (`"exports": [...]`) also supported

Fixes #2586
Fixes #2587

## Public API Changes

None — internal runtime resolution logic only.

## Files Changed

- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cjs-resolve-bugs/native/vtz/src/runtime/module_loader.rs) — JS CJS resolver (`_resolveCjsCondition`, `_resolveCjsExports`, `_resolveCjsPath`) + Rust ESM resolver (`resolve_condition_value`, `resolve_exports_entry`)
- [`native/vtz/src/deps/resolve.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cjs-resolve-bugs/native/vtz/src/deps/resolve.rs) — Rust deps resolver (`resolve_condition_value_from_entry`, `resolve_export_entry`)
- [`native/vtz/tests/v8_integration.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cjs-resolve-bugs/native/vtz/tests/v8_integration.rs) — 3 new integration tests

## Review Summary

Adversarial review approved. Findings addressed:
- Renamed shadowed `resolved` variable to `resolvedExport`
- Added top-level array exports support
- Created #2592 for pre-existing condition priority inconsistency across resolvers
- Created #2593 for pre-existing path traversal validation gap in deps resolver

## Test Plan

- [x] `test_cjs_require_relative_path_resolves_exports` — relative path resolves via exports field
- [x] `test_cjs_require_exports_array_fallback` — array with condition objects (first match wins)
- [x] `test_cjs_require_exports_array_string_fallback` — array with string entries
- [x] Unit tests for `resolve_exports_entry` and `resolve_condition_value` array handling
- [x] Unit tests for top-level array exports
- [x] All 13 existing CJS tests still pass (no regressions)
- [x] Full `cargo test --all --release` passes (32 integration + all unit tests)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)