### PR TITLE
fix(og): replace Bun-specific APIs with portable Node.js alternatives (#2556)

### DIFF
--- a/.changeset/fix-og-bun-apis.md
+++ b/.changeset/fix-og-bun-apis.md
@@ -1,0 +1,5 @@
+---
+'@vertz/og': patch
+---
+
+Replace Bun-specific APIs with portable Node.js alternatives in test files

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -1498,3 +1498,47 @@ async fn test_cjs_require_exports_array_string_fallback() {
         output.stdout
     );
 }
+
+// --- #2556: import.meta.dirname and import.meta.filename for ESM ---
+
+#[tokio::test]
+async fn test_import_meta_dirname_and_filename() {
+    let tmp = tempfile::tempdir().unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        console.log("dirname: " + import.meta.dirname);
+        console.log("filename: " + import.meta.filename);
+    "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    // Canonicalize to handle macOS /var → /private/var symlink
+    let canonical_dir = tmp.path().canonicalize().unwrap();
+    let expected_dirname = canonical_dir.to_string_lossy().to_string();
+    let expected_filename = canonical_dir.join("entry.js").to_string_lossy().to_string();
+    assert_eq!(
+        output.stdout[0],
+        format!("dirname: {}", expected_dirname),
+        "import.meta.dirname should return the directory path. Got: {:?}",
+        output.stdout
+    );
+    assert_eq!(
+        output.stdout[1],
+        format!("filename: {}", expected_filename),
+        "import.meta.filename should return the file path. Got: {:?}",
+        output.stdout
+    );
+}

--- a/packages/og/src/__tests__/image.test.ts
+++ b/packages/og/src/__tests__/image.test.ts
@@ -1,24 +1,33 @@
+import { unlinkSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { afterEach, describe, expect, it, mock } from '@vertz/test';
 import { loadImage } from '../image';
 
 describe('loadImage', () => {
   const originalFetch = globalThis.fetch;
+  const tmpFiles: string[] = [];
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    for (const f of tmpFiles) {
+      try {
+        unlinkSync(f);
+      } catch {}
+    }
+    tmpFiles.length = 0;
   });
 
   it('loads an SVG string and returns a data URI', async () => {
     const svg = '<svg viewBox="0 0 100 100"><rect width="100" height="100" fill="red"/></svg>';
     const result = await loadImage(svg);
-    expect(result).toStartWith('data:image/svg+xml,');
+    expect(result).toMatch(/^data:image\/svg\+xml,/);
     expect(result).toContain(encodeURIComponent('<svg'));
   });
 
   it('handles SVG string with leading whitespace', async () => {
     const svg = '  \n  <svg viewBox="0 0 10 10"><rect fill="blue"/></svg>';
     const result = await loadImage(svg);
-    expect(result).toStartWith('data:image/svg+xml,');
+    expect(result).toMatch(/^data:image\/svg\+xml,/);
   });
 
   it('loads a file path and returns a base64 data URI', async () => {
@@ -27,13 +36,11 @@ describe('loadImage', () => {
       0x52,
     ]);
     const tmpPath = `/tmp/test-og-image-${Date.now()}.png`;
-    await Bun.write(tmpPath, pngBytes);
+    tmpFiles.push(tmpPath);
+    await writeFile(tmpPath, pngBytes);
 
     const result = await loadImage(tmpPath);
-    expect(result).toStartWith('data:image/png;base64,');
-
-    const { unlinkSync } = await import('node:fs');
-    unlinkSync(tmpPath);
+    expect(result).toMatch(/^data:image\/png;base64,/);
   });
 
   it('loads a URL and returns a base64 data URI', async () => {
@@ -45,7 +52,7 @@ describe('loadImage', () => {
     }) as typeof fetch;
 
     const result = await loadImage('https://example.com/image.png');
-    expect(result).toStartWith('data:image/png;base64,');
+    expect(result).toMatch(/^data:image\/png;base64,/);
   });
 
   it('falls back to application/octet-stream when URL has no Content-Type', async () => {
@@ -55,18 +62,16 @@ describe('loadImage', () => {
     }) as typeof fetch;
 
     const result = await loadImage('https://example.com/file.bin');
-    expect(result).toStartWith('data:application/octet-stream;base64,');
+    expect(result).toMatch(/^data:application\/octet-stream;base64,/);
   });
 
   it('detects MIME type from file extension', async () => {
     const tmpPath = `/tmp/test-og-image-${Date.now()}.jpg`;
-    await Bun.write(tmpPath, new Uint8Array([0xff, 0xd8, 0xff]));
+    tmpFiles.push(tmpPath);
+    await writeFile(tmpPath, new Uint8Array([0xff, 0xd8, 0xff]));
 
     const result = await loadImage(tmpPath);
-    expect(result).toStartWith('data:image/jpeg;base64,');
-
-    const { unlinkSync } = await import('node:fs');
-    unlinkSync(tmpPath);
+    expect(result).toMatch(/^data:image\/jpeg;base64,/);
   });
 
   it('throws when file does not exist', async () => {

--- a/packages/og/src/__tests__/test-helpers.ts
+++ b/packages/og/src/__tests__/test-helpers.ts
@@ -3,19 +3,16 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { SatoriElement } from '../types';
 
 let cachedFont: ArrayBuffer | undefined;
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Load a test font from the local fixture (no network calls). */
 export async function getTestFont(): Promise<ArrayBuffer> {
   if (cachedFont) return cachedFont;
 
-  const fontPath = join(__dirname, 'fixtures', 'NotoSans-Regular-Latin.ttf');
+  const fontPath = join(import.meta.dirname, 'fixtures', 'NotoSans-Regular-Latin.ttf');
   const data = await readFile(fontPath);
   cachedFont = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
   return cachedFont;

--- a/packages/og/src/__tests__/test-helpers.ts
+++ b/packages/og/src/__tests__/test-helpers.ts
@@ -2,17 +2,22 @@
  * Shared test utilities for @vertz/og tests.
  */
 
-import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { SatoriElement } from '../types';
 
 let cachedFont: ArrayBuffer | undefined;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Load a test font from the local fixture (no network calls). */
 export async function getTestFont(): Promise<ArrayBuffer> {
   if (cachedFont) return cachedFont;
 
-  const fontPath = join(import.meta.dir, 'fixtures', 'NotoSans-Regular-Latin.ttf');
-  cachedFont = await Bun.file(fontPath).arrayBuffer();
+  const fontPath = join(__dirname, 'fixtures', 'NotoSans-Regular-Latin.ttf');
+  const data = await readFile(fontPath);
+  cachedFont = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
   return cachedFont;
 }
 

--- a/reviews/fix-og-typecheck/phase-01-portable-apis.md
+++ b/reviews/fix-og-typecheck/phase-01-portable-apis.md
@@ -1,0 +1,34 @@
+# Phase 1: Replace Bun APIs with Portable Node.js
+
+- **Author:** davis-v2
+- **Reviewer:** review-agent
+- **Date:** 2026-04-13
+
+## Changes
+
+- packages/og/src/__tests__/test-helpers.ts (modified)
+- packages/og/src/__tests__/image.test.ts (modified)
+- .changeset/fix-og-bun-apis.md (new)
+
+## CI Status
+
+- [x] Quality gates passed (typecheck, tests, lint, format)
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Test cleanup follows integration-test-safety rules
+
+## Findings
+
+### Approved
+
+No blockers found. Two should-fix items addressed inline:
+1. Temp file cleanup moved to `afterEach` (was in test body — leaked on assertion failure)
+2. Dynamic `import('node:fs')` for `unlinkSync` replaced with static top-level import
+
+## Resolution
+
+Both should-fix items addressed in the same commit.


### PR DESCRIPTION
## Summary

- Replace `import.meta.dir` (Bun-specific) with `import.meta.dirname` (Node.js convention, already supported by vtz runtime via deno_core)
- Replace `Bun.file()` with `readFile()` from `node:fs/promises`
- Replace `Bun.write()` with `writeFile()` from `node:fs/promises`
- Replace `toStartWith()` (Bun matcher) with `toMatch(/^.../)` regex assertions
- Move temp file cleanup to `afterEach` per integration-test-safety rules
- Add vtz runtime integration test confirming `import.meta.dirname` and `import.meta.filename` work

Fixes #2556

## Public API Changes

None — changes are test-only.

## Test plan

- [x] `npx tsgo --noEmit -p packages/og/tsconfig.typecheck.json` passes (0 errors)
- [x] `vtz test packages/og/src/__tests__/image.test.ts` passes (8/8)
- [x] `cargo test --package vtz test_import_meta_dirname_and_filename` passes
- [x] Lint + format clean (TS and Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)