### PR TITLE
fix(vtz): register preload script mocks in module loader (#2667)

### DIFF
--- a/.changeset/fix-preload-mock-registration.md
+++ b/.changeset/fix-preload-mock-registration.md
@@ -1,0 +1,7 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): register preload script mocks in module loader
+
+Preload scripts that called `mock.module()` / `vi.mock()` had their mocks silently ignored because the Rust module loader only checked mocks extracted at compile time from the test file. The runtime now bridges preload mocks to the module loader's registry after each preload evaluates.

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -232,11 +232,43 @@ fn execute_test_file_inner(
         .build()?;
 
     // 4. Load preload scripts as ES modules (supports import statements)
-    for preload_path in &options.preload {
-        let specifier = ModuleSpecifier::from_file_path(preload_path).map_err(|_| {
-            deno_core::anyhow::anyhow!("Invalid preload path: {}", preload_path.display())
-        })?;
-        tokio_rt.block_on(async { runtime.load_side_module(&specifier).await })?;
+    //    After each preload, register any mocks it declared via mock.module() / vi.mock()
+    //    in the Rust module loader so transitive imports are intercepted. (#2667)
+    {
+        let mut known_mock_keys: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
+        for preload_path in &options.preload {
+            let specifier = ModuleSpecifier::from_file_path(preload_path).map_err(|_| {
+                deno_core::anyhow::anyhow!("Invalid preload path: {}", preload_path.display())
+            })?;
+            tokio_rt.block_on(async { runtime.load_side_module(&specifier).await })?;
+
+            // Bridge preload mocks to the Rust-side registry.
+            // Preload mocks populate globalThis.__vertz_mocked_modules at runtime,
+            // but the module loader only checks its mocked_paths HashMap.
+            let current_keys = runtime.execute_script(
+                "[vertz:preload-mock-keys]",
+                "Object.keys(globalThis.__vertz_mocked_modules || {})",
+            )?;
+
+            if let serde_json::Value::Array(arr) = current_keys {
+                let new_specifiers: std::collections::HashSet<String> = arr
+                    .into_iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .filter(|k| !known_mock_keys.contains(k))
+                    .collect();
+
+                if !new_specifiers.is_empty() {
+                    for s in &new_specifiers {
+                        known_mock_keys.insert(s.clone());
+                    }
+                    runtime
+                        .loader()
+                        .register_mocked_specifiers(&new_specifiers, preload_path);
+                }
+            }
+        }
     }
 
     // 5. Pre-compile test file for mock extraction (transitive mocking support)
@@ -765,6 +797,59 @@ mod tests {
             err.contains("Cannot read module") || err.contains("nonexistent-setup.ts"),
             "Expected error about missing preload file, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_preload_mock_module_registers_in_loader() {
+        // Preload scripts that call vi.mock() / mock.module() should register
+        // mocked specifiers in the Rust module loader so that transitive imports
+        // from test files are intercepted. (#2667)
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        // Create a real module that the preload will mock
+        let helper = base.join("helper.ts");
+        fs::write(&helper, "export const value = 'real';").unwrap();
+
+        // Create a preload script that mocks the helper module
+        let preload = write_test_file(
+            base,
+            "preload-mock.ts",
+            r#"
+            vi.mock('./helper', () => ({ value: 'mocked-by-preload' }));
+            "#,
+        );
+
+        // Test file imports the helper — should get the mock, not the real module
+        let test_file = write_test_file(
+            base,
+            "consumer.test.ts",
+            r#"
+            import { value } from './helper';
+
+            describe('preload mock', () => {
+                it('receives mocked value from preload', () => {
+                    expect(value).toBe('mocked-by-preload');
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                preload: vec![preload],
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(result.passed(), 1, "Expected mock value from preload");
+        assert_eq!(result.failed(), 0);
     }
 
     #[test]

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -853,6 +853,124 @@ mod tests {
     }
 
     #[test]
+    fn test_preload_mock_conditional() {
+        // Conditional mocks in preloads (the real-world pattern from #2667):
+        // `if (!available) { vi.mock('spec', factory) }`
+        // The bridge queries runtime state after evaluation, so conditional mocks work.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        let helper = base.join("helper.ts");
+        fs::write(&helper, "export const value = 'real';").unwrap();
+
+        // Preload mocks conditionally — the condition is true, so the mock fires
+        let preload = write_test_file(
+            base,
+            "preload-conditional.ts",
+            r#"
+            const shouldMock = true;
+            if (shouldMock) {
+                vi.mock('./helper', () => ({ value: 'conditional-mock' }));
+            }
+            "#,
+        );
+
+        let test_file = write_test_file(
+            base,
+            "cond.test.ts",
+            r#"
+            import { value } from './helper';
+
+            describe('conditional preload mock', () => {
+                it('receives conditionally mocked value', () => {
+                    expect(value).toBe('conditional-mock');
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                preload: vec![preload],
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(result.passed(), 1, "Conditional mock should be effective");
+        assert_eq!(result.failed(), 0);
+    }
+
+    #[test]
+    fn test_preload_mock_multiple_preloads() {
+        // Two preload scripts each mocking different modules.
+        // The diff-based known_mock_keys approach correctly attributes
+        // each mock to its originating preload for resolution.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        let mod_a = base.join("mod-a.ts");
+        fs::write(&mod_a, "export const a = 'real-a';").unwrap();
+        let mod_b = base.join("mod-b.ts");
+        fs::write(&mod_b, "export const b = 'real-b';").unwrap();
+
+        let preload_a = write_test_file(
+            base,
+            "preload-a.ts",
+            r#"
+            vi.mock('./mod-a', () => ({ a: 'mocked-a' }));
+            "#,
+        );
+
+        let preload_b = write_test_file(
+            base,
+            "preload-b.ts",
+            r#"
+            vi.mock('./mod-b', () => ({ b: 'mocked-b' }));
+            "#,
+        );
+
+        let test_file = write_test_file(
+            base,
+            "multi.test.ts",
+            r#"
+            import { a } from './mod-a';
+            import { b } from './mod-b';
+
+            describe('multiple preload mocks', () => {
+                it('receives mock from first preload', () => {
+                    expect(a).toBe('mocked-a');
+                });
+                it('receives mock from second preload', () => {
+                    expect(b).toBe('mocked-b');
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                preload: vec![preload_a, preload_b],
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(result.passed(), 2, "Both preload mocks should be effective");
+        assert_eq!(result.failed(), 0);
+    }
+
+    #[test]
     fn test_root_dir_affects_bun_cache_resolution() {
         // The module loader's Bun cache fallback starts from `self.root_dir`.
         // When root_dir is the workspace root (not the test file's parent),

--- a/plans/2667-preload-mock-registration.md
+++ b/plans/2667-preload-mock-registration.md
@@ -1,0 +1,115 @@
+# fix(vtz): Preload Script Mock Registration (#2667)
+
+## Description
+
+The vtz test runner's mock system only registers mocks extracted at **compile time** from the test file itself (`register_mocked_specifiers`). Mocks registered by preload scripts at runtime (via `mock.module()` / `vi.mock()`) populate `globalThis.__vertz_mocked_modules` but are never registered in the Rust module loader's `mocked_paths` HashMap. This means the module loader never intercepts imports of preload-mocked modules.
+
+### Root Cause
+
+The mock system has two disjoint paths:
+
+1. **Compile-time (test file only):** `compile_for_mock_extraction()` scans the test file AST for top-level `vi.mock()` / `mock.module()` calls, extracts specifiers, and registers them via `register_mocked_specifiers()` in Rust's `mocked_paths`.
+2. **Runtime (preload scripts):** `mock.module()` stores the mock implementation in `globalThis.__vertz_mocked_modules[specifier]`, but nothing registers the specifier in `mocked_paths`.
+
+The module loader (in `resolve()`) only checks `mocked_paths` to decide whether to redirect an import to a mock proxy. Since preload mocks never enter `mocked_paths`, they are silently ignored.
+
+Compile-time extraction cannot solve this because preload mocks are **conditional** (inside `if` blocks), and the mock hoisting transform only processes top-level statements.
+
+### Affected Tests
+
+4 files in `@vertz/ui-server` rely on `preload-mock-native-compiler.ts` to mock `@vertz/ui-auth`:
+- `packages/ui-server/src/__tests__/node-handler.test.ts`
+- `packages/ui-server/src/__tests__/ssr-handler.test.ts`
+- `packages/ui-server/src/__tests__/ssr-render.test.ts`
+- `packages/ui-server/src/__tests__/ssr-single-pass.test.ts`
+
+## Fix
+
+After loading each preload script, query `globalThis.__vertz_mocked_modules` for newly added keys and register them in `mocked_paths` via `register_mocked_specifiers()`, using the preload file path as the referrer for resolution.
+
+### Implementation
+
+In `native/vtz/src/test/executor.rs`, modify the preload loading loop (step 4):
+
+```rust
+// 4. Load preload scripts as ES modules (supports import statements)
+let mut known_mock_keys: HashSet<String> = HashSet::new();
+
+for preload_path in &options.preload {
+    let specifier = ModuleSpecifier::from_file_path(preload_path).map_err(|_| {
+        deno_core::anyhow::anyhow!("Invalid preload path: {}", preload_path.display())
+    })?;
+    tokio_rt.block_on(async { runtime.load_side_module(&specifier).await })?;
+
+    // Register any mocks declared by this preload script.
+    // Preload mocks populate globalThis.__vertz_mocked_modules at runtime,
+    // but the module loader only checks the Rust-side mocked_paths registry.
+    // Bridge the gap by reading new keys and registering them.
+    let current_keys = runtime.execute_script(
+        "[vertz:preload-mock-keys]",
+        "Object.keys(globalThis.__vertz_mocked_modules || {})",
+    )?;
+
+    if let serde_json::Value::Array(arr) = current_keys {
+        let new_specifiers: HashSet<String> = arr
+            .into_iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|k| !known_mock_keys.contains(k))
+            .collect();
+
+        if !new_specifiers.is_empty() {
+            for s in &new_specifiers {
+                known_mock_keys.insert(s.clone());
+            }
+            runtime
+                .loader()
+                .register_mocked_specifiers(&new_specifiers, preload_path);
+        }
+    }
+}
+```
+
+### Why this approach
+
+1. **Reuses existing infrastructure** — `register_mocked_specifiers()` already handles specifier resolution and canonicalization.
+2. **Handles relative paths correctly** — Each preload's mocks are resolved relative to that preload's file path, not the test file.
+3. **Handles conditional mocks** — Queries the runtime state after evaluation, so `if (!available) { mock.module(...) }` patterns work.
+4. **No JS API changes** — `mock.module()` behavior is unchanged; the fix is purely in the Rust executor.
+5. **Handles multiple preloads** — The diff-based approach (`known_mock_keys`) correctly attributes mocks to their originating preload.
+
+## Manifesto Alignment
+
+- **Principle 4 (Test what matters):** Preload scripts are a standard testing pattern for shared setup. Mocks declared there should work identically to mocks in test files.
+- **Principle 5 (If you can't test it, don't build it):** The SSR tests need to mock `@vertz/ui-auth` (circular workspace dep). Without this fix, those tests can't run.
+
+## Non-Goals
+
+- **Transitive mock propagation** — This fix does not change the existing non-goal: if `test.ts` mocks `'foo'` and `bar.ts` imports `'foo'`, `bar.ts` still gets the real module. This fix only ensures that mock registrations in preload scripts reach the module loader.
+- **Compile-time preload mock extraction** — Not needed; runtime query is simpler and handles conditional mocks.
+- **Changes to the `mock.module()` JS API** — No API changes required.
+
+## Unknowns
+
+None identified. The fix is a well-understood bridge between existing systems.
+
+## Type Flow Map
+
+N/A — This is a Rust-only change with no TypeScript type changes.
+
+## E2E Acceptance Test
+
+```
+Given a preload script that conditionally calls mock.module('@vertz/ui-auth', factory)
+When a test file imports '@vertz/ui-auth'
+Then the import resolves to the mock, not the real module
+
+Given a preload script that calls mock.module('../relative/path', factory)
+When a test file's transitive import resolves to the same canonical path
+Then the import resolves to the mock
+
+Given multiple preload scripts each registering different mocks
+When test files import the mocked modules
+Then each mock resolves correctly
+```
+
+Concrete validation: All 4 affected `@vertz/ui-server` SSR test files pass without `Cannot find module '@vertz/ui-auth'` errors.

--- a/plans/2667-preload-mock-registration/phase-01-bridge-preload-mocks.md
+++ b/plans/2667-preload-mock-registration/phase-01-bridge-preload-mocks.md
@@ -1,0 +1,84 @@
+# Phase 1: Bridge Preload Mocks to Rust Registry
+
+## Context
+
+Bug fix for #2667. Preload scripts that call `mock.module()` populate `globalThis.__vertz_mocked_modules` at runtime, but the Rust module loader only checks its `mocked_paths` HashMap for mock interception. This phase adds a bridge: after each preload loads, query the JS global for new mock specifiers and register them in the Rust registry.
+
+Design doc: `plans/2667-preload-mock-registration.md`
+
+## Tasks
+
+### Task 1: Add Rust test for preload mock registration
+
+**Files:**
+- `native/vtz/src/test/executor.rs` (modified — add test)
+
+**What to implement:**
+Add a test that creates a preload script which calls `mock.module('some-specifier', factory)`, runs a test file that imports the mocked specifier, and verifies the mock is received instead of the real module.
+
+This test should fail (RED) because preload mocks are not yet registered in the module loader.
+
+**Acceptance criteria:**
+- [ ] Test exists and fails with the expected error (module not found or real module loaded instead of mock)
+
+---
+
+### Task 2: Bridge preload mocks in executor.rs
+
+**Files:**
+- `native/vtz/src/test/executor.rs` (modified — preload loop)
+
+**What to implement:**
+After each preload script loads via `load_side_module()`, execute a JS snippet to read `Object.keys(globalThis.__vertz_mocked_modules || {})`. Diff against previously known keys. Register new specifiers via `register_mocked_specifiers()` using the preload file path as the referrer.
+
+```rust
+let mut known_mock_keys: HashSet<String> = HashSet::new();
+
+for preload_path in &options.preload {
+    // ... existing load_side_module code ...
+
+    let current_keys = runtime.execute_script(
+        "[vertz:preload-mock-keys]",
+        "Object.keys(globalThis.__vertz_mocked_modules || {})",
+    )?;
+
+    if let serde_json::Value::Array(arr) = current_keys {
+        let new_specifiers: HashSet<String> = arr
+            .into_iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|k| !known_mock_keys.contains(k))
+            .collect();
+
+        if !new_specifiers.is_empty() {
+            for s in &new_specifiers {
+                known_mock_keys.insert(s.clone());
+            }
+            runtime
+                .loader()
+                .register_mocked_specifiers(&new_specifiers, preload_path);
+        }
+    }
+}
+```
+
+**Acceptance criteria:**
+- [ ] Task 1's test now passes (GREEN)
+- [ ] Existing tests still pass (`cargo test --all`)
+- [ ] `cargo clippy --all-targets --release -- -D warnings` clean
+- [ ] `cargo fmt --all -- --check` clean
+
+---
+
+### Task 3: Verify affected ui-server tests
+
+**Files:**
+- No code changes — validation only
+
+**What to implement:**
+Run the 4 affected `@vertz/ui-server` test files and verify they no longer fail with `Cannot find module '@vertz/ui-auth'`.
+
+**Acceptance criteria:**
+- [ ] `vtz test packages/ui-server/src/__tests__/node-handler.test.ts` passes
+- [ ] `vtz test packages/ui-server/src/__tests__/ssr-handler.test.ts` passes
+- [ ] `vtz test packages/ui-server/src/__tests__/ssr-render.test.ts` passes
+- [ ] `vtz test packages/ui-server/src/__tests__/ssr-single-pass.test.ts` passes

--- a/reviews/fix-preload-mocks/phase-01-bridge-preload-mocks.md
+++ b/reviews/fix-preload-mocks/phase-01-bridge-preload-mocks.md
@@ -1,0 +1,47 @@
+# Phase 1: Bridge Preload Mocks to Rust Registry
+
+- **Author:** claude-opus
+- **Reviewer:** claude-opus (adversarial)
+- **Commits:** bbacfd251..16aa41090
+- **Date:** 2026-04-15
+
+## Changes
+
+- native/vtz/src/test/executor.rs (modified)
+- plans/2667-preload-mock-registration.md (new)
+- plans/2667-preload-mock-registration/phase-01-bridge-preload-mocks.md (new)
+
+## CI Status
+
+- [x] Quality gates passed at 16aa41090
+  - cargo test -p vtz --lib: 3367 passed (3 new)
+  - cargo clippy --release: clean
+  - cargo fmt: clean
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (test written first, confirmed RED, then fix applied for GREEN)
+- [x] No type gaps or missing edge cases
+- [x] No security issues
+- [x] Public API changes match design doc (N/A — no API changes)
+
+## Findings
+
+### Approved
+
+**No blockers found.** The fix is correct, minimal, and well-targeted.
+
+**Should-fix items addressed:**
+1. Missing test for conditional mocking (real-world pattern) — ADDED in second commit
+2. Missing test for multiple preloads with different mocks — ADDED in second commit
+
+**Nits noted but not acted on (acceptable):**
+- Inner block scope around preload loop — adds clarity, kept
+- Fully-qualified `std::collections::HashSet` — consistent with surrounding code
+- `for s in &new_specifiers { insert }` vs `.extend()` — readable as-is
+- `test_file_path` parameter naming in `register_mocked_specifiers` — pre-existing, not in scope
+
+## Resolution
+
+All should-fix items resolved. No changes needed for nits.


### PR DESCRIPTION
## Summary

- **Fixes** #2667 — `mock.module()` from preload scripts was silently ignored because the Rust module loader only checked mocks extracted at compile time from the test file itself.
- After each preload script loads, the executor now queries `globalThis.__vertz_mocked_modules` for new keys and registers them in the Rust-side `mocked_paths` registry via `register_mocked_specifiers()`.
- Uses the preload file path as the referrer for correct relative path resolution.

## Public API Changes

None. This is an internal runtime fix — no API, type, or behavior changes for users.

## Changed Files

- [`native/vtz/src/test/executor.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-preload-mocks/native/vtz/src/test/executor.rs) — Bridge preload mocks to module loader + 3 new tests

## Test plan

- [x] `test_preload_mock_module_registers_in_loader` — single preload mock intercepted by test file import
- [x] `test_preload_mock_conditional` — conditional `if (flag) { vi.mock(...) }` pattern (real-world scenario)
- [x] `test_preload_mock_multiple_preloads` — two preloads each mocking different modules
- [x] `cargo test --all` — 4,907 tests pass (3 new)
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Adversarial review — approved, all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)