### PR TITLE
fix(cli): bypass jiti for dynamic TS imports under vtz runtime

### DIFF
--- a/packages/cli/src/__tests__/load-introspect-context.test.ts
+++ b/packages/cli/src/__tests__/load-introspect-context.test.ts
@@ -1,12 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi, mock, spyOn } from '@vertz/test';
+import { afterEach, beforeEach, describe, expect, it, vi, mock } from '@vertz/test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Mock external dependencies before importing the module under test.
-//
-// NOTE: We do NOT vi.mock('jiti') because Bun test runs all files in one
-// process and vi.mock() is global — it would break every other test file
-// that uses jiti (loader, load-db-context).
-// Instead, we spy on the exported _importConfig helper.
 // ---------------------------------------------------------------------------
 
 const mockQueryFn = mock();
@@ -21,33 +19,35 @@ vi.mock('postgres', () => ({
 }));
 
 // Now import the module under test
-import * as loadDbContextModule from '../commands/load-db-context';
-
-const { loadIntrospectContext } = loadDbContextModule;
+import { loadIntrospectContext } from '../commands/load-db-context';
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — use real temp files instead of spying on _importConfig
+// (vtz runtime's ESM modules have read-only exports, so spyOn doesn't work)
 // ---------------------------------------------------------------------------
 
 describe('loadIntrospectContext', () => {
-  let importConfigSpy: ReturnType<typeof vi.spyOn>;
+  const originalCwd = process.cwd;
+  let tempDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    importConfigSpy = spyOn(loadDbContextModule, '_importConfig').mockResolvedValue({
-      db: {
-        dialect: 'postgres',
-        url: 'postgres://localhost:5432/testdb',
-        schema: './src/schema.ts',
-      },
-    });
+    tempDir = join(
+      tmpdir(),
+      `vertz-test-introspect-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(tempDir, { recursive: true });
+    process.cwd = () => tempDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    process.cwd = originalCwd;
     vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
   });
 
   it('uses overrides directly when both url and dialect provided', async () => {
+    // No config file needed — zero-config mode
     const ctx = await loadIntrospectContext({
       url: 'postgres://localhost:5432/test',
       dialect: 'postgres',
@@ -57,20 +57,20 @@ describe('loadIntrospectContext', () => {
     expect(ctx.dialect).toBeDefined();
     expect(typeof ctx.queryFn).toBe('function');
     expect(typeof ctx.close).toBe('function');
-    // Should NOT load config when both overrides provided
-    expect(importConfigSpy).not.toHaveBeenCalled();
 
     await ctx.close();
   });
 
   it('uses dialect override from config when only dialect is provided', async () => {
-    importConfigSpy.mockResolvedValue({
-      db: {
-        dialect: 'sqlite',
-        url: 'postgres://localhost:5432/testdb',
-        schema: './src/schema.ts',
-      },
-    });
+    await writeFile(
+      join(tempDir, 'vertz.config.ts'),
+      `export default {};
+export const db = {
+  dialect: 'sqlite',
+  url: 'postgres://localhost:5432/testdb',
+  schema: './src/schema.ts',
+};`,
+    );
 
     // Override dialect to postgres (connection goes through mocked postgres driver)
     const ctx = await loadIntrospectContext({ dialect: 'postgres' });
@@ -80,39 +80,53 @@ describe('loadIntrospectContext', () => {
   });
 
   it('loads config when no overrides provided', async () => {
+    await writeFile(
+      join(tempDir, 'vertz.config.ts'),
+      `export default {};
+export const db = {
+  dialect: 'postgres',
+  url: 'postgres://localhost:5432/testdb',
+  schema: './src/schema.ts',
+};`,
+    );
+
     const ctx = await loadIntrospectContext();
 
     expect(ctx.dialectName).toBe('postgres');
-    expect(importConfigSpy).toHaveBeenCalled();
     expect(typeof ctx.queryFn).toBe('function');
 
     await ctx.close();
   });
 
   it('uses dialect from config when only url is overridden', async () => {
+    await writeFile(
+      join(tempDir, 'vertz.config.ts'),
+      `export default {};
+export const db = {
+  dialect: 'postgres',
+  url: 'postgres://localhost:5432/testdb',
+  schema: './src/schema.ts',
+};`,
+    );
+
     const ctx = await loadIntrospectContext({ url: 'postgres://custom:5432/db' });
 
     expect(ctx.dialectName).toBe('postgres');
-    expect(importConfigSpy).toHaveBeenCalled();
 
     await ctx.close();
   });
 
   it('throws when config file not found and no overrides', async () => {
-    // Simulate config import failure + file not found
-    importConfigSpy.mockRejectedValue(new Error('Module not found'));
-    // Also need to mock fs.access to throw (file not found)
-    spyOn(await import('node:fs/promises'), 'access').mockRejectedValue(
-      Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
-    );
-
+    // No config file created — should throw
     await expect(loadIntrospectContext()).rejects.toThrow('Could not find vertz.config.ts');
   });
 
   it('throws when config has no dialect', async () => {
-    importConfigSpy.mockResolvedValue({
-      db: { schema: './src/schema.ts' },
-    });
+    await writeFile(
+      join(tempDir, 'vertz.config.ts'),
+      `export default {};
+export const db = { schema: './src/schema.ts' };`,
+    );
 
     await expect(loadIntrospectContext()).rejects.toThrow('No `dialect` found');
   });

--- a/packages/cli/src/commands/__tests__/load-db-context.test.ts
+++ b/packages/cli/src/commands/__tests__/load-db-context.test.ts
@@ -10,6 +10,11 @@ import {
   parseSqliteUrl,
 } from '../load-db-context';
 
+import { detectRuntime } from '../../utils/runtime-detect';
+
+// PGlite uses process.binding() which vtz runtime does not support
+const isVtzRuntime = detectRuntime() === 'vtz';
+
 // ---------------------------------------------------------------------------
 // extractSchemaEntries
 // ---------------------------------------------------------------------------
@@ -661,7 +666,7 @@ describe('createConnection', () => {
 // createConnection — postgres (via PGlite in-memory)
 // ---------------------------------------------------------------------------
 
-describe('createConnection (postgres)', () => {
+describe.skipIf(isVtzRuntime)('createConnection (postgres)', () => {
   let pg: import('@electric-sql/pglite').PGlite;
 
   beforeAll(async () => {
@@ -730,7 +735,7 @@ describe('createConnection (postgres)', () => {
 // createConnection — postgres error path
 // ---------------------------------------------------------------------------
 
-describe('createConnection (postgres — real import)', () => {
+describe.skipIf(isVtzRuntime)('createConnection (postgres — real import)', () => {
   it('creates postgres connection and exercises queryFn and close', async () => {
     // The postgres package IS available in this monorepo.
     // It creates a lazy client even for invalid URLs — errors only happen on query.

--- a/packages/cli/src/commands/load-db-context.ts
+++ b/packages/cli/src/commands/load-db-context.ts
@@ -21,11 +21,18 @@ import {
   parseMigrationName,
 } from '@vertz/db';
 import { NodeSnapshotStorage } from '@vertz/db/internals';
-import { createJiti } from 'jiti';
+import { detectRuntime } from '../utils/runtime-detect';
 import type { DbCommandContext } from './db';
 
+/** vtz runtime natively compiles TypeScript — jiti is not needed */
+const isVtzRuntime = detectRuntime() === 'vtz';
+
 /** @internal — exported for test spying (avoids global vi.mock on 'jiti') */
-export function _importConfig(configPath: string): Promise<Record<string, unknown>> {
+export async function _importConfig(configPath: string): Promise<Record<string, unknown>> {
+  if (isVtzRuntime) {
+    return import(configPath) as Promise<Record<string, unknown>>;
+  }
+  const { createJiti } = await import('jiti');
   const jiti = createJiti(import.meta.url, { interopDefault: true });
   return jiti.import(configPath) as Promise<Record<string, unknown>>;
 }
@@ -292,7 +299,8 @@ export async function loadMigrationFiles(dir: string): Promise<MigrationFile[]> 
   try {
     entries = await readdir(dir);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || (!code && (error as Error).message?.includes('ENOENT'))) {
       return [];
     }
     throw error;

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { VertzConfig } from '@vertz/compiler';
+import { detectRuntime } from '../utils/runtime-detect';
 
 const CONFIG_FILES = ['vertz.config.ts', 'vertz.config.js', 'vertz.config.mjs'];
 
@@ -49,17 +50,24 @@ const defaultConfig: VertzConfig = {
   },
 };
 
+/** vtz runtime natively compiles TypeScript — jiti is not needed */
+const isVtzRuntime = detectRuntime() === 'vtz';
+
 export async function loadConfig(configPath?: string): Promise<VertzConfig> {
   if (!configPath) {
     return { ...defaultConfig };
   }
 
-  const { createJiti } = await import('jiti');
-  const jiti = createJiti(import.meta.url, {
-    interopDefault: true,
-  });
-
-  const loaded = (await jiti.import(configPath)) as { default?: VertzConfig } | VertzConfig;
+  let loaded: { default?: VertzConfig } | VertzConfig;
+  if (isVtzRuntime) {
+    loaded = (await import(configPath)) as { default?: VertzConfig } | VertzConfig;
+  } else {
+    const { createJiti } = await import('jiti');
+    const jiti = createJiti(import.meta.url, {
+      interopDefault: true,
+    });
+    loaded = (await jiti.import(configPath)) as { default?: VertzConfig } | VertzConfig;
+  }
 
   const userConfig =
     loaded && typeof loaded === 'object' && 'default' in loaded


### PR DESCRIPTION
## Summary

- Bypass jiti when running under vtz runtime — vtz natively compiles TypeScript, so jiti is unnecessary and causes failures (`process.binding` missing, `includes` undefined)
- Use `detectRuntime()` from `utils/runtime-detect` to detect vtz and switch to native `import()`
- Fix ENOENT detection in `loadMigrationFiles` — vtz filesystem errors lack `.code` property, fall back to checking error message
- Restructure `load-introspect-context.test.ts` to use real temp files instead of `spyOn` on ESM exports (read-only in vtz)
- Skip PGlite/postgres tests under vtz (`process.binding` not supported)

## Test plan

- [x] `loadConfig` tests pass (12/12)
- [x] `loadDbContext` tests pass (43/43, 4 postgres tests skipped under vtz)
- [x] `loadIntrospectContext` tests pass (6/6)
- [x] `detectRuntime` tests pass (6/6)
- [x] No new lint warnings introduced

Fixes #2698

🤖 Generated with [Claude Code](https://claude.com/claude-code)