### PR TITLE
fix(runtime): fix process.env spread and expectTypeOf chaining

### DIFF
--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -20,6 +20,13 @@ pub fn op_env_remove(#[string] key: String) {
     std::env::remove_var(&key);
 }
 
+/// List all environment variable names.
+#[op2]
+#[serde]
+pub fn op_env_keys() -> Vec<String> {
+    std::env::vars().map(|(k, _)| k).collect()
+}
+
 /// Get the current working directory.
 #[op2]
 #[string]
@@ -31,7 +38,13 @@ pub fn op_cwd() -> Result<String, deno_core::error::AnyError> {
 
 /// Get the op declarations for env ops.
 pub fn op_decls() -> Vec<OpDecl> {
-    vec![op_env_get(), op_env_set(), op_env_remove(), op_cwd()]
+    vec![
+        op_env_get(),
+        op_env_set(),
+        op_env_remove(),
+        op_env_keys(),
+        op_cwd(),
+    ]
 }
 
 /// JavaScript bootstrap code for process.env.
@@ -56,6 +69,15 @@ pub const ENV_BOOTSTRAP_JS: &str = r#"
     has(_target, prop) {
       if (typeof prop !== 'string') return false;
       return Deno.core.ops.op_env_get(prop) !== null;
+    },
+    ownKeys() {
+      return Deno.core.ops.op_env_keys();
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (typeof prop !== 'string') return undefined;
+      const val = Deno.core.ops.op_env_get(prop);
+      if (val === null) return undefined;
+      return { value: val, writable: true, enumerable: true, configurable: true };
     },
   });
 

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -84,7 +84,12 @@ pub const ENV_BOOTSTRAP_JS: &str = r#"
   if (!globalThis.process) {
     globalThis.process = {};
   }
-  globalThis.process.env = envProxy;
+  Object.defineProperty(globalThis.process, 'env', {
+    value: envProxy,
+    writable: false,
+    configurable: false,
+    enumerable: true,
+  });
   if (!globalThis.process.cwd) {
     globalThis.process.cwd = () => Deno.core.ops.op_cwd();
   }
@@ -188,5 +193,46 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_process_env_spread_includes_set_vars() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "process.env.VERTZ_SPREAD_TEST = 'spread_val'; const copy = {...process.env}; copy.VERTZ_SPREAD_TEST",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!("spread_val"));
+        std::env::remove_var("VERTZ_SPREAD_TEST");
+    }
+
+    #[test]
+    fn test_process_env_object_keys_includes_set_vars() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "process.env.VERTZ_KEYS_TEST = 'keys_val'; Object.keys(process.env).includes('VERTZ_KEYS_TEST')",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+        std::env::remove_var("VERTZ_KEYS_TEST");
+    }
+
+    #[test]
+    fn test_process_env_not_reassignable() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        // Assigning to process.env should silently fail (non-writable),
+        // and the proxy should remain functional.
+        let result = rt
+            .execute_script(
+                "<test>",
+                "process.env.VERTZ_REASSIGN_TEST = 'before'; process.env = {}; process.env.VERTZ_REASSIGN_TEST",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!("before"));
+        std::env::remove_var("VERTZ_REASSIGN_TEST");
     }
 }

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -1193,11 +1193,15 @@ if (typeof globalThis.HTMLElement === 'undefined') {
 
   // expectTypeOf — no-op at runtime (type-level assertions only matter at compile time).
   // Returns a chainable proxy so `expectTypeOf<T>().toEqualTypeOf<U>()` etc. don't crash.
+  // The proxy target must be a function so the proxy is callable (apply trap works),
+  // and get always returns another such proxy so `.not.toMatchTypeOf()` and
+  // `.returns.toEqualTypeOf()` chains work.
+  const _noop = () => {};
   const expectTypeOfHandler = {
-    get() { return function() { return new Proxy({}, expectTypeOfHandler); }; },
-    apply() { return new Proxy({}, expectTypeOfHandler); },
+    get() { return new Proxy(_noop, expectTypeOfHandler); },
+    apply() { return new Proxy(_noop, expectTypeOfHandler); },
   };
-  function expectTypeOf() { return new Proxy({}, expectTypeOfHandler); }
+  function expectTypeOf() { return new Proxy(_noop, expectTypeOfHandler); }
 
   // __vertz_unwrap_module — creates a mutable wrapper around ES module namespaces.
   // Dynamic `import()` returns frozen Module namespace objects. spyOn() needs to

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -1202,6 +1202,7 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     apply() { return new Proxy(_noop, expectTypeOfHandler); },
   };
   function expectTypeOf() { return new Proxy(_noop, expectTypeOfHandler); }
+  globalThis.expectTypeOf = expectTypeOf;
 
   // __vertz_unwrap_module — creates a mutable wrapper around ES module namespaces.
   // Dynamic `import()` returns frozen Module namespace objects. spyOn() needs to
@@ -3574,6 +3575,43 @@ mod tests {
             assert_eq!(
                 item["status"], "pass",
                 "__vertz_unwrap_module test {} ({}) failed: {:?}",
+                i, item["name"], item["error"]
+            );
+        }
+    }
+
+    #[test]
+    fn test_expect_type_of_property_chains_do_not_throw() {
+        let mut rt = create_test_runtime();
+        let results = run_test_code(
+            &mut rt,
+            r#"
+            describe('expectTypeOf', () => {
+                it('simple call does not throw', () => {
+                    expectTypeOf().toEqualTypeOf();
+                });
+                it('.not.toMatchTypeOf chain does not throw', () => {
+                    expectTypeOf().not.toMatchTypeOf();
+                });
+                it('.returns.toEqualTypeOf chain does not throw', () => {
+                    expectTypeOf().returns.toEqualTypeOf();
+                });
+                it('.toHaveProperty chain does not throw', () => {
+                    expectTypeOf().toHaveProperty('x');
+                });
+                it('deeply nested chain does not throw', () => {
+                    expectTypeOf().not.not.not.toBeString();
+                });
+            });
+            "#,
+        );
+
+        let arr = results.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        for (i, item) in arr.iter().enumerate() {
+            assert_eq!(
+                item["status"], "pass",
+                "expectTypeOf chain test {} ({}) failed: {:?}",
                 i, item["name"], item["error"]
             );
         }

--- a/packages/core/src/env/__tests__/env-validator.test.ts
+++ b/packages/core/src/env/__tests__/env-validator.test.ts
@@ -30,7 +30,18 @@ describe('createEnv', () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
-    process.env = { ...originalEnv };
+    // Remove keys added during the test
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    // Restore original values for modified keys
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (process.env[key] !== value) {
+        process.env[key] = value as string;
+      }
+    }
   });
 
   it('validates env against schema and returns typed result', () => {


### PR DESCRIPTION
## Summary

Fixes #2546 — 3 test failures in `@vertz/core` caused by two runtime bugs:

- **`process.env` Proxy missing `ownKeys`/`getOwnPropertyDescriptor` traps**: `{...process.env}` returned `{}` because the Proxy had no `ownKeys` trap. Added `op_env_keys` op and both traps. Also made `process.env` non-writable to prevent tests from accidentally replacing the proxy.
- **`expectTypeOf` Proxy handler broken chaining**: The `get` trap returned a plain function instead of a Proxy, so `.not.toMatchTypeOf()` and `.returns.toEqualTypeOf()` failed with "is not a function". Fixed by returning a callable Proxy from `get`.

## Public API Changes

None — these are internal runtime fixes.

## Files Changed

- [`native/vtz/src/runtime/ops/env.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-core-tests/native/vtz/src/runtime/ops/env.rs) — Added `op_env_keys` op, `ownKeys`/`getOwnPropertyDescriptor` traps, non-writable `process.env`, and 3 new Rust tests
- [`native/vtz/src/test/globals.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-core-tests/native/vtz/src/test/globals.rs) — Fixed `expectTypeOf` proxy to use callable Proxy targets, added `globalThis.expectTypeOf` assignment, added 1 new Rust test
- [`packages/core/src/env/__tests__/env-validator.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-core-tests/packages/core/src/env/__tests__/env-validator.test.ts) — Updated `afterEach` to restore env vars individually instead of reassigning `process.env`

## Test plan

- [x] All 4 target test files pass (23/23 tests)
- [x] Full `@vertz/core` test suite passes (287/287)
- [x] All Rust tests pass (4800+ tests, 0 failures)
- [x] Clippy clean, rustfmt clean
- [x] Adversarial review completed, all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)