### PR TITLE
fix(tests): update stale test assertions and path resolution

### DIFF
--- a/examples/linear/src/api/entitlement-access.test.ts
+++ b/examples/linear/src/api/entitlement-access.test.ts
@@ -217,7 +217,7 @@ describe('Entitlement-based access control', () => {
         const res = await req(app, 'POST', '/api/projects', {
           userId: 'user-member',
           tenantId: 'ws-1',
-          body: { name: 'New Project', key: 'NP', workspaceId: 'ws-1' },
+          body: { name: 'New Project', key: 'NP' },
         });
         expect(res.status).toBe(201);
         const body = (await res.json()) as { name?: string };
@@ -270,7 +270,7 @@ describe('Entitlement-based access control', () => {
         const res = await req(app, 'POST', '/api/projects', {
           userId: 'user-owner',
           tenantId: 'ws-1',
-          body: { name: 'Owner Project', key: 'OP', workspaceId: 'ws-1' },
+          body: { name: 'Owner Project', key: 'OP' },
         });
         expect(res.status).toBe(201);
       });
@@ -330,7 +330,7 @@ describe('Entitlement-based access control', () => {
         const res = await req(app, 'POST', '/api/projects', {
           userId: 'user-member',
           tenantId: 'ws-1',
-          body: { name: 'Unauthorized', key: 'UA', workspaceId: 'ws-1' },
+          body: { name: 'Unauthorized', key: 'UA' },
         });
         expect(res.status).toBe(403);
       });

--- a/packages/integration-tests/src/__tests__/lefthook-config.test.ts
+++ b/packages/integration-tests/src/__tests__/lefthook-config.test.ts
@@ -37,6 +37,8 @@ describe('lefthook configuration', () => {
     // Should NOT reference dagger or turbo (migrated away)
     expect(buildTypecheck).not.toContain('dagger');
     expect(buildTypecheck).not.toContain('turbo');
+    expect(test).not.toContain('dagger');
+    expect(test).not.toContain('turbo');
   });
 
   it('should not require LEFTHOOK=0 environment variable', () => {

--- a/packages/integration-tests/src/__tests__/lefthook-config.test.ts
+++ b/packages/integration-tests/src/__tests__/lefthook-config.test.ts
@@ -5,35 +5,38 @@ import YAML from 'yaml';
 
 describe('lefthook configuration', () => {
   const loadConfig = () => {
-    const monorepoRoot = path.resolve(process.cwd(), '../..');
+    const monorepoRoot = path.resolve(import.meta.dir, '../../../..');
     const lefthookPath = path.join(monorepoRoot, 'lefthook.yml');
     const content = fs.readFileSync(lefthookPath, 'utf-8');
     return YAML.parse(content);
   };
 
-  it('should have pre-push hook with quality-gates command', () => {
+  it('should have pre-push hook with build-typecheck and test commands', () => {
     const config = loadConfig();
 
     expect(config).toHaveProperty('pre-push');
     expect(config['pre-push']).toHaveProperty('commands');
-    expect(config['pre-push'].commands).toHaveProperty('quality-gates');
-    expect(config['pre-push'].commands['quality-gates']).toHaveProperty('run');
+    expect(config['pre-push'].commands).toHaveProperty('build-typecheck');
+    expect(config['pre-push'].commands['build-typecheck']).toHaveProperty('run');
+    expect(config['pre-push'].commands).toHaveProperty('test');
+    expect(config['pre-push'].commands['test']).toHaveProperty('run');
   });
 
-  it('should run turborepo for typecheck and test, with lint as separate command', () => {
+  it('should use vtz ci for typecheck and test, with lint as separate command', () => {
     const config = loadConfig();
-    const run = config['pre-push'].commands['quality-gates'].run;
+    const buildTypecheck = config['pre-push'].commands['build-typecheck'].run;
+    const test = config['pre-push'].commands['test'].run;
 
-    // Must use turborepo (not dagger, not bare bun run)
-    expect(run).toContain('turbo');
-    expect(run).toContain('typecheck');
-    expect(run).toContain('test');
+    // Must use vtz ci (not turbo, not dagger)
+    expect(buildTypecheck).toContain('vtz ci build-typecheck');
+    expect(test).toContain('vtz ci test');
 
-    // Lint runs as a separate lefthook command (not inside turbo)
+    // Lint runs as a separate lefthook command
     expect(config['pre-push'].commands).toHaveProperty('lint');
 
-    // Should NOT reference dagger (migrated away)
-    expect(run).not.toContain('dagger');
+    // Should NOT reference dagger or turbo (migrated away)
+    expect(buildTypecheck).not.toContain('dagger');
+    expect(buildTypecheck).not.toContain('turbo');
   });
 
   it('should not require LEFTHOOK=0 environment variable', () => {

--- a/scripts/__tests__/ci-coverage-packages.test.ts
+++ b/scripts/__tests__/ci-coverage-packages.test.ts
@@ -3,14 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../..');
-const CI_WORKFLOW_PATH = resolve(PROJECT_ROOT, '.github/workflows/ci.yml');
 const CODECOV_CONFIG_PATH = resolve(PROJECT_ROOT, 'codecov.yml');
-
-function extractWorkflowPackageLists(ciWorkflow: string): string[][] {
-  return [...ciWorkflow.matchAll(/for pkg in ([^;]+); do/g)].map((match) =>
-    match[1].trim().split(/\s+/).filter(Boolean),
-  );
-}
 
 function extractCodecovFlags(codecovConfig: string): string[] {
   const flagsBlock = codecovConfig.split('\nflags:\n')[1];
@@ -28,17 +21,6 @@ function missingPackageDirs(packageNames: string[]): string[] {
 }
 
 describe('CI coverage package configuration', () => {
-  it('only references package directories that exist in the coverage workflow', () => {
-    const ciWorkflow = readFileSync(CI_WORKFLOW_PATH, 'utf8');
-    const workflowPackageLists = extractWorkflowPackageLists(ciWorkflow);
-
-    expect(workflowPackageLists.length).toBeGreaterThan(0);
-
-    for (const packageList of workflowPackageLists) {
-      expect(missingPackageDirs(packageList)).toEqual([]);
-    }
-  });
-
   it('only declares Codecov flags for package directories that exist', () => {
     const codecovConfig = readFileSync(CODECOV_CONFIG_PATH, 'utf8');
     const codecovFlags = extractCodecovFlags(codecovConfig);


### PR DESCRIPTION
## Summary

Fixes three failing test suites with stale assertions and incorrect path resolution:

- **lefthook-config** (#2704): Use `import.meta.dir` instead of `process.cwd()` for monorepo root resolution; update assertions to match current `vtz ci` commands (was expecting `turbo` + `quality-gates`)
- **ci-coverage-packages** (#2703): Remove obsolete test that expected `for pkg in` loops in CI workflow — CI no longer uses per-package coverage loops
- **entitlement-access** (#2702): Remove `workspaceId` from create payloads — the entity framework now auto-injects it from tenant context and rejects it as an unrecognized key

Closes #2702
Closes #2703
Closes #2704

## Public API Changes

None — test-only changes.

## Test plan

- [x] All 3 lefthook configuration tests pass
- [x] CI coverage codecov flags test passes
- [x] All 14 entitlement access control tests pass
- [x] Lint and format clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)