### PR TITLE
fix(runtime): fix strip_leftover_typescript scoping bug (#2576)

### DIFF
--- a/.changeset/fix-strip-leftover-nesting.md
+++ b/.changeset/fix-strip-leftover-nesting.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix scoping bug where object properties inside nested parentheses were incorrectly stripped as TypeScript type annotations, causing `await expect(fn({key: Value})).rejects.toThrow()` to fail with "key is not defined"

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -608,12 +608,14 @@ fn strip_leftover_typescript(code: &str) -> String {
     let chars: Vec<char> = code.chars().collect();
     let len = chars.len();
     let mut i = 0;
-    // Track nesting depth to distinguish function params `(...)` from object literals `{...}`.
-    // NOTE: This depth tracking does not skip string literals, template literals, or comments.
-    // An unbalanced `{` or `(` inside a string could throw off counts. In practice this runs
-    // on compiled output where most type annotations are already gone, so the risk is minimal.
-    let mut paren_depth: i32 = 0;
-    let mut brace_depth: i32 = 0;
+    // Track nesting context with a stack to distinguish function params `(...)`
+    // from object literals `{...}`. Each entry is '(' or '{'.
+    // The old approach used flat depth counters (paren_depth > brace_depth) which
+    // broke when an object literal was nested inside multiple parens, e.g.:
+    //   expect(fn({ key: Value }))  →  paren=2, brace=1  →  incorrectly stripped `: Value`
+    // The stack approach checks the INNERMOST context: if the top of the stack is '{',
+    // we're inside an object literal and `: Value` is a property, not a type annotation.
+    let mut nesting_stack: Vec<char> = Vec::new();
 
     while i < len {
         // Skip string literals so unbalanced braces/parens inside them don't affect depth.
@@ -639,14 +641,25 @@ fn strip_leftover_typescript(code: &str) -> String {
             continue;
         }
 
-        // Track paren/brace depth for context-awareness
+        // Track nesting context with a stack
         match chars[i] {
-            '(' => paren_depth += 1,
-            ')' => paren_depth -= 1,
-            '{' => brace_depth += 1,
-            '}' => brace_depth -= 1,
+            '(' | '{' => nesting_stack.push(chars[i]),
+            ')' => {
+                if nesting_stack.last() == Some(&'(') {
+                    nesting_stack.pop();
+                }
+            }
+            '}' => {
+                if nesting_stack.last() == Some(&'{') {
+                    nesting_stack.pop();
+                }
+            }
             _ => {}
         }
+
+        // The innermost nesting context determines whether `:` is a type annotation
+        // (inside parens) or a property separator (inside braces).
+        let innermost_is_paren = nesting_stack.last() == Some(&'(');
 
         // Fix 1: Strip `?` before `)` or `,` in parameter lists.
         // Pattern: <identifier>?<whitespace*>) or <identifier>?<whitespace*>,
@@ -661,10 +674,10 @@ fn strip_leftover_typescript(code: &str) -> String {
 
         // Fix 2: Strip `: TypeName` or `: TypeName<Generic>` in function params.
         // Pattern: <identifier>: <UpperCaseName> immediately followed by ) or ,
-        // Only apply when deeper in parens than braces — inside object literals
-        // `{ key: Value, }` the colon separates a property key from a value.
-        // In `fn(x: Type)` paren_depth > brace_depth; in `fn({ k: V })` it's not.
-        if chars[i] == ':' && i > 0 && is_ident(chars[i - 1]) && paren_depth > brace_depth {
+        // Only apply when the innermost nesting context is a paren `(` — that means
+        // we're inside a function parameter list. If the innermost context is a brace
+        // `{`, we're inside an object literal where `:` separates key from value.
+        if chars[i] == ':' && i > 0 && is_ident(chars[i - 1]) && innermost_is_paren {
             let after_colon = skip_ws(&chars, i + 1, len);
             if after_colon < len && chars[after_colon].is_uppercase() {
                 // Read the type name (including generics)
@@ -2303,6 +2316,46 @@ export function App() {
         assert!(
             result.contains("schema: Schema"),
             "Destructured object param value should be preserved. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_leftover_preserves_object_in_nested_parens() {
+        // #2576: Object literal inside nested parens must NOT have property
+        // values stripped. `expect(fn({ key: Value }))` has paren_depth=2
+        // and brace_depth=1 — the old paren_depth > brace_depth check
+        // incorrectly stripped `: Value`.
+        let code =
+            "await expect(asyncFn({ toolCtx: OUTER_VALUE, msg: 'test' })).rejects.toThrow('x');";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            result.contains("toolCtx: OUTER_VALUE"),
+            "Object property in nested parens should be preserved. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_leftover_preserves_object_in_deeply_nested_parens() {
+        // Even deeper nesting: 3 parens, 1 brace
+        let code = "outer(middle(inner({ key: Value, other: Another })))";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            result.contains("key: Value") && result.contains("other: Another"),
+            "Object properties in deeply nested parens should be preserved. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_strip_leftover_strips_type_in_arrow_inside_parens() {
+        // Arrow function param inside parens: `((x: Type) => x)` — still strip `: Type`
+        let code = "const fn = ((x: Foo) => x);";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            !result.contains(": Foo"),
+            "Type annotation in arrow param inside parens should be stripped. Got: {}",
             result
         );
     }

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -900,4 +900,104 @@ mod tests {
         assert_eq!(result.passed(), 3, "Tests: {:?}", result.tests);
         assert_eq!(result.failed(), 0);
     }
+
+    /// Reproduces #2576: `expect(asyncFn({...})).rejects.toThrow()` fails with
+    /// a scoping error when the async call is inlined, but works when extracted
+    /// to a `const` first. The bug is in the compilation pipeline, not the test
+    /// harness (pure JS inline works fine — see globals.rs test).
+    #[test]
+    fn test_rejects_to_throw_inline_async_call_compiled() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Source module: async function that destructures and uses its arg
+        let source_file = tmp.path().join("async-fn.ts");
+        fs::write(
+            &source_file,
+            r#"
+export interface Options {
+  toolCtx: { id: string; name: string };
+  msg: string;
+  compress?: () => string[];
+}
+
+export async function asyncFnThatThrows(options: Options): Promise<void> {
+  const { toolCtx, msg, compress } = options;
+  // Use the destructured variable
+  if (!toolCtx || !toolCtx.id) {
+    throw new Error('toolCtx is not defined or missing id');
+  }
+  // Simulate async work
+  await new Promise<void>((r) => setTimeout(r, 1));
+  // Compression check (mirrors reactLoop's pattern)
+  if (compress) {
+    const result = compress();
+    if (result.length === 0) {
+      throw new Error('Compression returned empty: ' + msg);
+    }
+  }
+  throw new Error('Expected rejection: ' + msg);
+}
+"#,
+        )
+        .unwrap();
+
+        // Test file: both inline and extracted patterns
+        let file = write_test_file(
+            tmp.path(),
+            "async-fn.test.ts",
+            r#"
+import { asyncFnThatThrows } from './async-fn';
+
+const OUTER_VALUE = { id: 'test-id', name: 'test' };
+
+describe('rejects.toThrow with inline async call (#2576)', () => {
+    it('works with extracted const', async () => {
+        const promise = asyncFnThatThrows({
+            toolCtx: OUTER_VALUE,
+            msg: 'extracted test',
+        });
+        await expect(promise).rejects.toThrow('Expected rejection: extracted test');
+    });
+
+    it('works with inline call', async () => {
+        await expect(
+            asyncFnThatThrows({
+                toolCtx: OUTER_VALUE,
+                msg: 'inline test',
+            }),
+        ).rejects.toThrow('Expected rejection: inline test');
+    });
+
+    it('works with complex nested object inline', async () => {
+        await expect(
+            asyncFnThatThrows({
+                toolCtx: OUTER_VALUE,
+                msg: 'complex test',
+                compress: () => [],
+            }),
+        ).rejects.toThrow('Compression returned empty: complex test');
+    });
+});
+"#,
+        );
+
+        let result = execute_test_file(&file);
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        for test in &result.tests {
+            assert_eq!(
+                test.status,
+                TestStatus::Pass,
+                "Test '{}' failed: {:?}",
+                test.name,
+                test.error
+            );
+        }
+        assert_eq!(result.passed(), 3, "Tests: {:?}", result.tests);
+        assert_eq!(result.failed(), 0);
+    }
 }

--- a/packages/agents/src/loop/react-loop.test.ts
+++ b/packages/agents/src/loop/react-loop.test.ts
@@ -1060,20 +1060,20 @@ describe('reactLoop()', () => {
           { text: 'Done' },
         ]);
 
-        const promise = reactLoop({
-          llm,
-          tools: { noop },
-          systemPrompt: 'You are helpful.',
-          userMessage: 'Do stuff',
-          maxIterations: 10,
-          toolContext: TEST_TOOL_CONTEXT,
-          contextCompression: {
-            maxMessages: 5,
-            compress: () => [],
-          },
-        });
-
-        await expect(promise).rejects.toThrow('Context compression returned empty message array');
+        await expect(
+          reactLoop({
+            llm,
+            tools: { noop },
+            systemPrompt: 'You are helpful.',
+            userMessage: 'Do stuff',
+            maxIterations: 10,
+            toolContext: TEST_TOOL_CONTEXT,
+            contextCompression: {
+              maxMessages: 5,
+              compress: () => [],
+            },
+          }),
+        ).rejects.toThrow('Context compression returned empty message array');
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fix scoping bug in `strip_leftover_typescript()` where object property values inside nested parentheses were incorrectly stripped as TypeScript type annotations
- Replace flat `paren_depth > brace_depth` heuristic with a nesting stack that checks the innermost context
- Revert workaround in `react-loop.test.ts` from PR #2548

## Root Cause

The post-processing function `strip_leftover_typescript()` in [`native/vtz/src/compiler/pipeline.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-rejects-toThrow/native/vtz/src/compiler/pipeline.rs) used flat depth counters to decide when `:` was a TypeScript type annotation vs. an object property separator. The heuristic `paren_depth > brace_depth` failed for patterns like:

```ts
await expect(reactLoop({ toolContext: TEST_TOOL_CONTEXT })).rejects.toThrow('msg');
```

Here `paren_depth=2` (from `expect(` and `reactLoop(`) and `brace_depth=1` (from `{`), so `2 > 1 = true` — incorrectly stripping `: TEST_TOOL_CONTEXT` and turning `toolContext: TEST_TOOL_CONTEXT` into shorthand `toolContext` (referencing a non-existent variable).

## Fix

Replaced flat counters with a `Vec<char>` nesting stack. Now checks `nesting_stack.last() == Some(&'(')` — only strips `: TypeName` when the **innermost** context is a paren (function params), not a brace (object literal).

## Public API Changes

None — internal compiler post-processing fix only.

## Test Plan

- [x] 3 new Rust regression tests in `pipeline.rs` (nested parens, deep nesting, arrow inside parens)
- [x] 1 new E2E integration test in `executor.rs` (full compile + execute with both inline and extracted patterns)
- [x] Reverted workaround in `react-loop.test.ts` — the previously failing test now passes
- [x] All 3278 Rust tests pass
- [x] Clippy clean, fmt clean
- [x] TypeScript tests pass (181 passed, 0 failed in agents package)

Closes #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)