### PR TITLE
fix(vtz): resolve JWKS-based JWT verification null in full chain (#2671)

### DIFF
--- a/.changeset/fix-jwks-jwt-verification.md
+++ b/.changeset/fix-jwks-jwt-verification.md
@@ -1,0 +1,11 @@
+---
+'vtz': patch
+---
+
+fix(vtz): resolve JWKS-based JWT verification returning null in full chain
+
+Two bugs prevented the full JWT chain (generate → sign → JWKS → verify) from working:
+
+1. V8 snapshot cross-realm: after snapshot restore, `ArrayBuffer.isView()` in the crypto bootstrap IIFE failed for TypedArrays created in ES modules (different realm constructors). Replaced with duck-type property checks.
+
+2. HTTP serve URL hostname: `Bun.serve()` hardcoded the bind address (e.g. `0.0.0.0`) in `req.url`, causing JWT issuer mismatch. Now prefers the `Host` header.

--- a/native/vtz/src/runtime/ops/crypto.rs
+++ b/native/vtz/src/runtime/ops/crypto.rs
@@ -204,24 +204,36 @@ pub const CRYPTO_BOOTSTRAP_JS: &str = r#"
   // Snapshot-safe buffer detection.  After V8 snapshot restore, the built-in
   // constructors captured by this IIFE may differ from those used by ES modules
   // loaded post-restore, so `instanceof` and `ArrayBuffer.isView` can return
-  // false for cross-realm TypedArrays.  Duck-type checks avoid this.
+  // false for cross-realm TypedArrays.  We use Object.prototype.toString.call()
+  // which returns the correct @@toStringTag across realms.
+  const _toString = Object.prototype.toString;
+  const INTEGER_TYPED_ARRAY_TAGS = new Set([
+    '[object Int8Array]', '[object Uint8Array]', '[object Uint8ClampedArray]',
+    '[object Int16Array]', '[object Uint16Array]',
+    '[object Int32Array]', '[object Uint32Array]',
+    '[object BigInt64Array]', '[object BigUint64Array]',
+  ]);
+  const ALL_TYPED_ARRAY_TAGS = new Set([
+    ...INTEGER_TYPED_ARRAY_TAGS,
+    '[object Float32Array]', '[object Float64Array]',
+  ]);
+  function isIntegerTypedArray(v) {
+    return v != null && typeof v === 'object' && INTEGER_TYPED_ARRAY_TAGS.has(_toString.call(v));
+  }
   function isTypedArray(v) {
-    return v != null && typeof v === 'object' &&
-      typeof v.byteLength === 'number' && typeof v.byteOffset === 'number' &&
-      v.buffer != null && typeof v.buffer.byteLength === 'number';
+    return v != null && typeof v === 'object' && ALL_TYPED_ARRAY_TAGS.has(_toString.call(v));
   }
   function isBufferSource(v) {
-    if (v != null && typeof v === 'object' && typeof v.byteLength === 'number') {
-      // ArrayBuffer or SharedArrayBuffer (no byteOffset)
-      if (typeof v.byteOffset === 'undefined') return true;
-      // TypedArray or DataView
-      return typeof v.byteOffset === 'number';
-    }
-    return false;
+    if (v == null || typeof v !== 'object') return false;
+    const tag = _toString.call(v);
+    // ArrayBuffer or SharedArrayBuffer
+    if (tag === '[object ArrayBuffer]' || tag === '[object SharedArrayBuffer]') return true;
+    // TypedArray or DataView
+    return ALL_TYPED_ARRAY_TAGS.has(tag) || tag === '[object DataView]';
   }
 
   globalThis.crypto.getRandomValues = (typedArray) => {
-    if (!isTypedArray(typedArray)) {
+    if (!isIntegerTypedArray(typedArray)) {
       throw new TypeError('The provided value is not of type \'(ArrayBufferView)\'');
     }
     if (typedArray.byteLength > 65536) {
@@ -666,5 +678,60 @@ mod tests {
             "#,
         );
         assert_eq!(result.unwrap(), "correct_error");
+    }
+
+    #[test]
+    fn test_get_random_values_rejects_float64array() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                try {
+                    crypto.getRandomValues(new Float64Array(10));
+                    "no_error"
+                } catch (e) {
+                    e instanceof TypeError ? "correct_error" : e.message
+                }
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, "correct_error");
+    }
+
+    #[test]
+    fn test_get_random_values_rejects_plain_object() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                try {
+                    crypto.getRandomValues({ byteLength: 4, byteOffset: 0, buffer: { byteLength: 4 } });
+                    "no_error"
+                } catch (e) {
+                    e instanceof TypeError ? "correct_error" : e.message
+                }
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, "correct_error");
+    }
+
+    #[test]
+    fn test_get_random_values_accepts_uint8array() {
+        let mut rt = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const arr = new Uint8Array(16);
+                crypto.getRandomValues(arr);
+                // At least one byte should be non-zero (astronomically unlikely to be all zeros)
+                arr.some(b => b !== 0)
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, true);
     }
 }

--- a/native/vtz/src/runtime/ops/crypto.rs
+++ b/native/vtz/src/runtime/ops/crypto.rs
@@ -201,16 +201,27 @@ pub const CRYPTO_BOOTSTRAP_JS: &str = r#"
 
   globalThis.crypto.randomUUID = () => Deno.core.ops.op_crypto_random_uuid();
 
+  // Snapshot-safe buffer detection.  After V8 snapshot restore, the built-in
+  // constructors captured by this IIFE may differ from those used by ES modules
+  // loaded post-restore, so `instanceof` and `ArrayBuffer.isView` can return
+  // false for cross-realm TypedArrays.  Duck-type checks avoid this.
+  function isTypedArray(v) {
+    return v != null && typeof v === 'object' &&
+      typeof v.byteLength === 'number' && typeof v.byteOffset === 'number' &&
+      v.buffer != null && typeof v.buffer.byteLength === 'number';
+  }
+  function isBufferSource(v) {
+    if (v != null && typeof v === 'object' && typeof v.byteLength === 'number') {
+      // ArrayBuffer or SharedArrayBuffer (no byteOffset)
+      if (typeof v.byteOffset === 'undefined') return true;
+      // TypedArray or DataView
+      return typeof v.byteOffset === 'number';
+    }
+    return false;
+  }
+
   globalThis.crypto.getRandomValues = (typedArray) => {
-    if (!(typedArray instanceof Int8Array ||
-          typedArray instanceof Uint8Array ||
-          typedArray instanceof Uint8ClampedArray ||
-          typedArray instanceof Int16Array ||
-          typedArray instanceof Uint16Array ||
-          typedArray instanceof Int32Array ||
-          typedArray instanceof Uint32Array ||
-          typedArray instanceof BigInt64Array ||
-          typedArray instanceof BigUint64Array)) {
+    if (!isTypedArray(typedArray)) {
       throw new TypeError('The provided value is not of type \'(ArrayBufferView)\'');
     }
     if (typedArray.byteLength > 65536) {
@@ -256,19 +267,21 @@ pub const CRYPTO_BOOTSTRAP_JS: &str = r#"
     if (out.hash && typeof out.hash === 'object' && out.hash.name) {
       out.hash = out.hash.name;
     }
-    // Convert publicExponent Uint8Array to plain array for serde_v8 Vec<u8> compat.
-    // salt/info are NOT converted here — they're consumed by toBytes() first
-    // in deriveBits/deriveKey and converted to Array.from() there.
-    if (out.publicExponent && ArrayBuffer.isView(out.publicExponent)) {
-      out.publicExponent = Array.from(new Uint8Array(out.publicExponent.buffer, out.publicExponent.byteOffset, out.publicExponent.byteLength));
+    // Convert publicExponent TypedArray to plain array for serde_v8 Vec<u8> compat.
+    // Uses duck-type check (isTypedArray) instead of ArrayBuffer.isView to survive
+    // V8 snapshot restore where built-in constructor identity may differ.
+    if (out.publicExponent && isTypedArray(out.publicExponent)) {
+      out.publicExponent = Array.from(out.publicExponent);
     }
     return out;
   }
 
   function toBytes(data) {
-    if (data instanceof ArrayBuffer) return new Uint8Array(data);
-    if (ArrayBuffer.isView(data)) return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-    throw new TypeError('data must be BufferSource');
+    if (!isBufferSource(data)) throw new TypeError('data must be BufferSource');
+    // ArrayBuffer (no byteOffset) — wrap in Uint8Array
+    if (typeof data.byteOffset === 'undefined') return new Uint8Array(data);
+    // TypedArray or DataView — extract byte range
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
   }
 
   function makeCryptoKey(result) {

--- a/native/vtz/src/runtime/ops/crypto_subtle.rs
+++ b/native/vtz/src/runtime/ops/crypto_subtle.rs
@@ -3422,6 +3422,79 @@ mod tests {
         assert_eq!(result, serde_json::json!("correct-error"));
     }
 
+    /// RSA generateKey with explicit publicExponent as Uint8Array.
+    /// This is what jose.generateKeyPair('RS256') passes. The JS-side
+    /// normalizeAlgorithm must convert the Uint8Array to a plain array
+    /// before serde_v8 deserializes it into Vec<u8>.
+    #[tokio::test]
+    async fn test_rsa_generate_with_public_exponent_uint8array() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                {
+                    name: 'RSASSA-PKCS1-v1_5',
+                    hash: 'SHA-256',
+                    modulusLength: 2048,
+                    publicExponent: new Uint8Array([1, 0, 1]),
+                },
+                true, ['sign', 'verify']
+            );
+            return [
+                keyPair.privateKey.type === 'private',
+                keyPair.publicKey.type === 'public',
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(
+            arr[0].as_bool().unwrap(),
+            "private key type should be 'private'"
+        );
+        assert!(
+            arr[1].as_bool().unwrap(),
+            "public key type should be 'public'"
+        );
+    }
+
+    /// Same test as above but using the snapshot-restored runtime (new_for_test).
+    /// This specifically tests that the IIFE closure's ArrayBuffer.isView works
+    /// across V8 snapshot boundaries — the root cause of #2671.
+    #[tokio::test]
+    async fn test_rsa_generate_with_public_exponent_snapshot() {
+        let mut rt = VertzJsRuntime::new_for_test(VertzRuntimeOptions::default()).unwrap();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                {
+                    name: 'RSASSA-PKCS1-v1_5',
+                    hash: 'SHA-256',
+                    modulusLength: 2048,
+                    publicExponent: new Uint8Array([1, 0, 1]),
+                },
+                true, ['sign', 'verify']
+            );
+            return [
+                keyPair.privateKey.type === 'private',
+                keyPair.publicKey.type === 'public',
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(
+            arr[0].as_bool().unwrap(),
+            "private key type should be 'private' (snapshot runtime)"
+        );
+        assert!(
+            arr[1].as_bool().unwrap(),
+            "public key type should be 'public' (snapshot runtime)"
+        );
+    }
+
     #[tokio::test]
     async fn test_rsa_generate_unsupported_hash_fails() {
         let mut rt = create_runtime();

--- a/native/vtz/src/runtime/ops/http_serve.rs
+++ b/native/vtz/src/runtime/ops/http_serve.rs
@@ -292,10 +292,14 @@ pub const HTTP_SERVE_BOOTSTRAP_JS: &str = r#"
           // Process request without blocking the accept loop
           (async () => {
             try {
-              // Build full URL for Request constructor
+              // Build full URL for Request constructor.
+              // Prefer the Host header so the URL hostname matches what the
+              // client used (e.g. "localhost"), not the bind address (e.g. "0.0.0.0").
+              const hostHeader = req.headers.find(([k]) => k.toLowerCase() === 'host');
+              const authority = hostHeader ? hostHeader[1] : `${hostname}:${server.port}`;
               const fullUrl = req.url.startsWith('http')
                 ? req.url
-                : `http://${hostname}:${server.port}${req.url}`;
+                : `http://${authority}${req.url}`;
 
               // Decode base64 body if present
               let body = undefined;
@@ -451,5 +455,38 @@ mod tests {
         .await;
 
         assert_eq!(result.as_str().unwrap(), "POST");
+    }
+
+    /// req.url should use the Host header for the hostname component
+    /// so that `new URL(req.url).origin` matches the client's perspective.
+    #[tokio::test]
+    async fn test_http_serve_uses_host_header_for_url() {
+        let mut rt = create_runtime();
+
+        let result = run_async(
+            &mut rt,
+            r#"
+            const server = await globalThis.__vtz_http.serve(0, '0.0.0.0', async (req) => {
+                const url = new URL(req.url);
+                return new Response(url.hostname, { status: 200 });
+            });
+
+            // Fetch with Host header set to localhost
+            const resp = await fetch(
+                'http://localhost:' + server.port + '/test',
+                { headers: { 'Host': 'localhost:' + server.port } },
+            );
+            const body = await resp.text();
+            server.close();
+            return body;
+            "#,
+        )
+        .await;
+
+        assert_eq!(
+            result.as_str().unwrap(),
+            "localhost",
+            "req.url hostname should come from the Host header"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2671 — the full JWT chain (generate RSA keys → sign JWT → publish JWKS → verify via JWKS client) was returning `null` for a valid JWT. Two root causes were found and fixed:

- **V8 snapshot cross-realm issue in crypto bootstrap**: After snapshot restore, the IIFE closure in `CRYPTO_BOOTSTRAP_JS` captures snapshot-era built-in constructors (`ArrayBuffer`, `Uint8Array`, etc.) that differ from those used by ES modules loaded post-restore. `ArrayBuffer.isView()` and `instanceof` returned `false` for TypedArrays from module code, causing `serde_v8` deserialization errors. **Fix**: replaced identity-based checks with `Object.prototype.toString.call()` which returns the correct `@@toStringTag` across realms.

- **HTTP serve URL hostname mismatch**: `Bun.serve()` hardcoded the bind address (e.g., `0.0.0.0`) as the hostname in `req.url`, causing JWT issuer mismatch when the client connects via `localhost`. **Fix**: HTTP serve now prefers the `Host` header for URL authority construction.

## Public API Changes

None — this is an internal runtime fix.

## Files Changed

| File | Change |
|------|--------|
| [`native/vtz/src/runtime/ops/crypto.rs`](https://github.com/vertz-dev/vertz/blob/fix/jwks-jwt-verification-null/native/vtz/src/runtime/ops/crypto.rs) | `Object.prototype.toString`-based type checks replacing `instanceof`/`ArrayBuffer.isView`; `isIntegerTypedArray` for `getRandomValues` spec compliance; negative tests |
| [`native/vtz/src/runtime/ops/crypto_subtle.rs`](https://github.com/vertz-dev/vertz/blob/fix/jwks-jwt-verification-null/native/vtz/src/runtime/ops/crypto_subtle.rs) | Tests for RSA key generation with `Uint8Array` publicExponent (both direct and snapshot contexts) |
| [`native/vtz/src/runtime/ops/http_serve.rs`](https://github.com/vertz-dev/vertz/blob/fix/jwks-jwt-verification-null/native/vtz/src/runtime/ops/http_serve.rs) | Host header preference for `req.url` construction; test |

## Review Summary

Adversarial review identified:
- **BLOCKER (fixed)**: `getRandomValues` accepted `Float64Array` after duck-type migration — fixed with `isIntegerTypedArray` using `@@toStringTag` set matching the Web Crypto spec
- **SHOULD-FIX (fixed)**: duck-type checks accepted plain objects with matching properties — fixed by switching to `Object.prototype.toString.call()` for all type checks
- **Pre-existing issue filed**: `node:util.types.isTypedArray` has the same `instanceof` pattern → #2682

## Test Plan

- [x] `cloud-server-integration.test.ts` — full chain: JWKS → verifier → proxy → cookies → JWT verified
- [x] `test_rsa_generate_with_public_exponent_uint8array` — RSA key gen without snapshot
- [x] `test_rsa_generate_with_public_exponent_snapshot` — RSA key gen with snapshot
- [x] `test_http_serve_uses_host_header_for_url` — Host header preference
- [x] `test_get_random_values_rejects_float64array` — spec compliance
- [x] `test_get_random_values_rejects_plain_object` — robustness
- [x] `test_get_random_values_accepts_uint8array` — positive case
- [x] All Rust quality gates: `cargo test --all && cargo clippy && cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)