### PR TITLE
fix(runtime): add vm module to ESM resolution layer

### DIFF
--- a/.changeset/fix-vm-module-esm.md
+++ b/.changeset/fix-vm-module-esm.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Add `vm` module to ESM resolution layer and add `isContext` to both CJS and ESM implementations, fixing happy-dom test failures under `vtz test`

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1800,11 +1800,14 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
         return { serialize: () => new Uint8Array(0), deserialize: () => undefined };
       }
       case 'vm': {
+        const _vmContexts = new WeakSet();
+        function _vmCreateContext(sandbox) { const ctx = sandbox || {}; _vmContexts.add(ctx); return ctx; }
         return {
-          createContext: (sandbox) => sandbox || {},
+          createContext: _vmCreateContext,
+          isContext: (obj) => typeof obj === 'object' && obj !== null && _vmContexts.has(obj),
           runInContext: (code, context) => { return new Function('with(this){return eval(arguments[0])}').call(context, code); },
-          runInNewContext: (code, sandbox) => { return new Function('with(this){return eval(arguments[0])}').call(sandbox || {}, code); },
-          Script: class { constructor(code) { this._code = code; } runInContext(ctx) { return new Function('with(this){return eval(arguments[0])}').call(ctx, this._code); } },
+          runInNewContext: (code, sandbox) => { const ctx = _vmCreateContext(sandbox || {}); return new Function('with(this){return eval(arguments[0])}').call(ctx, code); },
+          Script: class { constructor(code, _options) { this._code = code; } runInContext(ctx) { return new Function('with(this){return eval(arguments[0])}').call(ctx, this._code); } runInNewContext(sandbox) { const ctx = _vmCreateContext(sandbox || {}); return this.runInContext(ctx); } },
         };
       }
       case 'constants': {
@@ -3142,6 +3145,47 @@ export function stop() {}
 export default { transformSync, transform, build, initialize, stop };
 "#;
 
+/// Synthetic module for `node:vm`.
+/// Provides createContext, runInContext, runInNewContext, isContext, and Script
+/// for happy-dom and other libraries that depend on `vm` for sandboxed eval.
+const NODE_VM_SPECIFIER: &str = "vertz:node_vm";
+const NODE_VM_MODULE: &str = r#"
+const _contexts = new WeakSet();
+
+export function createContext(sandbox) {
+  const ctx = sandbox || {};
+  _contexts.add(ctx);
+  return ctx;
+}
+
+export function isContext(obj) {
+  if (typeof obj !== 'object' || obj === null) return false;
+  return _contexts.has(obj);
+}
+
+export function runInContext(code, context) {
+  return new Function('with(this){return eval(arguments[0])}').call(context, code);
+}
+
+export function runInNewContext(code, sandbox) {
+  const ctx = createContext(sandbox || {});
+  return runInContext(code, ctx);
+}
+
+export class Script {
+  constructor(code, _options) { this._code = code; }
+  runInContext(ctx) {
+    return new Function('with(this){return eval(arguments[0])}').call(ctx, this._code);
+  }
+  runInNewContext(sandbox) {
+    const ctx = createContext(sandbox || {});
+    return this.runInContext(ctx);
+  }
+}
+
+export default { createContext, isContext, runInContext, runInNewContext, Script };
+"#;
+
 /// Map a `node:*` specifier to a synthetic module specifier.
 fn node_specifier_to_synthetic(specifier: &str) -> Option<&'static str> {
     match specifier {
@@ -3164,6 +3208,7 @@ fn node_specifier_to_synthetic(specifier: &str) -> Option<&'static str> {
         "stream" | "node:stream" | "stream/web" | "node:stream/web" => {
             Some(NODE_STREAM_WEB_SPECIFIER)
         }
+        "node:vm" | "vm" => Some(NODE_VM_SPECIFIER),
         _ => None,
     }
 }
@@ -3190,6 +3235,7 @@ fn synthetic_module_source(specifier: &str) -> Option<&'static str> {
         NODE_READLINE_SPECIFIER => Some(NODE_READLINE_MODULE),
         NODE_ZLIB_SPECIFIER => Some(NODE_ZLIB_MODULE),
         NODE_STREAM_WEB_SPECIFIER => Some(NODE_STREAM_WEB_MODULE),
+        NODE_VM_SPECIFIER => Some(NODE_VM_MODULE),
         VERTZ_SQLITE_SPECIFIER => Some(VERTZ_SQLITE_MODULE),
         ESBUILD_SPECIFIER => Some(ESBUILD_MODULE),
         _ => None,
@@ -5014,5 +5060,66 @@ Object.defineProperty(exports, "ModuleKind", {
             "Source should be wrapped in IIFE"
         );
         assert!(wrapped.contains("})();"), "IIFE should be closed");
+    }
+
+    // --- node:vm synthetic module (#2605) ---
+
+    #[test]
+    fn test_resolve_node_vm() {
+        let tmp = create_temp_dir();
+        let main_file = tmp.path().join("main.js");
+        std::fs::write(&main_file, "").unwrap();
+
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
+        let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
+        let result = loader.resolve("node:vm", referrer.as_str(), ResolutionKind::Import);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), NODE_VM_SPECIFIER);
+    }
+
+    #[test]
+    fn test_resolve_bare_vm() {
+        let tmp = create_temp_dir();
+        let main_file = tmp.path().join("main.js");
+        std::fs::write(&main_file, "").unwrap();
+
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
+        let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
+        let result = loader.resolve("vm", referrer.as_str(), ResolutionKind::Import);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), NODE_VM_SPECIFIER);
+    }
+
+    #[test]
+    fn test_load_node_vm_module() {
+        let tmp = create_temp_dir();
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
+        let specifier = ModuleSpecifier::parse(NODE_VM_SPECIFIER).unwrap();
+        let response = loader.load(&specifier, None, false, RequestedModuleType::None);
+
+        match response {
+            ModuleLoadResponse::Sync(Ok(source)) => match &source.code {
+                deno_core::ModuleSourceCode::String(code) => {
+                    let code_str = code.as_str();
+                    assert!(
+                        code_str.contains("createContext"),
+                        "Should export createContext"
+                    );
+                    assert!(
+                        code_str.contains("runInContext"),
+                        "Should export runInContext"
+                    );
+                    assert!(code_str.contains("isContext"), "Should export isContext");
+                    assert!(code_str.contains("Script"), "Should export Script class");
+                    assert!(
+                        code_str.contains("export default"),
+                        "Should have default export"
+                    );
+                }
+                _ => panic!("Expected string source code"),
+            },
+            ModuleLoadResponse::Sync(Err(e)) => panic!("Module load failed: {}", e),
+            _ => panic!("Expected synchronous module load"),
+        }
     }
 }

--- a/reviews/fix-vtz-vm-module/phase-01-vm-module.md
+++ b/reviews/fix-vtz-vm-module/phase-01-vm-module.md
@@ -1,0 +1,41 @@
+# Phase 1: vm Module ESM Support
+
+- **Author:** Claude Opus 4.6
+- **Reviewer:** Claude Opus 4.6 (adversarial review agent)
+- **Date:** 2026-04-13
+
+## Changes
+
+- native/vtz/src/runtime/module_loader.rs (modified)
+
+## CI Status
+
+- [x] Quality gates passed (cargo test --all, clippy, fmt)
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (failing tests written first)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API matches design
+
+## Findings
+
+### SHOULD-FIX-1: `isContext` crashes on non-object arguments (FIXED)
+
+`WeakSet.has()` throws TypeError on primitives (null, undefined, string, number).
+Node.js `vm.isContext()` returns `false` for non-objects. Added guard:
+`typeof obj === 'object' && obj !== null` before `_contexts.has(obj)`.
+
+Fixed in both CJS and ESM implementations.
+
+### Nits (accepted as-is)
+
+- CJS and ESM have separate WeakSet context stores (by design, no consumer mixes both)
+- `_code` property on Script is enumerable (matches other synthetic modules' simplicity)
+- Tests check string-contains, not JS validity (consistent with all other synthetic module tests)
+
+## Resolution
+
+SHOULD-FIX-1 addressed. Nits accepted. Approved.


### PR DESCRIPTION
## Summary

- Add `vm` module to ESM synthetic module resolution, fixing `Cannot find module 'vm'` errors when happy-dom is imported via ESM (`import VM from 'vm'`)
- Add `isContext()` to both CJS and ESM `vm` implementations (required by happy-dom's `BrowserWindow`)
- Guard `isContext()` against non-object arguments to match Node.js behavior

## Public API Changes

None — this is an internal Node.js compatibility fix in the vtz runtime.

## Affected packages

Fixes test failures in:
- `@vertz/icons` (render-icon.test.ts)
- `@vertz/ui-canvas` (all tests)
- `@vertz/ui-auth` (all tests)
- `@vertz/docs` (api-components, breadcrumbs, build-pipeline, compile-mdx-html, mdx-components)
- `@vertz/ui` (provider-icons.test.ts)

## Test plan

- [x] 3 new Rust unit tests: ESM resolution (`node:vm`, bare `vm`), module source content
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `vtz test packages/icons` — render-icon tests now pass
- [x] `vtz test packages/ui/src/auth/__tests__/provider-icons.test.ts` — passes
- [x] Adversarial review completed (1 should-fix found and resolved)

Fixes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)