### PR TITLE
fix(runtime): add credentials support to Request polyfill (#2551)

### DIFF
--- a/native/vtz/src/runtime/ops/web_api.rs
+++ b/native/vtz/src/runtime/ops/web_api.rs
@@ -411,14 +411,14 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
           ? createBodyMixin(init.body)
           : (input.bodyUsed ? createBodyMixin(null) : input.#body.clone());
         this.#signal = init.signal || input.signal || null;
-        this.#credentials = init.credentials || input.credentials || 'same-origin';
+        this.#credentials = init.credentials ?? input.credentials ?? 'same-origin';
       } else {
         this.#url = String(input);
         this.#method = (init.method || 'GET').toUpperCase();
         this.#headers = new Headers(init.headers);
         this.#body = createBodyMixin(init.body !== undefined ? init.body : null);
         this.#signal = init.signal || null;
-        this.#credentials = init.credentials || 'same-origin';
+        this.#credentials = init.credentials ?? 'same-origin';
       }
     }
 

--- a/native/vtz/src/runtime/ops/web_api.rs
+++ b/native/vtz/src/runtime/ops/web_api.rs
@@ -399,6 +399,7 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
     #headers;
     #body;
     #signal;
+    #credentials;
 
     constructor(input, init = {}) {
       if (input instanceof Request) {
@@ -410,12 +411,14 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
           ? createBodyMixin(init.body)
           : (input.bodyUsed ? createBodyMixin(null) : input.#body.clone());
         this.#signal = init.signal || input.signal || null;
+        this.#credentials = init.credentials || input.credentials || 'same-origin';
       } else {
         this.#url = String(input);
         this.#method = (init.method || 'GET').toUpperCase();
         this.#headers = new Headers(init.headers);
         this.#body = createBodyMixin(init.body !== undefined ? init.body : null);
         this.#signal = init.signal || null;
+        this.#credentials = init.credentials || 'same-origin';
       }
     }
 
@@ -425,6 +428,7 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
     get body() { return this.#body.body; }
     get bodyUsed() { return this.#body.bodyUsed; }
     get signal() { return this.#signal; }
+    get credentials() { return this.#credentials; }
 
     async text() { return this.#body.text(); }
     async json() { return this.#body.json(); }
@@ -436,6 +440,7 @@ pub const WEB_API_BOOTSTRAP_JS: &str = r#"
         headers: new Headers(this.#headers),
         body: this.#body.clone(),
         signal: this.#signal,
+        credentials: this.#credentials,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Added `credentials` property support to the `Request` polyfill in the vtz runtime
- The polyfill was missing `#credentials` private field, constructor handling, getter, and `clone()` propagation
- Uses `??` (nullish coalescing) for spec-correct defaulting to `'same-origin'`

## Public API Changes

None — this is an internal runtime polyfill fix. The `Request` class now correctly exposes the `credentials` property per the Fetch API spec.

## Test Status

- `packages/fetch/` — 163/163 passing (previously 51/1 failing in `client.test.ts`)
- Rust quality gates — clippy, fmt, test all clean

## Review

- Adversarial review in `reviews/fix-request-credentials/phase-01-credentials-polyfill.md`
- 1 SHOULD-FIX (use `??` instead of `||`) — addressed
- 1 NIT (clone path) — acknowledged, no change needed

Fixes #2551

🤖 Generated with [Claude Code](https://claude.com/claude-code)