### PR TITLE
fix(vtz): runtime detection tests support vtz runner (#2537)

### DIFF
--- a/.changeset/fix-runtime-detection-tests.md
+++ b/.changeset/fix-runtime-detection-tests.md
@@ -1,0 +1,6 @@
+---
+'@vertz/cli': patch
+'@vertz/runtime': patch
+---
+
+Fix runtime detection tests to support vtz as a valid runtime, fix path.dirname("/") returning "." instead of "/" in the vtz runtime, and fix version-check tests to explicitly chmod shell scripts

--- a/native/vtz/src/runtime/ops/path.rs
+++ b/native/vtz/src/runtime/ops/path.rs
@@ -31,13 +31,32 @@ pub fn op_path_resolve(#[serde] parts: Vec<String>) -> String {
 }
 
 /// Get the directory name of a path.
+/// Matches Node.js behavior: dirname("/") → "/", dirname("a") → "."
 #[op2]
 #[string]
 pub fn op_path_dirname(#[string] input: String) -> String {
+    if input.is_empty() {
+        return ".".to_string();
+    }
     let path = PathBuf::from(&input);
-    path.parent()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| ".".to_string())
+    match path.parent() {
+        Some(p) => {
+            let s = p.to_string_lossy().to_string();
+            if s.is_empty() {
+                ".".to_string()
+            } else {
+                s
+            }
+        }
+        // Root paths ("/" or "//") have no parent in Rust — normalize to "/"
+        None => {
+            if input.starts_with('/') {
+                "/".to_string()
+            } else {
+                input
+            }
+        }
+    }
 }
 
 /// Get the base name of a path.
@@ -284,6 +303,29 @@ mod tests {
             .execute_script("<test>", r#"path.dirname("/a/b/c.ts")"#)
             .unwrap();
         assert_eq!(result, serde_json::json!("/a/b"));
+    }
+
+    #[test]
+    fn test_path_dirname_root() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script("<test>", r#"path.dirname("/")"#).unwrap();
+        assert_eq!(result, serde_json::json!("/"));
+    }
+
+    #[test]
+    fn test_path_dirname_double_slash() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script("<test>", r#"path.dirname("//")"#)
+            .unwrap();
+        assert_eq!(result, serde_json::json!("/"));
+    }
+
+    #[test]
+    fn test_path_dirname_single_segment() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script("<test>", r#"path.dirname("a")"#).unwrap();
+        assert_eq!(result, serde_json::json!("."));
     }
 
     #[test]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,4 +39,4 @@ export { formatDiagnostic, formatDiagnosticSummary } from './ui/diagnostic-forma
 export { formatDuration, formatFileSize, formatPath } from './utils/format';
 export { findProjectRoot } from './utils/paths';
 export { isCI, requireParam } from './utils/prompt';
-export { detectRuntime } from './utils/runtime-detect';
+export { detectRuntime, type Runtime } from './utils/runtime-detect';

--- a/packages/cli/src/runtime/__tests__/version-check.test.ts
+++ b/packages/cli/src/runtime/__tests__/version-check.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from '@vertz/test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { checkVersionCompatibility, isNewerSemver } from '../launcher';
@@ -20,7 +20,8 @@ describe('Feature: version compatibility check', () => {
     describe('When version check runs', () => {
       it('Then warns to update @vertz/runtime', () => {
         const binaryPath = join(tmpDir, 'vertz-runtime');
-        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.40"', { mode: 0o755 });
+        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.40"');
+        chmodSync(binaryPath, 0o755);
 
         const warning = checkVersionCompatibility(binaryPath, '0.2.42');
 
@@ -35,7 +36,8 @@ describe('Feature: version compatibility check', () => {
     describe('When version check runs', () => {
       it('Then warns to update @vertz/cli', () => {
         const binaryPath = join(tmpDir, 'vertz-runtime');
-        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.42"', { mode: 0o755 });
+        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.42"');
+        chmodSync(binaryPath, 0o755);
 
         const warning = checkVersionCompatibility(binaryPath, '0.2.40');
 
@@ -50,7 +52,8 @@ describe('Feature: version compatibility check', () => {
     describe('When version check runs', () => {
       it('Then prints no warning', () => {
         const binaryPath = join(tmpDir, 'vertz-runtime');
-        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.42"', { mode: 0o755 });
+        writeFileSync(binaryPath, '#!/bin/sh\necho "vertz-runtime 0.2.42"');
+        chmodSync(binaryPath, 0o755);
 
         const warning = checkVersionCompatibility(binaryPath, '0.2.42');
 

--- a/packages/cli/src/utils/__tests__/runtime-detect.test.ts
+++ b/packages/cli/src/utils/__tests__/runtime-detect.test.ts
@@ -1,21 +1,72 @@
-import { describe, expect, it } from '@vertz/test';
+import { afterEach, describe, expect, it } from '@vertz/test';
 import { detectRuntime } from '../runtime-detect';
 
 describe('detectRuntime', () => {
-  it('returns bun when running under Bun', () => {
-    // Tests run under Bun, so Bun is always in globalThis
-    const result = detectRuntime();
-    expect(result).toBe('bun');
+  const g = globalThis as Record<string, unknown>;
+  let savedVtz: unknown;
+  let savedBun: unknown;
+  let hadVtz: boolean;
+  let hadBun: boolean;
+
+  afterEach(() => {
+    // Restore original globalThis state
+    if (hadVtz) {
+      g.__vtz_runtime = savedVtz;
+    } else {
+      delete g.__vtz_runtime;
+    }
+    if (hadBun) {
+      g.Bun = savedBun;
+    } else {
+      delete g.Bun;
+    }
   });
+
+  function saveAndClearGlobals() {
+    hadVtz = '__vtz_runtime' in globalThis;
+    hadBun = 'Bun' in globalThis;
+    savedVtz = g.__vtz_runtime;
+    savedBun = g.Bun;
+    delete g.__vtz_runtime;
+    delete g.Bun;
+  }
 
   it('returns a valid Runtime type', () => {
     const result = detectRuntime();
-    expect(['bun', 'node']).toContain(result);
+    expect(['vtz', 'bun', 'node']).toContain(result);
   });
 
-  it('verifies the detection logic checks globalThis.Bun', () => {
-    // When running under Bun, globalThis.Bun should be defined
-    expect('Bun' in globalThis).toBe(true);
+  it('returns vtz when __vtz_runtime is set on globalThis', () => {
+    saveAndClearGlobals();
+    g.__vtz_runtime = true;
+
+    expect(detectRuntime()).toBe('vtz');
+  });
+
+  it('returns vtz over bun when both globals are present', () => {
+    saveAndClearGlobals();
+    g.__vtz_runtime = true;
+    g.Bun = {};
+
+    expect(detectRuntime()).toBe('vtz');
+  });
+
+  it('returns bun when Bun is set but __vtz_runtime is not', () => {
+    saveAndClearGlobals();
+    g.Bun = {};
+
     expect(detectRuntime()).toBe('bun');
+  });
+
+  it('returns node when neither vtz nor Bun globals are present', () => {
+    saveAndClearGlobals();
+
+    expect(detectRuntime()).toBe('node');
+  });
+
+  it('detects the current runtime consistently', () => {
+    const first = detectRuntime();
+    const second = detectRuntime();
+    expect(first).toBe(second);
   });
 });

--- a/packages/cli/src/utils/runtime-detect.ts
+++ b/packages/cli/src/utils/runtime-detect.ts
@@ -1,6 +1,13 @@
-export type Runtime = 'bun' | 'node';
+export type Runtime = 'vtz' | 'bun' | 'node';
 
 export function detectRuntime(): Runtime {
+  if (
+    typeof globalThis !== 'undefined' &&
+    '__vtz_runtime' in globalThis &&
+    (globalThis as Record<string, unknown>).__vtz_runtime === true
+  ) {
+    return 'vtz';
+  }
   if (typeof globalThis !== 'undefined' && 'Bun' in globalThis) {
     return 'bun';
   }

--- a/reviews/fix-runtime-tests/phase-01-fix-tests.md
+++ b/reviews/fix-runtime-tests/phase-01-fix-tests.md
@@ -1,0 +1,43 @@
+# Phase 1: Fix Runtime Detection Tests
+
+- **Author:** riga
+- **Reviewer:** adversarial-review-agent
+- **Commits:** 688559849..HEAD
+- **Date:** 2026-04-14
+
+## Changes
+
+- `native/vtz/src/runtime/ops/path.rs` (modified) — fix `op_path_dirname` for root paths
+- `packages/cli/src/utils/runtime-detect.ts` (modified) — add `'vtz'` runtime type
+- `packages/cli/src/utils/__tests__/runtime-detect.test.ts` (modified) — isolated environment tests
+- `packages/cli/src/runtime/__tests__/version-check.test.ts` (modified) — add chmodSync
+- `packages/cli/src/index.ts` (modified) — export `Runtime` type
+- `.changeset/fix-runtime-detection-tests.md` (new) — changeset
+
+## CI Status
+
+- [x] Quality gates passed (Rust: clippy, fmt, tests; TS: lint, format, tests)
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (tests before/alongside implementation)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc (N/A — bug fix)
+
+## Findings
+
+### Round 1
+
+- **BLOCKER**: Runtime-detect tests were vacuously true for bun/node branches → Fixed: tests now isolate globalThis
+- **SHOULD-FIX**: `dirname("//")` returned `"//"` instead of `"/"` → Fixed: normalize root-like paths
+- **SHOULD-FIX**: `Runtime` type not exported from index → Fixed: added to exports
+
+### Resolution
+
+All blocker and should-fix items resolved. Re-verified all 29 tests pass. Quality gates clean.
+
+## Verdict
+
+**Approved** after fixes.


### PR DESCRIPTION
## Summary

Fixes #2537. Runtime detection tests were failing under `vtz test` due to three root causes:

- **`detectRuntime()`** didn't recognize vtz — added `'vtz'` to `Runtime` type, detected via `globalThis.__vtz_runtime`
- **`path.dirname("/")`** in vtz runtime returned `"."` instead of `"/"` — fixed `op_path_dirname` in Rust to match Node.js behavior
- **`writeFileSync` mode option** ignored by vtz — version-check tests now use explicit `chmodSync` for shell script executability

## Public API Changes

- `Runtime` type in `@vertz/cli` now includes `'vtz'` (`'vtz' | 'bun' | 'node'`)
- `Runtime` type is now re-exported from `@vertz/cli` index

## Files Changed

- [`native/vtz/src/runtime/ops/path.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-runtime-tests/native/vtz/src/runtime/ops/path.rs) — Fix `op_path_dirname` for root paths (`/`, `//`)
- [`packages/cli/src/utils/runtime-detect.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-runtime-tests/packages/cli/src/utils/runtime-detect.ts) — Add vtz detection
- [`packages/cli/src/utils/__tests__/runtime-detect.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-runtime-tests/packages/cli/src/utils/__tests__/runtime-detect.test.ts) — Properly isolated environment tests
- [`packages/cli/src/runtime/__tests__/version-check.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-runtime-tests/packages/cli/src/runtime/__tests__/version-check.test.ts) — Explicit chmodSync
- [`packages/cli/src/index.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-runtime-tests/packages/cli/src/index.ts) — Export `Runtime` type

## Review

- Adversarial review conducted: `reviews/fix-runtime-tests/phase-01-fix-tests.md`
- BLOCKER found (vacuously true tests) → fixed with proper globalThis isolation
- SHOULD-FIX found (`dirname("//")` edge case) → fixed with root normalization
- All 29 tests pass, quality gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)