### PR TITLE
fix(vtz): force-exit test runner to prevent CI hangs (#2607)

### DIFF
--- a/native/vtz/src/main.rs
+++ b/native/vtz/src/main.rs
@@ -380,6 +380,8 @@ async fn async_main(cli: Cli) {
                     std::thread::spawn(move || vertz_runtime::test::runner::run_tests(config));
                 let (result, output) = handle.join().expect("test runner thread panicked");
                 print!("{}", output);
+                // Flush stdout before exit — process::exit skips Drop/flush.
+                let _ = std::io::Write::flush(&mut std::io::stdout());
 
                 // Force-exit after tests complete (#2607). V8 platform threads
                 // keep the process alive after main() returns, causing CI hangs.

--- a/native/vtz/src/main.rs
+++ b/native/vtz/src/main.rs
@@ -381,9 +381,10 @@ async fn async_main(cli: Cli) {
                 let (result, output) = handle.join().expect("test runner thread panicked");
                 print!("{}", output);
 
-                if !result.success() {
-                    std::process::exit(1);
-                }
+                // Force-exit after tests complete (#2607). V8 platform threads
+                // keep the process alive after main() returns, causing CI hangs.
+                let code = if result.success() { 0 } else { 1 };
+                std::process::exit(code);
             }
         }
         Command::Install(args) => {

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -1000,4 +1000,47 @@ describe('rejects.toThrow with inline async call (#2576)', () => {
         assert_eq!(result.passed(), 3, "Tests: {:?}", result.tests);
         assert_eq!(result.failed(), 0);
     }
+
+    /// Reproduces #2607: test files with lingering async resources (e.g. setInterval)
+    /// should be caught by the per-file timeout and reported as a file error,
+    /// not hang indefinitely.
+    #[test]
+    fn test_lingering_interval_triggers_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = write_test_file(
+            tmp.path(),
+            "hang.test.ts",
+            r#"
+            describe('lingering interval', () => {
+                it('passes but leaves interval running', () => {
+                    // This interval is never cleared — keeps the event loop alive
+                    setInterval(() => {}, 50);
+                    expect(1 + 1).toBe(2);
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &file,
+            &ExecuteOptions {
+                // Short timeout so the test doesn't take long
+                timeout_ms: 500,
+                ..Default::default()
+            },
+        );
+
+        // The test itself passes, but the file should error due to timeout
+        // because the unclosed setInterval keeps the event loop alive.
+        assert!(
+            result.file_error.is_some(),
+            "Expected file error from timeout, but got none. Tests: {:?}",
+            result.tests
+        );
+        let err = result.file_error.as_ref().unwrap();
+        assert!(
+            err.contains("timed out"),
+            "Expected timeout error, got: {err}"
+        );
+    }
 }

--- a/native/vtz/src/test/runner.rs
+++ b/native/vtz/src/test/runner.rs
@@ -965,4 +965,50 @@ mod tests {
         // (Note: with a simple test file the coverage may actually be 100%,
         //  so this test verifies the structure rather than a guaranteed failure)
     }
+
+    /// #2607: Test files with lingering async resources (setInterval, open handles)
+    /// must not hang the runner. The per-file timeout catches them and the runner
+    /// returns a file error rather than hanging indefinitely.
+    #[test]
+    fn test_run_lingering_interval_does_not_hang() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_project(tmp.path());
+        write_file(
+            tmp.path(),
+            "src/hang.test.ts",
+            r#"
+            describe('lingering', () => {
+                it('passes but leaves interval', () => {
+                    setInterval(() => {}, 50);
+                    expect(true).toBeTruthy();
+                });
+            });
+            "#,
+        );
+
+        let config = TestRunConfig {
+            root_dir: tmp.path().to_path_buf(),
+            paths: vec![],
+            include: vec![],
+            exclude: vec![],
+            concurrency: Some(1),
+            filter: None,
+            bail: false,
+            timeout_ms: 500, // Short timeout to avoid slow tests
+            reporter: ReporterFormat::Terminal,
+            coverage: false,
+            coverage_threshold: 95.0,
+            preload: vec![],
+            no_cache: false,
+        };
+
+        let (result, _output) = run_tests(config);
+
+        // The runner must complete (not hang) and report a file error
+        assert_eq!(result.file_errors, 1, "Expected 1 file error from timeout");
+        assert!(
+            !result.success(),
+            "Run should fail due to file timeout error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Force-exit `vtz test` process after results are printed, preventing V8 platform threads from keeping the process alive and causing CI timeouts
- Flush stdout before `exit()` to avoid truncated output
- Add tests verifying per-file timeout catches lingering async resources (e.g. unclosed `setInterval`)

## Root Cause

After `run_tests()` completes, V8's background platform threads (created on first isolate init) keep the process alive indefinitely. The existing code only called `exit(1)` on failure — successful runs relied on natural process exit, which never happened due to these threads.

## Changes

- [`native/vtz/src/main.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/runtime-error-fmt/native/vtz/src/main.rs) — Always call `std::process::exit()` with appropriate code after test output is printed; flush stdout first
- [`native/vtz/src/test/executor.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/runtime-error-fmt/native/vtz/src/test/executor.rs) — Add test: lingering `setInterval` caught by per-file timeout
- [`native/vtz/src/test/runner.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/runtime-error-fmt/native/vtz/src/test/runner.rs) — Add test: runner handles files with lingering async resources

## Public API Changes

None — internal fix only.

## Test plan

- [x] New test `test_lingering_interval_triggers_timeout` verifies per-file timeout catches unclosed `setInterval`
- [x] New test `test_run_lingering_interval_does_not_hang` verifies runner-level handling
- [x] All 3,730 existing tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean
- [x] Pre-push hooks pass (lint, quality-gates, rust-clippy, rust-fmt, rust-test, trojan-source)

Fixes #2607

🤖 Generated with [Claude Code](https://claude.com/claude-code)