### PR TITLE
fix(runtime): align deps resolver condition priority with ESM resolver (#2592)

### DIFF
--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -184,7 +184,10 @@ fn resolve_condition_value(
     conditions: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<String> {
     // Priority: import > node > module > default > require
-    // Matches the ESM resolver in module_loader.rs
+    // Matches the ESM resolver in module_loader.rs and import_rewriter.rs.
+    // Note: this serves /@deps/ URLs to the browser. The "node" condition may
+    // resolve to Node-specific code for some packages; a future "browser"
+    // condition could be added if needed.
     for key in &["import", "node", "module", "default", "require"] {
         if let Some(val) = conditions.get(*key) {
             match val {

--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -183,8 +183,9 @@ fn resolve_condition_value_from_entry(value: &serde_json::Value) -> Option<Strin
 fn resolve_condition_value(
     conditions: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<String> {
-    // Priority: import > module > default
-    for key in &["import", "module", "default"] {
+    // Priority: import > node > module > default > require
+    // Matches the ESM resolver in module_loader.rs
+    for key in &["import", "node", "module", "default", "require"] {
         if let Some(val) = conditions.get(*key) {
             match val {
                 serde_json::Value::String(s) => return Some(s.clone()),
@@ -407,5 +408,66 @@ mod tests {
         );
         // Subpath on top-level array should return None
         assert_eq!(resolve_export_entry(&exports, "./utils"), None);
+    }
+
+    #[test]
+    fn test_resolve_export_entry_node_condition() {
+        // Packages that only export under the "node" condition
+        let exports = serde_json::json!({
+            ".": {
+                "node": "./dist/node.js",
+                "default": "./dist/index.js"
+            }
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/node.js".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_export_entry_node_condition_priority() {
+        // "node" should be preferred over "module" and "default" but not "import"
+        let exports = serde_json::json!({
+            ".": {
+                "module": "./dist/module.mjs",
+                "node": "./dist/node.js",
+                "default": "./dist/index.js"
+            }
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/node.js".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_export_entry_import_over_node() {
+        // "import" should be preferred over "node"
+        let exports = serde_json::json!({
+            ".": {
+                "node": "./dist/node.js",
+                "import": "./dist/esm.mjs",
+                "default": "./dist/index.js"
+            }
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/esm.mjs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_export_entry_require_fallback() {
+        // "require" should resolve as a last-resort fallback
+        let exports = serde_json::json!({
+            ".": {
+                "require": "./dist/index.cjs"
+            }
+        });
+        assert_eq!(
+            resolve_export_entry(&exports, "."),
+            Some("./dist/index.cjs".to_string())
+        );
     }
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -2224,11 +2224,14 @@ fn resolve_exports_entry(exports: &serde_json::Value, key: &str) -> Option<Strin
 }
 
 /// Resolve a condition value to a string path.
+/// Used by the ESM module loader. CJS uses `_resolveCjsCondition` (embedded JS)
+/// with priority: require > node > default.
 fn resolve_condition_value(value: &serde_json::Value) -> Option<String> {
     match value {
         serde_json::Value::String(s) => Some(s.clone()),
         serde_json::Value::Object(map) => {
-            // Priority: import > node > module > default > require
+            // ESM priority: import > node > module > default > require
+            // Must stay in sync with deps/resolve.rs::resolve_condition_value
             for key in &["import", "node", "module", "default", "require"] {
                 if let Some(entry) = map.get(*key) {
                     return resolve_condition_value(entry);


### PR DESCRIPTION
## Summary

- Fixed `deps/resolve.rs::resolve_condition_value` missing `node` and `require` conditions
- Updated priority from `import > module > default` to `import > node > module > default > require` to match the ESM resolver in `module_loader.rs`
- Added clarifying documentation comments across both Rust resolvers noting context (ESM vs CJS) and cross-references

## Public API Changes

None — internal resolver change only.

## Condition Priority (after fix)

| Resolver | Priority | Context |
|----------|----------|---------|
| CJS (`_resolveCjsCondition`) | `require` > `node` > `default` | `require()` calls |
| ESM (`module_loader.rs`) | `import` > `node` > `module` > `default` > `require` | ESM imports |
| Deps (`deps/resolve.rs`) | `import` > `node` > `module` > `default` > `require` | `/@deps/` URL resolution |

## Test plan

- [x] 4 new unit tests covering `node` condition, `node` priority over `module`, `import` priority over `node`, and `require` as last-resort fallback
- [x] All 19 deps resolver tests pass
- [x] Full `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Fixes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)