### PR TITLE
fix(runtime): fix runtime adapter integration tests (#2554)

### DIFF
--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1695,14 +1695,14 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
                   promise: null,
                   setHeader(n, v) { this._headers[n.toLowerCase()] = v; return this; },
                   getHeader(n) { return this._headers[n.toLowerCase()]; },
-                  writeHead(s, h) { this.statusCode = s; if (h) Object.entries(h).forEach(([k,v]) => this.setHeader(k,v)); return this; },
+                  writeHead(s, h) { this.statusCode = s; this.headersSent = true; if (h) Object.entries(h).forEach(([k,v]) => this.setHeader(k,v)); return this; },
                   write(chunk) { this._chunks.push(typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(String(chunk))); return true; },
                   end(data) { if (data != null) this.write(data); let len = 0; for (const c of this._chunks) len += c.length; const body = new Uint8Array(len); let off = 0; for (const c of this._chunks) { body.set(c, off); off += c.length; } this._resolve(new Response(body, { status: this.statusCode, headers: this._headers })); },
                 };
                 res.promise = new Promise((resolve) => { res._resolve = resolve; });
                 handler(msg, res);
                 return res.promise;
-              }).then((s) => { _server = s; _port = s.port; _hostname = s.hostname; if (cb) cb(); });
+              }).then((s) => { _server = s; _port = s.port; _hostname = s.hostname; if (cb) cb(); }).catch((err) => { if (cb) cb(err); else throw err; });
               return this;
             },
             close(cb) { if (_server) _server.close(); if (cb) cb(); },
@@ -3090,6 +3090,9 @@ function createServer(handler) {
         _port = s.port;
         _hostname = s.hostname;
         if (cb) cb();
+      }).catch((err) => {
+        if (cb) cb(err);
+        else throw err;
       });
       return this;
     },

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -1679,33 +1679,34 @@ pub const CJS_BOOTSTRAP_JS: &str = r#"
         return { promisify, format, inspect, deprecate, types: {}, callbackify };
       }
       case 'http': {
-        // Minimal http stub — createServer delegates to Deno.serve
+        // Minimal http stub — createServer delegates to globalThis.__vtz_http.serve
         function createServer(handler) {
-          let server = null;
+          let _server = null;
+          let _port = 0;
+          let _hostname = '0.0.0.0';
           return {
             listen(port, host, cb) {
               if (typeof host === 'function') { cb = host; host = '0.0.0.0'; }
-              server = Deno.serve({ port, hostname: host || '0.0.0.0' }, async (req) => {
+              globalThis.__vtz_http.serve(port, host || '0.0.0.0', async (req) => {
                 const url = new URL(req.url);
                 const msg = { url: url.pathname + url.search, method: req.method, headers: Object.fromEntries(req.headers.entries()), _body: req,
                   on(event, cb2) { if (event === 'data') req.text().then(cb2); else if (event === 'end') req.text().then(() => cb2()); return this; } };
-                const res = { statusCode: 200, _headers: {}, _body: '', _resolve: null,
+                const res = { statusCode: 200, _headers: {}, _chunks: [], _resolve: null,
                   promise: null,
                   setHeader(n, v) { this._headers[n.toLowerCase()] = v; return this; },
                   getHeader(n) { return this._headers[n.toLowerCase()]; },
                   writeHead(s, h) { this.statusCode = s; if (h) Object.entries(h).forEach(([k,v]) => this.setHeader(k,v)); return this; },
-                  write(chunk) { this._body += chunk; return true; },
-                  end(data) { if (data) this._body += data; this._resolve(new Response(this._body, { status: this.statusCode, headers: this._headers })); },
+                  write(chunk) { this._chunks.push(typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(String(chunk))); return true; },
+                  end(data) { if (data != null) this.write(data); let len = 0; for (const c of this._chunks) len += c.length; const body = new Uint8Array(len); let off = 0; for (const c of this._chunks) { body.set(c, off); off += c.length; } this._resolve(new Response(body, { status: this.statusCode, headers: this._headers })); },
                 };
                 res.promise = new Promise((resolve) => { res._resolve = resolve; });
                 handler(msg, res);
                 return res.promise;
-              });
-              if (cb) cb();
+              }).then((s) => { _server = s; _port = s.port; _hostname = s.hostname; if (cb) cb(); });
               return this;
             },
-            close(cb) { if (server) server.shutdown(); if (cb) cb(); },
-            address() { return { port: 0, address: '0.0.0.0' }; },
+            close(cb) { if (_server) _server.close(); if (cb) cb(); },
+            address() { return { port: _port, address: _hostname }; },
           };
         }
         return { createServer };
@@ -3011,7 +3012,7 @@ export default { execSync, execFile, execFileSync, spawn };
 "#;
 
 /// Synthetic module for `node:http`.
-/// Provides createServer stub backed by Deno.serve.
+/// Provides createServer stub backed by globalThis.__vtz_http.serve.
 const NODE_HTTP_SPECIFIER: &str = "vertz:node_http";
 const NODE_HTTP_MODULE: &str = r#"
 class IncomingMessage {
@@ -3035,21 +3036,37 @@ class ServerResponse {
   constructor() {
     this.statusCode = 200;
     this._headers = {};
-    this._body = '';
+    this._chunks = [];
     this._resolve = null;
+    this.headersSent = false;
     this.promise = new Promise((resolve) => { this._resolve = resolve; });
   }
   setHeader(name, value) { this._headers[name.toLowerCase()] = value; return this; }
   getHeader(name) { return this._headers[name.toLowerCase()]; }
   writeHead(status, headers) {
     this.statusCode = status;
+    this.headersSent = true;
     if (headers) Object.entries(headers).forEach(([k, v]) => this.setHeader(k, v));
     return this;
   }
-  write(chunk) { this._body += chunk; return true; }
+  write(chunk) {
+    if (typeof chunk === 'string') {
+      this._chunks.push(new TextEncoder().encode(chunk));
+    } else if (chunk instanceof Uint8Array) {
+      this._chunks.push(chunk);
+    } else {
+      this._chunks.push(new TextEncoder().encode(String(chunk)));
+    }
+    return true;
+  }
   end(data) {
-    if (data) this._body += data;
-    this._resolve(new Response(this._body, {
+    if (data != null) this.write(data);
+    let totalLength = 0;
+    for (const c of this._chunks) totalLength += c.length;
+    const body = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const c of this._chunks) { body.set(c, offset); offset += c.length; }
+    this._resolve(new Response(body, {
       status: this.statusCode,
       headers: this._headers,
     }));
@@ -3057,21 +3074,27 @@ class ServerResponse {
 }
 
 function createServer(handler) {
-  let server = null;
+  let _server = null;
+  let _port = 0;
+  let _hostname = '0.0.0.0';
   return {
     listen(port, host, cb) {
       if (typeof host === 'function') { cb = host; host = '0.0.0.0'; }
-      server = Deno.serve({ port, hostname: host || '0.0.0.0' }, async (req) => {
+      globalThis.__vtz_http.serve(port, host || '0.0.0.0', async (req) => {
         const msg = new IncomingMessage(req);
         const res = new ServerResponse();
         handler(msg, res);
         return res.promise;
+      }).then((s) => {
+        _server = s;
+        _port = s.port;
+        _hostname = s.hostname;
+        if (cb) cb();
       });
-      if (cb) cb();
       return this;
     },
-    close(cb) { if (server) server.shutdown(); if (cb) cb(); },
-    address() { return { port: 0, address: '0.0.0.0' }; },
+    close(cb) { if (_server) _server.close(); if (cb) cb(); },
+    address() { return { port: _port, address: _hostname }; },
   };
 }
 

--- a/packages/integration-tests/src/runtime-adapters/bun.ts
+++ b/packages/integration-tests/src/runtime-adapters/bun.ts
@@ -1,13 +1,5 @@
 import type { RuntimeAdapter } from './types';
 
-declare const __vtz_http: {
-  serve(
-    port: number,
-    hostname: string,
-    handler: (req: Request) => Promise<Response>,
-  ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
-};
-
 export const bunAdapter: RuntimeAdapter = {
   name: 'bun',
   async createServer(handler) {

--- a/packages/integration-tests/src/runtime-adapters/bun.ts
+++ b/packages/integration-tests/src/runtime-adapters/bun.ts
@@ -1,20 +1,21 @@
 import type { RuntimeAdapter } from './types';
 
-declare const Bun: {
-  serve(options: { port: number; fetch: (request: Request) => Promise<Response> }): {
-    port: number;
-    stop(closeActiveConnections?: boolean): void;
-  };
+declare const __vtz_http: {
+  serve(
+    port: number,
+    hostname: string,
+    handler: (req: Request) => Promise<Response>,
+  ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
 };
 
 export const bunAdapter: RuntimeAdapter = {
   name: 'bun',
   async createServer(handler) {
-    const server = Bun.serve({ fetch: handler, port: 0 });
+    const server = await __vtz_http.serve(0, '0.0.0.0', handler);
     return {
       port: server.port,
       url: `http://localhost:${server.port}`,
-      close: async () => server.stop(),
+      close: async () => server.close(),
     };
   },
 };

--- a/packages/integration-tests/src/runtime-adapters/cloudflare.test.ts
+++ b/packages/integration-tests/src/runtime-adapters/cloudflare.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from '@vertz/test';
 import { createHandler as directCreateHandler } from '@vertz/cloudflare';
 import { cloudflareAdapter } from './cloudflare';
+import { resolveRuntimeAdapter } from './index';
 import type { ServerHandle } from './types';
 
 describe('vertz/cloudflare meta-package smoke', () => {
@@ -26,22 +27,13 @@ describe('vertz/cloudflare meta-package smoke', () => {
 });
 
 describe('invalid RUNTIME rejection', () => {
-  it('fails with an explicit error listing supported runtimes including cloudflare', async () => {
-    const proc = Bun.spawn(['bun', '-e', 'await import("./index.ts")'], {
-      cwd: import.meta.dirname,
-      env: { ...process.env, RUNTIME: 'invalid-runtime' },
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const exitCode = await proc.exited;
-    const stderr = await new Response(proc.stderr).text();
-
-    expect(exitCode).not.toBe(0);
-    expect(stderr).toContain('Unknown RUNTIME: invalid-runtime');
-    expect(stderr).toContain('cloudflare');
-    expect(stderr).toContain('node');
-    expect(stderr).toContain('bun');
-    expect(stderr).toContain('deno');
+  it('fails with an explicit error listing supported runtimes including cloudflare', () => {
+    const fn = () => resolveRuntimeAdapter('invalid-runtime');
+    expect(fn).toThrow('Unknown RUNTIME: invalid-runtime');
+    expect(fn).toThrow('cloudflare');
+    expect(fn).toThrow('node');
+    expect(fn).toThrow('bun');
+    expect(fn).toThrow('deno');
   });
 });
 

--- a/packages/integration-tests/src/runtime-adapters/cloudflare.ts
+++ b/packages/integration-tests/src/runtime-adapters/cloudflare.ts
@@ -2,11 +2,12 @@ import { createHandler } from '@vertz/cloudflare';
 import type { AppBuilder } from '@vertz/core';
 import type { RuntimeAdapter } from './types';
 
-declare const Bun: {
-  serve(options: { port: number; fetch: (request: Request) => Promise<Response> }): {
-    port: number;
-    stop(closeActiveConnections?: boolean): void;
-  };
+declare const __vtz_http: {
+  serve(
+    port: number,
+    hostname: string,
+    handler: (req: Request) => Promise<Response>,
+  ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
 };
 
 interface WorkerExecutionContext {
@@ -27,15 +28,14 @@ export const cloudflareAdapter: RuntimeAdapter = {
       passThroughOnException: () => {},
     };
 
-    const server = Bun.serve({
-      port: 0,
-      fetch: (req: Request) => worker.fetch(req, {}, ctx),
-    });
+    const server = await __vtz_http.serve(0, '0.0.0.0', (req: Request) =>
+      worker.fetch(req, {}, ctx),
+    );
 
     return {
       port: server.port,
       url: `http://localhost:${server.port}`,
-      close: async () => server.stop(),
+      close: async () => server.close(),
     };
   },
 };

--- a/packages/integration-tests/src/runtime-adapters/cloudflare.ts
+++ b/packages/integration-tests/src/runtime-adapters/cloudflare.ts
@@ -2,14 +2,6 @@ import { createHandler } from '@vertz/cloudflare';
 import type { AppBuilder } from '@vertz/core';
 import type { RuntimeAdapter } from './types';
 
-declare const __vtz_http: {
-  serve(
-    port: number,
-    hostname: string,
-    handler: (req: Request) => Promise<Response>,
-  ): Promise<{ id: number; port: number; hostname: string; close(): void }>;
-};
-
 interface WorkerExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
   passThroughOnException(): void;

--- a/packages/integration-tests/src/runtime-adapters/index.ts
+++ b/packages/integration-tests/src/runtime-adapters/index.ts
@@ -1,7 +1,5 @@
 import type { RuntimeAdapter } from './types';
 
-const runtime = process.env.RUNTIME || 'node';
-
 const adapters: Record<string, () => Promise<{ adapter: RuntimeAdapter }>> = {
   node: () => import('./node'),
   bun: () => import('./bun'),
@@ -9,14 +7,17 @@ const adapters: Record<string, () => Promise<{ adapter: RuntimeAdapter }>> = {
   cloudflare: () => import('./cloudflare'),
 };
 
-const load = adapters[runtime];
-
-if (!load) {
-  throw new Error(
-    `Unknown RUNTIME: ${runtime}. Expected one of: ${Object.keys(adapters).join(', ')}`,
-  );
+export function resolveRuntimeAdapter(runtime: string): () => Promise<{ adapter: RuntimeAdapter }> {
+  const load = adapters[runtime];
+  if (!load) {
+    throw new Error(
+      `Unknown RUNTIME: ${runtime}. Expected one of: ${Object.keys(adapters).join(', ')}`,
+    );
+  }
+  return load;
 }
 
-const { adapter } = await load();
+const runtime = process.env.RUNTIME || 'node';
+const { adapter } = await resolveRuntimeAdapter(runtime)();
 
 export { adapter };

--- a/packages/integration-tests/src/runtime-adapters/types.ts
+++ b/packages/integration-tests/src/runtime-adapters/types.ts
@@ -8,3 +8,21 @@ export interface RuntimeAdapter {
   name: string;
   createServer(handler: (req: Request) => Promise<Response>): Promise<ServerHandle>;
 }
+
+export interface VtzHttpServer {
+  id: number;
+  port: number;
+  hostname: string;
+  close(): void;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __vtz_http: {
+    serve(
+      port: number,
+      hostname: string,
+      handler: (req: Request) => Promise<Response>,
+    ): Promise<VtzHttpServer>;
+  };
+}


### PR DESCRIPTION
## Summary

- Fixed 3 runtime adapter integration test files that failed under `vtz test` due to use of runtime-specific APIs unavailable in vtz
- **bun.ts/cloudflare.ts**: Replaced `Bun.serve()` with `__vtz_http.serve()` (vtz native HTTP server API)
- **node:http stub** (CJS + ESM in `module_loader.rs`): Replaced `Deno.serve` with `globalThis.__vtz_http.serve()`, fixed `address()` to return actual bound port, fixed `ServerResponse.write()` to handle `Uint8Array` chunks, added `.catch()` for bind error handling
- **cloudflare.test.ts**: Replaced `Bun.spawn()` subprocess test with direct call to exported `resolveRuntimeAdapter()` function
- **index.ts**: Extracted `resolveRuntimeAdapter()` for testability

## Public API Changes

None — all changes are internal (runtime stubs and integration test utilities).

## Test plan

- [x] All 21 runtime adapter tests pass (0 failures → 21/21)
- [x] Rust `http_serve` unit tests pass (3/3)
- [x] Clippy clean, rustfmt clean
- [x] oxlint clean (only pre-existing warnings)
- [x] Adversarial review completed, all findings addressed

Closes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)