### PR TITLE
fix(runtime,cli): add missing Node.js APIs — process.chdir, generateKeyPairSync, mock (#2538)

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -2802,74 +2802,103 @@ function randomUUID() {
 // webcrypto: expose the Web Crypto API (available in V8 via globalThis.crypto)
 const webcrypto = globalThis.crypto;
 
-// Detect asymmetric key type from PEM data by checking for known OID byte sequences.
-// RSA OID 1.2.840.113549.1.1.1: 2a 86 48 86 f7 0d 01 01 01
-// EC OID 1.2.840.10045.2.1:     2a 86 48 ce 3d 02 01
-function _detectKeyType(pem) {
-  if (typeof pem !== 'string') return undefined;
-  const b64 = pem.replace(/-----[A-Z0-9 ]+-----/g, '').replace(/\s/g, '');
-  const raw = atob(b64);
-  if (raw.includes('\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01')) return 'rsa';
-  if (raw.includes('\x2a\x86\x48\xce\x3d\x02\x01')) return 'ec';
-  return undefined;
+// --- KeyObject: Node.js-compatible wrapper for asymmetric keys ---
+
+function _pemToBase64(pem) {
+  return pem.replace(/-----[A-Z ]+-----/g, '').replace(/\s/g, '');
 }
 
-// Detect EC named curve from PEM. P-256 OID (prime256v1): 2a 86 48 ce 3d 03 01 07
-function _detectECDetails(pem) {
-  if (typeof pem !== 'string') return undefined;
-  const b64 = pem.replace(/-----[A-Z0-9 ]+-----/g, '').replace(/\s/g, '');
+function _base64ToUint8Array(b64) {
   const raw = atob(b64);
-  if (raw.includes('\x2a\x86\x48\xce\x3d\x03\x01\x07')) return { namedCurve: 'prime256v1' };
-  return undefined;
+  const buf = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+  return buf;
 }
 
-// KeyObject stub for RSA/EC key operations (the runtime uses Rust-native JWT ops)
+function _pemToDer(pem) {
+  return _base64ToUint8Array(_pemToBase64(pem));
+}
+
 class KeyObject {
-  constructor(type, data) {
-    this._type = type;
-    this._data = data;
-    this._asymmetricKeyType = _detectKeyType(data);
-    this._asymmetricKeyDetails = this._asymmetricKeyType === 'ec' ? _detectECDetails(data) : undefined;
+  constructor(type, pem, keyType, keyDetails) {
+    this._type = type;        // 'private' | 'public'
+    this._data = pem;         // PEM string
+    this._keyType = keyType;  // 'rsa' | 'ec'
+    this._keyDetails = keyDetails || {};
   }
   get type() { return this._type; }
-  get asymmetricKeyType() { return this._asymmetricKeyType; }
-  get asymmetricKeyDetails() { return this._asymmetricKeyDetails; }
+  get asymmetricKeyType() { return this._keyType; }
+  get asymmetricKeyDetails() { return this._keyDetails; }
   export(options) {
-    if (options && options.type === 'pkcs1' && options.format === 'pem') {
-      return this._data;
-    }
-    if (options && options.type === 'spki' && options.format === 'pem') {
-      return this._data;
+    if (!options) return this._data;
+    if (options.format === 'der') {
+      return Buffer.from(_pemToDer(this._data));
     }
     return this._data;
   }
 }
 
+function _detectKeyType(pem) {
+  // Check PEM header for explicit key type
+  if (pem.includes('BEGIN RSA')) return 'rsa';
+  if (pem.includes('BEGIN EC')) return 'ec';
+  // For PKCS#8/SPKI (generic headers), inspect DER for OIDs
+  const der = _pemToDer(pem);
+  // EC OID 1.2.840.10045.2.1 = 06 07 2a 86 48 ce 3d 02 01
+  const ecOid = [0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01];
+  for (let i = 0; i < der.length - ecOid.length; i++) {
+    let match = true;
+    for (let j = 0; j < ecOid.length; j++) {
+      if (der[i + j] !== ecOid[j]) { match = false; break; }
+    }
+    if (match) return 'ec';
+  }
+  return 'rsa';
+}
+
 function createPrivateKey(input) {
   if (input instanceof KeyObject) return input;
-  const key = typeof input === 'string' ? input : (input.key || input);
-  return new KeyObject('private', key);
+  const pem = typeof input === 'string' ? input : (input.key || String(input));
+  const keyType = _detectKeyType(pem);
+  const details = keyType === 'ec' ? { namedCurve: 'prime256v1' } : {};
+  return new KeyObject('private', pem, keyType, details);
 }
 
 function createPublicKey(input) {
-  if (input instanceof KeyObject) return new KeyObject('public', input._data);
-  const key = typeof input === 'string' ? input : (input.key || input);
-  return new KeyObject('public', key);
+  if (input instanceof KeyObject) {
+    if (input._type === 'private') {
+      throw new Error('createPublicKey(privateKeyObject) is not yet supported in the Vertz runtime. Pass the public PEM string directly.');
+    }
+    return input;
+  }
+  const pem = typeof input === 'string' ? input : (input.key || String(input));
+  const keyType = _detectKeyType(pem);
+  const details = keyType === 'ec' ? { namedCurve: 'prime256v1' } : {};
+  return new KeyObject('public', pem, keyType, details);
 }
 
 function generateKeyPairSync(type, options) {
+  const opts = options || {};
   const result = Deno.core.ops.op_crypto_generate_keypair({
     type,
-    modulusLength: options.modulusLength,
-    namedCurve: options.namedCurve,
+    modulusLength: opts.modulusLength,
+    namedCurve: opts.namedCurve,
   });
-  // When encoding options specify format: 'pem', return raw PEM strings (Node.js behavior).
-  // When no encoding options, return KeyObject instances.
-  const pubEnc = options.publicKeyEncoding;
-  const privEnc = options.privateKeyEncoding;
-  const pubVal = (pubEnc && pubEnc.format === 'pem') ? result.publicKey : createPublicKey(result.publicKey);
-  const privVal = (privEnc && privEnc.format === 'pem') ? result.privateKey : createPrivateKey(result.privateKey);
-  return { publicKey: pubVal, privateKey: privVal };
+  // Node.js returns PEM strings when encoding options are provided
+  const hasEncoding = opts.publicKeyEncoding || opts.privateKeyEncoding;
+  if (hasEncoding) {
+    return {
+      publicKey: result.publicKey,
+      privateKey: result.privateKey,
+    };
+  }
+  const keyDetails = type === 'ec'
+    ? { namedCurve: opts.namedCurve === 'P-256' ? 'prime256v1' : (opts.namedCurve || 'prime256v1') }
+    : {};
+  return {
+    publicKey: new KeyObject('public', result.publicKey, type, keyDetails),
+    privateKey: new KeyObject('private', result.privateKey, type, keyDetails),
+  };
 }
 
 function randomFillSync(buf, offset, size) {

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -36,6 +36,13 @@ pub fn op_cwd() -> Result<String, deno_core::error::AnyError> {
         .map_err(|e| deno_core::error::type_error(format!("Failed to get current directory: {e}")))
 }
 
+/// Change the current working directory.
+#[op2(fast)]
+pub fn op_chdir(#[string] dir: String) -> Result<(), deno_core::error::AnyError> {
+    std::env::set_current_dir(&dir)
+        .map_err(|e| deno_core::error::type_error(format!("Failed to change directory: {e}")))
+}
+
 /// Get the op declarations for env ops.
 pub fn op_decls() -> Vec<OpDecl> {
     vec![
@@ -44,6 +51,7 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_env_remove(),
         op_env_keys(),
         op_cwd(),
+        op_chdir(),
     ]
 }
 
@@ -92,6 +100,9 @@ pub const ENV_BOOTSTRAP_JS: &str = r#"
   });
   if (!globalThis.process.cwd) {
     globalThis.process.cwd = () => Deno.core.ops.op_cwd();
+  }
+  if (!globalThis.process.chdir) {
+    globalThis.process.chdir = (dir) => Deno.core.ops.op_chdir(dir);
   }
   if (!globalThis.process.versions) {
     globalThis.process.versions = {};
@@ -180,6 +191,52 @@ mod tests {
             .unwrap();
         assert_eq!(result, serde_json::json!("set_value"));
         std::env::remove_var("VERTZ_SET_TEST");
+    }
+
+    #[test]
+    fn test_process_chdir_is_a_function() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script("<test>", "typeof process.chdir").unwrap();
+        assert_eq!(result, serde_json::json!("function"));
+    }
+
+    #[test]
+    fn test_process_chdir_changes_directory() {
+        let original = std::env::current_dir().unwrap();
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const before = process.cwd();
+                process.chdir('/tmp');
+                const after = process.cwd();
+                [before !== '/tmp' && before !== '/private/tmp', after === '/tmp' || after === '/private/tmp']
+                "#,
+            )
+            .unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr[0].as_bool().unwrap(), "Before should not be /tmp");
+        assert!(arr[1].as_bool().unwrap(), "After should be /tmp");
+        // Restore
+        std::env::set_current_dir(&original).unwrap();
+    }
+
+    #[test]
+    fn test_process_chdir_invalid_directory_throws() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script(
+            "<test>",
+            r#"
+            try {
+                process.chdir('/nonexistent_vertz_test_dir_12345');
+                'no_error'
+            } catch (e) {
+                e.message.includes('Failed to change directory') ? 'correct_error' : e.message
+            }
+            "#,
+        );
+        assert_eq!(result.unwrap(), "correct_error");
     }
 
     #[test]

--- a/packages/cli/src/dev-server/__tests__/process-manager.test.ts
+++ b/packages/cli/src/dev-server/__tests__/process-manager.test.ts
@@ -40,10 +40,10 @@ describe('createProcessManager', () => {
   });
 
   it('isRunning returns true after start', () => {
-    const mock = createMockChild();
+    const mc = createMockChild();
     // Prevent the exit event from setting child to undefined immediately
-    mock.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    mc.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
@@ -52,27 +52,27 @@ describe('createProcessManager', () => {
   });
 
   it('isRunning returns false after process exits', () => {
-    const mock = createMockChild();
-    mock.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    const mc = createMockChild();
+    mc.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
     expect(pm.isRunning()).toBe(true);
 
-    mock.emitter.emit('exit', 0, null);
+    mc.emitter.emit('exit', 0, null);
     expect(pm.isRunning()).toBe(false);
   });
 
   it('stop terminates the child process with SIGTERM', async () => {
-    const mock = createMockChild();
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    const mc = createMockChild();
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
     await pm.stop();
 
-    expect(mock.child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mc.child.kill).toHaveBeenCalledWith('SIGTERM');
     expect(pm.isRunning()).toBe(false);
   });
 
@@ -95,37 +95,37 @@ describe('createProcessManager', () => {
   });
 
   it('onOutput receives stdout data from child', () => {
-    const mock = createMockChild();
-    mock.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    const mc = createMockChild();
+    mc.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
     const outputHandler = mock();
 
     pm.onOutput(outputHandler);
     pm.start('app.ts');
 
-    mock.stdout.emit('data', Buffer.from('hello'));
+    mc.stdout.emit('data', Buffer.from('hello'));
     expect(outputHandler).toHaveBeenCalledWith('hello');
   });
 
   it('onError receives stderr data from child', () => {
-    const mock = createMockChild();
-    mock.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    const mc = createMockChild();
+    mc.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
     const errorHandler = mock();
 
     pm.onError(errorHandler);
     pm.start('app.ts');
 
-    mock.stderr.emit('data', Buffer.from('error!'));
+    mc.stderr.emit('data', Buffer.from('error!'));
     expect(errorHandler).toHaveBeenCalledWith('error!');
   });
 
   it('start passes env to spawn function', () => {
-    const mock = createMockChild();
-    mock.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mock.child as never);
+    const mc = createMockChild();
+    mc.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mc.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts', { NODE_ENV: 'development' });


### PR DESCRIPTION
## Summary

Fixes #2538 — 3 missing Node.js APIs in the vtz runtime causing test failures.

- **`process.chdir()`** — New Rust op `op_chdir` in [`native/vtz/src/runtime/ops/env.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/add-missing-node-apis/native/vtz/src/runtime/ops/env.rs) with JS bootstrap wiring
- **`generateKeyPairSync` + `KeyObject`** — Enhanced `node:crypto` shim in [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/add-missing-node-apis/native/vtz/src/runtime/module_loader.rs) with `KeyObject` class, `createPrivateKey`, `createPublicKey`, proper encoding options support, and DER OID-based key type detection
- **`mock` naming collision** — Fixed variable shadowing in [`packages/cli/src/dev-server/__tests__/process-manager.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/add-missing-node-apis/packages/cli/src/dev-server/__tests__/process-manager.test.ts) where `const mock = createMockChild()` shadowed the `mock` import from `@vertz/test`

## Public API Changes

None — all changes are internal runtime shims and test fixes.

## Test Results

| Test file | Before | After |
|-----------|--------|-------|
| `process-manager.test.ts` | 4/10 (mock not a function) | **10/10** |
| `create.test.ts` | 0/5 (process.chdir not a function) | Pre-existing: `Cannot find module '@vertz/ui'` (unrelated to chdir) |
| `entitlement-access.test.ts` | 0/15 (generateKeyPairSync not supported) | Pre-existing: timeout (no `@vertz/server/dist/` in examples/linear) |

**Rust tests**: 33/33 passed | **Clippy**: clean | **rustfmt**: clean

## Known Pre-existing Issues (not caused by this PR)

- `create.test.ts` fails with `Cannot find module '@vertz/ui'` — template files reference `@vertz/ui` which isn't a dependency of `create-vertz-app`
- `entitlement-access.test.ts` times out — `@vertz/server` has no built `dist/` in `examples/linear/`, causing the test runner to hang during module compilation
- JWT tests (`jwt.test.ts`) fail with `serde_v8 error` — `crypto.subtle` ops (`importKey`, `sign`, `verify`) don't have Rust implementations yet

## Review

Adversarial review at `reviews/fix-missing-node-apis/phase-01-implementation.md`. Approved with recommendations — F2 (createPublicKey leaking private key) addressed by throwing explicitly instead of silently wrapping. O3 (tautological assertion) fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)