### PR TITLE
chore(rules): remove --release from dev clippy quality gates

### DIFF
--- a/.claude/rules/local-phase-workflow.md
+++ b/.claude/rules/local-phase-workflow.md
@@ -43,7 +43,7 @@ Before a phase is considered "done" and the next phase starts, run the **full qu
 ```bash
 vtz test && vtz run typecheck && vtz run lint
 # If native/ changed:
-cd native && cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check
+cd native && cargo test --all && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check
 ```
 
 This validates the **entire monorepo**, not just the changed package — because changes in one package can break dependents.
@@ -150,7 +150,7 @@ Standard post-merge process:
 |--------|-------|
 | GitHub PR per phase | Local commits + local review markdown |
 | `gh-as.sh` for every PR | Only for final PR to main |
-| GitHub CI per phase | Local quality gates (TS: `vtz test && vtz run typecheck && vtz run lint`, Rust: `cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check`) |
+| GitHub CI per phase | Local quality gates (TS: `vtz test && vtz run typecheck && vtz run lint`, Rust: `cargo test --all && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`) |
 | Wait for GitHub API | Instant local operations |
 | Multiple branches per feature | One feature branch, phases as commit ranges |
 

--- a/.claude/rules/policies.md
+++ b/.claude/rules/policies.md
@@ -31,7 +31,7 @@
 
 ## Linting & Formatting (Rust)
 
-- **Linter:** `cargo clippy --all-targets --release -- -D warnings`
+- **Linter:** `cargo clippy --all-targets -- -D warnings`
 - **Formatter:** `cargo fmt --all`
 - All clippy warnings are errors in CI (`-D warnings`)
 - No `#[allow(clippy::*)]` without a comment explaining why

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -88,7 +88,7 @@ Before pushing ANY code:
 
 ### Rust (native/)
 - `cargo test --all` — tests pass
-- `cargo clippy --all-targets --release -- -D warnings` — no warnings
+- `cargo clippy --all-targets -- -D warnings` — no warnings
 - `cargo fmt --all -- --check` — formatting clean
 - Never push code that fails clippy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,13 @@ vtz run format:fix   # Auto-fix formatting
 ```bash
 cd native
 cargo test --all           # Run all tests
-cargo clippy --all-targets --release -- -D warnings  # Lint
+cargo clippy --all-targets -- -D warnings  # Lint
 cargo fmt --all -- --check # Format check
 cargo fmt --all            # Auto-format
-cargo build --release      # Release build
+cargo build --release      # Release build (CI/deploy only, NOT for dev quality gates)
 ```
+
+> **Never use `--release` for clippy or quality gates during development.** Release builds are significantly slower and only needed for CI pipelines and final deployment. Debug mode catches the same lint issues.
 
 ## Crate Structure
 
@@ -91,5 +93,5 @@ vtz test && vtz run typecheck && vtz run lint
 
 ### Rust
 ```bash
-cd native && cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check
+cd native && cargo test --all && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check
 ```


### PR DESCRIPTION
## Summary
- Removed `--release` flag from all `cargo clippy` commands in dev quality gates across rule files (`CLAUDE.md`, `policies.md`, `workflow.md`, `local-phase-workflow.md`)
- Added explicit callout that `--release` is only for CI/deploy, not local development
- Debug mode catches the same lint issues but compiles significantly faster

## Test plan
- [ ] Verify agents no longer use `--release` for clippy during phase quality gates
- [ ] Confirm CI pipeline (when it exists) still uses `--release` separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)