### PR TITLE
fix(runtime): walk full PATH in cli.sh to find native binary (#2609)

### DIFF
--- a/.changeset/fix-cli-vtz-path-walk.md
+++ b/.changeset/fix-cli-vtz-path-walk.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix cli.sh to walk full PATH when resolving native binary, so nested vtz invocations in CI find the binary even when self-referencing symlinks shadow it

--- a/packages/runtime/cli.sh
+++ b/packages/runtime/cli.sh
@@ -58,18 +58,38 @@ case "$1" in
   *)
     # Try system-installed vtz before giving up:
     # 1. Check ~/.vtz/bin/vtz (standard install location)
-    # 2. Fall back to PATH lookup (avoiding self-reference)
     if [ -x "$HOME/.vtz/bin/vtz" ]; then
       exec "$HOME/.vtz/bin/vtz" "$@"
     fi
-    SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
-    SYSTEM_VTZ="$(command -v vtz 2>/dev/null || true)"
-    if [ -n "$SYSTEM_VTZ" ]; then
-      RESOLVED_SYSTEM="$(cd "$(dirname "$SYSTEM_VTZ")" && pwd)/$(basename "$SYSTEM_VTZ")"
-      if [ "$RESOLVED_SYSTEM" != "$SELF" ] && [ -x "$SYSTEM_VTZ" ]; then
-        exec "$SYSTEM_VTZ" "$@"
+
+    # 2. Walk PATH to find a non-self vtz binary.
+    #    `command -v` only returns the first match, which may be a symlink back
+    #    to this script (e.g. node_modules/.bin/vtz in a nested invocation).
+    #    We resolve symlinks on each candidate to detect self-references.
+    SELF_REAL="$PKG_DIR/$(basename "$SOURCE")"
+    _path_rest="$PATH"
+    while [ -n "$_path_rest" ]; do
+      _dir="${_path_rest%%:*}"
+      if [ "$_path_rest" = "$_dir" ]; then
+        _path_rest=""
+      else
+        _path_rest="${_path_rest#*:}"
       fi
-    fi
+      [ -z "$_dir" ] && continue
+      [ -x "$_dir/vtz" ] || continue
+      # Resolve symlinks on the candidate
+      _cand="$_dir/vtz"
+      while [ -L "$_cand" ]; do
+        _cand_dir="$(cd "$(dirname "$_cand")" 2>/dev/null && pwd)" || break
+        _cand="$(readlink "$_cand")"
+        [[ "$_cand" != /* ]] && _cand="$_cand_dir/$_cand"
+      done
+      _cand_real="$(cd "$(dirname "$_cand")" 2>/dev/null && pwd)/$(basename "$_cand")" 2>/dev/null || continue
+      if [ "$_cand_real" != "$SELF_REAL" ]; then
+        exec "$_dir/vtz" "$@"
+      fi
+    done
+
     SUB="${1:-}"
     if [ -n "$SUB" ]; then
       echo "vtz: native binary not available and '$SUB' has no fallback." >&2

--- a/packages/runtime/cli.sh
+++ b/packages/runtime/cli.sh
@@ -77,14 +77,17 @@ case "$1" in
       fi
       [ -z "$_dir" ] && continue
       [ -x "$_dir/vtz" ] || continue
-      # Resolve symlinks on the candidate
+      # Resolve symlinks on the candidate (max 40 hops to guard against loops)
       _cand="$_dir/vtz"
-      while [ -L "$_cand" ]; do
+      _hops=0
+      while [ -L "$_cand" ] && [ $_hops -lt 40 ]; do
+        _hops=$((_hops + 1))
         _cand_dir="$(cd "$(dirname "$_cand")" 2>/dev/null && pwd)" || break
         _cand="$(readlink "$_cand")"
         [[ "$_cand" != /* ]] && _cand="$_cand_dir/$_cand"
       done
-      _cand_real="$(cd "$(dirname "$_cand")" 2>/dev/null && pwd)/$(basename "$_cand")" 2>/dev/null || continue
+      _cand_real_dir="$(cd "$(dirname "$_cand")" 2>/dev/null && pwd)" || continue
+      _cand_real="$_cand_real_dir/$(basename "$_cand")"
       if [ "$_cand_real" != "$SELF_REAL" ]; then
         exec "$_dir/vtz" "$@"
       fi

--- a/packages/runtime/index.test.ts
+++ b/packages/runtime/index.test.ts
@@ -208,8 +208,7 @@ describe('Feature: bin scripts are pure bash with no Node/Bun dependency (#2419)
 });
 
 describe('Feature: cli.sh finds native binary in nested invocations (#2609)', () => {
-  const pkgDir2 = dirname(new URL(import.meta.url).pathname);
-  const cliShSrc = join(pkgDir2, 'cli.sh');
+  const cliShSrc = join(pkgDir, 'cli.sh');
   let tmpDir: string;
   let nativeBinDir: string;
   let selfBinDir: string;

--- a/packages/runtime/index.test.ts
+++ b/packages/runtime/index.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from '@vertz/test';
+import { describe, it, expect, beforeAll, afterAll } from '@vertz/test';
 import { dirname, join, resolve } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execSync, execFileSync } from 'node:child_process';
 
 describe('Feature: getBinaryPath() resolves platform binary', () => {
   describe('Given a platform package is installed at the expected path', () => {
@@ -193,6 +203,75 @@ describe('Feature: bin scripts are pure bash with no Node/Bun dependency (#2419)
       expect(content).toContain('node_modules/.bin');
       expect(content).toContain('PATH');
       expect(content).toContain('exec "$@"');
+    });
+  });
+});
+
+describe('Feature: cli.sh finds native binary in nested invocations (#2609)', () => {
+  const pkgDir2 = dirname(new URL(import.meta.url).pathname);
+  const cliShSrc = join(pkgDir2, 'cli.sh');
+  let tmpDir: string;
+  let nativeBinDir: string;
+  let selfBinDir: string;
+  let cliShCopy: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'vtz-path-test-'));
+
+    // Copy cli.sh to a temp location where no sibling platform package exists
+    cliShCopy = join(tmpDir, 'cli.sh');
+    writeFileSync(cliShCopy, readFileSync(cliShSrc, 'utf8'));
+    chmodSync(cliShCopy, 0o755);
+
+    // Create a fake "native" vtz binary that echoes a marker
+    nativeBinDir = join(tmpDir, 'native-bin');
+    mkdirSync(nativeBinDir);
+    writeFileSync(join(nativeBinDir, 'vtz'), '#!/bin/bash\necho "NATIVE_VTZ_FOUND"');
+    chmodSync(join(nativeBinDir, 'vtz'), 0o755);
+
+    // Create a self-referencing symlink (simulates node_modules/.bin/vtz → cli.sh)
+    selfBinDir = join(tmpDir, 'self-bin');
+    mkdirSync(selfBinDir);
+    execSync(`ln -s "${cliShCopy}" "${join(selfBinDir, 'vtz')}"`, { encoding: 'utf-8' });
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('Given a self-referencing vtz symlink appears before native binary on PATH', () => {
+    describe('When cli.sh is invoked via the symlink', () => {
+      it('Then finds the native binary by walking remaining PATH entries', () => {
+        // PATH: self-referencing dir first, then native binary, then system essentials
+        const testPath = `${selfBinDir}:${nativeBinDir}:/usr/bin:/bin:/usr/local/bin`;
+
+        const stdout = execFileSync(join(selfBinDir, 'vtz'), ['test'], {
+          env: { PATH: testPath, HOME: tmpDir },
+          encoding: 'utf-8',
+        });
+
+        expect(stdout.trim()).toBe('NATIVE_VTZ_FOUND');
+      });
+    });
+  });
+
+  describe('Given no native binary exists anywhere on PATH', () => {
+    describe('When cli.sh is invoked', () => {
+      it('Then exits with error and descriptive message', () => {
+        // PATH: only self-referencing dir + system essentials (no native binary)
+        const testPath = `${selfBinDir}:/usr/bin:/bin`;
+
+        try {
+          execFileSync(join(selfBinDir, 'vtz'), ['test'], {
+            env: { PATH: testPath, HOME: tmpDir },
+            encoding: 'utf-8',
+          });
+          // Should not reach here
+          expect(true).toBe(false);
+        } catch (err: unknown) {
+          expect((err as { stderr: string }).stderr).toContain('no fallback');
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix `cli.sh` PATH resolution for nested `vtz test` invocations in CI
- Replace single `command -v vtz` (returns first match only) with a full PATH walk that resolves symlinks and skips self-references
- Add behavioral tests verifying PATH resolution works with self-referencing symlinks

## Root Cause

When `vtz ci test` runs `bun run test` for `@vertz/cli`, bun prepends `node_modules/.bin` to PATH. The package-level `packages/cli/node_modules/.bin/vtz` symlink (pointing to `cli.sh`) shadows the native binary installed by `setup-vtz`. The old code used `command -v vtz` which returns only the **first** PATH match — the self-referencing symlink. After the self-reference check blocked it, the script gave up without searching remaining PATH entries.

## Changes

- [`packages/runtime/cli.sh`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cli-vtz-path/packages/runtime/cli.sh) — Replace `command -v` with manual PATH walk + symlink resolution + 40-hop safety limit
- [`packages/runtime/index.test.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-cli-vtz-path/packages/runtime/index.test.ts) — Behavioral tests: creates temp dir with self-referencing symlink + fake native binary, verifies PATH walk finds the native binary

## Public API Changes

None — internal shell wrapper fix only.

## Test plan

- [x] Behavioral test: self-referencing symlink before native binary on PATH → finds native binary
- [x] Behavioral test: no native binary on PATH → exits with descriptive error
- [x] All 19 existing runtime tests pass
- [x] Lint and format clean
- [ ] GitHub CI passes

Fixes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)