### PR TITLE
fix(vtz): respect @jsx pragma for classic JSX (#2699)

### DIFF
--- a/native/vtz/src/plugin/vertz.rs
+++ b/native/vtz/src/plugin/vertz.rs
@@ -3,15 +3,28 @@ use crate::plugin::{
     PluginMcpTool,
 };
 
-/// Detect a classic JSX factory pragma (`@jsx <name>`) in leading comments.
+/// Classic JSX pragma info extracted from leading comments.
+struct ClassicJsxPragma {
+    /// The factory function name (e.g., `"h"` or `"React.createElement"`).
+    factory: String,
+    /// Optional fragment factory (from `@jsxFrag`), e.g., `"Fragment"`.
+    frag: Option<String>,
+}
+
+/// Detect classic JSX pragmas (`@jsx`, `@jsxFrag`) in leading comments.
 ///
-/// Returns `Some(factory_name)` if found (e.g., `Some("h")`), `None` otherwise.
-/// Only scans comment lines at the top of the file before any code.
-fn detect_classic_jsx_pragma(source: &str) -> Option<String> {
+/// Returns `Some(ClassicJsxPragma)` if `@jsx <factory>` is found, `None` otherwise.
+/// Only scans comment lines at the top of the file before any code — pragmas
+/// after the first non-comment line are ignored (intentionally stricter than
+/// the TypeScript compiler, which scans all comments).
+fn detect_classic_jsx_pragma(source: &str) -> Option<ClassicJsxPragma> {
     // Quick check: bail early if no @jsx anywhere
     if !source.contains("@jsx ") {
         return None;
     }
+
+    let mut factory: Option<String> = None;
+    let mut frag: Option<String> = None;
 
     for line in source.lines() {
         let trimmed = line.trim();
@@ -23,32 +36,59 @@ fn detect_classic_jsx_pragma(source: &str) -> Option<String> {
             // Hit a non-comment line — stop scanning
             break;
         }
-        // Look for @jsx <factory>, but skip @jsxRuntime (different pragma)
-        if let Some(pos) = trimmed.find("@jsx ") {
-            let after_at_jsx = &trimmed[pos + 5..];
-            // Skip if this is @jsxRuntime (not @jsx <factory>)
-            if after_at_jsx.starts_with("Runtime") || after_at_jsx.starts_with("runtime") {
-                continue;
-            }
-            // Extract the identifier
-            let factory: String = after_at_jsx
+
+        // Check for @jsxFrag <factory> (must check before @jsx to avoid substring conflict)
+        if let Some(pos) = trimmed.find("@jsxFrag ") {
+            let after = &trimmed[pos + 9..];
+            let name: String = after
                 .chars()
                 .take_while(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '$')
                 .collect();
-            if !factory.is_empty() {
-                return Some(factory);
+            if !name.is_empty() {
+                frag = Some(name);
+            }
+        }
+
+        // Check for @jsx <factory> — defensive guard against "@jsx Runtime" typo
+        // (the standard "@jsxRuntime" has no space so "@jsx " won't match it)
+        if let Some(pos) = trimmed.find("@jsx ") {
+            let after_at_jsx = &trimmed[pos + 5..];
+            // Guard: skip "@jsx Runtime"/"@jsx runtime" (typo variant of @jsxRuntime)
+            if after_at_jsx.starts_with("Runtime") || after_at_jsx.starts_with("runtime") {
+                continue;
+            }
+            // Also skip if this matched inside @jsxFrag
+            if pos > 0 && trimmed[..pos].ends_with('@') {
+                continue;
+            }
+            // Extract the identifier
+            let name: String = after_at_jsx
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '$')
+                .collect();
+            if !name.is_empty() {
+                factory = Some(name);
             }
         }
     }
 
-    None
+    factory.map(|f| ClassicJsxPragma { factory: f, frag })
 }
 
 /// Compile a file with classic JSX runtime using oxc_transformer.
 ///
 /// Used when a `@jsx` pragma is detected — skips all Vertz-specific transforms
-/// (signals, reactivity, mount frames) and compiles JSX with the specified factory.
-fn compile_classic_jsx(source: &str, ctx: &CompileContext, pragma: &str) -> CompileOutput {
+/// (signals, reactivity, mount frames, mock hoisting) and compiles JSX with
+/// the specified factory.
+///
+/// Note: `post_process()` still runs on this output, but its Vertz-specific
+/// string replacements (effect→domEffect, internals import rewriting) are
+/// harmless for classic JSX files since they don't reference `@vertz/ui`.
+fn compile_classic_jsx(
+    source: &str,
+    ctx: &CompileContext,
+    pragma: &ClassicJsxPragma,
+) -> CompileOutput {
     use oxc_allocator::Allocator;
     use oxc_codegen::Codegen;
     use oxc_parser::Parser;
@@ -90,7 +130,8 @@ fn compile_classic_jsx(source: &str, ctx: &CompileContext, pragma: &str) -> Comp
     let transform_options = TransformOptions {
         jsx: JsxOptions {
             runtime: JsxRuntime::Classic,
-            pragma: Some(pragma.to_string()),
+            pragma: Some(pragma.factory.clone()),
+            pragma_frag: pragma.frag.clone(),
             ..JsxOptions::default()
         },
         ..TransformOptions::default()
@@ -139,8 +180,8 @@ impl FrameworkPlugin for VertzPlugin {
 
     fn compile(&self, source: &str, ctx: &CompileContext) -> CompileOutput {
         // Check for classic JSX pragma — skip Vertz transforms entirely
-        if let Some(pragma) = detect_classic_jsx_pragma(source) {
-            return compile_classic_jsx(source, ctx, &pragma);
+        if let Some(ref pragma) = detect_classic_jsx_pragma(source) {
+            return compile_classic_jsx(source, ctx, pragma);
         }
 
         let filename = ctx.file_path.to_string_lossy().to_string();
@@ -793,6 +834,132 @@ export function Card({ title }: Props) {
             "Should use h() factory: {}",
             output.code
         );
+    }
+
+    #[test]
+    fn classic_jsx_pragma_line_comment() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"// @jsx h
+import { h } from './h';
+export function X() { return <div />; }
+"#;
+        let output = plugin.compile(source, &ctx);
+        assert!(
+            output.code.contains("h("),
+            "Line comment pragma should work: {}",
+            output.code
+        );
+    }
+
+    #[test]
+    fn classic_jsx_pragma_jsdoc_comment() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"/** @jsx h */
+import { h } from './h';
+export function X() { return <div />; }
+"#;
+        let output = plugin.compile(source, &ctx);
+        assert!(
+            output.code.contains("h("),
+            "JSDoc-style pragma should work: {}",
+            output.code
+        );
+    }
+
+    #[test]
+    fn classic_jsx_pragma_multiline_block_comment() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"/*
+ * @jsxRuntime classic
+ * @jsx h
+ */
+import { h } from './h';
+export function X() { return <div />; }
+"#;
+        let output = plugin.compile(source, &ctx);
+        assert!(
+            output.code.contains("h("),
+            "Multi-line block comment pragma should work: {}",
+            output.code
+        );
+    }
+
+    // ── detect_classic_jsx_pragma unit tests ─────────────────────
+
+    #[test]
+    fn detect_pragma_none_for_empty_source() {
+        assert!(detect_classic_jsx_pragma("").is_none());
+    }
+
+    #[test]
+    fn detect_pragma_none_for_no_jsx() {
+        assert!(detect_classic_jsx_pragma("const x = 1;").is_none());
+    }
+
+    #[test]
+    fn detect_pragma_none_when_after_code() {
+        let source = "import { h } from './h';\n/* @jsx h */\n";
+        assert!(
+            detect_classic_jsx_pragma(source).is_none(),
+            "Pragma after code should be ignored"
+        );
+    }
+
+    #[test]
+    fn detect_pragma_extracts_factory() {
+        let source = "/* @jsx h */\n";
+        let pragma = detect_classic_jsx_pragma(source).unwrap();
+        assert_eq!(pragma.factory, "h");
+        assert!(pragma.frag.is_none());
+    }
+
+    #[test]
+    fn detect_pragma_extracts_dotted_factory() {
+        let source = "/* @jsx React.createElement */\n";
+        let pragma = detect_classic_jsx_pragma(source).unwrap();
+        assert_eq!(pragma.factory, "React.createElement");
+    }
+
+    #[test]
+    fn detect_pragma_ignores_jsx_runtime() {
+        let source = "/* @jsxRuntime classic */\n";
+        assert!(
+            detect_classic_jsx_pragma(source).is_none(),
+            "@jsxRuntime alone should not trigger classic mode"
+        );
+    }
+
+    #[test]
+    fn detect_pragma_with_frag() {
+        let source = "/* @jsx h */\n/* @jsxFrag Fragment */\n";
+        let pragma = detect_classic_jsx_pragma(source).unwrap();
+        assert_eq!(pragma.factory, "h");
+        assert_eq!(pragma.frag.as_deref(), Some("Fragment"));
+    }
+
+    #[test]
+    fn detect_pragma_skips_blank_lines() {
+        let source = "\n\n/* @jsx h */\n";
+        let pragma = detect_classic_jsx_pragma(source).unwrap();
+        assert_eq!(pragma.factory, "h");
     }
 
     #[test]

--- a/native/vtz/src/plugin/vertz.rs
+++ b/native/vtz/src/plugin/vertz.rs
@@ -3,6 +3,123 @@ use crate::plugin::{
     PluginMcpTool,
 };
 
+/// Detect a classic JSX factory pragma (`@jsx <name>`) in leading comments.
+///
+/// Returns `Some(factory_name)` if found (e.g., `Some("h")`), `None` otherwise.
+/// Only scans comment lines at the top of the file before any code.
+fn detect_classic_jsx_pragma(source: &str) -> Option<String> {
+    // Quick check: bail early if no @jsx anywhere
+    if !source.contains("@jsx ") {
+        return None;
+    }
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Only look at comment lines (block or line comments)
+        if !trimmed.starts_with("/*") && !trimmed.starts_with("*") && !trimmed.starts_with("//") {
+            // Hit a non-comment line — stop scanning
+            break;
+        }
+        // Look for @jsx <factory>, but skip @jsxRuntime (different pragma)
+        if let Some(pos) = trimmed.find("@jsx ") {
+            let after_at_jsx = &trimmed[pos + 5..];
+            // Skip if this is @jsxRuntime (not @jsx <factory>)
+            if after_at_jsx.starts_with("Runtime") || after_at_jsx.starts_with("runtime") {
+                continue;
+            }
+            // Extract the identifier
+            let factory: String = after_at_jsx
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '$')
+                .collect();
+            if !factory.is_empty() {
+                return Some(factory);
+            }
+        }
+    }
+
+    None
+}
+
+/// Compile a file with classic JSX runtime using oxc_transformer.
+///
+/// Used when a `@jsx` pragma is detected — skips all Vertz-specific transforms
+/// (signals, reactivity, mount frames) and compiles JSX with the specified factory.
+fn compile_classic_jsx(source: &str, ctx: &CompileContext, pragma: &str) -> CompileOutput {
+    use oxc_allocator::Allocator;
+    use oxc_codegen::Codegen;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
+    use oxc_transformer::{JsxOptions, JsxRuntime, TransformOptions, Transformer};
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(ctx.file_path).unwrap_or_default();
+
+    let parser_ret = Parser::new(&allocator, source, source_type).parse();
+
+    let mut diagnostics = Vec::new();
+    for error in &parser_ret.errors {
+        diagnostics.push(CompileDiagnostic {
+            message: error.to_string(),
+            line: None,
+            column: None,
+            is_warning: false,
+        });
+    }
+
+    if parser_ret.panicked {
+        return CompileOutput {
+            code: source.to_string(),
+            css: None,
+            source_map: None,
+            diagnostics,
+            mocked_specifiers: std::collections::HashSet::new(),
+            mock_preamble: None,
+        };
+    }
+
+    let mut program = parser_ret.program;
+
+    let semantic_ret = SemanticBuilder::new().build(&program);
+    let scoping = semantic_ret.semantic.into_scoping();
+
+    let transform_options = TransformOptions {
+        jsx: JsxOptions {
+            runtime: JsxRuntime::Classic,
+            pragma: Some(pragma.to_string()),
+            ..JsxOptions::default()
+        },
+        ..TransformOptions::default()
+    };
+
+    let transformer = Transformer::new(&allocator, ctx.file_path, &transform_options);
+    let transform_ret = transformer.build_with_scoping(scoping, &mut program);
+
+    for error in &transform_ret.errors {
+        diagnostics.push(CompileDiagnostic {
+            message: error.to_string(),
+            line: None,
+            column: None,
+            is_warning: true,
+        });
+    }
+
+    let codegen_ret = Codegen::new().build(&program);
+
+    CompileOutput {
+        code: codegen_ret.code,
+        css: None,
+        source_map: codegen_ret.map.map(|sm| sm.to_json_string()),
+        diagnostics,
+        mocked_specifiers: std::collections::HashSet::new(),
+        mock_preamble: None,
+    }
+}
+
 /// Fast Refresh runtime JS (embedded at compile time).
 const FAST_REFRESH_RUNTIME_JS: &str = include_str!("../assets/fast-refresh-runtime.js");
 
@@ -21,6 +138,11 @@ impl FrameworkPlugin for VertzPlugin {
     }
 
     fn compile(&self, source: &str, ctx: &CompileContext) -> CompileOutput {
+        // Check for classic JSX pragma — skip Vertz transforms entirely
+        if let Some(pragma) = detect_classic_jsx_pragma(source) {
+            return compile_classic_jsx(source, ctx, &pragma);
+        }
+
         let filename = ctx.file_path.to_string_lossy().to_string();
         let is_test = crate::test::is_test_file(ctx.file_path);
 
@@ -557,6 +679,118 @@ mod tests {
         assert!(
             output.code.contains("__$fr"),
             "Fast Refresh preamble should be injected in non-test files: {}",
+            output.code
+        );
+    }
+
+    // ── Classic JSX pragma detection ─────────────────────────────
+
+    #[test]
+    fn classic_jsx_pragma_uses_custom_factory() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"/* @jsxRuntime classic */
+/* @jsx h */
+import { h } from './h';
+
+export function Card({ title }) {
+    return <div>{title}</div>;
+}
+"#;
+        let output = plugin.compile(source, &ctx);
+        // Should call h() instead of Vertz DOM helpers
+        assert!(
+            output.code.contains("h("),
+            "Expected h() factory call, got: {}",
+            output.code
+        );
+        // Should NOT contain Vertz internals imports
+        assert!(
+            !output.code.contains("@vertz/ui/internals"),
+            "Should not inject Vertz internals for classic JSX: {}",
+            output.code
+        );
+    }
+
+    #[test]
+    fn classic_jsx_pragma_preserves_import() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"/* @jsxRuntime classic */
+/* @jsx h */
+import { h } from '../h';
+
+export function Minimal({ title }) {
+    return <div style={{ fontSize: '72px' }}>{title}</div>;
+}
+"#;
+        let output = plugin.compile(source, &ctx);
+        // The h import should be preserved
+        assert!(
+            output.code.contains("from \"../h\"") || output.code.contains("from '../h'"),
+            "Should preserve h import, got: {}",
+            output.code
+        );
+    }
+
+    #[test]
+    fn no_pragma_still_uses_vertz_transforms() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/App.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let output = plugin.compile(
+            "export default function App() { return <div>Hello</div>; }",
+            &ctx,
+        );
+        // Without pragma, Vertz transforms should be applied
+        assert!(
+            !output.code.contains("React.createElement"),
+            "Without pragma, should not use React.createElement: {}",
+            output.code
+        );
+    }
+
+    #[test]
+    fn classic_jsx_pragma_strips_typescript() {
+        let plugin = make_plugin();
+        let ctx = CompileContext {
+            file_path: Path::new("/project/src/template.tsx"),
+            root_dir: Path::new("/project"),
+            src_dir: Path::new("/project/src"),
+            target: "dom",
+        };
+        let source = r#"/* @jsx h */
+import { h } from './h';
+interface Props { title: string; }
+export function Card({ title }: Props) {
+    return <div>{title}</div>;
+}
+"#;
+        let output = plugin.compile(source, &ctx);
+        // TypeScript should be stripped
+        assert!(
+            !output.code.contains("interface Props"),
+            "TypeScript should be stripped: {}",
+            output.code
+        );
+        // Should use h() factory
+        assert!(
+            output.code.contains("h("),
+            "Should use h() factory: {}",
             output.code
         );
     }


### PR DESCRIPTION
## Summary

- Teach the vtz compiler to detect `@jsx` / `@jsxFrag` pragmas in leading comments and route to oxc's classic JSX compilation path instead of applying Vertz-specific transforms
- Fixes `@vertz/og` template tests (Card, Hero, Minimal) that use `/* @jsx h */` with a custom Satori-compatible factory

## What changed

**File:** [`native/vtz/src/plugin/vertz.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-jsx-pragma/native/vtz/src/plugin/vertz.rs)

- Added `detect_classic_jsx_pragma()` — scans leading comments for `@jsx <factory>` and `@jsxFrag <factory>` pragmas
- Added `compile_classic_jsx()` — compiles with oxc_transformer using classic JSX runtime and the specified factory, skipping all Vertz-specific transforms (signals, reactivity, mount frames)
- Modified `VertzPlugin::compile()` to check for pragmas first and route accordingly

## Public API Changes

None — this is an internal compiler behavior fix. No API surface changes.

## Test plan

- [x] 4 integration tests: block comment, line comment, JSDoc, multi-line block comment pragmas
- [x] 8 unit tests for `detect_classic_jsx_pragma` edge cases (empty source, no pragma, after code, dotted factory, @jsxFrag, @jsxRuntime)
- [x] All 40 vertz plugin tests pass
- [x] All 4895+ Rust tests pass across all crates
- [x] Clippy clean, rustfmt clean
- [x] OG template tests pass: Card (7), Hero (7), Minimal (3) = 17 tests

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)