### PR TITLE
fix(theme-shadcn): fix app-shell, primitive-styles, and styles test failures

### DIFF
--- a/native/vertz-compiler-core/src/css_transform.rs
+++ b/native/vertz-compiler-core/src/css_transform.rs
@@ -66,10 +66,13 @@ pub fn transform_css(ms: &mut MagicString, program: &Program, file_path: &str) -
             css_rules.extend(rules);
         }
 
+        let call_css = css_rules.join("\n");
         all_css_rules.extend(css_rules);
 
-        // Build replacement: { blockName: '_hash', ... }
-        let replacement = build_replacement(&class_names);
+        // Build replacement: Object.defineProperty({ blockName: '_hash', ... }, 'css', ...)
+        // This preserves the `.css` property on the returned object, matching the runtime
+        // css() contract (CSSOutput<T>) that consumers rely on.
+        let replacement = build_replacement(&class_names, &call_css);
         ms.overwrite(call.start, call.end, &replacement);
     }
 
@@ -513,12 +516,20 @@ fn resolve_shorthand(parsed: &ParsedShorthand) -> Option<Vec<String>> {
 
 // ─── Replacement Building ──────────────────────────────────────
 
-fn build_replacement(class_names: &[(String, String)]) -> String {
+fn build_replacement(class_names: &[(String, String)], css_text: &str) -> String {
     let entries: Vec<String> = class_names
         .iter()
         .map(|(name, class)| format!("{name}: '{class}'"))
         .collect();
-    format!("{{ {} }}", entries.join(", "))
+    let obj = format!("{{ {} }}", entries.join(", "));
+
+    // Attach the extracted CSS as a non-enumerable `.css` property, matching the
+    // runtime css() behavior (Object.defineProperty with enumerable: false).
+    let escaped_css = css_text
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n");
+    format!("Object.defineProperty({obj}, 'css', {{ value: '{escaped_css}', enumerable: false }})")
 }
 
 #[cfg(test)]
@@ -996,6 +1007,33 @@ const b = css({ root: ['grid'] });
             css.contains("background-color: blue;"),
             "backgroundColor → background-color: css={}",
             css
+        );
+    }
+
+    // ── Replacement includes .css property ─────────────────────
+
+    #[test]
+    fn replacement_includes_css_property() {
+        let (code, _) = transform("const s = css({ root: ['flex', 'p:4'] });");
+        assert!(
+            code.contains("Object.defineProperty("),
+            "replacement should use Object.defineProperty: {}",
+            code
+        );
+        assert!(
+            code.contains("'css'"),
+            "replacement should define 'css' property: {}",
+            code
+        );
+        assert!(
+            code.contains("enumerable: false"),
+            "css property should be non-enumerable: {}",
+            code
+        );
+        assert!(
+            code.contains("display: flex;"),
+            "css property value should contain the CSS: {}",
+            code
         );
     }
 

--- a/native/vertz-compiler-core/src/css_transform.rs
+++ b/native/vertz-compiler-core/src/css_transform.rs
@@ -528,7 +528,8 @@ fn build_replacement(class_names: &[(String, String)], css_text: &str) -> String
     let escaped_css = css_text
         .replace('\\', "\\\\")
         .replace('\'', "\\'")
-        .replace('\n', "\\n");
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
     format!("Object.defineProperty({obj}, 'css', {{ value: '{escaped_css}', enumerable: false }})")
 }
 

--- a/packages/theme-shadcn/src/__tests__/app-shell.test.ts
+++ b/packages/theme-shadcn/src/__tests__/app-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@vertz/test';
+import { isPathActive } from '../components/primitives/path-active';
 import { createAppShell } from '../styles/app-shell';
-import { isPathActive } from '../components/primitives/app-shell';
 
 // ── Style factory ─────────────────────────────────────────
 

--- a/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@vertz/test';
 import { createAccordionStyles } from '../styles/accordion';
 import { createCheckboxStyles } from '../styles/checkbox';
 import { createDialogStyles } from '../styles/dialog';
+import { createDropdownMenuStyles } from '../styles/dropdown-menu';
 import { createPopoverStyles } from '../styles/popover';
 import { createProgressStyles } from '../styles/progress';
 import { createSelectStyles } from '../styles/select';
@@ -296,9 +297,9 @@ describe('toast', () => {
 });
 
 describe('dropdown-menu', () => {
+  const dm = createDropdownMenuStyles();
+
   it('has content, item, group, label, and separator blocks', () => {
-    const { createDropdownMenuStyles } = require('../styles/dropdown-menu');
-    const dm = createDropdownMenuStyles();
     expect(typeof dm.content).toBe('string');
     expect(typeof dm.item).toBe('string');
     expect(typeof dm.group).toBe('string');
@@ -307,8 +308,6 @@ describe('dropdown-menu', () => {
   });
 
   it('all class names are non-empty', () => {
-    const { createDropdownMenuStyles } = require('../styles/dropdown-menu');
-    const dm = createDropdownMenuStyles();
     expect(dm.content.length).toBeGreaterThan(0);
     expect(dm.item.length).toBeGreaterThan(0);
     expect(dm.group.length).toBeGreaterThan(0);
@@ -317,15 +316,11 @@ describe('dropdown-menu', () => {
   });
 
   it('CSS contains enter/exit animations for content', () => {
-    const { createDropdownMenuStyles } = require('../styles/dropdown-menu');
-    const dm = createDropdownMenuStyles();
     expect(dm.css).toContain('vz-zoom-in');
     expect(dm.css).toContain('vz-zoom-out');
   });
 
   it('CSS constrains content width to fit-content', () => {
-    const { createDropdownMenuStyles } = require('../styles/dropdown-menu');
-    const dm = createDropdownMenuStyles();
     expect(dm.css).toContain('fit-content');
   });
 });

--- a/packages/theme-shadcn/src/components/primitives/app-shell.tsx
+++ b/packages/theme-shadcn/src/components/primitives/app-shell.tsx
@@ -2,6 +2,7 @@ import type { ChildValue } from '@vertz/ui';
 import { isBrowser, useRouter } from '@vertz/ui';
 import type { ComposedAppShellProps } from '@vertz/ui-primitives';
 import { ComposedAppShell, withStyles } from '@vertz/ui-primitives';
+import { isPathActive } from './path-active';
 // ── Style classes ─────────────────────────────────────────
 
 export interface AppShellStyleClasses {
@@ -56,21 +57,8 @@ export interface ThemedAppShellComponent {
   User: (props: SlotProps) => HTMLElement;
 }
 
-// ── Active state matching ────────────────────────────────
-
-/**
- * Check if a pathname matches a nav href.
- * - exact: pathname === href
- * - prefix: pathname starts with href, handling "/" specially and ensuring
- *   "/projects" doesn't match "/projects-archive" (requires segment boundary).
- */
-export function isPathActive(pathname: string, href: string, match: 'exact' | 'prefix'): boolean {
-  if (match === 'exact') return pathname === href;
-  // Root path only matches exactly to prevent matching all routes
-  if (href === '/') return pathname === '/';
-  // Prefix match: exact match or href followed by a '/' segment boundary
-  return pathname === href || pathname.startsWith(href + '/');
-}
+// Re-export for consumers
+export { isPathActive } from './path-active';
 
 // ── NavItem factory ───────────────────────────────────────
 

--- a/packages/theme-shadcn/src/components/primitives/path-active.ts
+++ b/packages/theme-shadcn/src/components/primitives/path-active.ts
@@ -1,0 +1,13 @@
+/**
+ * Check if a pathname matches a nav href.
+ * - exact: pathname === href
+ * - prefix: pathname starts with href, handling "/" specially and ensuring
+ *   "/projects" doesn't match "/projects-archive" (requires segment boundary).
+ */
+export function isPathActive(pathname: string, href: string, match: 'exact' | 'prefix'): boolean {
+  if (match === 'exact') return pathname === href;
+  // Root path only matches exactly to prevent matching all routes
+  if (href === '/') return pathname === '/';
+  // Prefix match: exact match or href followed by a '/' segment boundary
+  return pathname === href || pathname.startsWith(href + '/');
+}


### PR DESCRIPTION
## Summary

Fixes all 3 failing test files in `@vertz/theme-shadcn` under `vtz test` (#2544):

- **`styles.test.ts`** — `label > CSS contains disabled sibling selector` failed because the compiler's static CSS extraction replaced `css()` calls with plain object literals, losing the non-enumerable `.css` property. Fixed in the native compiler (`css_transform.rs`) by using `Object.defineProperty` in the replacement to preserve the `.css` property, matching the runtime `css()` contract.

- **`primitive-styles.test.ts`** — 4 dropdown-menu tests failed because they used `require()` which doesn't work in the vtz ESM runtime. Converted to static `import`.

- **`app-shell.test.ts`** — Failed with `SyntaxError: Unexpected token '<'` because the test imported `isPathActive` from a `.tsx` file, pulling in JSX that couldn't be compiled in the test import chain. Extracted `isPathActive` to a separate `.ts` file (`path-active.ts`).

## Public API Changes

None — all changes are internal (compiler output format and test infrastructure).

## Files Changed

- [`native/vertz-compiler-core/src/css_transform.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-theme-shadcn-tests/native/vertz-compiler-core/src/css_transform.rs) — `build_replacement` now attaches `.css` property via `Object.defineProperty`
- [`packages/theme-shadcn/src/__tests__/primitive-styles.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-theme-shadcn-tests/packages/theme-shadcn/src/__tests__/primitive-styles.test.ts) — `require()` → static `import`
- [`packages/theme-shadcn/src/__tests__/app-shell.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-theme-shadcn-tests/packages/theme-shadcn/src/__tests__/app-shell.test.ts) — Import from `.ts` file instead of `.tsx`
- [`packages/theme-shadcn/src/components/primitives/path-active.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-theme-shadcn-tests/packages/theme-shadcn/src/components/primitives/path-active.ts) — New: extracted `isPathActive` pure function
- [`packages/theme-shadcn/src/components/primitives/app-shell.tsx`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-theme-shadcn-tests/packages/theme-shadcn/src/components/primitives/app-shell.tsx) — Imports + re-exports `isPathActive` from `path-active.ts`

## Test Plan

- [x] All 3 target test files pass: `app-shell.test.ts` (14 tests), `primitive-styles.test.ts` (53 tests), `styles.test.ts` (23 tests)
- [x] All Rust compiler tests pass (1143 tests)
- [x] Clippy clean, rustfmt clean
- [x] Adversarial review completed

Closes #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)