### PR TITLE
fix(compiler): shorthand method definition triggers false import injection

### DIFF
--- a/.changeset/fix-shorthand-method-import.md
+++ b/.changeset/fix-shorthand-method-import.md
@@ -1,0 +1,7 @@
+---
+'vtz': patch
+---
+
+fix(compiler): shorthand method definitions no longer trigger false import injection
+
+`contains_standalone_call()` now detects shorthand method definitions like `{ batch(items) { } }` by matching the closing `)` and checking for a following `{`. Previously, these were incorrectly treated as standalone function calls, causing spurious `import { batch } from '@vertz/ui'` injections.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.64"
+version = "0.2.65"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.64"
+version = "0.2.65"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.64"
+version = "0.2.65"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -221,23 +221,32 @@ fn strip_comments(code: &str) -> String {
     result
 }
 
-/// Check if `name(` appears as a standalone call (not a method call like `obj.name(`).
+/// Check if `name(` appears as a standalone call (not a method call like `obj.name(`
+/// or a shorthand method definition like `{ name(params) { } }`).
 ///
 /// Returns true only when the character before `name(` is NOT an identifier character
 /// or a `.`, and when it is not preceded by a method-definition keyword like `async`,
 /// `get`, `set`, or `static`.
 fn contains_standalone_call(code: &str, name: &str) -> bool {
     let pattern = format!("{name}(");
+    let bytes = code.as_bytes();
     let mut search_from = 0;
     while let Some(pos) = code[search_from..].find(&pattern) {
         let abs_pos = search_from + pos;
-        if abs_pos == 0 {
-            return true;
+        if abs_pos > 0 {
+            let prev = bytes[abs_pos - 1];
+            // If the preceding character is an identifier char or `.`, this is a
+            // method call or part of a larger identifier — not a standalone call.
+            if prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'$' || prev == b'.' {
+                search_from = abs_pos + pattern.len();
+                continue;
+            }
         }
-        let prev = code.as_bytes()[abs_pos - 1];
-        // If the preceding character is an identifier char or `.`, this is a
-        // method call or part of a larger identifier — not a standalone call.
-        if prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'$' || prev == b'.' {
+
+        // Check for shorthand method definition: name(params) { body }
+        // Find the matching ')' after the '(' and check if '{' follows.
+        let open_paren = abs_pos + name.len();
+        if is_shorthand_method(bytes, open_paren) {
             search_from = abs_pos + pattern.len();
             continue;
         }
@@ -250,6 +259,31 @@ fn contains_standalone_call(code: &str, name: &str) -> bool {
         return true;
     }
     false
+}
+
+/// Determine if `(` at `open_paren_pos` starts a shorthand method parameter list.
+///
+/// Finds the matching `)` (tracking paren depth) and returns `true` if the next
+/// non-whitespace character is `{`, indicating a method body — not a function call.
+fn is_shorthand_method(bytes: &[u8], open_paren_pos: usize) -> bool {
+    let mut depth: u32 = 1;
+    let mut i = open_paren_pos + 1;
+    while i < bytes.len() && depth > 0 {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 {
+        return false;
+    }
+    // Skip whitespace after the closing ')'
+    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
+        i += 1;
+    }
+    i < bytes.len() && bytes[i] == b'{'
 }
 
 /// Check if the token before position `name_pos` is a method-definition keyword.
@@ -872,5 +906,54 @@ mod tests {
         assert!(contains_standalone_call("await batch()", "batch"));
         assert!(contains_standalone_call("yield batch()", "batch"));
         assert!(contains_standalone_call("void batch()", "batch"));
+    }
+
+    // ── Shorthand method definitions (no keyword prefix) ─────────
+
+    #[test]
+    fn shorthand_method_in_object_literal_is_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = { batch(items) { return []; } };",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn shorthand_method_does_not_trigger_import_injection() {
+        let code = "const obj = { batch(items) { return []; } };";
+        let result = inject(code);
+        assert!(
+            !result.contains("import { batch }"),
+            "shorthand method should not trigger import: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn standalone_call_with_arrow_still_detected() {
+        assert!(contains_standalone_call("batch(() => { });", "batch"));
+    }
+
+    #[test]
+    fn standalone_call_with_arrow_triggers_import() {
+        let code = "batch(() => { a.set(1); b.set(2); });";
+        let result = inject(code);
+        assert!(result.contains("import { batch } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn shorthand_method_after_comma_is_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = { foo: 1, batch(items) { return []; } };",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn shorthand_method_on_new_line_is_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = {\n  batch(items) {\n    return [];\n  }\n};",
+            "batch"
+        ));
     }
 }

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -956,4 +956,32 @@ mod tests {
             "batch"
         ));
     }
+
+    #[test]
+    fn async_shorthand_method_is_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = { async batch(items) { return []; } };",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn generator_shorthand_method_is_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = { *batch() { yield 1; } };",
+            "batch"
+        ));
+    }
+
+    #[test]
+    fn getter_setter_methods_are_not_standalone() {
+        assert!(!contains_standalone_call(
+            "const obj = { get signal() { return 0; } };",
+            "signal"
+        ));
+        assert!(!contains_standalone_call(
+            "const obj = { set signal(v) { } };",
+            "signal"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- Fix false positive in `contains_standalone_call()` where shorthand method definitions like `{ batch(items) { return []; } }` were incorrectly detected as standalone function calls, triggering spurious `import { batch } from '@vertz/ui'` injection
- Add `is_shorthand_method()` helper that finds the matching `)` via paren-depth tracking and checks if `{` follows — indicating a method body, not a call
- Add tests for `async`, generator (`*`), and getter/setter shorthand method variants

## Public API Changes

None — internal compiler heuristic fix only.

## Key Files

- [`native/vertz-compiler-core/src/import_injection.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-shorthand-method/native/vertz-compiler-core/src/import_injection.rs) — `contains_standalone_call()` + `is_shorthand_method()`

## Test Plan

- [x] `{ batch(items) { } }` shorthand method does NOT trigger import injection
- [x] Standalone `batch(() => { })` calls still correctly trigger import injection
- [x] `async batch(){}`, `*batch(){}`, `get signal(){}`, `set signal(v){}` all correctly skipped
- [x] All 60 import_injection tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

Fixes #2684

🤖 Generated with [Claude Code](https://claude.com/claude-code)