### PR TITLE
fix(pm): install optional platform-specific dependencies

### DIFF
--- a/.changeset/fix-optional-deps.md
+++ b/.changeset/fix-optional-deps.md
@@ -1,0 +1,11 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(pm): install optional platform-specific dependencies from stale v1 lockfiles
+
+Packages using the `optionalDependencies` pattern for platform-specific native binaries
+(e.g., lefthook, @typescript/native-preview, oxfmt) were not getting their binaries installed
+because v1 lockfiles didn't record optional dependencies. Added lockfile versioning (v1/v2)
+and a migration path that discovers missing optional deps from the registry for direct
+dependencies when upgrading from a v1 lockfile.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.60"
+version = "0.2.62"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.60"
+version = "0.2.62"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.60"
+version = "0.2.62"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/pm/lockfile.rs
+++ b/native/vtz/src/pm/lockfile.rs
@@ -2,13 +2,14 @@ use crate::pm::types::{Lockfile, LockfileEntry};
 use std::collections::BTreeMap;
 use std::path::Path;
 
-const LOCKFILE_HEADER: &str =
-    "# vertz.lock v1 (custom format) — DO NOT EDIT\n# Run \"vertz install\" to regenerate\n";
+const LOCKFILE_HEADER_V2: &str =
+    "# vertz.lock v2 (custom format) — DO NOT EDIT\n# Run \"vertz install\" to regenerate\n";
 
-/// Write a lockfile to disk in the custom text format
+/// Write a lockfile to disk in the custom text format.
+/// Always writes as v2 (current format with complete optional deps tracking).
 pub fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<(), std::io::Error> {
     let mut output = String::new();
-    output.push_str(LOCKFILE_HEADER);
+    output.push_str(LOCKFILE_HEADER_V2);
     output.push('\n');
 
     // Entries sorted alphabetically by spec key (BTreeMap guarantees this)
@@ -66,9 +67,32 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, Box<dyn std::error::Error>
     parse_lockfile(&content)
 }
 
+/// Parse lockfile version from header comment.
+/// Returns 1 for legacy lockfiles (or missing header), 2+ for current format.
+fn parse_lockfile_version(content: &str) -> u32 {
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("# vertz.lock v") {
+            if let Some(ver_str) = rest.split(|c: char| !c.is_ascii_digit()).next() {
+                if let Ok(v) = ver_str.parse::<u32>() {
+                    return v;
+                }
+            }
+        }
+        // Only check the first few lines (header is at the top)
+        if !line.starts_with('#') && !line.trim().is_empty() {
+            break;
+        }
+    }
+    1 // Default to v1 for old lockfiles without a version header
+}
+
 /// Parse lockfile content into a Lockfile struct
 pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Error>> {
-    let mut lockfile = Lockfile::default();
+    let version = parse_lockfile_version(content);
+    let mut lockfile = Lockfile {
+        version,
+        ..Default::default()
+    };
     let mut current_key: Option<String> = None;
     let mut current_entry = LockfileEntry {
         name: String::new(),
@@ -311,7 +335,7 @@ mod tests {
         write_lockfile(&path, &lockfile).unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
-        assert!(content.starts_with("# vertz.lock v1"));
+        assert!(content.starts_with("# vertz.lock v2"));
         assert!(content.contains("DO NOT EDIT"));
     }
 
@@ -859,5 +883,62 @@ lightningcss@^1.30.0:
             entry.optional_dependencies["lightningcss-linux-x64"],
             "1.32.0"
         );
+    }
+
+    #[test]
+    fn test_parse_lockfile_version_v1() {
+        let content = "# vertz.lock v1 (custom format) — DO NOT EDIT\n# Run \"vertz install\" to regenerate\n";
+        let lockfile = parse_lockfile(content).unwrap();
+        assert_eq!(lockfile.version, 1);
+    }
+
+    #[test]
+    fn test_parse_lockfile_version_v2() {
+        let content = "# vertz.lock v2 (custom format) — DO NOT EDIT\n# Run \"vertz install\" to regenerate\n";
+        let lockfile = parse_lockfile(content).unwrap();
+        assert_eq!(lockfile.version, 2);
+    }
+
+    #[test]
+    fn test_parse_lockfile_version_missing_defaults_v1() {
+        let content = "# some other lockfile format\n\nzod@^3.24.0:\n  version \"3.24.4\"\n  resolved \"url\"\n  integrity \"hash\"\n\n";
+        let lockfile = parse_lockfile(content).unwrap();
+        assert_eq!(lockfile.version, 1);
+    }
+
+    #[test]
+    fn test_write_lockfile_produces_v2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vertz.lock");
+        let lockfile = Lockfile::default();
+        write_lockfile(&path, &lockfile).unwrap();
+
+        let parsed = read_lockfile(&path).unwrap();
+        assert_eq!(parsed.version, 2);
+    }
+
+    #[test]
+    fn test_v1_lockfile_is_detected_for_migration() {
+        // Simulates a stale v1 lockfile (lefthook without optional deps)
+        let content = r#"# vertz.lock v1 (custom format) — DO NOT EDIT
+# Run "vertz install" to regenerate
+
+lefthook@^2.1.1:
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/lefthook/-/lefthook-2.1.5.tgz"
+  integrity "sha512-fake"
+  bin:
+    "lefthook" "bin/index.js"
+
+"#;
+        let lockfile = parse_lockfile(content).unwrap();
+
+        // Should be detected as v1
+        assert_eq!(lockfile.version, 1);
+
+        // lefthook entry should have no optional deps (stale)
+        let entry = &lockfile.entries["lefthook@^2.1.1"];
+        assert!(entry.optional_dependencies.is_empty());
+        assert!(!entry.bin.is_empty());
     }
 }

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -263,6 +263,70 @@ pub async fn install(
         }
     }
 
+    // Discover optional deps missing from stale v1 lockfiles.
+    // v1 lockfiles may not have recorded optional_dependencies for packages,
+    // causing platform-specific binaries (e.g., lefthook-darwin-arm64) to be missing.
+    // Only check direct dependencies to avoid fetching metadata for all transitive packages.
+    if existing_lockfile.version < 2 && !existing_lockfile.entries.is_empty() {
+        let direct_dep_names: HashSet<String> = all_deps.keys().cloned().collect();
+        let discovered =
+            discover_stale_optional_deps(&graph, &registry_client, &direct_dep_names).await;
+
+        if !discovered.is_empty() {
+            let mut all_optional_deps_to_resolve = BTreeMap::new();
+            for (parent_name, parent_version, opt_deps) in &discovered {
+                // Update the parent package via direct key lookup (O(1))
+                let key = format!("{}@{}", parent_name, parent_version);
+                if let Some(pkg) = graph.packages.get_mut(&key) {
+                    if pkg.optional_dependencies.is_empty() {
+                        pkg.optional_dependencies = opt_deps.clone();
+                    }
+                }
+                for (name, range) in opt_deps {
+                    // Keep first range if multiple parents declare the same optional dep
+                    all_optional_deps_to_resolve
+                        .entry(name.clone())
+                        .or_insert_with(|| range.clone());
+                }
+            }
+
+            // Resolve the discovered optional deps (failures are warnings)
+            if !all_optional_deps_to_resolve.is_empty() {
+                output.info(&format!(
+                    "Discovered {} optional dependencies from stale lockfile, resolving...",
+                    all_optional_deps_to_resolve.len()
+                ));
+                match resolver::resolve_all(
+                    &all_optional_deps_to_resolve,
+                    &BTreeMap::new(),
+                    &registry_client,
+                    &existing_lockfile,
+                    &empty_overrides,
+                    Vec::new(),
+                    None,
+                )
+                .await
+                {
+                    Ok((optional_graph, _)) => {
+                        let count = optional_graph.packages.len();
+                        for (key, pkg) in optional_graph.packages {
+                            graph.packages.entry(key).or_insert(pkg);
+                        }
+                        for (key, scripts) in optional_graph.scripts {
+                            graph.scripts.entry(key).or_insert(scripts);
+                        }
+                        if count > 0 {
+                            output.info(&format!("Resolved {} platform-specific packages", count));
+                        }
+                    }
+                    Err(e) => {
+                        output.warning(&format!("Failed to resolve stale optional deps: {}", e));
+                    }
+                }
+            }
+        }
+    }
+
     // Report override applications
     for app in &override_applications {
         output.info(&format!(
@@ -2996,6 +3060,61 @@ pub fn format_audit_json(
     output.push('\n');
 
     output
+}
+
+/// Discover optional dependencies missing from a stale v1 lockfile.
+///
+/// v1 lockfiles may not have recorded `optionalDependencies` for packages.
+/// This function fetches registry metadata (ETag-cached) for **direct** dependencies
+/// that have empty `optional_dependencies` in the graph and returns any discovered optional deps.
+///
+/// Only direct deps are checked to avoid fetching metadata for hundreds of transitive
+/// packages that legitimately have no optional deps.
+///
+/// Returns: Vec of (package_name, package_version, optional_dependencies)
+async fn discover_stale_optional_deps(
+    graph: &resolver::ResolvedGraph,
+    registry: &registry::RegistryClient,
+    direct_dep_names: &HashSet<String>,
+) -> Vec<(String, String, BTreeMap<String, String>)> {
+    // Only check direct deps with empty optional deps in the graph
+    let mut candidates: BTreeMap<String, String> = BTreeMap::new();
+    for pkg in graph.packages.values() {
+        if direct_dep_names.contains(&pkg.name)
+            && pkg.optional_dependencies.is_empty()
+            && !candidates.contains_key(&pkg.name)
+        {
+            candidates.insert(pkg.name.clone(), pkg.version.clone());
+        }
+    }
+
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    // Batch-fetch metadata concurrently (ETag-cached, no network cost for cached entries)
+    let results: Vec<_> = stream::iter(candidates.into_iter())
+        .map(|(name, version)| {
+            let reg = registry;
+            async move {
+                match reg.fetch_metadata_for_install(&name).await {
+                    Ok(meta) => {
+                        if let Some(vm) = meta.versions.get(&version) {
+                            if !vm.optional_dependencies.is_empty() {
+                                return Some((name, version, vm.optional_dependencies.clone()));
+                            }
+                        }
+                        None
+                    }
+                    Err(_) => None,
+                }
+            }
+        })
+        .buffer_unordered(50)
+        .collect()
+        .await;
+
+    results.into_iter().flatten().collect()
 }
 
 #[cfg(test)]

--- a/native/vtz/src/pm/types.rs
+++ b/native/vtz/src/pm/types.rs
@@ -163,9 +163,20 @@ pub struct LockfileEntry {
 }
 
 /// Full lockfile representation
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Lockfile {
+    /// Format version: 1 = legacy (may be missing optional deps), 2 = current
+    pub version: u32,
     pub entries: BTreeMap<String, LockfileEntry>,
+}
+
+impl Default for Lockfile {
+    fn default() -> Self {
+        Self {
+            version: 2,
+            entries: BTreeMap::new(),
+        }
+    }
 }
 
 impl Lockfile {

--- a/reviews/fix-optional-deps/phase-01-stale-lockfile-migration.md
+++ b/reviews/fix-optional-deps/phase-01-stale-lockfile-migration.md
@@ -1,0 +1,50 @@
+# Phase 1: Stale Lockfile Migration for Optional Dependencies
+
+- **Author:** Claude Opus 4.6
+- **Reviewer:** Claude Opus 4.6 (adversarial)
+- **Commits:** (single phase)
+- **Date:** 2026-04-14
+
+## Changes
+
+- native/vtz/src/pm/types.rs (modified) — Added `version` field to `Lockfile`
+- native/vtz/src/pm/lockfile.rs (modified) — Version parsing, v2 header, 5 new tests
+- native/vtz/src/pm/mod.rs (modified) — `discover_stale_optional_deps()` + install integration
+
+## CI Status
+
+- [x] Quality gates passed — `cargo test -p vtz` (3334+ tests), clippy clean, fmt clean
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for (#2644)
+- [x] TDD compliance (version detection tests written)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc (N/A — internal fix)
+
+## Findings
+
+### Initial Review — Changes Requested
+
+**B1 (BLOCKER): Performance — fetched metadata for ALL packages with empty optional deps**
+- Fixed: Now only checks direct dependencies (root + workspace), not transitive packages
+
+**B2 (BLOCKER): Range collision — duplicate optional deps silently collapsed**
+- Fixed: Uses `entry().or_insert_with()` to keep first range
+
+**S1 (SHOULD-FIX): O(N*M) graph update loop**
+- Fixed: Direct key lookup via `format!("{}@{}", name, version)` — O(1) per parent
+
+**S3 (SHOULD-FIX): Lockfile doesn't persist os/cpu constraints**
+- Pre-existing issue. Created #2645 to track.
+
+**S4 (SHOULD-FIX): No version validation in parser**
+- Accepted as NITPICK: only v1 and v2 exist; future versions will be handled when added.
+
+**S2 (SHOULD-FIX): No integration test for discovery flow**
+- Accepted: discovery is async + requires real registry. Lockfile version tests cover the detection path. The real integration test is `vtz install` on a v1 lockfile.
+
+## Resolution
+
+All blockers and should-fix items addressed. Re-reviewed after fixes — approved.


### PR DESCRIPTION
## Summary

Fixes #2644 — `vtz install` now installs optional platform-specific native dependencies.

- **Root cause**: v1 lockfiles didn't record `optionalDependencies` for packages. When the resolver reads from lockfile (the fast path), it used the entry's empty `optional_dependencies`, so platform-specific binaries (e.g., `lefthook-darwin-arm64`, `@typescript/native-preview-darwin-arm64`, `@oxfmt/binding-darwin-arm64`) were never queued for resolution.

- **Fix**: Added lockfile versioning (v1 → v2) with a one-time migration path. When a v1 lockfile is detected, the installer fetches registry metadata for **direct dependencies** with empty optional deps, discovers the missing optional deps, resolves them, and writes a v2 lockfile. Subsequent installs use the v2 lockfile with no extra overhead.

### Changes
- [`native/vtz/src/pm/types.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-optional-deps/native/vtz/src/pm/types.rs) — Added `version: u32` field to `Lockfile` struct
- [`native/vtz/src/pm/lockfile.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-optional-deps/native/vtz/src/pm/lockfile.rs) — Version detection from header, v2 header constant, 5 new tests
- [`native/vtz/src/pm/mod.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-optional-deps/native/vtz/src/pm/mod.rs) — `discover_stale_optional_deps()` function + integration in `install()`

### Public API Changes
None — internal package manager behavior change.

### Review
- Adversarial review completed: `reviews/fix-optional-deps/phase-01-stale-lockfile-migration.md`
- 2 blockers found and fixed (performance regression on full-graph metadata fetch, range collision in dedup)
- Pre-existing issue #2645 created for lockfile os/cpu persistence gap

## Test plan
- [x] 5 new lockfile version detection tests
- [x] All 3334+ existing pm tests pass
- [x] clippy clean, fmt clean
- [x] Manual verification: `vtz install` on repo with v1 lockfile discovers and resolves platform-specific packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)