### PR TITLE
fix(mdx): remove Bun dependency from @vertz/mdx (#2611)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -512,12 +512,10 @@
         "unified": "^11.0.0",
       },
       "devDependencies": {
-        "@types/bun": "latest",
         "@types/node": "^25.3.1",
         "@vertz/build": "workspace:^",
         "@vertz/test": "workspace:*",
         "@vertz/ui-server": "workspace:^",
-        "bun-types": "^1.3.10",
         "typescript": "^5.7.0",
       },
     },
@@ -3142,8 +3140,6 @@
     "@vertz/landing-nextjs/wrangler": ["wrangler@4.72.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260310.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260310.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260310.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg=="],
 
     "@vertz/landing-nextjs-vercel/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
-
-    "@vertz/mdx/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/runtime/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vertz/mdx",
   "version": "0.1.0",
-  "description": "MDX support for Vertz — Bun plugin that compiles .mdx files to Vertz components",
+  "description": "MDX support for Vertz — compiles .mdx files to Vertz components",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -39,12 +39,10 @@
     "unified": "^11.0.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
     "@types/node": "^25.3.1",
     "@vertz/build": "workspace:^",
     "@vertz/test": "workspace:*",
     "@vertz/ui-server": "workspace:^",
-    "bun-types": "^1.3.10",
     "typescript": "^5.7.0"
   },
   "engines": {

--- a/packages/mdx/src/__tests__/plugin.test.ts
+++ b/packages/mdx/src/__tests__/plugin.test.ts
@@ -1,91 +1,61 @@
+import { writeFile } from 'node:fs/promises';
 import { beforeAll, describe, expect, it } from '@vertz/test';
+import { compileMdx } from '../compile-mdx';
 import { createMdxPlugin } from '../index';
 
-// Pre-created plugin instances — reuse Shiki highlighter across tests.
-// Without this, each test creates a new plugin instance that re-initializes
-// Shiki's WASM + grammar loading, causing >30s timeouts on CI runners.
-const defaultPlugin = createMdxPlugin();
-const jsxImportSourcePlugin = createMdxPlugin({ jsxImportSource: '@vertz/ui-server' });
-const noFrontmatterPlugin = createMdxPlugin({ remarkFrontmatter: false });
-const noShikiPlugin = createMdxPlugin({ shikiTheme: false });
-
-// Helper: resolve a pre-created plugin for the given options, or create a new one.
-function resolvePlugin(options?: Parameters<typeof createMdxPlugin>[0]) {
-  if (!options) return defaultPlugin;
-  // Match known option combinations to pre-created instances
-  if (options.jsxImportSource === '@vertz/ui-server' && Object.keys(options).length === 1)
-    return jsxImportSourcePlugin;
-  if (options.remarkFrontmatter === false && Object.keys(options).length === 1)
-    return noFrontmatterPlugin;
-  if (options.shikiTheme === false && Object.keys(options).length === 1) return noShikiPlugin;
-  // Empty remarkPlugins/rehypePlugins arrays are semantically identical to default
-  const isEmptyArrayOnly =
-    Object.keys(options).length === 1 &&
-    (('remarkPlugins' in options &&
-      Array.isArray(options.remarkPlugins) &&
-      options.remarkPlugins.length === 0) ||
-      ('rehypePlugins' in options &&
-        Array.isArray(options.rehypePlugins) &&
-        options.rehypePlugins.length === 0));
-  if (isEmptyArrayOnly) return defaultPlugin;
-  // Unknown combination — create a new plugin (will cold-init Shiki if enabled)
-  return createMdxPlugin(options);
-}
-
-// Helper: build an MDX file through the plugin, marking jsx-runtime as external.
-async function buildMdx(content: string, options?: Parameters<typeof createMdxPlugin>[0]) {
-  const path = `/tmp/vertz-mdx-test-${Date.now()}-${Math.random().toString(36).slice(2)}.mdx`;
-  await Bun.write(path, content);
-
-  const result = await Bun.build({
-    entrypoints: [path],
-    plugins: [resolvePlugin(options)],
-    target: 'bun',
-    external: ['@vertz/ui', '@vertz/ui-server'],
-  });
-
-  if (!result.success) {
-    throw new Error(`Build failed: ${result.logs.map((l) => l.message).join('\n')}`);
-  }
-
-  return result.outputs[0]?.text() ?? '';
-}
-
 describe('createMdxPlugin', () => {
-  it('returns a BunPlugin with name "vertz-mdx"', () => {
+  it('returns a plugin with name "vertz-mdx"', () => {
     const plugin = createMdxPlugin();
     expect(plugin.name).toBe('vertz-mdx');
     expect(plugin.setup).toBeFunction();
   });
+
+  it('onLoad reads a file and compiles MDX', async () => {
+    const plugin = createMdxPlugin({ shikiTheme: false });
+    let onLoadCallback:
+      | ((args: { path: string }) => Promise<{ contents: string; loader: string }>)
+      | undefined;
+
+    plugin.setup({
+      onLoad(_opts, cb) {
+        onLoadCallback = cb;
+      },
+    });
+
+    const tmpPath = `/tmp/vertz-mdx-onload-${Date.now()}.mdx`;
+    await writeFile(tmpPath, '# Plugin Test');
+    const result = await onLoadCallback!({ path: tmpPath });
+    expect(result.loader).toBe('js');
+    expect(result.contents).toContain('MDXContent');
+  });
 });
 
-describe('MDX compilation via Bun plugin', () => {
-  // Pre-warm ALL Shiki-enabled plugins: first Bun.build() + Shiki WASM init is
-  // slow on CI runners (~15-30s per instance). Paying the cost here prevents
-  // individual tests from timing out. noShikiPlugin doesn't need warm-up.
+describe('MDX compilation via compileMdx', () => {
+  // Pre-warm Shiki: first call initializes WASM + grammar loading (~15-30s on CI).
+  // Paying the cost here prevents individual tests from timing out.
   beforeAll(async () => {
     await Promise.all([
-      buildMdx('# warm-default'),
-      buildMdx('# warm-jsx', { jsxImportSource: '@vertz/ui-server' }),
-      buildMdx('# warm-no-frontmatter', { remarkFrontmatter: false }),
+      compileMdx('# warm-default'),
+      compileMdx('# warm-jsx', { jsxImportSource: '@vertz/ui-server' }),
+      compileMdx('# warm-no-frontmatter', { remarkFrontmatter: false }),
     ]);
   }, 120_000);
 
   it('compiles a simple MDX file to a JS module with MDXContent', async () => {
-    const output = await buildMdx('# Hello World\n\nA paragraph.');
+    const output = await compileMdx('# Hello World\n\nA paragraph.');
 
     expect(output).toContain('MDXContent');
     expect(output).toMatch(/jsx|jsxs|Fragment/);
   });
 
   it('defaults jsxImportSource to @vertz/ui', async () => {
-    const output = await buildMdx('# Hello');
+    const output = await compileMdx('# Hello');
 
     expect(output).toContain('@vertz/ui/jsx-runtime');
   });
 
   it('compiles with custom jsxImportSource when specified', async () => {
-    const output = await buildMdx('# Hello', {
+    const output = await compileMdx('# Hello', {
       jsxImportSource: '@vertz/ui-server',
     });
 
@@ -93,7 +63,7 @@ describe('MDX compilation via Bun plugin', () => {
   });
 
   it('extracts frontmatter as a named export', async () => {
-    const output = await buildMdx(`---
+    const output = await compileMdx(`---
 title: Button
 description: A button component.
 ---
@@ -106,7 +76,7 @@ description: A button component.
   });
 
   it('disables frontmatter extraction when remarkFrontmatter is false', async () => {
-    const output = await buildMdx(
+    const output = await compileMdx(
       `---
 title: NoExtract
 ---
@@ -120,7 +90,7 @@ title: NoExtract
   });
 
   it('applies Shiki syntax highlighting to code fences', async () => {
-    const output = await buildMdx(`# Code
+    const output = await compileMdx(`# Code
 
 \`\`\`tsx
 const x: number = 42;
@@ -133,7 +103,7 @@ const x: number = 42;
   });
 
   it('disables Shiki when shikiTheme is false', async () => {
-    const output = await buildMdx(
+    const output = await compileMdx(
       `# Code
 
 \`\`\`tsx
@@ -150,61 +120,38 @@ const x = 1;
   });
 
   it('passes custom remark plugins through', async () => {
-    // Verify it doesn't crash with empty plugins array
-    const output = await buildMdx('# Test', { remarkPlugins: [] });
+    const output = await compileMdx('# Test', { remarkPlugins: [] });
     expect(output).toContain('MDXContent');
   });
 
   it('passes custom rehype plugins through', async () => {
-    // Verify it doesn't crash with empty plugins array
-    const output = await buildMdx('# Test', { rehypePlugins: [] });
+    const output = await compileMdx('# Test', { rehypePlugins: [] });
     expect(output).toContain('MDXContent');
   });
 
-  it('fails build on malformed MDX with unclosed JSX', async () => {
-    await expect(buildMdx('<div>unclosed')).rejects.toThrow();
+  it('fails on malformed MDX with unclosed JSX', async () => {
+    await expect(compileMdx('<div>unclosed')).rejects.toThrow();
   });
 });
 
 describe('dual Shiki theme support', () => {
-  const dualThemePlugin = createMdxPlugin({
-    shikiTheme: { light: 'github-light', dark: 'github-dark' },
-  });
+  const dualThemeOptions = {
+    shikiTheme: { light: 'github-light', dark: 'github-dark' } as const,
+  };
 
   beforeAll(async () => {
-    const path = `/tmp/vertz-mdx-dual-warm-${Date.now()}.mdx`;
-    await Bun.write(path, '# warm');
-    await Bun.build({
-      entrypoints: [path],
-      plugins: [dualThemePlugin],
-      target: 'bun',
-      external: ['@vertz/ui'],
-    });
+    await compileMdx('# warm', dualThemeOptions);
   }, 120_000);
 
   it('produces CSS variable-based dual theme output', async () => {
-    const path = `/tmp/vertz-mdx-dual-${Date.now()}.mdx`;
-    await Bun.write(
-      path,
+    const output = await compileMdx(
       `# Code
 
 \`\`\`ts
 const x: number = 42;
 \`\`\``,
+      dualThemeOptions,
     );
-
-    const result = await Bun.build({
-      entrypoints: [path],
-      plugins: [dualThemePlugin],
-      target: 'bun',
-      external: ['@vertz/ui'],
-    });
-
-    if (!result.success) {
-      throw new Error(`Build failed: ${result.logs.map((l) => l.message).join('\n')}`);
-    }
-
-    const output = await result.outputs[0]!.text();
 
     // Dual theme uses CSS variables like --shiki-light and --shiki-dark
     expect(output).toContain('--shiki-');

--- a/packages/mdx/src/compile-mdx.ts
+++ b/packages/mdx/src/compile-mdx.ts
@@ -1,0 +1,110 @@
+import type { PluggableList } from 'unified';
+
+export interface MdxPluginOptions {
+  /** JSX import source for the compiled output. Defaults to '@vertz/ui'. */
+  jsxImportSource?: string;
+  /** Remark plugins to apply during MDX compilation. */
+  remarkPlugins?: PluggableList;
+  /** Rehype plugins to apply during MDX compilation. */
+  rehypePlugins?: PluggableList;
+  /** Whether to extract YAML frontmatter. Defaults to true. */
+  remarkFrontmatter?: boolean;
+  /**
+   * Shiki theme for code fence highlighting.
+   * - `string` — single theme name (e.g., 'github-dark')
+   * - `{ light: string; dark: string }` — dual theme using CSS variables
+   * - `false` — disable syntax highlighting
+   * Defaults to 'github-dark'.
+   */
+  shikiTheme?: string | { light: string; dark: string } | false;
+  /** Languages to load for Shiki highlighting. Defaults to ['tsx', 'ts', 'bash', 'json']. */
+  shikiLangs?: string[];
+}
+
+// Module-level highlighter cache keyed by sorted theme names.
+// Avoids re-initializing Shiki WASM + grammar loading on every call.
+const highlighterCache = new Map<string, Promise<unknown>>();
+
+function getOrCreateHighlighter(themeNames: string[], shikiLangs: string[]): Promise<unknown> {
+  const key = [...themeNames].sort().join(',') + '|' + [...shikiLangs].sort().join(',');
+  let promise = highlighterCache.get(key);
+  if (!promise) {
+    promise = (async () => {
+      const { createHighlighter } = await import('shiki');
+      return createHighlighter({ themes: themeNames, langs: shikiLangs });
+    })().catch((err) => {
+      highlighterCache.delete(key);
+      throw err;
+    });
+    highlighterCache.set(key, promise);
+  }
+  return promise;
+}
+
+/**
+ * Compile MDX source to a JS module string.
+ *
+ * Runtime-agnostic — no Bun or Node.js file system access.
+ * Takes an MDX source string and returns compiled JavaScript.
+ */
+export async function compileMdx(source: string, options?: MdxPluginOptions): Promise<string> {
+  const jsxImportSource = options?.jsxImportSource ?? '@vertz/ui';
+  const enableFrontmatter = options?.remarkFrontmatter !== false;
+  const shikiLangs = options?.shikiLangs ?? ['tsx', 'ts', 'bash', 'json'];
+
+  const rawTheme = options?.shikiTheme;
+  const isDualTheme = typeof rawTheme === 'object' && rawTheme !== null && 'light' in rawTheme;
+  const shikiEnabled = rawTheme !== false;
+  const themeNames: string[] = isDualTheme
+    ? [rawTheme.light, rawTheme.dark]
+    : shikiEnabled
+      ? [typeof rawTheme === 'string' ? rawTheme : 'github-dark']
+      : [];
+
+  const { compile } = await import('@mdx-js/mdx');
+
+  // Build remark plugins
+  const remarkPlugins: PluggableList = [...(options?.remarkPlugins ?? [])];
+  if (enableFrontmatter) {
+    const { default: remarkFrontmatter } = await import('remark-frontmatter');
+    const { default: remarkMdxFrontmatter } = await import('remark-mdx-frontmatter');
+    remarkPlugins.push(remarkFrontmatter, remarkMdxFrontmatter);
+  }
+
+  // Build rehype plugins
+  const rehypePlugins: PluggableList = [...(options?.rehypePlugins ?? [])];
+  if (shikiEnabled && themeNames.length > 0) {
+    const highlighter = await getOrCreateHighlighter(themeNames, shikiLangs);
+    const { default: rehypeShiki } = await import('@shikijs/rehype');
+
+    if (isDualTheme) {
+      rehypePlugins.push([
+        rehypeShiki,
+        {
+          highlighter,
+          themes: { light: rawTheme.light, dark: rawTheme.dark },
+          defaultColor: false,
+        },
+      ]);
+    } else {
+      rehypePlugins.push([
+        rehypeShiki,
+        {
+          highlighter,
+          themes: { dark: themeNames[0] },
+          defaultColor: 'dark',
+        },
+      ]);
+    }
+  }
+
+  const compiled = await compile(source, {
+    jsxImportSource,
+    outputFormat: 'program',
+    development: false,
+    remarkPlugins,
+    rehypePlugins,
+  });
+
+  return String(compiled);
+}

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -1,2 +1,4 @@
-export type { MdxPluginOptions } from './plugin';
+export type { MdxPluginOptions } from './compile-mdx';
+export { compileMdx } from './compile-mdx';
+export type { MdxPlugin } from './plugin';
 export { createMdxPlugin } from './plugin';

--- a/packages/mdx/src/plugin.ts
+++ b/packages/mdx/src/plugin.ts
@@ -1,120 +1,36 @@
-import type { BunPlugin } from 'bun';
-import type { PluggableList } from 'unified';
+import { readFile } from 'node:fs/promises';
+import type { MdxPluginOptions } from './compile-mdx';
+import { compileMdx } from './compile-mdx';
 
-export interface MdxPluginOptions {
-  /** JSX import source for the compiled output. Defaults to '@vertz/ui'. */
-  jsxImportSource?: string;
-  /** Remark plugins to apply during MDX compilation. */
-  remarkPlugins?: PluggableList;
-  /** Rehype plugins to apply during MDX compilation. */
-  rehypePlugins?: PluggableList;
-  /** Whether to extract YAML frontmatter. Defaults to true. */
-  remarkFrontmatter?: boolean;
-  /**
-   * Shiki theme for code fence highlighting.
-   * - `string` — single theme name (e.g., 'github-dark')
-   * - `{ light: string; dark: string }` — dual theme using CSS variables
-   * - `false` — disable syntax highlighting
-   * Defaults to 'github-dark'.
-   */
-  shikiTheme?: string | { light: string; dark: string } | false;
-  /** Languages to load for Shiki highlighting. Defaults to ['tsx', 'ts', 'bash', 'json']. */
-  shikiLangs?: string[];
+/** Minimal plugin interface compatible with Bun's build plugin system. */
+export interface MdxPlugin {
+  name: string;
+  setup(build: {
+    onLoad(
+      options: { filter: RegExp },
+      callback: (args: { path: string }) => Promise<{ contents: string; loader: string }>,
+    ): void;
+  }): void;
 }
 
 /**
- * Create a Bun plugin that compiles `.mdx` files to Vertz-compatible JS modules.
+ * Create a build plugin that compiles `.mdx` files to Vertz-compatible JS modules.
  *
  * Uses `@mdx-js/mdx` for compilation with:
  * - `jsxImportSource` targeting Vertz's JSX runtime (client or server)
  * - Frontmatter extraction via remark-frontmatter + remark-mdx-frontmatter
  * - Code fence highlighting via @shikijs/rehype + Shiki
  */
-export function createMdxPlugin(options?: MdxPluginOptions): BunPlugin {
-  const jsxImportSource = options?.jsxImportSource ?? '@vertz/ui';
-  const enableFrontmatter = options?.remarkFrontmatter !== false;
-  const shikiLangs = options?.shikiLangs ?? ['tsx', 'ts', 'bash', 'json'];
-
-  // Resolve theme configuration
-  const rawTheme = options?.shikiTheme;
-  const isDualTheme = typeof rawTheme === 'object' && rawTheme !== null && 'light' in rawTheme;
-  const shikiEnabled = rawTheme !== false;
-  const themeNames: string[] = isDualTheme
-    ? [rawTheme.light, rawTheme.dark]
-    : shikiEnabled
-      ? [typeof rawTheme === 'string' ? rawTheme : 'github-dark']
-      : [];
-
-  // Shared highlighter instance — created lazily on first .mdx load
-  let highlighterPromise: Promise<unknown> | null = null;
-
+export function createMdxPlugin(options?: MdxPluginOptions): MdxPlugin {
   return {
     name: 'vertz-mdx',
     setup(build) {
       build.onLoad({ filter: /\.mdx$/ }, async (args) => {
-        const source = await Bun.file(args.path).text();
-        const { compile } = await import('@mdx-js/mdx');
-
-        // Build remark plugins
-        const remarkPlugins: PluggableList = [...(options?.remarkPlugins ?? [])];
-        if (enableFrontmatter) {
-          const { default: remarkFrontmatter } = await import('remark-frontmatter');
-          const { default: remarkMdxFrontmatter } = await import('remark-mdx-frontmatter');
-          remarkPlugins.push(remarkFrontmatter, remarkMdxFrontmatter);
-        }
-
-        // Build rehype plugins
-        const rehypePlugins: PluggableList = [...(options?.rehypePlugins ?? [])];
-        if (shikiEnabled && themeNames.length > 0) {
-          // Create shared highlighter on first use
-          if (!highlighterPromise) {
-            highlighterPromise = (async () => {
-              const { createHighlighter } = await import('shiki');
-              return createHighlighter({
-                themes: themeNames,
-                langs: shikiLangs,
-              });
-            })().catch((err) => {
-              highlighterPromise = null;
-              throw err;
-            });
-          }
-          const highlighter = await highlighterPromise;
-          const { default: rehypeShiki } = await import('@shikijs/rehype');
-
-          if (isDualTheme) {
-            // Dual theme: CSS variables for light/dark switching
-            rehypePlugins.push([
-              rehypeShiki,
-              {
-                highlighter,
-                themes: { light: rawTheme.light, dark: rawTheme.dark },
-                defaultColor: false,
-              },
-            ]);
-          } else {
-            // Single theme: direct color output
-            rehypePlugins.push([
-              rehypeShiki,
-              {
-                highlighter,
-                themes: { dark: themeNames[0] },
-                defaultColor: 'dark',
-              },
-            ]);
-          }
-        }
-
-        const compiled = await compile(source, {
-          jsxImportSource,
-          outputFormat: 'program',
-          development: false,
-          remarkPlugins,
-          rehypePlugins,
-        });
+        const source = await readFile(args.path, 'utf-8');
+        const contents = await compileMdx(source, options);
 
         return {
-          contents: String(compiled),
+          contents,
           loader: 'js',
         };
       });

--- a/packages/mdx/tsconfig.json
+++ b/packages/mdx/tsconfig.json
@@ -5,7 +5,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"]
+    "types": ["@types/node"]
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"],
   "extends": "../../tsconfig.json",


### PR DESCRIPTION
## Summary

- Extracts runtime-agnostic `compileMdx()` function from the Bun-specific plugin wrapper
- Tests now call `compileMdx()` directly instead of `Bun.build()` / `Bun.write()` / `Bun.file()`
- Removes `@types/bun` and `bun-types` dev dependencies from `@vertz/mdx`
- `createMdxPlugin()` uses `readFile` from `node:fs/promises` instead of `Bun.file().text()`

## Public API Changes

- **New export:** `compileMdx(source: string, options?: MdxPluginOptions): Promise<string>` — runtime-agnostic MDX compilation
- **New export:** `MdxPlugin` interface — replaces `BunPlugin` from `bun` types (structurally compatible)
- **Breaking:** `createMdxPlugin()` return type changed from `BunPlugin` to `MdxPlugin` (structurally compatible, no runtime change)

## Test plan

- [x] 14 tests pass on `vtz test` (all `Bun.*` globals removed)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] Lint/format clean (`oxlint` + `oxfmt`)
- [x] `createMdxPlugin` `onLoad` handler tested via mock build object
- [ ] Verify `ssr-integration.test.ts` failure is pre-existing (encoding `latin1` unsupported in vtz)

Fixes #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)