### PR TITLE
fix(vtz): resolve runtime gaps in type stripping, test runner, and matchers (#2668)

### DIFF
--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -700,6 +700,34 @@ fn strip_leftover_typescript(code: &str) -> String {
     let mut nesting_stack: Vec<char> = Vec::new();
 
     while i < len {
+        // Skip single-line comments (`// ...`) so quotes inside them don't
+        // trigger string scanning mode.  E.g. `// Import each module's factory`
+        // contains a `'` that would otherwise open an unterminated string.
+        if chars[i] == '/' && i + 1 < len && chars[i + 1] == '/' {
+            while i < len && chars[i] != '\n' {
+                result.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+        // Skip block comments (`/* ... */`) for the same reason.
+        if chars[i] == '/' && i + 1 < len && chars[i + 1] == '*' {
+            result.push(chars[i]);
+            result.push(chars[i + 1]);
+            i += 2;
+            while i < len {
+                if chars[i] == '*' && i + 1 < len && chars[i + 1] == '/' {
+                    result.push(chars[i]);
+                    result.push(chars[i + 1]);
+                    i += 2;
+                    break;
+                }
+                result.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+
         // Skip string literals so unbalanced braces/parens inside them don't affect depth.
         if chars[i] == '\'' || chars[i] == '"' || chars[i] == '`' {
             let quote = chars[i];
@@ -2524,6 +2552,43 @@ export function App() {
         );
     }
 
+    #[test]
+    fn test_strip_leftover_skips_comments_with_quotes() {
+        // A single quote inside a JS comment (like `module's`) must NOT trigger
+        // the string scanner in Phase 2.  If it does, the scanner enters string
+        // mode, consumes characters across lines until it finds a matching quote
+        // (possibly inside a template literal), and corrupts nesting state —
+        // causing later string-literal content to be modified.
+        let code = r#"export function emitClientFile(moduleNames) {
+  const lines = ['// Auto-generated', ''];
+
+  // Import each module's factory
+  for (const name of moduleNames) {
+    const pascalName = capitalize(name);
+    lines.push(`import { create${pascalName}Module } from './modules/${name}';`);
+  }
+
+  lines.push('');
+  lines.push('export function createClient(client: HttpClient) {');
+  lines.push('  return {');
+
+  lines.push('  };');
+  lines.push('}');
+  lines.push('');
+
+  return lines.join('\n');
+}"#;
+
+        let result = strip_leftover_typescript(code);
+
+        // The `: HttpClient` is INSIDE a string literal — must be preserved.
+        assert!(
+            result.contains("client: HttpClient"),
+            "String literal content `: HttpClient` was incorrectly stripped. Got:\n{}",
+            result
+        );
+    }
+
     // ── CompilationPipeline methods ─────────────────────────────────
 
     #[test]
@@ -2917,5 +2982,72 @@ export function App() {
         let pipeline = create_pipeline(tmp.path());
         let result = pipeline.compile_for_browser(&src_dir.join("app.ts"));
         assert!(result.code.contains("compiled by vertz-native"));
+    }
+
+    /// Regression test for #2668: the full pipeline (AST strip + strip_leftover_typescript)
+    /// must not modify string literal content in large files.
+    #[test]
+    fn test_full_pipeline_preserves_string_literal_type_annotations() {
+        // Use the actual spike.ts content from the compiler package
+        let spike_ts =
+            include_str!("../../../../packages/compiler/src/__tests__/codegen-poc/spike.ts");
+
+        // Run the AST stripper (same as vertz_compiler_core::compile does)
+        let compile_result = vertz_compiler_core::compile(
+            spike_ts,
+            vertz_compiler_core::CompileOptions {
+                filename: Some("spike.ts".to_string()),
+                target: Some("server".to_string()),
+                fast_refresh: Some(false),
+                skip_css_transform: Some(true),
+                ..Default::default()
+            },
+        );
+
+        // Run strip_leftover_typescript on the AST-stripped output
+        let result = strip_leftover_typescript(&compile_result.code);
+
+        // First, check what the AST stripper produced (before strip_leftover_typescript)
+        // This helps us understand what strip_leftover_typescript receives
+        let ast_output_has_it = compile_result
+            .code
+            .contains("'export function createClient(client: HttpClient) {'");
+        if !ast_output_has_it {
+            panic!(
+                "BUG IS IN AST STRIPPER: The AST stripper itself corrupted the string literal.\n\
+                 Lines containing 'createClient' in AST output:\n{}",
+                compile_result
+                    .code
+                    .lines()
+                    .filter(|l| l.contains("createClient"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+
+        // The string literal 'export function createClient(client: HttpClient) {'
+        // must NOT have `: HttpClient` stripped from it.
+        assert!(
+            result.contains("'export function createClient(client: HttpClient) {'"),
+            "BUG IS IN strip_leftover_typescript: The `: HttpClient` inside the string was \
+             incorrectly stripped. AST output was correct but strip_leftover_typescript corrupted it.\n\
+             Lines containing 'createClient' after strip_leftover_typescript:\n{}",
+            result.lines()
+                .filter(|l| l.contains("createClient"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    #[test]
+    fn test_strip_leftover_skips_block_comments_with_quotes() {
+        // Block comments can also contain quotes that confuse the scanner.
+        let code = "function test() { /* it's a comment */ const s = 'hello: World'; return s; }";
+        let result = strip_leftover_typescript(code);
+        assert!(
+            result.contains("'hello: World'"),
+            "String after block comment with quote must be preserved. Got: {}",
+            result
+        );
     }
 }

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -90,9 +90,31 @@ if (typeof globalThis.HTMLElement === 'undefined') {
   }
 
   // --- Public API: describe ---
-  function describe(name, fn) { addSuite(name, fn, {}); }
-  describe.skip = function(name, fn) { addSuite(name, fn, { skip: true }); };
-  describe.only = function(name, fn) { addSuite(name, fn, { only: true }); };
+  // Supports both describe(name, fn) and describe(name, options, fn) overloads
+  function describe(name, optionsOrFn, maybeFn) {
+    if (typeof optionsOrFn === 'function') {
+      addSuite(name, optionsOrFn, {});
+    } else {
+      const opts = optionsOrFn || {};
+      addSuite(name, maybeFn, { timeout: opts.timeout });
+    }
+  }
+  describe.skip = function(name, optionsOrFn, maybeFn) {
+    if (typeof optionsOrFn === 'function') {
+      addSuite(name, optionsOrFn, { skip: true });
+    } else {
+      const opts = optionsOrFn || {};
+      addSuite(name, maybeFn, { skip: true, timeout: opts.timeout });
+    }
+  };
+  describe.only = function(name, optionsOrFn, maybeFn) {
+    if (typeof optionsOrFn === 'function') {
+      addSuite(name, optionsOrFn, { only: true });
+    } else {
+      const opts = optionsOrFn || {};
+      addSuite(name, maybeFn, { only: true, timeout: opts.timeout });
+    }
+  };
 
   // --- Public API: it / test ---
   // Supports both it(name, fn) and it(name, options, fn) overloads
@@ -465,6 +487,8 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     matchers.toContain = (item) => {
       const has = typeof actual === 'string'
         ? actual.includes(item)
+        : actual instanceof Set
+        ? actual.has(item)
         : Array.isArray(actual) && actual.includes(item);
       assert(has, () =>
         `Expected ${formatValue(actual)} ${negated ? 'not ' : ''}to contain ${formatValue(item)}`
@@ -1831,6 +1855,45 @@ mod tests {
         assert_eq!(arr[1]["status"], "pass");
         assert_eq!(arr[2]["name"], "trims");
         assert_eq!(arr[2]["status"], "skip");
+    }
+
+    #[test]
+    fn test_to_contain_with_set() {
+        let mut rt = create_test_runtime();
+        let results = run_test_code(
+            &mut rt,
+            r#"
+            describe('toContain with Set', () => {
+                it('checks Set membership', () => {
+                    const s = new Set(['a', 'b', 'c']);
+                    expect(s).toContain('a');
+                    expect(s).toContain('c');
+                });
+                it('fails for missing value', () => {
+                    let caught = false;
+                    try {
+                        expect(new Set(['a'])).toContain('z');
+                    } catch (e) {
+                        caught = true;
+                    }
+                    expect(caught).toBe(true);
+                });
+                it('works with .not', () => {
+                    expect(new Set(['a', 'b'])).not.toContain('z');
+                });
+            });
+            "#,
+        );
+
+        let arr = results.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        for (i, item) in arr.iter().enumerate() {
+            assert_eq!(
+                item["status"], "pass",
+                "toContain Set test {} failed: {:?}",
+                i, item["error"]
+            );
+        }
     }
 
     #[test]

--- a/native/vtz/tests/test_runner.rs
+++ b/native/vtz/tests/test_runner.rs
@@ -1294,3 +1294,36 @@ fn e2e_spy_on_dynamic_import() {
     );
     assert_eq!(result.total_passed, 2);
 }
+
+#[test]
+fn e2e_describe_three_arg_overload() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_project(tmp.path());
+
+    write_file(
+        tmp.path(),
+        "src/__tests__/describe-options.test.ts",
+        r#"
+        describe('outer', { timeout: 10000 }, () => {
+            it('runs inside describe with options', () => {
+                expect(1 + 1).toBe(2);
+            });
+        });
+
+        describe('two-arg still works', () => {
+            it('basic test', () => {
+                expect(true).toBe(true);
+            });
+        });
+        "#,
+    );
+
+    let (result, output) = run_tests(make_config(tmp.path()));
+
+    assert!(
+        result.success(),
+        "describe(name, options, fn) overload should work: output={output}, results={:?}",
+        result.results
+    );
+    assert_eq!(result.total_passed, 2);
+}

--- a/packages/compiler/src/__tests__/codegen-poc/spike.test.ts
+++ b/packages/compiler/src/__tests__/codegen-poc/spike.test.ts
@@ -830,11 +830,8 @@ describe('Unknown 3: File Generation', () => {
           }
           return msg;
         });
-        const detail = messages.join('\n');
-        expect(errors.length).toBe(0);
-        throw new Error(`tsc errors:\n${detail}`);
+        throw new Error(`Expected 0 tsc errors but got ${errors.length}:\n${messages.join('\n')}`);
       }
-      expect(errors.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Type stripping bug**: Phase 2 of `strip_leftover_typescript()` now skips JS comments (`//` and `/* */`) before the string literal scanner. A quote inside a comment (e.g., `module's`) was opening string scanning mode, cascading corruption through the file and stripping `: HttpClient` from inside string literals.
- **describe() overload**: `describe(name, options, fn)` 3-argument form now works, matching the existing `it()` pattern. `describe.skip` and `describe.only` also correctly forward options.
- **Set support in toContain**: `expect(set).toContain(item)` now works via `Set.has()`, matching vitest semantics.
- **spike.test.ts error reporting**: Fixed dead code where `expect()` threw before the detailed error message was reached.

## Public API Changes

None. These are internal runtime/test harness fixes.

## Test plan

- [x] Rust unit tests: 3367 passed, 0 failed
- [x] Rust integration tests: 24 passed, 0 failed
- [x] `spike.test.ts`: 36/36 pass (was failing on tsc type-check)
- [x] `route-analyzer.test.ts`: 8/8 pass (was failing on describe overload)
- [x] `dependency-graph-analyzer.test.ts`: 34/34 pass (was failing on Set toContain)
- [x] Full `@vertz/compiler` test suite: 977/977 pass
- [x] Clippy clean, rustfmt clean

Closes #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)