### PR TITLE
fix(vtz): resolve runtime gaps in fs, crypto, and HTTP serve ops (#2654)

### DIFF
--- a/native/vtz/src/runtime/ops/bun_compat.rs
+++ b/native/vtz/src/runtime/ops/bun_compat.rs
@@ -67,31 +67,27 @@ pub const BUN_COMPAT_BOOTSTRAP_JS: &str = r#"
       throw new Error('Bun.serve() is not available: vtz HTTP server not initialized');
     }
 
-    const port = options.port || 3000;
-    const hostname = options.hostname || '0.0.0.0';
+    const port = options.port ?? 3000;
+    const hostname = options.hostname ?? '0.0.0.0';
     const handler = options.fetch;
 
     if (typeof handler !== 'function') {
       throw new Error('Bun.serve() requires a fetch handler');
     }
 
-    let serverRef = null;
-    const serverPromise = globalThis.__vtz_http.serve(port, hostname, handler).then(s => {
-      serverRef = s;
-      return s;
-    });
+    // __vtz_http.serve is synchronous — socket is bound and port is
+    // available immediately, matching Bun.serve() semantics.
+    const serverRef = globalThis.__vtz_http.serve(port, hostname, handler);
 
     // Return a Bun-compatible server object
     return {
-      port,
-      hostname,
-      get ref() { return serverRef; },
+      port: serverRef.port,
+      hostname: serverRef.hostname,
       stop() {
-        if (serverRef && typeof serverRef.stop === 'function') {
-          return serverRef.stop();
+        if (serverRef && typeof serverRef.close === 'function') {
+          return serverRef.close();
         }
       },
-      _promise: serverPromise,
     };
   }
 

--- a/native/vtz/src/runtime/ops/crypto.rs
+++ b/native/vtz/src/runtime/ops/crypto.rs
@@ -251,11 +251,18 @@ pub const CRYPTO_BOOTSTRAP_JS: &str = r#"
 
   function normalizeAlgorithm(algo) {
     if (typeof algo === 'string') return { name: algo };
+    const out = { ...algo };
     // Flatten hash: { name: 'SHA-256' } → hash: 'SHA-256' for Rust serde compat
-    if (algo && typeof algo.hash === 'object' && algo.hash !== null && algo.hash.name) {
-      return { ...algo, hash: algo.hash.name };
+    if (out.hash && typeof out.hash === 'object' && out.hash.name) {
+      out.hash = out.hash.name;
     }
-    return algo;
+    // Convert publicExponent Uint8Array to plain array for serde_v8 Vec<u8> compat.
+    // salt/info are NOT converted here — they're consumed by toBytes() first
+    // in deriveBits/deriveKey and converted to Array.from() there.
+    if (out.publicExponent && ArrayBuffer.isView(out.publicExponent)) {
+      out.publicExponent = Array.from(new Uint8Array(out.publicExponent.buffer, out.publicExponent.byteOffset, out.publicExponent.byteLength));
+    }
+    return out;
   }
 
   function toBytes(data) {
@@ -308,6 +315,16 @@ pub const CRYPTO_BOOTSTRAP_JS: &str = r#"
 
     async importKey(format, keyData, algorithm, extractable, usages) {
       const algo = normalizeAlgorithm(algorithm);
+      if (format === 'jwk') {
+        // JWK import — keyData is a plain JSON object, not a BufferSource
+        const result = Deno.core.ops.op_crypto_subtle_import_key_jwk({
+          jwk: keyData,
+          algorithm: algo,
+          extractable,
+          usages,
+        });
+        return makeCryptoKey(result);
+      }
       const bytes = toBytes(keyData);
       const result = Deno.core.ops.op_crypto_subtle_import_key({
         format,

--- a/native/vtz/src/runtime/ops/crypto_subtle.rs
+++ b/native/vtz/src/runtime/ops/crypto_subtle.rs
@@ -1495,11 +1495,13 @@ pub fn op_crypto_subtle_generate_key(
                     .collect(),
                 key_type: "public".to_string(),
             })?;
+            let result_algo = format!("RSASSA-PKCS1-v1_5::{}", hash.to_uppercase());
+            let mod_bits = Some(modulus_length);
             Ok(serde_json::to_value(CryptoKeyPairResult {
                 public_key: CryptoKeyResult {
                     key_id: pub_id,
                     key_type: "public".to_string(),
-                    algorithm: "RSASSA-PKCS1-v1_5".to_string(),
+                    algorithm: result_algo.clone(),
                     extractable: true,
                     usages: args
                         .usages
@@ -1507,12 +1509,12 @@ pub fn op_crypto_subtle_generate_key(
                         .filter(|u| *u == "verify")
                         .cloned()
                         .collect(),
-                    modulus_length: None,
+                    modulus_length: mod_bits,
                 },
                 private_key: CryptoKeyResult {
                     key_id: priv_id,
                     key_type: "private".to_string(),
-                    algorithm: "RSASSA-PKCS1-v1_5".to_string(),
+                    algorithm: result_algo,
                     extractable: args.extractable,
                     usages: args
                         .usages
@@ -1520,7 +1522,7 @@ pub fn op_crypto_subtle_generate_key(
                         .filter(|u| *u == "sign")
                         .cloned()
                         .collect(),
-                    modulus_length: None,
+                    modulus_length: mod_bits,
                 },
             })?)
         }
@@ -1829,6 +1831,235 @@ pub fn op_crypto_subtle_derive_key(
 }
 
 // ---------------------------------------------------------------------------
+// JWK Import
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportKeyJwkArgs {
+    pub jwk: serde_json::Value,
+    pub algorithm: AlgorithmIdentifier,
+    pub extractable: bool,
+    pub usages: Vec<String>,
+}
+
+/// crypto.subtle.importKey('jwk', jwkObj, algorithm, extractable, usages)
+///
+/// Converts JWK JSON to DER and stores the key material.
+#[op2]
+#[serde]
+pub fn op_crypto_subtle_import_key_jwk(
+    state: &mut OpState,
+    #[serde] args: ImportKeyJwkArgs,
+) -> Result<CryptoKeyResult, AnyError> {
+    let algo_name = args.algorithm.name.to_uppercase();
+    let jwk = &args.jwk;
+    let kty = jwk["kty"]
+        .as_str()
+        .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: JWK missing 'kty' field"))?;
+
+    match (algo_name.as_str(), kty) {
+        ("RSASSA-PKCS1-V1_5" | "RSASSA-PKCS1-V1.5", "RSA") => {
+            let hash = args.algorithm.hash.as_deref().ok_or_else(|| {
+                deno_core::anyhow::anyhow!("TypeError: hash is required for RSASSA-PKCS1-v1_5")
+            })?;
+            import_rsa_jwk(state, jwk, hash, args.extractable, args.usages)
+        }
+        ("ECDSA", "EC") => {
+            let curve = args.algorithm.named_curve.as_deref().ok_or_else(|| {
+                deno_core::anyhow::anyhow!("TypeError: namedCurve is required for ECDSA")
+            })?;
+            import_ec_jwk(state, jwk, curve, args.extractable, args.usages)
+        }
+        _ => Err(deno_core::anyhow::anyhow!(
+            "NotSupportedError: JWK import not supported for algorithm '{}' with kty '{}'",
+            algo_name,
+            kty
+        )),
+    }
+}
+
+fn b64url_decode(s: &str) -> Result<Vec<u8>, AnyError> {
+    URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|e| deno_core::anyhow::anyhow!("DataError: invalid base64url: {}", e))
+}
+
+fn import_rsa_jwk(
+    state: &mut OpState,
+    jwk: &serde_json::Value,
+    hash: &str,
+    extractable: bool,
+    usages: Vec<String>,
+) -> Result<CryptoKeyResult, AnyError> {
+    use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey};
+    use rsa::traits::PublicKeyParts;
+    use rsa::BigUint;
+
+    let n_b64 = jwk["n"]
+        .as_str()
+        .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: RSA JWK missing 'n'"))?;
+    let e_b64 = jwk["e"]
+        .as_str()
+        .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: RSA JWK missing 'e'"))?;
+
+    let n = BigUint::from_bytes_be(&b64url_decode(n_b64)?);
+    let e = BigUint::from_bytes_be(&b64url_decode(e_b64)?);
+
+    let has_private = jwk["d"].is_string();
+
+    if has_private {
+        let d =
+            BigUint::from_bytes_be(&b64url_decode(jwk["d"].as_str().ok_or_else(|| {
+                deno_core::anyhow::anyhow!("DataError: RSA JWK missing 'd'")
+            })?)?);
+        let primes: Vec<BigUint> = ["p", "q"]
+            .iter()
+            .filter_map(|k| jwk[*k].as_str())
+            .map(|s| b64url_decode(s).map(|b| BigUint::from_bytes_be(&b)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let key = rsa::RsaPrivateKey::from_components(n, e, d, primes)
+            .map_err(|e| deno_core::anyhow::anyhow!("DataError: invalid RSA JWK: {}", e))?;
+        let der = key
+            .to_pkcs8_der()
+            .map_err(|e| deno_core::anyhow::anyhow!("DataError: RSA JWK to PKCS8: {}", e))?;
+        let mod_len = Some(key.size() as u32 * 8);
+
+        let store = state.borrow_mut::<CryptoKeyStore>();
+        let id = store.insert(StoredKey {
+            material: KeyMaterial::RsaPrivate(der.as_bytes().to_vec()),
+            algorithm: format!("RSASSA-PKCS1-v1_5::{}", hash.to_uppercase()),
+            extractable,
+            usages: usages.clone(),
+            key_type: "private".to_string(),
+        })?;
+        Ok(CryptoKeyResult {
+            key_id: id,
+            key_type: "private".to_string(),
+            algorithm: format!("RSASSA-PKCS1-v1_5::{}", hash.to_uppercase()),
+            extractable,
+            usages,
+            modulus_length: mod_len,
+        })
+    } else {
+        let key = rsa::RsaPublicKey::new(n, e)
+            .map_err(|e| deno_core::anyhow::anyhow!("DataError: invalid RSA public JWK: {}", e))?;
+        let der = key
+            .to_public_key_der()
+            .map_err(|e| deno_core::anyhow::anyhow!("DataError: RSA JWK to SPKI: {}", e))?;
+        let mod_len = Some(key.size() as u32 * 8);
+
+        let store = state.borrow_mut::<CryptoKeyStore>();
+        let id = store.insert(StoredKey {
+            material: KeyMaterial::RsaPublic(der.as_ref().to_vec()),
+            algorithm: format!("RSASSA-PKCS1-v1_5::{}", hash.to_uppercase()),
+            extractable,
+            usages: usages.clone(),
+            key_type: "public".to_string(),
+        })?;
+        Ok(CryptoKeyResult {
+            key_id: id,
+            key_type: "public".to_string(),
+            algorithm: format!("RSASSA-PKCS1-v1_5::{}", hash.to_uppercase()),
+            extractable,
+            usages,
+            modulus_length: mod_len,
+        })
+    }
+}
+
+fn import_ec_jwk(
+    state: &mut OpState,
+    jwk: &serde_json::Value,
+    curve: &str,
+    extractable: bool,
+    usages: Vec<String>,
+) -> Result<CryptoKeyResult, AnyError> {
+    let crv = jwk["crv"]
+        .as_str()
+        .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: EC JWK missing 'crv'"))?;
+    if crv != curve {
+        return Err(deno_core::anyhow::anyhow!(
+            "DataError: JWK curve '{}' does not match algorithm curve '{}'",
+            crv,
+            curve
+        ));
+    }
+
+    let x = b64url_decode(
+        jwk["x"]
+            .as_str()
+            .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: EC JWK missing 'x'"))?,
+    )?;
+    let y = b64url_decode(
+        jwk["y"]
+            .as_str()
+            .ok_or_else(|| deno_core::anyhow::anyhow!("DataError: EC JWK missing 'y'"))?,
+    )?;
+
+    let has_private = jwk["d"].is_string();
+
+    if has_private {
+        // EC private key: reconstruct PKCS#8 DER
+        let d_bytes = b64url_decode(jwk["d"].as_str().unwrap())?;
+        match curve {
+            "P-256" => {
+                use p256::SecretKey;
+
+                let sk = SecretKey::from_slice(&d_bytes).map_err(|e| {
+                    deno_core::anyhow::anyhow!("DataError: invalid P-256 private key: {}", e)
+                })?;
+                let der = p256::pkcs8::EncodePrivateKey::to_pkcs8_der(&sk)
+                    .map_err(|e| deno_core::anyhow::anyhow!("DataError: EC JWK to PKCS8: {}", e))?;
+                let store = state.borrow_mut::<CryptoKeyStore>();
+                let id = store.insert(StoredKey {
+                    material: KeyMaterial::EcPrivate(der.as_bytes().to_vec()),
+                    algorithm: format!("ECDSA::{}", curve),
+                    extractable,
+                    usages: usages.clone(),
+                    key_type: "private".to_string(),
+                })?;
+                Ok(CryptoKeyResult {
+                    key_id: id,
+                    key_type: "private".to_string(),
+                    algorithm: format!("ECDSA::{}", curve),
+                    extractable,
+                    usages,
+                    modulus_length: None,
+                })
+            }
+            _ => Err(deno_core::anyhow::anyhow!(
+                "NotSupportedError: EC JWK import for curve '{}' not implemented",
+                curve
+            )),
+        }
+    } else {
+        // EC public key: construct uncompressed point (0x04 || x || y)
+        let mut point = Vec::with_capacity(1 + x.len() + y.len());
+        point.push(0x04);
+        point.extend_from_slice(&x);
+        point.extend_from_slice(&y);
+
+        let store = state.borrow_mut::<CryptoKeyStore>();
+        let id = store.insert(StoredKey {
+            material: KeyMaterial::EcPublic(point),
+            algorithm: format!("ECDSA::{}", curve),
+            extractable,
+            usages: usages.clone(),
+            key_type: "public".to_string(),
+        })?;
+        Ok(CryptoKeyResult {
+            key_id: id,
+            key_type: "public".to_string(),
+            algorithm: format!("ECDSA::{}", curve),
+            extractable,
+            usages,
+            modulus_length: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Op registration
 // ---------------------------------------------------------------------------
 
@@ -1836,6 +2067,7 @@ pub fn op_decls() -> Vec<OpDecl> {
     vec![
         op_crypto_subtle_digest(),
         op_crypto_subtle_import_key(),
+        op_crypto_subtle_import_key_jwk(),
         op_crypto_subtle_export_key(),
         op_crypto_subtle_sign(),
         op_crypto_subtle_verify(),

--- a/native/vtz/src/runtime/ops/fs.rs
+++ b/native/vtz/src/runtime/ops/fs.rs
@@ -900,6 +900,24 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     };
   }
 
+  // Normalize file path: strip file:// URLs to plain paths (Node.js compat).
+  function normalizePath(p) {
+    if (typeof p === 'object' && p !== null && p.href && p.protocol === 'file:') {
+      // URL object with file: protocol
+      p = p.pathname;
+    } else {
+      p = String(p);
+    }
+    if (p.startsWith('file:///')) {
+      p = p.slice(7); // file:///Users/... -> /Users/...
+    } else if (p.startsWith('file://')) {
+      p = p.slice(7);
+    }
+    // Decode percent-encoded characters (e.g. %20 -> space)
+    try { p = decodeURIComponent(p); } catch {}
+    return p;
+  }
+
   // Enrich fs errors with a .code property for Node.js compatibility
   function enrichFsError(err) {
     if (err && typeof err.message === 'string' && !err.code) {
@@ -914,32 +932,32 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     try {
       const encoding = typeof options === 'string' ? options : (options && options.encoding);
       if (encoding === 'utf-8' || encoding === 'utf8') {
-        return Deno.core.ops.op_fs_read_file_sync(String(path));
+        return Deno.core.ops.op_fs_read_file_sync(normalizePath(path));
       }
-      const bytes = Deno.core.ops.op_fs_read_file_bytes_sync(String(path));
+      const bytes = Deno.core.ops.op_fs_read_file_bytes_sync(normalizePath(path));
       return Buffer.from(bytes);
     } catch (e) { throw enrichFsError(e); }
   }
 
   function writeFileSync(path, data, options) {
     if (typeof data === 'string') {
-      Deno.core.ops.op_fs_write_file_sync(String(path), data);
+      Deno.core.ops.op_fs_write_file_sync(normalizePath(path), data);
     } else {
-      Deno.core.ops.op_fs_write_file_bytes_sync(String(path), data);
+      Deno.core.ops.op_fs_write_file_bytes_sync(normalizePath(path), data);
     }
   }
 
   function appendFileSync(path, data) {
-    Deno.core.ops.op_fs_append_file_sync(String(path), String(data));
+    Deno.core.ops.op_fs_append_file_sync(normalizePath(path), String(data));
   }
 
   function existsSync(path) {
-    return Deno.core.ops.op_fs_exists_sync(String(path));
+    return Deno.core.ops.op_fs_exists_sync(normalizePath(path));
   }
 
   function mkdirSync(path, options) {
     const recursive = options && options.recursive ? true : false;
-    Deno.core.ops.op_fs_mkdir_sync(String(path), recursive);
+    Deno.core.ops.op_fs_mkdir_sync(normalizePath(path), recursive);
   }
 
   function createDirentObject(raw) {
@@ -956,43 +974,43 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     const withFileTypes = options && options.withFileTypes;
     const recursive = options && options.recursive;
     if (withFileTypes) {
-      const raw = Deno.core.ops.op_fs_readdir_with_types_sync(String(path), !!recursive);
+      const raw = Deno.core.ops.op_fs_readdir_with_types_sync(normalizePath(path), !!recursive);
       return raw.map(createDirentObject);
     }
     if (recursive) {
-      return Deno.core.ops.op_fs_readdir_recursive_sync(String(path));
+      return Deno.core.ops.op_fs_readdir_recursive_sync(normalizePath(path));
     }
-    return Deno.core.ops.op_fs_readdir_sync(String(path));
+    return Deno.core.ops.op_fs_readdir_sync(normalizePath(path));
   }
 
   function statSync(path) {
     try {
-      return createStatObject(Deno.core.ops.op_fs_stat_sync(String(path)));
+      return createStatObject(Deno.core.ops.op_fs_stat_sync(normalizePath(path)));
     } catch (e) { throw enrichFsError(e); }
   }
 
   function lstatSync(path) {
     try {
-      return createStatObject(Deno.core.ops.op_fs_lstat_sync(String(path)));
+      return createStatObject(Deno.core.ops.op_fs_lstat_sync(normalizePath(path)));
     } catch (e) { throw enrichFsError(e); }
   }
 
   function rmSync(path, options) {
     const recursive = options && options.recursive ? true : false;
     const force = options && options.force ? true : false;
-    Deno.core.ops.op_fs_rm_sync(String(path), recursive, force);
+    Deno.core.ops.op_fs_rm_sync(normalizePath(path), recursive, force);
   }
 
   function unlinkSync(path) {
-    Deno.core.ops.op_fs_unlink_sync(String(path));
+    Deno.core.ops.op_fs_unlink_sync(normalizePath(path));
   }
 
   function renameSync(oldPath, newPath) {
-    Deno.core.ops.op_fs_rename_sync(String(oldPath), String(newPath));
+    Deno.core.ops.op_fs_rename_sync(normalizePath(oldPath), normalizePath(newPath));
   }
 
   function realpathSync(path) {
-    return Deno.core.ops.op_fs_realpath_sync(String(path));
+    return Deno.core.ops.op_fs_realpath_sync(normalizePath(path));
   }
 
   function mkdtempSync(prefix) {
@@ -1000,24 +1018,24 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
   }
 
   function copyFileSync(src, dest) {
-    Deno.core.ops.op_fs_copy_file_sync(String(src), String(dest));
+    Deno.core.ops.op_fs_copy_file_sync(normalizePath(src), normalizePath(dest));
   }
 
   function cpSync(src, dest, options) {
     const recursive = options && options.recursive ? true : false;
-    Deno.core.ops.op_fs_cp_sync(String(src), String(dest), recursive);
+    Deno.core.ops.op_fs_cp_sync(normalizePath(src), normalizePath(dest), recursive);
   }
 
   function chmodSync(path, mode) {
-    Deno.core.ops.op_fs_chmod_sync(String(path), mode);
+    Deno.core.ops.op_fs_chmod_sync(normalizePath(path), mode);
   }
 
   function symlinkSync(target, path) {
-    Deno.core.ops.op_fs_symlink_sync(String(target), String(path));
+    Deno.core.ops.op_fs_symlink_sync(normalizePath(target), normalizePath(path));
   }
 
   function accessSync(path, mode) {
-    Deno.core.ops.op_fs_access_sync(String(path), mode === undefined ? 0 : mode);
+    Deno.core.ops.op_fs_access_sync(normalizePath(path), mode === undefined ? 0 : mode);
   }
 
   function mkdtemp(prefix, options, callback) {
@@ -1035,11 +1053,11 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     if (typeof options === 'function') { listener = options; options = {}; }
     const interval = (options && options.interval) || 500;
     let lastMtime = null;
-    try { lastMtime = Deno.core.ops.op_fs_stat_sync(String(filename)).mtimeMs; } catch {}
+    try { lastMtime = Deno.core.ops.op_fs_stat_sync(normalizePath(filename)).mtimeMs; } catch {}
 
     const timerId = setInterval(() => {
       try {
-        const raw = Deno.core.ops.op_fs_stat_sync(String(filename));
+        const raw = Deno.core.ops.op_fs_stat_sync(normalizePath(filename));
         if (raw.mtimeMs !== lastMtime) {
           lastMtime = raw.mtimeMs;
           if (listener) listener('change', filename);
@@ -1066,9 +1084,9 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     try {
       const encoding = typeof options === 'string' ? options : (options && options.encoding);
       if (encoding === 'utf-8' || encoding === 'utf8') {
-        return await Deno.core.ops.op_fs_read_file(String(path));
+        return await Deno.core.ops.op_fs_read_file(normalizePath(path));
       }
-      const bytes = await Deno.core.ops.op_fs_read_file_bytes(String(path));
+      const bytes = await Deno.core.ops.op_fs_read_file_bytes(normalizePath(path));
       return Buffer.from(bytes);
     } catch (e) { throw enrichFsError(e); }
   }
@@ -1076,38 +1094,38 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
   async function writeFile(path, data, options) {
     try {
       if (typeof data === 'string') {
-        await Deno.core.ops.op_fs_write_file(String(path), data);
+        await Deno.core.ops.op_fs_write_file(normalizePath(path), data);
       } else {
         // Binary data — use bytes op to avoid UTF-8 corruption
         const bytes = data instanceof Uint8Array
           ? data
           : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-        await Deno.core.ops.op_fs_write_file_bytes(String(path), Array.from(bytes));
+        await Deno.core.ops.op_fs_write_file_bytes(normalizePath(path), Array.from(bytes));
       }
     } catch (e) { throw enrichFsError(e); }
   }
 
   async function mkdir(path, options) {
     const recursive = options && options.recursive ? true : false;
-    await Deno.core.ops.op_fs_mkdir(String(path), recursive);
+    await Deno.core.ops.op_fs_mkdir(normalizePath(path), recursive);
   }
 
   async function readdir(path, options) {
     const withFileTypes = options && options.withFileTypes;
     const recursive = options && options.recursive;
     if (withFileTypes) {
-      const raw = await Deno.core.ops.op_fs_readdir_with_types(String(path), !!recursive);
+      const raw = await Deno.core.ops.op_fs_readdir_with_types(normalizePath(path), !!recursive);
       return raw.map(createDirentObject);
     }
     if (recursive) {
-      return Deno.core.ops.op_fs_readdir_recursive(String(path));
+      return Deno.core.ops.op_fs_readdir_recursive(normalizePath(path));
     }
-    return Deno.core.ops.op_fs_readdir(String(path));
+    return Deno.core.ops.op_fs_readdir(normalizePath(path));
   }
 
   async function stat(path) {
     try {
-      const raw = await Deno.core.ops.op_fs_stat(String(path));
+      const raw = await Deno.core.ops.op_fs_stat(normalizePath(path));
       return createStatObject(raw);
     } catch (e) { throw enrichFsError(e); }
   }
@@ -1115,19 +1133,19 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
   async function rm(path, options) {
     const recursive = options && options.recursive ? true : false;
     const force = options && options.force ? true : false;
-    await Deno.core.ops.op_fs_rm(String(path), recursive, force);
+    await Deno.core.ops.op_fs_rm(normalizePath(path), recursive, force);
   }
 
   async function unlink(path) {
-    await Deno.core.ops.op_fs_unlink(String(path));
+    await Deno.core.ops.op_fs_unlink(normalizePath(path));
   }
 
   async function rename(oldPath, newPath) {
-    await Deno.core.ops.op_fs_rename(String(oldPath), String(newPath));
+    await Deno.core.ops.op_fs_rename(normalizePath(oldPath), normalizePath(newPath));
   }
 
   async function realpath(path) {
-    return Deno.core.ops.op_fs_realpath(String(path));
+    return Deno.core.ops.op_fs_realpath(normalizePath(path));
   }
 
   // --- Module object ---
@@ -1143,7 +1161,7 @@ pub const FS_BOOTSTRAP_JS: &str = r#"
     promises: {
       readFile, writeFile, mkdir, readdir, stat, rm, unlink, rename, realpath,
       async mkdtemp(prefix) { return Deno.core.ops.op_fs_mkdtemp_sync(String(prefix)); },
-      async access(path, mode) { Deno.core.ops.op_fs_access_sync(String(path), mode === undefined ? 0 : mode); },
+      async access(path, mode) { Deno.core.ops.op_fs_access_sync(normalizePath(path), mode === undefined ? 0 : mode); },
     },
   };
 
@@ -1179,6 +1197,37 @@ mod tests {
         );
         let result = rt.execute_script("<test>", &read_code).unwrap();
         assert_eq!(result, serde_json::json!("hello world"));
+    }
+
+    #[test]
+    fn test_fs_read_file_sync_with_file_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("url-test.txt");
+        std::fs::write(&file_path, "file url content").unwrap();
+        let mut rt = create_runtime();
+
+        // file:// URL should be normalized to a plain path
+        let code = format!(
+            r#"__vertz_fs.readFileSync("file://{}", "utf-8")"#,
+            file_path.to_string_lossy().replace('\\', "/")
+        );
+        let result = rt.execute_script("<test>", &code).unwrap();
+        assert_eq!(result, serde_json::json!("file url content"));
+    }
+
+    #[test]
+    fn test_fs_exists_sync_with_file_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("exists-url.txt");
+        std::fs::write(&file_path, "x").unwrap();
+        let mut rt = create_runtime();
+
+        let code = format!(
+            r#"__vertz_fs.existsSync("file://{}")"#,
+            file_path.to_string_lossy().replace('\\', "/")
+        );
+        let result = rt.execute_script("<test>", &code).unwrap();
+        assert_eq!(result, serde_json::json!(true));
     }
 
     #[test]

--- a/native/vtz/src/runtime/ops/http_serve.rs
+++ b/native/vtz/src/runtime/ops/http_serve.rs
@@ -77,17 +77,24 @@ mod serde_bytes_option {
 ///
 /// Returns `{ id, port, hostname }` where `port` is the actual bound port
 /// (important when the requested port is 0 for OS-assigned).
-#[op2(async)]
+///
+/// The socket is bound synchronously so that `Bun.serve()` can return the
+/// actual port immediately (Bun's API is synchronous).  The async accept
+/// loop is spawned in the background.
+#[op2]
 #[serde]
-pub async fn op_http_serve(
-    state: Rc<RefCell<OpState>>,
+pub fn op_http_serve(
+    state: &mut OpState,
     #[smi] port: u16,
     #[string] hostname: String,
 ) -> Result<serde_json::Value, AnyError> {
     let addr = format!("{}:{}", hostname, port);
-    let listener = TcpListener::bind(&addr)
-        .await
+
+    // Bind synchronously so the port is known before returning to JS.
+    let std_listener = std::net::TcpListener::bind(&addr)
         .map_err(|e| deno_core::anyhow::anyhow!("Failed to bind {}: {}", addr, e))?;
+    std_listener.set_nonblocking(true)?;
+    let listener = TcpListener::from_std(std_listener)?;
 
     let actual_port = listener.local_addr()?.port();
     let actual_hostname = hostname.clone();
@@ -165,8 +172,7 @@ pub async fn op_http_serve(
 
     // Store server state
     {
-        let mut op_state = state.borrow_mut();
-        let http_state = op_state.borrow_mut::<HttpServeState>();
+        let http_state = state.borrow_mut::<HttpServeState>();
         http_state.servers.insert(
             server_id,
             ServerInstance {
@@ -271,8 +277,10 @@ pub const HTTP_SERVE_BOOTSTRAP_JS: &str = r#"
   const ops = Deno.core.ops;
 
   globalThis.__vtz_http = {
-    async serve(port, hostname, handler) {
-      const server = await ops.op_http_serve(port, hostname);
+    serve(port, hostname, handler) {
+      // op_http_serve is synchronous — the socket is already bound when it
+      // returns, so the port is immediately available (matching Bun.serve).
+      const server = ops.op_http_serve(port, hostname);
       let stopped = false;
 
       // Accept loop: runs in the background, dispatching requests to the handler


### PR DESCRIPTION
## Summary

Second round of fixes for #2654 (pre-existing test failures under `vtz test`). Closes gaps in the Rust runtime that were causing failures across `@vertz/server` auth, `@vertz/db`, and any package using `Bun.serve()` with port 0.

**6 fixes across 5 Rust files:**

- **fs.rs** — Add `normalizePath()` JS helper to strip `file://` protocol and handle URL objects before all sync/async fs operations. PGlite loads `.data` files via `file:///…` URLs.
- **crypto.rs** — Convert `publicExponent` from `Uint8Array` to plain array in `normalizeAlgorithm()` so `serde_v8` can deserialize it as `Vec<u8>`.
- **crypto_subtle.rs** — Include hash suffix in RSA `generateKey` result algorithm string (`RSASSA-PKCS1-v1_5::SHA-256` not just the bare name), fixing jose's `key.algorithm.hash.name` lookup during JWT verification.
- **crypto_subtle.rs** — Add `op_crypto_subtle_import_key_jwk` for RSA and EC JWK import — jose uses `importKey('jwk', …)` for JWKS verification.
- **bun_compat.rs** — Use `??` instead of `||` for port/hostname defaults so `port: 0` (OS-assigned) is not treated as falsy and coerced to 3000.
- **http_serve.rs** — Bind TCP socket synchronously (`std::net::TcpListener`) so `Bun.serve()` returns the actual port immediately, matching Bun's synchronous API contract.

## Public API Changes

None — all changes are internal to the vtz runtime.

## Test plan

- [x] `cargo test --all` — 3363 Rust tests pass
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)