### PR TITLE
fix(compiler): exclude method definitions from import injection (#2664)

### DIFF
--- a/.changeset/fix-batch-import-injection.md
+++ b/.changeset/fix-batch-import-injection.md
@@ -1,0 +1,5 @@
+---
+'@vertz/native-compiler': patch
+---
+
+Fix false-positive `batch` import injection when `async batch()` appears as an object method definition

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -224,7 +224,8 @@ fn strip_comments(code: &str) -> String {
 /// Check if `name(` appears as a standalone call (not a method call like `obj.name(`).
 ///
 /// Returns true only when the character before `name(` is NOT an identifier character
-/// or a `.`, preventing false positives like `db.batch(` from matching `batch(`.
+/// or a `.`, and when it is not preceded by a method-definition keyword like `async`,
+/// `get`, `set`, or `static`.
 fn contains_standalone_call(code: &str, name: &str) -> bool {
     let pattern = format!("{name}(");
     let mut search_from = 0;
@@ -240,8 +241,48 @@ fn contains_standalone_call(code: &str, name: &str) -> bool {
             search_from = abs_pos + pattern.len();
             continue;
         }
+        // Check if this is a method definition preceded by a keyword like
+        // `async batch(`, `get batch(`, `set batch(`, `static batch(`.
+        if is_method_definition_context(code, abs_pos) {
+            search_from = abs_pos + pattern.len();
+            continue;
+        }
         return true;
     }
+    false
+}
+
+/// Check if the token before position `name_pos` is a method-definition keyword.
+///
+/// Matches patterns like `async name(`, `get name(`, `set name(`, `static name(`,
+/// and `* name(` (generator methods). The keyword itself must be at a word boundary
+/// to avoid false matches like `myasync name(`.
+fn is_method_definition_context(code: &str, name_pos: usize) -> bool {
+    let before = code[..name_pos].trim_end();
+    if before.is_empty() {
+        return false;
+    }
+
+    // Generator method: `* name(`
+    if before.ends_with('*') {
+        return true;
+    }
+
+    for keyword in &["async", "get", "set", "static"] {
+        if before.ends_with(keyword) {
+            let kw_start = before.len() - keyword.len();
+            // Keyword at start of string — definitely a word boundary
+            if kw_start == 0 {
+                return true;
+            }
+            let before_kw = before.as_bytes()[kw_start - 1];
+            // The keyword itself must be preceded by a non-identifier char
+            if !before_kw.is_ascii_alphanumeric() && before_kw != b'_' && before_kw != b'$' {
+                return true;
+            }
+        }
+    }
+
     false
 }
 
@@ -730,5 +771,65 @@ mod tests {
             "db.batch(x); other.batch(y);",
             "batch"
         ));
+    }
+
+    // ── Method definition false-positive prevention ───────────────
+
+    #[test]
+    fn does_not_inject_batch_for_async_method_definition() {
+        // async batch(statements) { ... } is a method definition, not a standalone call
+        let code = "const mock = { async batch(statements) { return []; } };";
+        let result = inject(code);
+        assert!(
+            !result.contains("import { batch }"),
+            "should not inject batch for async method definition: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn standalone_call_preceded_by_async_keyword_is_rejected() {
+        assert!(!contains_standalone_call(
+            "async batch(statements) {",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn standalone_batch_call_still_detected_alongside_async_method() {
+        // An async method definition AND a real standalone call in the same code
+        let code = "const mock = { async batch(stmts) { } };\nbatch(() => { });";
+        let result = inject(code);
+        assert!(
+            result.contains("import { batch } from '@vertz/ui';"),
+            "should still inject batch for standalone call: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn get_method_definition_is_rejected() {
+        assert!(!contains_standalone_call("get signal() {", "signal"));
+    }
+
+    #[test]
+    fn set_method_definition_is_rejected() {
+        assert!(!contains_standalone_call("set signal(value) {", "signal"));
+    }
+
+    #[test]
+    fn static_method_definition_is_rejected() {
+        assert!(!contains_standalone_call("static batch(items) {", "batch"));
+    }
+
+    #[test]
+    fn generator_method_definition_is_rejected() {
+        assert!(!contains_standalone_call("* batch(items) {", "batch"));
+    }
+
+    #[test]
+    fn longer_identifier_ending_in_keyword_does_not_false_exclude() {
+        // `myasync` ends with `async` but is not the keyword — batch is still standalone
+        assert!(contains_standalone_call("myasync batch()", "batch"));
     }
 }

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -264,8 +264,26 @@ fn is_method_definition_context(code: &str, name_pos: usize) -> bool {
     }
 
     // Generator method: `* name(`
-    if before.ends_with('*') {
-        return true;
+    // Must verify the `*` is a generator star (preceded by a structural char
+    // like `,`, `{`, `;`), not a multiplication operator (preceded by an
+    // identifier, number, or closing paren/bracket).
+    if let Some(without_star) = before.strip_suffix('*') {
+        let before_star = without_star.trim_end();
+        if before_star.is_empty() {
+            return true;
+        }
+        let last = before_star.as_bytes()[before_star.len() - 1];
+        // If preceded by an expression-producing token, this is multiplication
+        if last.is_ascii_alphanumeric()
+            || last == b'_'
+            || last == b'$'
+            || last == b')'
+            || last == b']'
+        {
+            // Multiplication — not a generator
+        } else {
+            return true;
+        }
     }
 
     for keyword in &["async", "get", "set", "static"] {
@@ -831,5 +849,28 @@ mod tests {
     fn longer_identifier_ending_in_keyword_does_not_false_exclude() {
         // `myasync` ends with `async` but is not the keyword — batch is still standalone
         assert!(contains_standalone_call("myasync batch()", "batch"));
+    }
+
+    #[test]
+    fn multiplication_before_call_is_not_generator() {
+        // `a * batch(fn)` — the `*` is multiplication, not a generator star
+        assert!(contains_standalone_call("a * batch(fn)", "batch"));
+        assert!(contains_standalone_call("count * signal(0)", "signal"));
+    }
+
+    #[test]
+    fn static_async_method_is_rejected() {
+        assert!(!contains_standalone_call(
+            "static async batch(items) {",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn return_await_yield_are_standalone_calls() {
+        assert!(contains_standalone_call("return batch()", "batch"));
+        assert!(contains_standalone_call("await batch()", "batch"));
+        assert!(contains_standalone_call("yield batch()", "batch"));
+        assert!(contains_standalone_call("void batch()", "batch"));
     }
 }

--- a/reviews/fix-batch-import/phase-01-fix.md
+++ b/reviews/fix-batch-import/phase-01-fix.md
@@ -1,0 +1,38 @@
+# Phase 1: Fix false-positive batch() import injection
+
+- **Author:** claude-opus
+- **Reviewer:** claude-opus (adversarial review agent)
+- **Commits:** 252c0e392..90739b003
+- **Date:** 2026-04-15
+
+## Changes
+
+- native/vertz-compiler-core/src/import_injection.rs (modified)
+
+## CI Status
+
+- [x] Quality gates passed at 90739b003
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (tests before/alongside implementation)
+- [x] No type gaps or missing edge cases
+- [x] No security issues (injection, XSS, etc.)
+- [x] Public API changes match design doc
+
+## Findings
+
+### Changes Requested (resolved)
+
+1. **BLOCKER: `*` generator check had no boundary validation** — `a * batch(fn)` was falsely excluded because the `*` was unconditionally treated as a generator star. Fixed by checking the token before `*` (expression-producing tokens like identifiers, `)`, `]` indicate multiplication).
+
+2. **SHOULD-FIX: Missing test for `static async` compound keyword** — Added test.
+
+3. **SHOULD-FIX: Missing tests for `return`/`await`/`yield`/`void` contexts** — Added regression tests confirming these are still detected as standalone calls.
+
+4. **NOTE: Shorthand method `{ batch(items) }` false positive** — Pre-existing bug, not introduced by this PR. Tracked as #2684.
+
+## Resolution
+
+All blocker and should-fix findings resolved in commit 90739b003. Pre-existing issue tracked in #2684.


### PR DESCRIPTION
## Summary

- Fixed false-positive `batch()` import injection when `async batch()` appears as an object method definition
- Added `is_method_definition_context()` to detect and exclude `async`, `get`, `set`, `static`, and generator `*` method keywords
- Fixed generator `*` detection to distinguish from multiplication operator (found during adversarial review)

## Key Changes

- [`native/vertz-compiler-core/src/import_injection.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-batch-import/native/vertz-compiler-core/src/import_injection.rs) — Added `is_method_definition_context()` helper and integrated into `contains_standalone_call()`

## Public API Changes

None — internal compiler heuristic fix only.

## Test Plan

- [x] `async batch(statements) {}` in object literal does NOT trigger import injection
- [x] Standalone `batch(() => { ... })` calls still correctly trigger injection
- [x] `get`/`set`/`static` method definitions excluded
- [x] Generator `*` vs multiplication `*` correctly distinguished
- [x] `return`/`await`/`yield`/`void` before calls still detected as standalone
- [x] All 1206 vertz-compiler-core tests pass
- [x] Clippy clean, rustfmt clean

## Related

- Closes #2664
- Created #2684 for pre-existing shorthand method false positive (not addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)