### PR TITLE
fix(runtime,server): fix auth server-instance test failure

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1646,8 +1646,14 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
           webcrypto: globalThis.crypto, constants: {},
           getCiphers: () => [], getCurves: () => ['prime256v1', 'secp384r1', 'secp521r1'],
           createHmac: () => { throw new Error('createHmac requires ESM import'); },
-          createPrivateKey: (input) => ({ type: 'private', _data: typeof input === 'string' ? input : (input.key || input), export: function(o) { return this._data; } }),
-          createPublicKey: (input) => ({ type: 'public', _data: typeof input === 'string' ? input : (input.key || input), export: function(o) { return this._data; } }),
+          createPrivateKey: (input) => {
+            const key = typeof input === 'string' ? input : (input.key || input);
+            return { type: 'private', _data: key, get asymmetricKeyType() { return globalThis.__vertz_crypto ? globalThis.__vertz_crypto._detectKeyType(key) : undefined; }, export: function(o) { return this._data; } };
+          },
+          createPublicKey: (input) => {
+            const key = typeof input === 'string' ? input : (input.key || input);
+            return { type: 'public', _data: key, get asymmetricKeyType() { return globalThis.__vertz_crypto ? globalThis.__vertz_crypto._detectKeyType(key) : undefined; }, export: function(o) { return this._data; } };
+          },
         };
       }
       case 'async_hooks': return globalThis.__vertz_async_hooks || { AsyncLocalStorage: undefined, AsyncResource: undefined };
@@ -2787,13 +2793,38 @@ function randomUUID() {
 // webcrypto: expose the Web Crypto API (available in V8 via globalThis.crypto)
 const webcrypto = globalThis.crypto;
 
-// KeyObject stub for RSA key operations (the runtime uses Rust-native JWT ops)
+// Detect asymmetric key type from PEM data by checking for known OID byte sequences.
+// RSA OID 1.2.840.113549.1.1.1: 2a 86 48 86 f7 0d 01 01 01
+// EC OID 1.2.840.10045.2.1:     2a 86 48 ce 3d 02 01
+function _detectKeyType(pem) {
+  if (typeof pem !== 'string') return undefined;
+  const b64 = pem.replace(/-----[A-Z0-9 ]+-----/g, '').replace(/\s/g, '');
+  const raw = atob(b64);
+  if (raw.includes('\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01')) return 'rsa';
+  if (raw.includes('\x2a\x86\x48\xce\x3d\x02\x01')) return 'ec';
+  return undefined;
+}
+
+// Detect EC named curve from PEM. P-256 OID (prime256v1): 2a 86 48 ce 3d 03 01 07
+function _detectECDetails(pem) {
+  if (typeof pem !== 'string') return undefined;
+  const b64 = pem.replace(/-----[A-Z0-9 ]+-----/g, '').replace(/\s/g, '');
+  const raw = atob(b64);
+  if (raw.includes('\x2a\x86\x48\xce\x3d\x03\x01\x07')) return { namedCurve: 'prime256v1' };
+  return undefined;
+}
+
+// KeyObject stub for RSA/EC key operations (the runtime uses Rust-native JWT ops)
 class KeyObject {
   constructor(type, data) {
     this._type = type;
     this._data = data;
+    this._asymmetricKeyType = _detectKeyType(data);
+    this._asymmetricKeyDetails = this._asymmetricKeyType === 'ec' ? _detectECDetails(data) : undefined;
   }
   get type() { return this._type; }
+  get asymmetricKeyType() { return this._asymmetricKeyType; }
+  get asymmetricKeyDetails() { return this._asymmetricKeyDetails; }
   export(options) {
     if (options && options.type === 'pkcs1' && options.format === 'pem') {
       return this._data;
@@ -2806,11 +2837,13 @@ class KeyObject {
 }
 
 function createPrivateKey(input) {
+  if (input instanceof KeyObject) return input;
   const key = typeof input === 'string' ? input : (input.key || input);
   return new KeyObject('private', key);
 }
 
 function createPublicKey(input) {
+  if (input instanceof KeyObject) return new KeyObject('public', input._data);
   const key = typeof input === 'string' ? input : (input.key || input);
   return new KeyObject('public', key);
 }
@@ -2821,10 +2854,13 @@ function generateKeyPairSync(type, options) {
     modulusLength: options.modulusLength,
     namedCurve: options.namedCurve,
   });
-  return {
-    publicKey: createPublicKey(result.publicKey),
-    privateKey: createPrivateKey(result.privateKey),
-  };
+  // When encoding options specify format: 'pem', return raw PEM strings (Node.js behavior).
+  // When no encoding options, return KeyObject instances.
+  const pubEnc = options.publicKeyEncoding;
+  const privEnc = options.privateKeyEncoding;
+  const pubVal = (pubEnc && pubEnc.format === 'pem') ? result.publicKey : createPublicKey(result.publicKey);
+  const privVal = (privEnc && privEnc.format === 'pem') ? result.privateKey : createPrivateKey(result.privateKey);
+  return { publicKey: pubVal, privateKey: privVal };
 }
 
 function randomFillSync(buf, offset, size) {
@@ -2853,7 +2889,7 @@ function getCurves() { return ['prime256v1', 'secp384r1', 'secp521r1']; }
 
 const constants = {};
 
-const __cryptoModule = { createHash, createHmac, timingSafeEqual, randomBytes, randomUUID, randomFillSync, randomInt, webcrypto, KeyObject, createPrivateKey, createPublicKey, generateKeyPairSync, getHashes, getCiphers, getCurves, constants };
+const __cryptoModule = { createHash, createHmac, timingSafeEqual, randomBytes, randomUUID, randomFillSync, randomInt, webcrypto, KeyObject, createPrivateKey, createPublicKey, generateKeyPairSync, getHashes, getCiphers, getCurves, constants, _detectKeyType };
 globalThis.__vertz_crypto = __cryptoModule;
 
 export { createHash, createHmac, timingSafeEqual, randomBytes, randomUUID, randomFillSync, randomInt, Hash, webcrypto, KeyObject, createPrivateKey, createPublicKey, generateKeyPairSync, getHashes, getCiphers, getCurves, constants };

--- a/packages/server/src/auth/__tests__/server-instance.test.ts
+++ b/packages/server/src/auth/__tests__/server-instance.test.ts
@@ -1,10 +1,21 @@
 import { Database } from '@vertz/sqlite';
 import { afterEach, describe, expect, it } from '@vertz/test';
 import { createDb } from '@vertz/db';
-import { createServer } from '../../create-server';
+import { createServer, type ServerInstance } from '../../create-server';
 import { authModels } from '../auth-models';
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from './test-keys';
 
 describe('createServer with db + auth', () => {
+  let serverApp: ServerInstance | null = null;
+
+  afterEach(() => {
+    // Dispose auth stores to clear setInterval timers that keep the event loop alive
+    if (serverApp?.auth) {
+      serverApp.auth.dispose();
+      serverApp = null;
+    }
+  });
+
   function createSqliteDb() {
     const rawDb = new Database(':memory:');
     const queryFn = async <T>(sqlStr: string, params: readonly unknown[]) => {
@@ -64,8 +75,14 @@ describe('createServer with db + auth', () => {
     const { db, rawDb } = createSqliteDb();
     const app = createServer({
       db,
-      auth: { session: { strategy: 'jwt', ttl: '60s' } },
+      auth: {
+        session: { strategy: 'jwt', ttl: '60s' },
+        privateKey: TEST_PRIVATE_KEY as string,
+        publicKey: TEST_PUBLIC_KEY as string,
+        isProduction: false,
+      },
     });
+    serverApp = app;
 
     expect(app.auth).toBeDefined();
     expect(typeof app.auth.api.signUp).toBe('function');
@@ -78,8 +95,14 @@ describe('createServer with db + auth', () => {
     const { db, rawDb } = createSqliteDb();
     const app = createServer({
       db,
-      auth: { session: { strategy: 'jwt', ttl: '60s' } },
+      auth: {
+        session: { strategy: 'jwt', ttl: '60s' },
+        privateKey: TEST_PRIVATE_KEY as string,
+        publicKey: TEST_PUBLIC_KEY as string,
+        isProduction: false,
+      },
     });
+    serverApp = app;
 
     await app.initialize();
 


### PR DESCRIPTION
## Summary
- Fix `packages/server/src/auth/__tests__/server-instance.test.ts` failing under `vtz test`
- Two root causes identified and fixed:
  - **Runtime**: `generateKeyPairSync` always returned `KeyObject` instances, ignoring `publicKeyEncoding`/`privateKeyEncoding` options with `format: 'pem'`. Node.js returns raw PEM strings when encoding options are specified. Also added `asymmetricKeyType` and `asymmetricKeyDetails` to `KeyObject` via OID detection from the PEM DER payload.
  - **Test**: `InMemorySessionStore` and `InMemoryRateLimitStore` create `setInterval` timers in constructors that keep the event loop alive. The test never called `dispose()`, causing the vtz test runner to hang indefinitely. Added `afterEach` cleanup and explicit test keys.

Closes #2552

## Test plan
- [x] `vtz test packages/server/src/auth/__tests__/server-instance.test.ts` — all 4 tests pass
- [x] `cargo test -p vtz` — all 33 Rust tests pass
- [x] `cargo clippy -p vtz --release -- -D warnings` — clean
- [x] `cargo fmt -p vtz -- --check` — clean
- [x] No regressions on `create-server.test.ts`, `auth-initialize.test.ts`, `auth-tables.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)