### PR TITLE
fix(vtz): implement process.binding() shim for PGlite NODEFS (#2666)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,5 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "ignorePatterns": ["**/.vertz/**", "**/CHANGELOG.md", "**/.tmp-*/**"]
+  "ignorePatterns": ["**/.vertz/**", "**/CHANGELOG.md", "**/.tmp-*/**", "**/cli/my-app/**"]
 }

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -2732,6 +2732,7 @@ export const nextTick = proc.nextTick;
 export const stdout = proc.stdout;
 export const stderr = proc.stderr;
 export const stdin = proc.stdin;
+export const binding = proc.binding;
 "#;
 
 /// Synthetic module for `node:fs`.

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -50,6 +50,7 @@ pub fn op_chdir(#[string] dir: String) -> Result<(), deno_core::error::AnyError>
 #[serde]
 pub fn op_fs_constants() -> HashMap<&'static str, i32> {
     let mut m = HashMap::new();
+    // Open flags
     m.insert("O_RDONLY", libc::O_RDONLY);
     m.insert("O_WRONLY", libc::O_WRONLY);
     m.insert("O_RDWR", libc::O_RDWR);
@@ -60,6 +61,35 @@ pub fn op_fs_constants() -> HashMap<&'static str, i32> {
     m.insert("O_APPEND", libc::O_APPEND);
     m.insert("O_SYNC", libc::O_SYNC);
     m.insert("O_NOFOLLOW", libc::O_NOFOLLOW);
+    m.insert("O_DIRECTORY", libc::O_DIRECTORY);
+    m.insert("O_DSYNC", libc::O_DSYNC);
+    m.insert("O_NONBLOCK", libc::O_NONBLOCK);
+    // Access flags
+    m.insert("F_OK", libc::F_OK);
+    m.insert("R_OK", libc::R_OK);
+    m.insert("W_OK", libc::W_OK);
+    m.insert("X_OK", libc::X_OK);
+    // Stat mode constants
+    m.insert("S_IFMT", libc::S_IFMT as i32);
+    m.insert("S_IFREG", libc::S_IFREG as i32);
+    m.insert("S_IFDIR", libc::S_IFDIR as i32);
+    m.insert("S_IFCHR", libc::S_IFCHR as i32);
+    m.insert("S_IFBLK", libc::S_IFBLK as i32);
+    m.insert("S_IFIFO", libc::S_IFIFO as i32);
+    m.insert("S_IFLNK", libc::S_IFLNK as i32);
+    m.insert("S_IFSOCK", libc::S_IFSOCK as i32);
+    m.insert("S_IRWXU", libc::S_IRWXU as i32);
+    m.insert("S_IRUSR", libc::S_IRUSR as i32);
+    m.insert("S_IWUSR", libc::S_IWUSR as i32);
+    m.insert("S_IXUSR", libc::S_IXUSR as i32);
+    m.insert("S_IRWXG", libc::S_IRWXG as i32);
+    m.insert("S_IRGRP", libc::S_IRGRP as i32);
+    m.insert("S_IWGRP", libc::S_IWGRP as i32);
+    m.insert("S_IXGRP", libc::S_IXGRP as i32);
+    m.insert("S_IRWXO", libc::S_IRWXO as i32);
+    m.insert("S_IROTH", libc::S_IROTH as i32);
+    m.insert("S_IWOTH", libc::S_IWOTH as i32);
+    m.insert("S_IXOTH", libc::S_IXOTH as i32);
     m
 }
 
@@ -581,5 +611,41 @@ mod tests {
             .execute_script("<test>", "typeof process.binding('buffer')")
             .unwrap();
         assert_eq!(result, serde_json::json!("object"));
+    }
+
+    #[test]
+    fn test_process_binding_constants_has_stat_mode_constants() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const c = process.binding('constants');
+                const fs = c.fs || c;
+                ({
+                    hasIfmt: typeof fs.S_IFMT === 'number',
+                    hasIfreg: typeof fs.S_IFREG === 'number',
+                    hasIfdir: typeof fs.S_IFDIR === 'number',
+                    hasIflnk: typeof fs.S_IFLNK === 'number',
+                })
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result["hasIfmt"], serde_json::json!(true));
+        assert_eq!(result["hasIfreg"], serde_json::json!(true));
+        assert_eq!(result["hasIfdir"], serde_json::json!(true));
+        assert_eq!(result["hasIflnk"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_process_binding_caches_results() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "process.binding('constants') === process.binding('constants')",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
     }
 }

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -1,5 +1,6 @@
 use deno_core::op2;
 use deno_core::OpDecl;
+use std::collections::HashMap;
 
 /// Get an environment variable. Returns null if not set.
 #[op2]
@@ -43,6 +44,25 @@ pub fn op_chdir(#[string] dir: String) -> Result<(), deno_core::error::AnyError>
         .map_err(|e| deno_core::error::type_error(format!("Failed to change directory: {e}")))
 }
 
+/// Return platform-correct POSIX fs constants (O_RDONLY, O_CREAT, etc.).
+/// Used by `process.binding("constants")` to support Node.js compat (e.g. PGlite NODEFS).
+#[op2]
+#[serde]
+pub fn op_fs_constants() -> HashMap<&'static str, i32> {
+    let mut m = HashMap::new();
+    m.insert("O_RDONLY", libc::O_RDONLY);
+    m.insert("O_WRONLY", libc::O_WRONLY);
+    m.insert("O_RDWR", libc::O_RDWR);
+    m.insert("O_CREAT", libc::O_CREAT);
+    m.insert("O_EXCL", libc::O_EXCL);
+    m.insert("O_NOCTTY", libc::O_NOCTTY);
+    m.insert("O_TRUNC", libc::O_TRUNC);
+    m.insert("O_APPEND", libc::O_APPEND);
+    m.insert("O_SYNC", libc::O_SYNC);
+    m.insert("O_NOFOLLOW", libc::O_NOFOLLOW);
+    m
+}
+
 /// Get the op declarations for env ops.
 pub fn op_decls() -> Vec<OpDecl> {
     vec![
@@ -52,6 +72,7 @@ pub fn op_decls() -> Vec<OpDecl> {
         op_env_keys(),
         op_cwd(),
         op_chdir(),
+        op_fs_constants(),
     ]
 }
 
@@ -191,6 +212,21 @@ pub const ENV_BOOTSTRAP_JS: &str = r#"
       removeListener: function(_event, _cb) { return this; },
       resume: function() { return this; },
       pause: function() { return this; },
+    };
+  }
+  if (!globalThis.process.binding) {
+    var _bindingCache = {};
+    globalThis.process.binding = function(name) {
+      if (_bindingCache[name]) return _bindingCache[name];
+      if (name === 'constants') {
+        _bindingCache[name] = { fs: Deno.core.ops.op_fs_constants() };
+        return _bindingCache[name];
+      }
+      if (name === 'buffer') {
+        _bindingCache[name] = { kStringMaxLength: 536870888 };
+        return _bindingCache[name];
+      }
+      throw new Error('No such binding: ' + name);
     };
   }
 })(globalThis);
@@ -431,7 +467,6 @@ mod tests {
         assert_eq!(result, serde_json::json!(true));
     }
 
-    #[test]
     fn test_process_arch_is_a_string() {
         let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
         let result = rt.execute_script("<test>", "typeof process.arch").unwrap();
@@ -448,5 +483,103 @@ mod tests {
             "Unexpected arch: {}",
             arch
         );
+    }
+
+    #[test]
+    fn test_process_binding_is_a_function() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script("<test>", "typeof process.binding")
+            .unwrap();
+        assert_eq!(result, serde_json::json!("function"));
+    }
+
+    #[test]
+    fn test_process_binding_constants_returns_object() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script("<test>", "typeof process.binding('constants')")
+            .unwrap();
+        assert_eq!(result, serde_json::json!("object"));
+    }
+
+    #[test]
+    fn test_process_binding_constants_has_fs_open_flags() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const c = process.binding('constants');
+                const fs = c.fs || c;
+                ({
+                    hasAppend: typeof fs.O_APPEND === 'number',
+                    hasCreat: typeof fs.O_CREAT === 'number',
+                    hasExcl: typeof fs.O_EXCL === 'number',
+                    hasRdonly: typeof fs.O_RDONLY === 'number',
+                    hasRdwr: typeof fs.O_RDWR === 'number',
+                    hasTrunc: typeof fs.O_TRUNC === 'number',
+                    hasWronly: typeof fs.O_WRONLY === 'number',
+                    hasSync: typeof fs.O_SYNC === 'number',
+                    hasNoctty: typeof fs.O_NOCTTY === 'number',
+                    hasNofollow: typeof fs.O_NOFOLLOW === 'number',
+                })
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result["hasAppend"], serde_json::json!(true));
+        assert_eq!(result["hasCreat"], serde_json::json!(true));
+        assert_eq!(result["hasExcl"], serde_json::json!(true));
+        assert_eq!(result["hasRdonly"], serde_json::json!(true));
+        assert_eq!(result["hasRdwr"], serde_json::json!(true));
+        assert_eq!(result["hasTrunc"], serde_json::json!(true));
+        assert_eq!(result["hasWronly"], serde_json::json!(true));
+        assert_eq!(result["hasSync"], serde_json::json!(true));
+        assert_eq!(result["hasNoctty"], serde_json::json!(true));
+        assert_eq!(result["hasNofollow"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_process_binding_constants_fs_rdonly_is_zero() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const c = process.binding('constants');
+                const fs = c.fs || c;
+                fs.O_RDONLY
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(0));
+    }
+
+    #[test]
+    fn test_process_binding_unknown_throws() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                try {
+                    process.binding('nonexistent_binding');
+                    'no_error'
+                } catch (e) {
+                    e.message.includes('No such binding') ? 'correct_error' : e.message
+                }
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!("correct_error"));
+    }
+
+    #[test]
+    fn test_process_binding_buffer_returns_object() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script("<test>", "typeof process.binding('buffer')")
+            .unwrap();
+        assert_eq!(result, serde_json::json!("object"));
     }
 }

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -497,6 +497,7 @@ mod tests {
         assert_eq!(result, serde_json::json!(true));
     }
 
+    #[test]
     fn test_process_arch_is_a_string() {
         let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
         let result = rt.execute_script("<test>", "typeof process.arch").unwrap();


### PR DESCRIPTION
## Summary

- Implement minimal `process.binding()` shim in the vtz runtime to unblock PGlite and postgres driver
- Add `op_fs_constants` Rust op that returns platform-correct POSIX constants from `libc`
- Support `process.binding("constants")` (fs open flags, stat modes, access flags) and `process.binding("buffer")` (kStringMaxLength)
- Cache binding results for repeated calls; throw on unknown bindings
- Add `binding` named export to `node:process` ESM module
- Ignore generated `cli/my-app/` in oxfmt checks (pre-existing build artifact issue)

## Changes

- [`native/vtz/src/runtime/ops/env.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-process-binding/native/vtz/src/runtime/ops/env.rs) — New `op_fs_constants` Rust op + `process.binding()` JS bootstrap + 8 tests
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-process-binding/native/vtz/src/runtime/module_loader.rs) — Added `binding` named export to `node:process`
- [`.oxfmtrc.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-process-binding/.oxfmtrc.json) — Ignore generated `cli/my-app/` directory

## Public API Changes

None — internal runtime shim only.

## Test plan

- [x] 8 new Rust unit tests covering all `process.binding()` code paths
- [x] All 29 env tests pass (21 existing + 8 new)
- [x] Full Rust test suite passes (all crates, 0 failures)
- [x] Clippy clean, rustfmt clean
- [x] Build-typecheck passes
- [x] Adversarial review completed

Fixes #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)