### PR TITLE
fix(vtz): use toString tag-set for isTypedArray to survive V8 snapshot boundaries

### DIFF
--- a/.changeset/fix-is-typed-array-snapshot.md
+++ b/.changeset/fix-is-typed-array-snapshot.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix `node:util.types.isTypedArray` to use `Object.prototype.toString` tag-set check instead of `instanceof`, preventing false negatives when TypedArrays cross V8 snapshot boundaries (e.g., PGlite NODEFS)

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -3390,12 +3390,24 @@ function inherits(ctor, superCtor) {
   Object.setPrototypeOf(ctor, superCtor);
 }
 
+// Use Object.prototype.toString for isTypedArray to survive V8 snapshot boundaries (#2682).
+// Note: this is spoofable via Symbol.toStringTag, but that is acceptable for this shim —
+// it is not a security boundary. A V8-native op (v8::Value::is_typed_array) would be
+// needed for spoofing resistance.
+const _toString = Object.prototype.toString;
+const TYPED_ARRAY_TAGS = new Set([
+  '[object Int8Array]', '[object Uint8Array]', '[object Uint8ClampedArray]',
+  '[object Int16Array]', '[object Uint16Array]',
+  '[object Int32Array]', '[object Uint32Array]',
+  '[object BigInt64Array]', '[object BigUint64Array]',
+  '[object Float32Array]', '[object Float64Array]',
+]);
 const _types = {
   isDate: (v) => v instanceof Date,
   isRegExp: (v) => v instanceof RegExp,
   isPromise: (v) => v instanceof Promise,
   isArrayBuffer: (v) => v instanceof ArrayBuffer,
-  isTypedArray: (v) => ArrayBuffer.isView(v) && !(v instanceof DataView),
+  isTypedArray: (v) => v != null && typeof v === 'object' && TYPED_ARRAY_TAGS.has(_toString.call(v)),
   isUint8Array: (v) => v instanceof Uint8Array,
   isSet: (v) => v instanceof Set,
   isMap: (v) => v instanceof Map,

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -1542,3 +1542,120 @@ async fn test_import_meta_dirname_and_filename() {
         output.stdout
     );
 }
+
+// --- Bug #2682: node:util.types.isTypedArray must survive V8 snapshot boundaries ---
+// These tests verify correctness of the toString-based tag check. The actual snapshot
+// boundary bug requires cross-realm TypedArrays (e.g., PGlite NODEFS), which cannot
+// be reproduced in a simple unit test without snapshot restore infrastructure.
+
+#[tokio::test]
+async fn test_node_util_types_is_typed_array_positive() {
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier =
+        deno_core::ModuleSpecifier::parse("file:///virtual/util-types-typed-array.js").unwrap();
+
+    rt.load_main_module_from_code(
+        &specifier,
+        r#"
+        import { types } from 'node:util';
+
+        // All TypedArray subtypes must return true
+        console.log("Int8Array: " + types.isTypedArray(new Int8Array(1)));
+        console.log("Uint8Array: " + types.isTypedArray(new Uint8Array(1)));
+        console.log("Uint8ClampedArray: " + types.isTypedArray(new Uint8ClampedArray(1)));
+        console.log("Int16Array: " + types.isTypedArray(new Int16Array(1)));
+        console.log("Uint16Array: " + types.isTypedArray(new Uint16Array(1)));
+        console.log("Int32Array: " + types.isTypedArray(new Int32Array(1)));
+        console.log("Uint32Array: " + types.isTypedArray(new Uint32Array(1)));
+        console.log("BigInt64Array: " + types.isTypedArray(new BigInt64Array(1)));
+        console.log("BigUint64Array: " + types.isTypedArray(new BigUint64Array(1)));
+        console.log("Float32Array: " + types.isTypedArray(new Float32Array(1)));
+        console.log("Float64Array: " + types.isTypedArray(new Float64Array(1)));
+    "#
+        .to_string(),
+    )
+    .await
+    .unwrap();
+
+    let output = rt.captured_output();
+    let typed_arrays = [
+        "Int8Array",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "Int16Array",
+        "Uint16Array",
+        "Int32Array",
+        "Uint32Array",
+        "BigInt64Array",
+        "BigUint64Array",
+        "Float32Array",
+        "Float64Array",
+    ];
+    for (i, name) in typed_arrays.iter().enumerate() {
+        assert_eq!(
+            output.stdout[i],
+            format!("{}: true", name),
+            "isTypedArray should return true for {}. Got: {:?}",
+            name,
+            output.stdout
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_node_util_types_is_typed_array_negative() {
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier =
+        deno_core::ModuleSpecifier::parse("file:///virtual/util-types-typed-array-neg.js").unwrap();
+
+    rt.load_main_module_from_code(
+        &specifier,
+        r#"
+        import { types } from 'node:util';
+
+        // These must all return false
+        console.log("DataView: " + types.isTypedArray(new DataView(new ArrayBuffer(1))));
+        console.log("ArrayBuffer: " + types.isTypedArray(new ArrayBuffer(1)));
+        console.log("plain-object: " + types.isTypedArray({ length: 1, byteLength: 1 }));
+        console.log("null: " + types.isTypedArray(null));
+        console.log("undefined: " + types.isTypedArray(undefined));
+        console.log("number: " + types.isTypedArray(42));
+        console.log("string: " + types.isTypedArray("hello"));
+        console.log("array: " + types.isTypedArray([1, 2, 3]));
+    "#
+        .to_string(),
+    )
+    .await
+    .unwrap();
+
+    let output = rt.captured_output();
+    let negatives = [
+        "DataView",
+        "ArrayBuffer",
+        "plain-object",
+        "null",
+        "undefined",
+        "number",
+        "string",
+        "array",
+    ];
+    for (i, name) in negatives.iter().enumerate() {
+        assert_eq!(
+            output.stdout[i],
+            format!("{}: false", name),
+            "isTypedArray should return false for {}. Got: {:?}",
+            name,
+            output.stdout
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2682

## Summary

- Replace `ArrayBuffer.isView(v) && !(v instanceof DataView)` with `Object.prototype.toString.call(v)` checked against a `TYPED_ARRAY_TAGS` set in the `node:util.types.isTypedArray` shim
- The `instanceof` approach fails after V8 snapshot restore because the `ArrayBuffer.isView` captured in the closure references the snapshot-era constructor
- Same fix pattern as #2671 (crypto bootstrap)

## Public API Changes

None — internal shim behavior fix, no API surface change.

## Test plan

- [x] Positive test: all 11 TypedArray subtypes return `true`
- [x] Negative test: DataView, ArrayBuffer, plain objects, null, undefined, number, string, array all return `false`
- [x] All existing `node:util` tests pass
- [x] `cargo test --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Follow-up

- #2686 — convert remaining `instanceof` checks in `_types` to the same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)