### PR TITLE
fix(vtz): handle non-finite delays in setTimeout/setInterval (#2672)

### DIFF
--- a/native/vtz/src/runtime/ops/timers.rs
+++ b/native/vtz/src/runtime/ops/timers.rs
@@ -31,7 +31,9 @@ pub const TIMERS_BOOTSTRAP_JS: &str = r#"
   const CANCEL_CHECK_MS = 100;
 
   async function sleepCancellable(state, delay) {
-    let remaining = Math.max(0, delay);
+    // Non-finite or negative delays fire immediately (matches browser ToInt32 semantics).
+    // Without this guard, Infinity causes an infinite loop (Infinity - 100 === Infinity).
+    let remaining = Number.isFinite(delay) ? Math.max(0, delay) : 0;
     if (remaining <= CANCEL_CHECK_MS) {
       // Short delay — sleep in one go (common fast path)
       await Deno.core.ops.op_timer_sleep(BigInt(Math.floor(remaining)));
@@ -360,6 +362,67 @@ mod tests {
         rt.run_event_loop().await.unwrap();
         let output = rt.captured_output();
         assert_eq!(output.stdout, vec!["chunked float ok"]);
+    }
+
+    /// setTimeout(fn, Infinity) must fire immediately, not hang the event loop.
+    /// Infinity delay causes remaining to never decrease (Infinity - 100 === Infinity).
+    #[tokio::test]
+    async fn test_set_timeout_infinity_delay() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            setTimeout(() => console.log('infinity ok'), Infinity);
+        "#,
+        )
+        .unwrap();
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), rt.run_event_loop()).await;
+
+        assert!(result.is_ok(), "Event loop hung on Infinity delay");
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["infinity ok"]);
+    }
+
+    /// setTimeout(fn, NaN) must fire immediately (NaN coerces to 0 per spec).
+    #[tokio::test]
+    async fn test_set_timeout_nan_delay() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            setTimeout(() => console.log('nan ok'), NaN);
+        "#,
+        )
+        .unwrap();
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), rt.run_event_loop()).await;
+
+        assert!(result.is_ok(), "Event loop hung on NaN delay");
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["nan ok"]);
+    }
+
+    /// setTimeout(fn, -1) must fire immediately (negative coerces to 0 per spec).
+    #[tokio::test]
+    async fn test_set_timeout_negative_delay() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            setTimeout(() => console.log('negative ok'), -1);
+        "#,
+        )
+        .unwrap();
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), rt.run_event_loop()).await;
+
+        assert!(result.is_ok(), "Event loop hung on negative delay");
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["negative ok"]);
     }
 
     /// Self-rescheduling setTimeout chain (like RelativeTime component) must

--- a/native/vtz/src/runtime/ops/timers.rs
+++ b/native/vtz/src/runtime/ops/timers.rs
@@ -425,6 +425,34 @@ mod tests {
         assert_eq!(output.stdout, vec!["negative ok"]);
     }
 
+    /// setInterval(fn, Infinity) must not spin the CPU. After the fix,
+    /// sleepCancellable returns immediately for non-finite delays, so the
+    /// interval fires rapidly. Clearing it must stop the loop and free the
+    /// event loop.
+    #[tokio::test]
+    async fn test_set_interval_infinity_delay() {
+        let mut rt = create_capturing_runtime();
+        rt.execute_script_void(
+            "<test>",
+            r#"
+            let count = 0;
+            const id = setInterval(() => {
+                count++;
+                console.log('tick ' + count);
+                if (count >= 3) clearInterval(id);
+            }, Infinity);
+        "#,
+        )
+        .unwrap();
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), rt.run_event_loop()).await;
+
+        assert!(result.is_ok(), "Event loop hung on Infinity interval");
+        let output = rt.captured_output();
+        assert_eq!(output.stdout, vec!["tick 1", "tick 2", "tick 3"]);
+    }
+
     /// Self-rescheduling setTimeout chain (like RelativeTime component) must
     /// clean up properly when clearTimeout cancels the pending timer.
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `setTimeout(fn, Infinity)` caused `sleepCancellable()` to loop forever because `Infinity - 100 === Infinity` — the `remaining` counter never decreased
- Added `Number.isFinite(delay)` guard at the top of `sleepCancellable` to coerce non-finite delays (Infinity, NaN, -Infinity) to 0, matching browser ToInt32 semantics
- Added tests for `setTimeout` with `Infinity`, `NaN`, and negative delays, plus `setInterval` with `Infinity`

## Public API Changes

None — internal runtime fix only. Timer behavior now matches browser semantics for edge-case delay values.

## Files Changed

- [`native/vtz/src/runtime/ops/timers.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-infinity-timer/native/vtz/src/runtime/ops/timers.rs) — 1-line fix + 4 new tests

## Test Plan

- [x] `test_set_timeout_infinity_delay` — verifies `setTimeout(fn, Infinity)` fires immediately
- [x] `test_set_timeout_nan_delay` — verifies `setTimeout(fn, NaN)` fires immediately
- [x] `test_set_timeout_negative_delay` — verifies `setTimeout(fn, -1)` fires immediately
- [x] `test_set_interval_infinity_delay` — verifies `setInterval(fn, Infinity)` fires and can be cleared
- [x] All 16 timer tests pass
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #2672

🤖 Generated with [Claude Code](https://claude.com/claude-code)