### PR TITLE
fix(ci): remove workarounds that swallowed test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,44 +314,10 @@ jobs:
         run: cd packages/ci && vtz run build
 
       - name: Build & typecheck
-        run: |
-          # TODO: Remove timeout wrapper once vtz 0.2.59 is published with
-          # the ConfigBridge stdin-close fix (PR #2518). The current npm
-          # binary (0.2.58) hangs after completion because the JS readline
-          # interface keeps the process alive.
-          set +eo pipefail
-          timeout --kill-after=10 600 vtz ci build-typecheck --concurrency 2 2>&1 | tee /tmp/build-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -eo pipefail
-          if [ $EXIT_CODE -eq 0 ]; then exit 0; fi
-          if [ $EXIT_CODE -eq 124 ] || [ $EXIT_CODE -eq 137 ]; then
-            if grep -q '\[pipe\] Done in' /tmp/build-output.log && grep -q '0 failed' /tmp/build-output.log; then
-              echo "::warning::vtz process did not exit cleanly (pending runtime release with ConfigBridge fix)"
-              exit 0
-            fi
-          fi
-          echo "::error::Build/typecheck failed with exit code $EXIT_CODE"
-          exit 1
+        run: vtz ci build-typecheck --concurrency 2
 
       - name: Test
-        run: |
-          # TODO: Remove timeout wrapper once vtz 0.2.59 is published.
-          set +eo pipefail
-          timeout --kill-after=10 600 vtz ci test --concurrency 2 2>&1 | tee /tmp/test-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -eo pipefail
-          if [ $EXIT_CODE -eq 0 ]; then exit 0; fi
-          # Check if any vtz test reported actual failures (N fail where N > 0)
-          FAIL_LINES=$(grep -cE '^\s*[1-9][0-9]*\s+fail' /tmp/test-output.log || true)
-          if [ "$FAIL_LINES" -gt 0 ]; then
-            echo "::error::Tests failed"
-            exit 1
-          fi
-          # Exit 124/137 = timeout, or vtz ci exited non-zero due to
-          # task timeouts (hung processes). If no actual vtz test failures
-          # were detected, treat as success — matching old CI behavior.
-          echo "::warning::Test processes did not exit cleanly (pending runtime release with ConfigBridge fix)"
-          exit 0
+        run: vtz ci test --concurrency 2
 
   # ---------------------------------------------------------------------------
   # Rust checks — runs in parallel with TS jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
 
           # Config files that ALWAYS trigger full CI
           CONFIG_PATTERNS=(
+            ".github/"
             ".oxlintrc.json"
             ".oxfmtrc.json"
             "tsconfig.json"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,28 +75,14 @@ jobs:
         run: cd packages/ci && vtz run build
 
       - name: Build packages
-        run: |
-          set +eo pipefail
-          timeout --kill-after=10 120 vtz ci build-typecheck --concurrency 2 2>&1 | tee /tmp/build-output.log
-          EXIT_CODE=${PIPESTATUS[0]}
-          set -eo pipefail
-
-          if [ $EXIT_CODE -eq 0 ]; then exit 0; fi
-
-          if [ $EXIT_CODE -eq 124 ] || [ $EXIT_CODE -eq 137 ]; then
-            if grep -q '\[pipe\] Done in' /tmp/build-output.log && grep -q '0 failed' /tmp/build-output.log; then
-              echo "::warning::vtz ci completed but process did not exit cleanly"
-              exit 0
-            fi
-          fi
-
-          echo "::error::Build failed with exit code $EXIT_CODE"
-          exit 1
+        run: vtz ci build-typecheck --concurrency 2
 
       - name: Run tests with coverage
         env:
           DATABASE_TEST_URL: postgres://postgres:postgres@localhost:5432/vertz_test
         run: |
+          FAILED_PKGS=()
+
           run_coverage() {
             local pkg=$1
             echo "::group::Coverage — $pkg"
@@ -106,14 +92,18 @@ jobs:
             TEST_SCRIPT=$(node -e "console.log(require('./package.json').scripts?.test ?? '')")
 
             if echo "$TEST_SCRIPT" | grep -q "vtz test"; then
-              timeout --kill-after=10 120 vtz test --coverage || true
+              if ! vtz test --coverage; then
+                FAILED_PKGS+=("$pkg")
+              fi
             else
-              timeout --kill-after=10 120 vitest run \
+              if ! vitest run \
                 --coverage \
                 --coverage.reporter=json-summary \
                 --coverage.reporter=json \
                 --coverage.reporter=text \
-                --coverage.reportOnFailure || true
+                --coverage.reportOnFailure; then
+                FAILED_PKGS+=("$pkg")
+              fi
             fi
 
             cd "$GITHUB_WORKSPACE"
@@ -123,6 +113,11 @@ jobs:
           for pkg in core schema compiler codegen cli cli-runtime fetch testing db cloudflare errors server tui ui ui-canvas ui-primitives ui-server; do
             run_coverage "$pkg"
           done
+
+          if [ ${#FAILED_PKGS[@]} -gt 0 ]; then
+            echo "::error::Tests failed in ${#FAILED_PKGS[@]} package(s): ${FAILED_PKGS[*]}"
+            exit 1
+          fi
 
       - name: Verify coverage output
         run: |

--- a/packages/core/src/app/__tests__/bun-adapter.test.ts
+++ b/packages/core/src/app/__tests__/bun-adapter.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from '@vertz/test';
 import { createBunAdapter } from '../bun-adapter';
 
+// This test requires the Bun runtime — skip when running under vtz
+const hasBun = typeof globalThis.Bun !== 'undefined';
+
 // Types for Bun.serve
 type BunServeOptions = {
   port: number;
@@ -23,22 +26,24 @@ const mockServer: BunServer = {
 };
 const mockServe = mock<(options: BunServeOptions) => BunServer>(() => mockServer);
 
-// Save original so we can restore after tests
-const originalServe = Bun.serve;
+// Save original so we can restore after tests (only when Bun is available)
+const originalServe = hasBun ? Bun.serve : undefined;
 
 beforeEach(() => {
+  if (!hasBun) return;
   // Override Bun.serve with our mock (Bun.serve is writable)
   (Bun as Record<string, unknown>).serve = mockServe;
 });
 
 afterEach(() => {
+  if (!hasBun) return;
   mockServe.mockClear();
   mockStop.mockClear();
   // Restore original Bun.serve
   (Bun as Record<string, unknown>).serve = originalServe;
 });
 
-describe('createBunAdapter', () => {
+describe.skipIf(!hasBun)('createBunAdapter', () => {
   describe('listen', () => {
     it('passes the port and handler to Bun.serve', async () => {
       const adapter = createBunAdapter();

--- a/packages/server/src/agent/route-generator.ts
+++ b/packages/server/src/agent/route-generator.ts
@@ -91,7 +91,7 @@ export function generateAgentRoutes(
     routes.push({
       method: 'POST',
       path: routePath,
-      handler: async (ctx) => {
+      handler: async (ctx: Record<string, unknown>) => {
         try {
           // Build context for access evaluation
           const userId = (ctx.userId as string | null | undefined) ?? null;

--- a/packages/server/src/entity/route-generator.ts
+++ b/packages/server/src/entity/route-generator.ts
@@ -229,7 +229,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'GET',
         path: basePath,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const query = (ctx.query ?? {}) as Record<string, string>;
@@ -295,7 +295,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'POST',
         path: `${basePath}/query`,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const body = (ctx.body ?? {}) as Record<string, unknown>;
@@ -416,7 +416,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'GET',
         path: `${basePath}${idPath}`,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const id = extractEntityId(ctx);
@@ -498,7 +498,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'POST',
         path: basePath,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const data = (ctx.body ?? {}) as Record<string, unknown>;
@@ -553,7 +553,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'PATCH',
         path: `${basePath}${idPath}`,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const id = extractEntityId(ctx);
@@ -609,7 +609,7 @@ export function generateEntityRoutes(
       routes.push({
         method: 'DELETE',
         path: `${basePath}${idPath}`,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const id = extractEntityId(ctx);
@@ -669,7 +669,7 @@ export function generateEntityRoutes(
       routes.push({
         method,
         path: actionPath,
-        handler: async (ctx) => {
+        handler: async (ctx: Record<string, unknown>) => {
           try {
             const entityCtx = makeEntityCtx(ctx);
             const id = hasId ? extractEntityId(ctx) : null;

--- a/packages/server/src/service/route-generator.ts
+++ b/packages/server/src/service/route-generator.ts
@@ -110,7 +110,7 @@ export function generateServiceRoutes(
     routes.push({
       method,
       path: routePath,
-      handler: async (ctx) => {
+      handler: async (ctx: Record<string, unknown>) => {
         try {
           const requestInfo = extractRequestInfo(ctx);
           const raw = ctx.raw as { url?: string; method?: string; headers?: Headers } | undefined;

--- a/packages/test/src/__tests__/exports.test.ts
+++ b/packages/test/src/__tests__/exports.test.ts
@@ -31,8 +31,10 @@ import type {
 // --- Bun runtime bridge ---
 // When running under `bun test`, @vertz/test re-exports from bun:test.
 // These tests verify the bridge works correctly.
+// Skip under vtz test — require() + bun:test bridge is Bun-specific.
+const hasBun = typeof globalThis.Bun !== 'undefined';
 
-describe('@vertz/test Bun bridge', () => {
+describe.skipIf(!hasBun)('@vertz/test Bun bridge', () => {
   it('describe is a function from bun:test', () => {
     const mod = require('../index');
     expect(typeof mod.describe).toBe('function');


### PR DESCRIPTION
## Summary

- Remove `set +eo pipefail`, `|| true`, and timeout wrappers from CI workflows that were masking test failures, causing CI to report success even when tests fail
- Add `.github/` to change detection `CONFIG_PATTERNS` so workflow file changes trigger CI
- Skip Bun-specific tests (`bun-adapter`, `@vertz/test` Bun bridge) when running under the vtz runtime
- Fix implicit `any` type errors in `@vertz/server` route generators flagged by `tsgo` strict mode

## Files Changed

- [`.github/workflows/ci.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/.github/workflows/ci.yml) — remove workarounds, add `.github/` to config patterns
- [`.github/workflows/coverage.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/.github/workflows/coverage.yml) — remove `|| true`, add proper failure tracking
- [`packages/core/src/app/__tests__/bun-adapter.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/packages/core/src/app/__tests__/bun-adapter.test.ts) — skip when Bun not available
- [`packages/test/src/__tests__/exports.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/packages/test/src/__tests__/exports.test.ts) — skip Bun bridge tests on vtz
- [`packages/server/src/agent/route-generator.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/packages/server/src/agent/route-generator.ts) — add `ctx` type annotation
- [`packages/server/src/entity/route-generator.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/packages/server/src/entity/route-generator.ts) — add `ctx` type annotations (7 handlers)
- [`packages/server/src/service/route-generator.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/ci-false-success/packages/server/src/service/route-generator.ts) — add `ctx` type annotation

## Related Issues

- Closes #2537
- Created #2643 (pre-push hook is a no-op — deferred until test failures resolved)
- Created #2644 (vtz install doesn't install platform-specific optional deps)
- Tracked test failures: #2631, #2632, #2633, #2634, #2635, #2636, #2609, #2610

## Test plan

- [x] CI now properly reports test failures instead of masking them
- [x] Change detection triggers on `.github/` file changes
- [x] Bun-specific tests skip gracefully on vtz runtime
- [x] `@vertz/server` typecheck passes with `tsgo --noEmit`
- [ ] GitHub CI completes and reports accurate results

🤖 Generated with [Claude Code](https://claude.com/claude-code)