### PR TITLE
fix(vtz): strip export type *, fix pre-push hook, persist lockfile os/cpu

### DIFF
--- a/.changeset/fix-misc-bugs.md
+++ b/.changeset/fix-misc-bugs.md
@@ -1,0 +1,9 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): strip `export type *` in SSR, persist lockfile platform constraints
+
+- Strip `export type * from` and `export type * as Ns from` in the TypeScript strip pass, fixing SSR crashes on type-only star re-exports (#2638)
+- Persist `os` and `cpu` platform constraints in lockfile entries so they round-trip correctly through write/parse (#2645)
+- Replace no-op pre-push hook with working `vtz ci` quality gates (#2643)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,8 +4,10 @@ pre-push:
       run: bash scripts/check-unicode.sh
     lint:
       run: node_modules/.bin/vtzx oxlint packages/ && node_modules/.bin/vtzx oxfmt --check packages/
-    quality-gates:
-      run: turbo run build typecheck test --filter=!@vertz-examples/* --filter=!entity-todo-example --filter=!@vertz/landing-nextjs --filter=!@vertz/landing-nextjs-vercel --filter=!@vertz/landing --filter=!@vertz/component-docs --filter=!@vertz/site --filter=!@vertz/og --filter=!@vertz/mint-docs --filter=!@vertz-benchmarks/* --filter=!contacts-api-example --filter=!create-vertz --filter=!@vertz/create-vertz-app --filter=!landing --filter=!@vertz/ui-primitives --filter=!@vertz/ui-server --filter=!@vertz/dev-orchestrator --filter=!@vertz/test --filter=!@vertz/icons --filter=!@vertz/compiler --filter=!@vertz/desktop --filter=!@vertz/fetch --filter=!@vertz/openapi --filter=!@vertz/core --filter=!@vertz/codegen --filter=!@vertz/db --filter=!@vertz/ui-canvas --filter=!@vertz/ui --filter=!@vertz/ui-auth --filter=!@vertz/theme-shadcn --filter=!@vertz/docs --filter=!@vertz/integration-tests --filter=!@vertz/agents --filter=!@vertz/testing --filter=!@vertz/cloudflare --filter=!@vertz/mdx --filter=!@vertz/native-compiler --filter=!@vertz/tui --filter=!hmr-e2e-fixture --filter=!vertz --filter=!@vertz/runtime --filter=!@vertz/runtime-darwin-arm64 --filter=!@vertz/runtime-darwin-x64 --filter=!@vertz/runtime-linux-arm64 --filter=!@vertz/runtime-linux-x64 --filter=!@vertz/server --filter=!@vertz/schema --filter=!@vertz/errors --filter=!@vertz/ci --filter=!@vertz/cli --filter=!@vertz/cli-runtime --filter=!@vertz/build --filter=!@vertz/sqlite --output-logs=errors-only
+    build-typecheck:
+      run: node_modules/.bin/vtz ci build-typecheck --concurrency 2
+    test:
+      run: node_modules/.bin/vtz ci test --concurrency 2
     rust-fmt:
       run: cd native && cargo fmt --all -- --check
       glob: "native/**/*.rs"

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -549,6 +549,11 @@ fn strip_leftover_typescript(code: &str) -> String {
             i += 1;
             continue;
         }
+        // `export type * from '...'` or `export type * as Ns from '...'`
+        if trimmed.starts_with("export type *") {
+            i += 1;
+            continue;
+        }
         // Type alias: `export type X = ...` or `type X = ...` (single or multi-line)
         // Guard: the token after `type ` must be an identifier (e.g., `type Foo =`),
         // NOT an operator like `=` or `+=`. Otherwise `type = 'value'` (a variable
@@ -2672,6 +2677,30 @@ export function App() {
             result.contains("const x = 1;"),
             "Non-type code should be preserved"
         );
+    }
+
+    #[test]
+    fn test_strip_export_type_star_from() {
+        let code = "export type * from './types';\nconst x = 1;";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            !result.contains("export type"),
+            "export type * from should be stripped. Got: {}",
+            result
+        );
+        assert!(result.contains("const x = 1;"));
+    }
+
+    #[test]
+    fn test_strip_export_type_star_as_namespace_from() {
+        let code = "export type * as Types from './types';\nconst x = 1;";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            !result.contains("export type"),
+            "export type * as namespace from should be stripped. Got: {}",
+            result
+        );
+        assert!(result.contains("const x = 1;"));
     }
 
     #[test]

--- a/native/vtz/src/pm/lockfile.rs
+++ b/native/vtz/src/pm/lockfile.rs
@@ -55,6 +55,8 @@ pub fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<(), std::io::E
             }
         }
 
+        // Some(vec![]) intentionally collapses to None on round-trip (no section written).
+        // matches_platform treats both identically, so this is semantically correct.
         if let Some(ref os_list) = entry.os {
             if !os_list.is_empty() {
                 output.push_str("  os:\n");
@@ -1141,5 +1143,40 @@ lefthook@^2.1.1:
         let entry = &parsed.entries["pkg@^1.0.0"];
         assert_eq!(entry.os, None);
         assert_eq!(entry.cpu, None);
+    }
+
+    #[test]
+    fn test_negated_os_cpu_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vertz.lock");
+
+        let mut lockfile = Lockfile::default();
+        lockfile.entries.insert(
+            "pkg@^1.0.0".to_string(),
+            LockfileEntry {
+                name: "pkg".to_string(),
+                range: "^1.0.0".to_string(),
+                version: "1.0.0".to_string(),
+                resolved: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz".to_string(),
+                integrity: "sha512-xyz".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                scripts: BTreeMap::new(),
+                optional: false,
+                overridden: false,
+                os: Some(vec!["!win32".to_string()]),
+                cpu: Some(vec!["!ia32".to_string(), "!mips".to_string()]),
+            },
+        );
+
+        write_lockfile(&path, &lockfile).unwrap();
+        let parsed = read_lockfile(&path).unwrap();
+        let entry = &parsed.entries["pkg@^1.0.0"];
+        assert_eq!(entry.os, Some(vec!["!win32".to_string()]));
+        assert_eq!(
+            entry.cpu,
+            Some(vec!["!ia32".to_string(), "!mips".to_string()])
+        );
     }
 }

--- a/native/vtz/src/pm/lockfile.rs
+++ b/native/vtz/src/pm/lockfile.rs
@@ -55,6 +55,24 @@ pub fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<(), std::io::E
             }
         }
 
+        if let Some(ref os_list) = entry.os {
+            if !os_list.is_empty() {
+                output.push_str("  os:\n");
+                for os_val in os_list {
+                    output.push_str(&format!("    \"{}\"\n", os_val));
+                }
+            }
+        }
+
+        if let Some(ref cpu_list) = entry.cpu {
+            if !cpu_list.is_empty() {
+                output.push_str("  cpu:\n");
+                for cpu_val in cpu_list {
+                    output.push_str(&format!("    \"{}\"\n", cpu_val));
+                }
+            }
+        }
+
         output.push('\n');
     }
 
@@ -106,6 +124,8 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
         scripts: BTreeMap::new(),
         optional: false,
         overridden: false,
+        os: None,
+        cpu: None,
     };
     let mut in_section: Option<&'static str> = None;
 
@@ -128,6 +148,8 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
                     scripts: BTreeMap::new(),
                     optional: false,
                     overridden: false,
+                    os: None,
+                    cpu: None,
                 };
                 in_section = None;
             }
@@ -137,8 +159,14 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
         let trimmed = line.trim();
 
         // Subsection headers that are NOT top-level entry keys
-        const SECTION_HEADERS: &[&str] =
-            &["dependencies:", "optionalDependencies:", "bin:", "scripts:"];
+        const SECTION_HEADERS: &[&str] = &[
+            "dependencies:",
+            "optionalDependencies:",
+            "bin:",
+            "scripts:",
+            "os:",
+            "cpu:",
+        ];
 
         // New entry: "name@range:" at column 0
         if !line.starts_with(' ') && trimmed.ends_with(':') && !SECTION_HEADERS.contains(&trimmed) {
@@ -157,6 +185,8 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
                     scripts: BTreeMap::new(),
                     optional: false,
                     overridden: false,
+                    os: None,
+                    cpu: None,
                 };
                 in_section = None;
             }
@@ -188,6 +218,14 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
                 in_section = Some("scripts");
                 continue;
             }
+            if trimmed == "os:" {
+                in_section = Some("os");
+                continue;
+            }
+            if trimmed == "cpu:" {
+                in_section = Some("cpu");
+                continue;
+            }
 
             match in_section {
                 Some("dependencies") => {
@@ -215,6 +253,20 @@ pub fn parse_lockfile(content: &str) -> Result<Lockfile, Box<dyn std::error::Err
                             .scripts
                             .insert(name.to_string(), cmd.to_string());
                     }
+                }
+                Some("os") => {
+                    let val = unquote(trimmed);
+                    current_entry
+                        .os
+                        .get_or_insert_with(Vec::new)
+                        .push(val.to_string());
+                }
+                Some("cpu") => {
+                    let val = unquote(trimmed);
+                    current_entry
+                        .cpu
+                        .get_or_insert_with(Vec::new)
+                        .push(val.to_string());
                 }
                 _ => {
                     if let Some(rest) = trimmed.strip_prefix("version ") {
@@ -294,6 +346,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -311,6 +365,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -361,6 +417,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
         lockfile.entries.insert(
@@ -377,6 +435,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -408,6 +468,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
         lockfile.entries.insert(
@@ -424,6 +486,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -497,6 +561,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -515,6 +581,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -569,6 +637,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: true,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
         lockfile.entries.insert(
@@ -585,6 +655,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -640,6 +712,8 @@ fsevents@^2.3.0:
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: true,
+                os: None,
+                cpu: None,
             },
         );
         lockfile.entries.insert(
@@ -656,6 +730,8 @@ fsevents@^2.3.0:
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -708,6 +784,8 @@ zod@^3.24.0:
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -749,6 +827,8 @@ zod@^3.24.0:
                 scripts,
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -831,6 +911,8 @@ zod@^3.24.0:
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -940,5 +1022,124 @@ lefthook@^2.1.1:
         let entry = &lockfile.entries["lefthook@^2.1.1"];
         assert!(entry.optional_dependencies.is_empty());
         assert!(!entry.bin.is_empty());
+    }
+
+    #[test]
+    fn test_write_and_read_os_cpu_constraints() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vertz.lock");
+
+        let mut lockfile = Lockfile::default();
+        lockfile.entries.insert(
+            "@esbuild/darwin-arm64@0.25.0".to_string(),
+            LockfileEntry {
+                name: "@esbuild/darwin-arm64".to_string(),
+                range: "0.25.0".to_string(),
+                version: "0.25.0".to_string(),
+                resolved:
+                    "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz"
+                        .to_string(),
+                integrity: "sha512-abc".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                scripts: BTreeMap::new(),
+                optional: true,
+                overridden: false,
+                os: Some(vec!["darwin".to_string()]),
+                cpu: Some(vec!["arm64".to_string()]),
+            },
+        );
+
+        write_lockfile(&path, &lockfile).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("os:\n"),
+            "lockfile should contain os section"
+        );
+        assert!(
+            content.contains("cpu:\n"),
+            "lockfile should contain cpu section"
+        );
+
+        let parsed = read_lockfile(&path).unwrap();
+        let entry = &parsed.entries["@esbuild/darwin-arm64@0.25.0"];
+        assert_eq!(entry.os, Some(vec!["darwin".to_string()]));
+        assert_eq!(entry.cpu, Some(vec!["arm64".to_string()]));
+    }
+
+    #[test]
+    fn test_write_and_read_multi_os_cpu() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vertz.lock");
+
+        let mut lockfile = Lockfile::default();
+        lockfile.entries.insert(
+            "pkg@^1.0.0".to_string(),
+            LockfileEntry {
+                name: "pkg".to_string(),
+                range: "^1.0.0".to_string(),
+                version: "1.0.0".to_string(),
+                resolved: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz".to_string(),
+                integrity: "sha512-xyz".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                scripts: BTreeMap::new(),
+                optional: false,
+                overridden: false,
+                os: Some(vec!["darwin".to_string(), "linux".to_string()]),
+                cpu: Some(vec!["arm64".to_string(), "x64".to_string()]),
+            },
+        );
+
+        write_lockfile(&path, &lockfile).unwrap();
+        let parsed = read_lockfile(&path).unwrap();
+        let entry = &parsed.entries["pkg@^1.0.0"];
+        assert_eq!(
+            entry.os,
+            Some(vec!["darwin".to_string(), "linux".to_string()])
+        );
+        assert_eq!(
+            entry.cpu,
+            Some(vec!["arm64".to_string(), "x64".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_no_os_cpu_roundtrips_as_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vertz.lock");
+
+        let mut lockfile = Lockfile::default();
+        lockfile.entries.insert(
+            "pkg@^1.0.0".to_string(),
+            LockfileEntry {
+                name: "pkg".to_string(),
+                range: "^1.0.0".to_string(),
+                version: "1.0.0".to_string(),
+                resolved: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz".to_string(),
+                integrity: "sha512-xyz".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                scripts: BTreeMap::new(),
+                optional: false,
+                overridden: false,
+                os: None,
+                cpu: None,
+            },
+        );
+
+        write_lockfile(&path, &lockfile).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("os "), "should not write os when None");
+        assert!(!content.contains("cpu "), "should not write cpu when None");
+
+        let parsed = read_lockfile(&path).unwrap();
+        let entry = &parsed.entries["pkg@^1.0.0"];
+        assert_eq!(entry.os, None);
+        assert_eq!(entry.cpu, None);
     }
 }

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -3172,6 +3172,8 @@ mod tests {
             scripts: BTreeMap::new(),
             optional: false,
             overridden: false,
+            os: None,
+            cpu: None,
         }
     }
 
@@ -4911,6 +4913,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 
@@ -4957,6 +4961,8 @@ mod tests {
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
 

--- a/native/vtz/src/pm/resolver.rs
+++ b/native/vtz/src/pm/resolver.rs
@@ -273,8 +273,8 @@ async fn resolve_one_task<'a>(
                 optional_dependencies: entry.optional_dependencies.clone(),
                 bin: entry.bin.clone(),
                 nest_path: vec![],
-                os: None,
-                cpu: None,
+                os: entry.os.clone(),
+                cpu: entry.cpu.clone(),
             };
 
             // Atomic check-and-insert into graph
@@ -544,6 +544,8 @@ pub fn graph_to_lockfile(
                     scripts,
                     optional: optional_names.contains(name),
                     overridden: false,
+                    os: pkg.os.clone(),
+                    cpu: pkg.cpu.clone(),
                 },
             );
         }
@@ -597,6 +599,8 @@ pub fn graph_to_lockfile(
                         scripts: dep_scripts,
                         optional: false,
                         overridden: false,
+                        os: dep_pkg.os.clone(),
+                        cpu: dep_pkg.cpu.clone(),
                     });
                 }
             }
@@ -620,6 +624,8 @@ pub fn graph_to_lockfile(
                 scripts: BTreeMap::new(),
                 optional: false,
                 overridden: false,
+                os: None,
+                cpu: None,
             },
         );
     }

--- a/native/vtz/src/pm/types.rs
+++ b/native/vtz/src/pm/types.rs
@@ -160,6 +160,10 @@ pub struct LockfileEntry {
     pub optional: bool,
     /// Whether this version was forced by an override
     pub overridden: bool,
+    /// Platform constraint: which OS this package is for (e.g., ["darwin", "linux"])
+    pub os: Option<Vec<String>>,
+    /// Platform constraint: which CPU arch this package is for (e.g., ["arm64", "x64"])
+    pub cpu: Option<Vec<String>>,
 }
 
 /// Full lockfile representation


### PR DESCRIPTION
## Summary

- **#2638** — Strip `export type * from '...'` and `export type * as Ns from '...'` in the TypeScript strip pass (`strip_leftover_typescript`), fixing SSR crashes on type-only star re-exports from the default scaffold template
- **#2643** — Replace no-op pre-push hook quality-gates (turbo with 52 exclusion filters filtering ALL packages) with working `vtz ci build-typecheck` and `vtz ci test` workflows
- **#2645** — Add `os` and `cpu` fields to `LockfileEntry`, update write/parse for round-tripping, and wire the resolver's lockfile path to read platform constraints instead of hardcoding `None`
- **#2635** — Already fixed in cc8ea652c (import injection word-boundary bug)

## Public API Changes

None — all changes are internal to the vtz runtime and build tooling.

## Test plan

- [x] 2 new Rust unit tests for `export type *` stripping (both variants)
- [x] 3 new Rust unit tests for lockfile os/cpu round-tripping (single, multi, None)
- [x] All 3341 vtz lib tests pass
- [x] All 576 PM tests pass
- [x] All 44 strip tests pass
- [x] Clippy clean, rustfmt clean

Fixes #2638
Fixes #2643
Fixes #2645

🤖 Generated with [Claude Code](https://claude.com/claude-code)