### PR TITLE
fix(vtz): add codegen subcommand to resolve bin shadowing

### DIFF
--- a/.changeset/fix-codegen-cmd.md
+++ b/.changeset/fix-codegen-cmd.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Add `codegen` subcommand to the vtz CLI, fixing `vtz run codegen` and `vtz dev` codegen step that broke when `@vertz/runtime` bin entry shadowed `@vertz/cli`

--- a/native/vtz/src/cli.rs
+++ b/native/vtz/src/cli.rs
@@ -451,7 +451,7 @@ pub struct CodegenArgs {
     pub dry_run: bool,
 
     /// Output directory for generated files
-    #[arg(long, short = 'o')]
+    #[arg(long)]
     pub output: Option<String>,
 }
 

--- a/native/vtz/src/cli.rs
+++ b/native/vtz/src/cli.rs
@@ -60,6 +60,8 @@ pub enum Command {
     SelfUpdate(SelfUpdateArgs),
     /// Monorepo CI task orchestration
     Ci(CiArgs),
+    /// Run code generation (delegates to @vertz/cli)
+    Codegen(CodegenArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -440,6 +442,17 @@ pub struct RunArgs {
     /// Target a specific workspace package (by name or path)
     #[arg(short = 'w', long = "workspace")]
     pub workspace: Option<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct CodegenArgs {
+    /// Preview generated files without writing
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Output directory for generated files
+    #[arg(long, short = 'o')]
+    pub output: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/native/vtz/src/main.rs
+++ b/native/vtz/src/main.rs
@@ -286,6 +286,22 @@ async fn run_codegen_if_available(root_dir: &std::path::Path) {
     }
 }
 
+/// Resolve the `@vertz/cli/dist/vertz.js` entry point from node_modules.
+/// Returns `Some(path)` if found, `None` otherwise.
+fn resolve_vertz_cli_js(root_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let candidate = root_dir
+        .join("node_modules")
+        .join("@vertz")
+        .join("cli")
+        .join("dist")
+        .join("vertz.js");
+    if candidate.exists() {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
 async fn async_main(cli: Cli) {
     match cli.command {
         Command::Create(args) => {
@@ -1622,6 +1638,48 @@ async fn async_main(cli: Cli) {
             // that keep the tokio runtime alive indefinitely.
             std::process::exit(0);
         }
+        Command::Codegen(args) => {
+            let root_dir =
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+
+            let cli_js = match resolve_vertz_cli_js(&root_dir) {
+                Some(path) => path,
+                None => {
+                    eprintln!("error: @vertz/cli is not installed. Run `vtz install` first.");
+                    std::process::exit(1);
+                }
+            };
+
+            // Build node arguments: node <cli_js> codegen [--dry-run] [--output <dir>]
+            let mut node_args = vec![cli_js.to_string_lossy().to_string(), "codegen".to_string()];
+            if args.dry_run {
+                node_args.push("--dry-run".to_string());
+            }
+            if let Some(ref output) = args.output {
+                node_args.push("--output".to_string());
+                node_args.push(output.clone());
+            }
+
+            let status = tokio::process::Command::new("node")
+                .args(&node_args)
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .stdin(std::process::Stdio::inherit())
+                .current_dir(&root_dir)
+                .spawn()
+                .unwrap_or_else(|e| {
+                    eprintln!("error: failed to run node: {e}");
+                    std::process::exit(1);
+                })
+                .wait()
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("error: node process failed: {e}");
+                    std::process::exit(1);
+                });
+
+            std::process::exit(status.code().unwrap_or(1));
+        }
     }
 }
 
@@ -1646,5 +1704,48 @@ mod tests {
         .unwrap();
         // Has package.json but no "codegen" script → should return immediately
         run_codegen_if_available(tmp.path()).await;
+    }
+
+    #[test]
+    fn cli_parses_codegen_subcommand() {
+        let cli = Cli::parse_from(["vtz", "codegen"]);
+        assert!(matches!(cli.command, Command::Codegen(_)));
+    }
+
+    #[test]
+    fn cli_parses_codegen_dry_run() {
+        let cli = Cli::parse_from(["vtz", "codegen", "--dry-run"]);
+        if let Command::Codegen(args) = cli.command {
+            assert!(args.dry_run);
+            assert!(args.output.is_none());
+        } else {
+            panic!("expected Codegen command");
+        }
+    }
+
+    #[test]
+    fn cli_parses_codegen_output() {
+        let cli = Cli::parse_from(["vtz", "codegen", "--output", "./custom"]);
+        if let Command::Codegen(args) = cli.command {
+            assert!(!args.dry_run);
+            assert_eq!(args.output.as_deref(), Some("./custom"));
+        } else {
+            panic!("expected Codegen command");
+        }
+    }
+
+    #[test]
+    fn resolve_vertz_cli_js_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(resolve_vertz_cli_js(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn resolve_vertz_cli_js_finds_package() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cli_dir = tmp.path().join("node_modules/@vertz/cli/dist");
+        std::fs::create_dir_all(&cli_dir).unwrap();
+        std::fs::write(cli_dir.join("vertz.js"), "// stub").unwrap();
+        assert!(resolve_vertz_cli_js(tmp.path()).is_some());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2658

- **Root cause**: `@vertz/runtime` registers a `vertz` bin entry that shadows `@vertz/cli`'s `vertz` binary. When `vertz codegen` runs from a package.json script, it routes to the Rust native binary which had no `codegen` command, breaking both `vtz dev` (codegen step) and `vtz run codegen`.
- **Fix**: Added a `Codegen` subcommand to the Rust vtz CLI that resolves `@vertz/cli/dist/vertz.js` from `node_modules` and delegates via Node.js.

## Public API Changes

- **Addition**: `vtz codegen [--dry-run] [--output <dir>]` — new CLI subcommand that delegates to `@vertz/cli`'s codegen pipeline

## Files Changed

- [`native/vtz/src/cli.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-codegen-cmd/native/vtz/src/cli.rs) — Added `Codegen(CodegenArgs)` variant and `CodegenArgs` struct
- [`native/vtz/src/main.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-codegen-cmd/native/vtz/src/main.rs) — Added `resolve_vertz_cli_js()` helper and `Command::Codegen` handler with 5 tests

## Test plan

- [x] `vtz codegen` parses as valid subcommand
- [x] `vtz codegen --dry-run` sets dry_run flag
- [x] `vtz codegen --output ./custom` sets output path
- [x] `resolve_vertz_cli_js` returns `None` when `@vertz/cli` not installed
- [x] `resolve_vertz_cli_js` finds package when present in node_modules
- [x] All Rust quality gates pass (clippy, fmt, test)
- [x] Adversarial review completed (approved with nits, all addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)