### PR TITLE
fix(sqlite): add missing test script to prevent CI failure (#2608)

### DIFF
--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "vtzx vertz-build",
+    "test": "vtz test",
     "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `"test": "vtz test"` script to `packages/sqlite/package.json`
- `@vertz/sqlite` had no test script, causing `vtz ci test` to fall back to `/usr/bin/test` (POSIX test utility) which exits with code 1
- `vtz test` exits 0 with "No test files found" when a package has no tests yet

## Public API Changes

None.

## Test plan

- [x] `vtz test` in `packages/sqlite/` exits 0 with "No test files found"
- [x] Pre-push quality gates pass (build + typecheck + test)

Fixes #2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)