### PR TITLE
fix(runtime): add P-384 EC curve support and fix mock shadowing

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2475,6 +2476,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -4088,6 +4098,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6432,6 +6454,7 @@ dependencies = [
  "oxc_span",
  "oxc_transformer",
  "p256",
+ "p384",
  "rand 0.8.5",
  "rcgen",
  "regex",

--- a/native/vtz/Cargo.toml
+++ b/native/vtz/Cargo.toml
@@ -38,6 +38,7 @@ notify = "6"
 owo-colors = "4"
 base64 = "0.22"
 p256 = { version = "0.13", features = ["pem"] }
+p384 = { version = "0.13", features = ["pem"] }
 rand = "0.8"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 regex = "1"

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1644,7 +1644,7 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
           Hash, createHash, randomBytes, randomUUID, timingSafeEqual,
           randomFillSync, randomInt, getHashes,
           webcrypto: globalThis.crypto, constants: {},
-          getCiphers: () => [], getCurves: () => ['prime256v1', 'secp384r1', 'secp521r1'],
+          getCiphers: () => [], getCurves: () => ['prime256v1', 'secp384r1'],
           createHmac: () => { throw new Error('createHmac requires ESM import'); },
           createPrivateKey: (input) => {
             const key = typeof input === 'string' ? input : (input.key || input);
@@ -2923,7 +2923,7 @@ function getHashes() {
 }
 
 function getCiphers() { return []; }
-function getCurves() { return ['prime256v1', 'secp384r1', 'secp521r1']; }
+function getCurves() { return ['prime256v1', 'secp384r1']; }
 
 const constants = {};
 

--- a/native/vtz/src/runtime/ops/crypto.rs
+++ b/native/vtz/src/runtime/ops/crypto.rs
@@ -594,6 +594,29 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_keypair_via_js_ec_p384() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const result = Deno.core.ops.op_crypto_generate_keypair({
+                    type: "ec",
+                    namedCurve: "P-384",
+                });
+                [
+                    result.publicKey.includes("BEGIN PUBLIC KEY"),
+                    result.privateKey.includes("BEGIN PRIVATE KEY"),
+                ]
+                "#,
+            )
+            .unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr[0].as_bool().unwrap(), "Public key should be PEM");
+        assert!(arr[1].as_bool().unwrap(), "Private key should be PEM");
+    }
+
+    #[test]
     fn test_generate_keypair_via_js_unsupported_type() {
         let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
         let result = rt.execute_script(

--- a/native/vtz/src/runtime/ops/crypto.rs
+++ b/native/vtz/src/runtime/ops/crypto.rs
@@ -119,7 +119,7 @@ fn generate_rsa_keypair(modulus_length: u32) -> Result<KeyPairResult, deno_core:
     })
 }
 
-/// Generate an EC P-256 key pair in PEM format.
+/// Generate an EC key pair in PEM format. Supports P-256 and P-384 curves.
 fn generate_ec_keypair(curve: &str) -> Result<KeyPairResult, deno_core::error::AnyError> {
     match curve {
         "P-256" | "prime256v1" => {
@@ -131,6 +131,21 @@ fn generate_ec_keypair(curve: &str) -> Result<KeyPairResult, deno_core::error::A
             let private_pem = secret_key.to_pkcs8_pem(p256::pkcs8::LineEnding::LF)?;
             let public_key = secret_key.public_key();
             let public_pem = public_key.to_public_key_pem(p256::pkcs8::LineEnding::LF)?;
+
+            Ok(KeyPairResult {
+                public_key: public_pem,
+                private_key: private_pem.to_string(),
+            })
+        }
+        "P-384" | "secp384r1" => {
+            use p384::pkcs8::EncodePrivateKey;
+            use p384::pkcs8::EncodePublicKey;
+            use p384::SecretKey;
+
+            let secret_key = SecretKey::random(&mut rand::thread_rng());
+            let private_pem = secret_key.to_pkcs8_pem(p384::pkcs8::LineEnding::LF)?;
+            let public_key = secret_key.public_key();
+            let public_pem = public_key.to_public_key_pem(p384::pkcs8::LineEnding::LF)?;
 
             Ok(KeyPairResult {
                 public_key: public_pem,
@@ -149,6 +164,7 @@ fn generate_ec_keypair(curve: &str) -> Result<KeyPairResult, deno_core::error::A
 /// Supports:
 /// - RSA: `{ type: "rsa", modulusLength: 2048 }`
 /// - EC P-256: `{ type: "ec", namedCurve: "P-256" }`
+/// - EC P-384: `{ type: "ec", namedCurve: "P-384" }`
 #[op2]
 #[serde]
 pub fn op_crypto_generate_keypair(
@@ -499,6 +515,26 @@ mod tests {
             result.public_key.contains("-----BEGIN PUBLIC KEY-----"),
             "Public key should be SPKI PEM"
         );
+    }
+
+    #[test]
+    fn test_generate_ec_p384_keypair() {
+        let result = super::generate_ec_keypair("P-384").unwrap();
+        assert!(
+            result.private_key.contains("-----BEGIN PRIVATE KEY-----"),
+            "Private key should be PKCS#8 PEM"
+        );
+        assert!(
+            result.public_key.contains("-----BEGIN PUBLIC KEY-----"),
+            "Public key should be SPKI PEM"
+        );
+    }
+
+    #[test]
+    fn test_generate_ec_p384_via_prime_name() {
+        let result = super::generate_ec_keypair("secp384r1").unwrap();
+        assert!(result.private_key.contains("-----BEGIN PRIVATE KEY-----"));
+        assert!(result.public_key.contains("-----BEGIN PUBLIC KEY-----"));
     }
 
     #[test]

--- a/packages/cli/src/dev-server/__tests__/process-manager.test.ts
+++ b/packages/cli/src/dev-server/__tests__/process-manager.test.ts
@@ -40,10 +40,10 @@ describe('createProcessManager', () => {
   });
 
   it('isRunning returns true after start', () => {
-    const mc = createMockChild();
+    const mockChild = createMockChild();
     // Prevent the exit event from setting child to undefined immediately
-    mc.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    mockChild.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
@@ -52,27 +52,27 @@ describe('createProcessManager', () => {
   });
 
   it('isRunning returns false after process exits', () => {
-    const mc = createMockChild();
-    mc.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    const mockChild = createMockChild();
+    mockChild.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
     expect(pm.isRunning()).toBe(true);
 
-    mc.emitter.emit('exit', 0, null);
+    mockChild.emitter.emit('exit', 0, null);
     expect(pm.isRunning()).toBe(false);
   });
 
   it('stop terminates the child process with SIGTERM', async () => {
-    const mc = createMockChild();
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    const mockChild = createMockChild();
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts');
     await pm.stop();
 
-    expect(mc.child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mockChild.child.kill).toHaveBeenCalledWith('SIGTERM');
     expect(pm.isRunning()).toBe(false);
   });
 
@@ -95,37 +95,37 @@ describe('createProcessManager', () => {
   });
 
   it('onOutput receives stdout data from child', () => {
-    const mc = createMockChild();
-    mc.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    const mockChild = createMockChild();
+    mockChild.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
     const outputHandler = mock();
 
     pm.onOutput(outputHandler);
     pm.start('app.ts');
 
-    mc.stdout.emit('data', Buffer.from('hello'));
+    mockChild.stdout.emit('data', Buffer.from('hello'));
     expect(outputHandler).toHaveBeenCalledWith('hello');
   });
 
   it('onError receives stderr data from child', () => {
-    const mc = createMockChild();
-    mc.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    const mockChild = createMockChild();
+    mockChild.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
     const errorHandler = mock();
 
     pm.onError(errorHandler);
     pm.start('app.ts');
 
-    mc.stderr.emit('data', Buffer.from('error!'));
+    mockChild.stderr.emit('data', Buffer.from('error!'));
     expect(errorHandler).toHaveBeenCalledWith('error!');
   });
 
   it('start passes env to spawn function', () => {
-    const mc = createMockChild();
-    mc.child.kill = mock(() => true);
-    const spawnFn: SpawnFn = mock(() => mc.child as never);
+    const mockChild = createMockChild();
+    mockChild.child.kill = mock(() => true);
+    const spawnFn: SpawnFn = mock(() => mockChild.child as never);
     const pm = createProcessManager(spawnFn);
 
     pm.start('app.ts', { NODE_ENV: 'development' });


### PR DESCRIPTION
Fixes #2538

## Summary

- **P-384 EC curve support**: Added `secp384r1`/`P-384` to the Rust `generate_ec_keypair` op, enabling `generateKeyPairSync('ec', { namedCurve: 'P-384' })` for ES384 JWT signing
- **Mock shadowing fix**: Renamed `mock` → `mockChild` in `process-manager.test.ts` to avoid shadowing the imported `mock` function from `@vertz/test`
- **getCurves() accuracy**: Removed `secp521r1` from both CJS and ESM crypto shims since P-521 is not implemented

## Public API Changes

- `node:crypto` → `getCurves()` now returns `['prime256v1', 'secp384r1']` (removed unadvertised `secp521r1`)
- `node:crypto` → `generateKeyPairSync('ec', { namedCurve: 'P-384' })` now works

## Out of Scope (pre-existing issues)

- `create.test.ts` failures: Module loader incorrectly resolves `@vertz/ui` imports inside template literal strings — separate bug
- `auth-algorithm.test.ts` / `entitlement-access.test.ts` OOM: `jose` module loading crashes the runtime — separate runtime issue
- `process.chdir`: Already implemented and working — original issue report was stale
- CJS shim missing `generateKeyPairSync` export — tracked as NIT in review

## Changed Files

- [`native/vtz/Cargo.toml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-missing-node-apis/native/vtz/Cargo.toml) — added `p384` crate
- [`native/vtz/src/runtime/ops/crypto.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-missing-node-apis/native/vtz/src/runtime/ops/crypto.rs) — P-384 keygen + tests
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-missing-node-apis/native/vtz/src/runtime/module_loader.rs) — removed P-521 from getCurves()
- [`packages/cli/src/dev-server/__tests__/process-manager.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-missing-node-apis/packages/cli/src/dev-server/__tests__/process-manager.test.ts) — mock shadowing fix

## Review

Phase 1 review: [`reviews/fix-missing-node-apis/phase-01-fixes.md`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-missing-node-apis/reviews/fix-missing-node-apis/phase-01-fixes.md) — approved with 2 SHOULD-FIX findings (both resolved) and 1 NIT (pre-existing, out of scope).

## Test Plan

- [x] Rust unit tests: `test_generate_ec_p384_keypair`, `test_generate_ec_p384_via_prime_name`
- [x] JS integration test through V8 op bridge: `test_generate_keypair_via_js_ec_p384`
- [x] process-manager.test.ts: all 10 tests pass with renamed mock variables
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)