### PR TITLE
fix(cli): fix production build pipeline — native compiler publishing, bin link, esbuild (#2692)

### DIFF
--- a/.changeset/fix-prod-build-pipeline.md
+++ b/.changeset/fix-prod-build-pipeline.md
@@ -1,0 +1,7 @@
+---
+'@vertz/cli': patch
+'@vertz/ui-server': patch
+'@vertz/runtime': patch
+---
+
+Fix production build pipeline: publish native compiler via platform packages, remove bin link shadowing, align esbuild versions, and hard-fail when native compiler is unavailable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,18 +67,22 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
             pkg: runtime-darwin-arm64
+            compiler_pkg: native-compiler-darwin-arm64
             expected_arch: arm64
           - target: x86_64-apple-darwin
             os: macos-14
             pkg: runtime-darwin-x64
+            compiler_pkg: native-compiler-darwin-x64
             expected_arch: x86_64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
             pkg: runtime-linux-x64
+            compiler_pkg: native-compiler-linux-x64
             expected_arch: x86_64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             pkg: runtime-linux-arm64
+            compiler_pkg: native-compiler-linux-arm64
             expected_arch: aarch64
 
     runs-on: ${{ matrix.os }}
@@ -137,6 +141,36 @@ jobs:
         with:
           name: ${{ matrix.pkg }}
           path: packages/${{ matrix.pkg }}/vtz
+          retention-days: 1
+
+      - name: Build native compiler
+        working-directory: native
+        run: cargo build --release --target ${{ matrix.target }} -p vertz-compiler
+
+      - name: Copy compiler binary to platform package
+        run: |
+          COMPILER_PKG="${{ matrix.compiler_pkg }}"
+          PLATFORM_SUFFIX="${COMPILER_PKG#native-compiler-}"
+          if [[ "${{ matrix.target }}" == *apple* ]]; then
+            cp native/target/${{ matrix.target }}/release/libvertz_compiler.dylib \
+              "packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
+          else
+            cp native/target/${{ matrix.target }}/release/libvertz_compiler.so \
+              "packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
+          fi
+
+      - name: Ad-hoc code sign compiler binary (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          COMPILER_PKG="${{ matrix.compiler_pkg }}"
+          PLATFORM_SUFFIX="${COMPILER_PKG#native-compiler-}"
+          codesign -s - "packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
+
+      - name: Upload compiler artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.compiler_pkg }}
+          path: packages/${{ matrix.compiler_pkg }}/vertz-compiler.*.node
           retention-days: 1
 
   # ---------------------------------------------------------------------------
@@ -224,6 +258,34 @@ jobs:
             fi
           done
 
+      - name: Download native-compiler-darwin-arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: native-compiler-darwin-arm64
+          path: packages/native-compiler-darwin-arm64/
+        continue-on-error: true
+
+      - name: Download native-compiler-darwin-x64
+        uses: actions/download-artifact@v4
+        with:
+          name: native-compiler-darwin-x64
+          path: packages/native-compiler-darwin-x64/
+        continue-on-error: true
+
+      - name: Download native-compiler-linux-x64
+        uses: actions/download-artifact@v4
+        with:
+          name: native-compiler-linux-x64
+          path: packages/native-compiler-linux-x64/
+        continue-on-error: true
+
+      - name: Download native-compiler-linux-arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: native-compiler-linux-arm64
+          path: packages/native-compiler-linux-arm64/
+        continue-on-error: true
+
       - name: Download runtime from latest release (when not built from source)
         if: ${{ !contains(needs.build-binaries.result, 'success') }}
         env:
@@ -253,20 +315,37 @@ jobs:
         working-directory: packages/runtime
         run: vtzx bun build index.ts --outdir . --target node
 
+      - name: Prepare compiler binary for library builds
+        id: compiler
+        run: |
+          # Use the linux-x64 compiler artifact for library builds on the release runner
+          if [ -f packages/native-compiler-linux-x64/vertz-compiler.linux-x64.node ]; then
+            cp packages/native-compiler-linux-x64/vertz-compiler.linux-x64.node \
+              native/vertz-compiler/vertz-compiler.linux-x64.node
+            echo "Native compiler binary ready (from artifact)"
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No compiler artifact — will build from source"
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Rust (for native compiler)
+        if: steps.compiler.outputs.needs_build == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo dependencies
+        if: steps.compiler.outputs.needs_build == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: native
           key: compiler-only
 
-      - name: Build native compiler for library builds
+      - name: Build native compiler for library builds (fallback)
+        if: steps.compiler.outputs.needs_build == 'true'
         run: |
           cargo build --release --manifest-path native/Cargo.toml -p vertz-compiler
           cp native/target/release/libvertz_compiler.so native/vertz-compiler/vertz-compiler.linux-x64.node
-          echo "Native compiler binary ready: $(ls -la native/vertz-compiler/vertz-compiler.linux-x64.node)"
+          echo "Native compiler binary ready (built from source)"
 
       - name: Build @vertz/build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,17 @@ jobs:
               "packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
           fi
 
+      - name: Verify compiler binary exists
+        run: |
+          COMPILER_PKG="${{ matrix.compiler_pkg }}"
+          PLATFORM_SUFFIX="${COMPILER_PKG#native-compiler-}"
+          FILE="packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
+          if [ ! -f "$FILE" ]; then
+            echo "::error::Compiler binary not found: $FILE"
+            exit 1
+          fi
+          echo "Compiler binary: $(ls -la "$FILE")"
+
       - name: Ad-hoc code sign compiler binary (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "benchmarks/vertz": {
       "name": "@vertz-benchmarks/vertz-app",
-      "version": "0.0.58",
+      "version": "0.0.63",
       "dependencies": {
         "@vertz/theme-shadcn": "workspace:*",
         "@vertz/ui": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "examples/task-manager": {
       "name": "@vertz-examples/task-manager",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/errors": "workspace:*",
         "@vertz/fetch": "workspace:*",
@@ -138,14 +138,20 @@
     },
     "native/vertz-compiler": {
       "name": "@vertz/native-compiler",
-      "version": "0.1.1",
+      "version": "0.2.65",
       "devDependencies": {
         "@vertz/test": "workspace:*",
+      },
+      "optionalDependencies": {
+        "@vertz/native-compiler-darwin-arm64": "0.2.65",
+        "@vertz/native-compiler-darwin-x64": "0.2.65",
+        "@vertz/native-compiler-linux-arm64": "0.2.65",
+        "@vertz/native-compiler-linux-x64": "0.2.65",
       },
     },
     "packages/agents": {
       "name": "@vertz/agents",
-      "version": "0.2.44",
+      "version": "0.2.45",
       "dependencies": {
         "@vertz/errors": "workspace:^",
         "@vertz/schema": "workspace:^",
@@ -194,7 +200,7 @@
     },
     "packages/cli": {
       "name": "@vertz/cli",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "bin": {
         "vertz": "./dist/vertz.js",
       },
@@ -209,7 +215,7 @@
         "@vertz/tui": "workspace:^",
         "@vertz/ui-server": "workspace:^",
         "commander": "^14.0.0",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.3",
         "jiti": "^2.4.2",
       },
       "devDependencies": {
@@ -227,7 +233,7 @@
     },
     "packages/cli-runtime": {
       "name": "@vertz/cli-runtime",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -240,7 +246,7 @@
     },
     "packages/cloudflare": {
       "name": "@vertz/cloudflare",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/core": "workspace:^",
       },
@@ -259,7 +265,7 @@
     },
     "packages/codegen": {
       "name": "@vertz/codegen",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/compiler": "workspace:^",
       },
@@ -273,7 +279,7 @@
     },
     "packages/compiler": {
       "name": "@vertz/compiler",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -304,7 +310,7 @@
     },
     "packages/core": {
       "name": "@vertz/core",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/schema": "workspace:^",
       },
@@ -318,7 +324,7 @@
     },
     "packages/create-vertz": {
       "name": "create-vertz",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "bin": {
         "create-vertz": "./bin/create-vertz.ts",
       },
@@ -328,7 +334,7 @@
     },
     "packages/create-vertz-app": {
       "name": "@vertz/create-vertz-app",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "bin": {
         "create-vertz-app": "./bin/create-vertz-app.ts",
       },
@@ -343,7 +349,7 @@
     },
     "packages/db": {
       "name": "@vertz/db",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.3.0",
         "@vertz/errors": "workspace:^",
@@ -375,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@vertz/desktop",
-      "version": "0.2.59",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/errors": "workspace:*",
       },
@@ -389,7 +395,7 @@
     },
     "packages/docs": {
       "name": "@vertz/docs",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@shikijs/rehype": "^4.0.2",
@@ -416,7 +422,7 @@
     },
     "packages/errors": {
       "name": "@vertz/errors",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/build": "workspace:^",
@@ -427,7 +433,7 @@
     },
     "packages/fetch": {
       "name": "@vertz/fetch",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -440,7 +446,7 @@
     },
     "packages/icons": {
       "name": "@vertz/icons",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.7.0",
         "@vertz/build": "workspace:^",
@@ -521,9 +527,25 @@
       "name": "@vertz/mint-docs",
       "version": "0.2.1",
     },
+    "packages/native-compiler-darwin-arm64": {
+      "name": "@vertz/native-compiler-darwin-arm64",
+      "version": "0.2.65",
+    },
+    "packages/native-compiler-darwin-x64": {
+      "name": "@vertz/native-compiler-darwin-x64",
+      "version": "0.2.65",
+    },
+    "packages/native-compiler-linux-arm64": {
+      "name": "@vertz/native-compiler-linux-arm64",
+      "version": "0.2.65",
+    },
+    "packages/native-compiler-linux-x64": {
+      "name": "@vertz/native-compiler-linux-x64",
+      "version": "0.2.65",
+    },
     "packages/og": {
       "name": "@vertz/og",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
         "satori": "^0.25.0",
@@ -562,9 +584,8 @@
     },
     "packages/runtime": {
       "name": "@vertz/runtime",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "bin": {
-        "vertz": "./cli.sh",
         "vtz": "./cli.sh",
         "vtzx": "./cli-exec.sh",
       },
@@ -573,31 +594,31 @@
         "@vertz/test": "workspace:*",
       },
       "optionalDependencies": {
-        "@vertz/runtime-darwin-arm64": "0.2.60",
-        "@vertz/runtime-darwin-x64": "0.2.60",
-        "@vertz/runtime-linux-arm64": "0.2.60",
-        "@vertz/runtime-linux-x64": "0.2.60",
+        "@vertz/runtime-darwin-arm64": "0.2.65",
+        "@vertz/runtime-darwin-x64": "0.2.65",
+        "@vertz/runtime-linux-arm64": "0.2.65",
+        "@vertz/runtime-linux-x64": "0.2.65",
       },
     },
     "packages/runtime-darwin-arm64": {
       "name": "@vertz/runtime-darwin-arm64",
-      "version": "0.2.60",
+      "version": "0.2.65",
     },
     "packages/runtime-darwin-x64": {
       "name": "@vertz/runtime-darwin-x64",
-      "version": "0.2.60",
+      "version": "0.2.65",
     },
     "packages/runtime-linux-arm64": {
       "name": "@vertz/runtime-linux-arm64",
-      "version": "0.2.60",
+      "version": "0.2.65",
     },
     "packages/runtime-linux-x64": {
       "name": "@vertz/runtime-linux-x64",
-      "version": "0.2.60",
+      "version": "0.2.65",
     },
     "packages/schema": {
       "name": "@vertz/schema",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/errors": "workspace:^",
       },
@@ -611,7 +632,7 @@
     },
     "packages/server": {
       "name": "@vertz/server",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -639,7 +660,7 @@
     },
     "packages/sqlite": {
       "name": "@vertz/sqlite",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "devDependencies": {
         "@types/node": "^25.3.1",
         "@vertz/build": "workspace:^",
@@ -648,7 +669,7 @@
     },
     "packages/test": {
       "name": "@vertz/test",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "devDependencies": {
         "@types/node": "^25.3.1",
         "bun-types": "^1.3.10",
@@ -657,7 +678,7 @@
     },
     "packages/testing": {
       "name": "@vertz/testing",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/core": "workspace:^",
         "@vertz/db": "workspace:^",
@@ -674,7 +695,7 @@
     },
     "packages/theme-shadcn": {
       "name": "@vertz/theme-shadcn",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/ui": "workspace:^",
         "@vertz/ui-primitives": "workspace:^",
@@ -690,7 +711,7 @@
     },
     "packages/tui": {
       "name": "@vertz/tui",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/ui": "workspace:^",
       },
@@ -703,7 +724,7 @@
     },
     "packages/ui": {
       "name": "@vertz/ui",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/fetch": "workspace:^",
       },
@@ -734,7 +755,7 @@
     },
     "packages/ui-canvas": {
       "name": "@vertz/ui-canvas",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "pixi.js": "^8.0.0",
       },
@@ -752,7 +773,7 @@
     },
     "packages/ui-primitives": {
       "name": "@vertz/ui-primitives",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@floating-ui/dom": "^1.7.5",
         "@vertz/ui": "workspace:^",
@@ -769,7 +790,7 @@
     },
     "packages/ui-server": {
       "name": "@vertz/ui-server",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@capsizecss/unpack": "^4.0.0",
@@ -791,6 +812,9 @@
         "happy-dom": "^20.8.3",
         "typescript": "^5.7.0",
       },
+      "optionalDependencies": {
+        "@vertz/native-compiler": "workspace:^",
+      },
     },
     "packages/ui-server/e2e/fixture": {
       "name": "hmr-e2e-fixture",
@@ -803,7 +827,7 @@
     },
     "packages/vertz": {
       "name": "vertz",
-      "version": "0.2.60",
+      "version": "0.2.65",
       "dependencies": {
         "@vertz/cli": "workspace:^",
         "@vertz/cloudflare": "workspace:^",
@@ -1799,6 +1823,14 @@
     "@vertz/mint-docs": ["@vertz/mint-docs@workspace:packages/mint-docs"],
 
     "@vertz/native-compiler": ["@vertz/native-compiler@workspace:native/vertz-compiler"],
+
+    "@vertz/native-compiler-darwin-arm64": ["@vertz/native-compiler-darwin-arm64@workspace:packages/native-compiler-darwin-arm64"],
+
+    "@vertz/native-compiler-darwin-x64": ["@vertz/native-compiler-darwin-x64@workspace:packages/native-compiler-darwin-x64"],
+
+    "@vertz/native-compiler-linux-arm64": ["@vertz/native-compiler-linux-arm64@workspace:packages/native-compiler-linux-arm64"],
+
+    "@vertz/native-compiler-linux-x64": ["@vertz/native-compiler-linux-x64@workspace:packages/native-compiler-linux-x64"],
 
     "@vertz/og": ["@vertz/og@workspace:packages/og"],
 
@@ -2976,8 +3008,6 @@
 
     "@vertz/cli/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "@vertz/cli/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
     "@vertz/codegen/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@vertz/component-docs/wrangler": ["wrangler@4.81.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260405.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260405.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260405.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-9fLPDuDcb8Nu6iXrl5E3HGYt3TVhQr/UvqtTvWr9Nl1X7PlQrmWMwQCfSioqN8VHYyQCyESV5jQsoKg8Sx+sEA=="],
@@ -3085,58 +3115,6 @@
     "@vertz-examples/task-manager/wrangler/miniflare": ["miniflare@4.20260310.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260310.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw=="],
 
     "@vertz-examples/task-manager/wrangler/workerd": ["workerd@1.20260310.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260310.1", "@cloudflare/workerd-darwin-arm64": "1.20260310.1", "@cloudflare/workerd-linux-64": "1.20260310.1", "@cloudflare/workerd-linux-arm64": "1.20260310.1", "@cloudflare/workerd-windows-64": "1.20260310.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ=="],
-
-    "@vertz/cli/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
-
-    "@vertz/cli/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
-
-    "@vertz/cli/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
-
-    "@vertz/cli/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
-
-    "@vertz/cli/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
-
-    "@vertz/cli/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
-
-    "@vertz/cli/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
-
-    "@vertz/cli/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
-
-    "@vertz/cli/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
-
-    "@vertz/cli/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
-
-    "@vertz/cli/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
-
-    "@vertz/cli/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
-
-    "@vertz/cli/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
-
-    "@vertz/cli/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
-
-    "@vertz/cli/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
-
-    "@vertz/cli/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
-
-    "@vertz/cli/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
-
-    "@vertz/cli/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@vertz/component-docs/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
 

--- a/native/vertz-compiler/package.json
+++ b/native/vertz-compiler/package.json
@@ -1,20 +1,29 @@
 {
   "name": "@vertz/native-compiler",
-  "version": "0.1.1",
-  "private": true,
+  "version": "0.2.65",
   "exports": {
     "./vertz-compiler.darwin-arm64.node": "./vertz-compiler.darwin-arm64.node",
+    "./vertz-compiler.darwin-x64.node": "./vertz-compiler.darwin-x64.node",
     "./vertz-compiler.linux-x64.node": "./vertz-compiler.linux-x64.node",
-    "./vertz-compiler.linux-arm64.node": "./vertz-compiler.linux-arm64.node"
+    "./vertz-compiler.linux-arm64.node": "./vertz-compiler.linux-arm64.node",
+    "./package.json": "./package.json"
   },
   "files": [
-    "vertz-compiler.*.node"
+    "vertz-compiler.*.node",
+    "postinstall.cjs"
   ],
   "scripts": {
+    "postinstall": "node postinstall.cjs",
     "build": "which cargo > /dev/null 2>&1 && bash -c 'cargo build --release --manifest-path ../Cargo.toml -p vertz-compiler && if [ \"$(uname)\" = \"Darwin\" ]; then cp ../target/release/libvertz_compiler.dylib ./vertz-compiler.darwin-$([ \"$(uname -m)\" = \"arm64\" ] && echo arm64 || echo x64).node; else cp ../target/release/libvertz_compiler.so ./vertz-compiler.linux-$([ \"$(uname -m)\" = \"aarch64\" ] && echo arm64 || echo x64).node; fi' || echo 'Skipping native build (cargo not found)'",
     "build:debug": "cargo build --manifest-path ../Cargo.toml -p vertz-compiler && if [ \"$(uname)\" = \"Darwin\" ]; then cp ../target/debug/libvertz_compiler.dylib ./vertz-compiler.darwin-arm64.node; else cp ../target/debug/libvertz_compiler.so ./vertz-compiler.linux-x64.node; fi",
     "test": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/*.test.ts || echo 'Skipping native tests (binary not found)'",
     "test:parity": "ls vertz-compiler.*.node 1>/dev/null 2>&1 && bun test __tests__/parity/ || echo 'Skipping parity tests'"
+  },
+  "optionalDependencies": {
+    "@vertz/native-compiler-darwin-arm64": "0.2.65",
+    "@vertz/native-compiler-darwin-x64": "0.2.65",
+    "@vertz/native-compiler-linux-x64": "0.2.65",
+    "@vertz/native-compiler-linux-arm64": "0.2.65"
   },
   "devDependencies": {
     "@vertz/test": "workspace:*"

--- a/native/vertz-compiler/postinstall.cjs
+++ b/native/vertz-compiler/postinstall.cjs
@@ -12,7 +12,7 @@ try {
   const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
   const src = path.join(pkgDir, binaryName);
   const dest = path.join(__dirname, binaryName);
-  if (fs.existsSync(src) && !fs.existsSync(dest)) {
+  if (fs.existsSync(src)) {
     fs.copyFileSync(src, dest);
   }
 } catch {

--- a/native/vertz-compiler/postinstall.cjs
+++ b/native/vertz-compiler/postinstall.cjs
@@ -1,0 +1,20 @@
+// Copies the correct platform .node binary from the platform package
+// into this selector package directory so require.resolve() finds it.
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+const binaryName = `vertz-compiler.${platform}-${arch}.node`;
+const pkgName = `@vertz/native-compiler-${platform}-${arch}`;
+
+try {
+  const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
+  const src = path.join(pkgDir, binaryName);
+  const dest = path.join(__dirname, binaryName);
+  if (fs.existsSync(src) && !fs.existsSync(dest)) {
+    fs.copyFileSync(src, dest);
+  }
+} catch {
+  // Platform package not available — native compiler will fall back gracefully
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "@vertz/tui": "workspace:^",
     "@vertz/ui-server": "workspace:^",
     "commander": "^14.0.0",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.27.3",
     "jiti": "^2.4.2"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -33,7 +33,7 @@ export async function createAction(options: CreateOptions): Promise<Result<void,
     console.log(`\nNext steps:`);
     console.log(`  cd ${resolved.projectName}`);
     console.log(`  vtz install`);
-    console.log(`  vtz dev`);
+    console.log(`  vertz dev`);
     return ok(undefined);
   } catch (error) {
     if (error instanceof Error && error.message.includes('already exists')) {

--- a/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
+++ b/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
@@ -161,6 +161,18 @@ describe('buildUI', () => {
     Bun.build = originalBunBuild;
   });
 
+  it('should return failure when native compiler is unavailable', async () => {
+    mockLoadNativeCompiler.mockImplementation(() => {
+      throw new Error('Binary not found');
+    });
+
+    const result = await buildUI(config);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Native compiler not available');
+    expect(result.durationMs).toBe(0);
+  });
+
   it('should produce correct output structure', async () => {
     const result = await buildUI(config);
 

--- a/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
+++ b/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
@@ -38,9 +38,12 @@ const mockGenerateAotBuildManifest = mock(() => ({
 
 const mockExtractFontMetrics = mock(async () => ({}));
 
+const mockLoadNativeCompiler = mock(() => ({ compile: mock(() => ({ code: '' })) }));
+
 vi.mock('@vertz/ui-server', () => ({
   generateAotBuildManifest: (...args: unknown[]) => mockGenerateAotBuildManifest(...args),
   extractFontMetrics: (...args: unknown[]) => mockExtractFontMetrics(...args),
+  loadNativeCompiler: (...args: unknown[]) => mockLoadNativeCompiler(...args),
 }));
 
 const mockDiscoverRoutes = mock(async () => [] as string[]);

--- a/packages/cli/src/production-build/ui-build-pipeline.ts
+++ b/packages/cli/src/production-build/ui-build-pipeline.ts
@@ -118,6 +118,22 @@ export const aotJsxStubPlugin: {
 export async function buildUI(config: UIBuildConfig): Promise<UIBuildResult> {
   const startTime = performance.now();
 
+  // Fail fast if native compiler is unavailable — the esbuild fallback
+  // produces apps without signal reactivity, CSS extraction, or hydration.
+  try {
+    const { loadNativeCompiler } = await import('@vertz/ui-server');
+    loadNativeCompiler();
+  } catch {
+    return {
+      success: false,
+      error:
+        'Native compiler not available. Production builds require @vertz/native-compiler.\n' +
+        'Install it: vtz add @vertz/native-compiler\n' +
+        'Or install the platform-specific package for your OS.',
+      durationMs: 0,
+    };
+  }
+
   const {
     projectRoot,
     clientEntry,

--- a/packages/native-compiler-darwin-arm64/package.json
+++ b/packages/native-compiler-darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vertz/native-compiler-darwin-arm64",
+  "version": "0.2.65",
+  "private": true,
+  "description": "Vertz native compiler binary for macOS arm64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz"
+  },
+  "files": [
+    "vertz-compiler.darwin-arm64.node"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "preferUnplugged": true
+}

--- a/packages/native-compiler-darwin-x64/package.json
+++ b/packages/native-compiler-darwin-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vertz/native-compiler-darwin-x64",
+  "version": "0.2.65",
+  "private": true,
+  "description": "Vertz native compiler binary for macOS x64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz"
+  },
+  "files": [
+    "vertz-compiler.darwin-x64.node"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "preferUnplugged": true
+}

--- a/packages/native-compiler-linux-arm64/package.json
+++ b/packages/native-compiler-linux-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vertz/native-compiler-linux-arm64",
+  "version": "0.2.65",
+  "private": true,
+  "description": "Vertz native compiler binary for Linux arm64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz"
+  },
+  "files": [
+    "vertz-compiler.linux-arm64.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "preferUnplugged": true
+}

--- a/packages/native-compiler-linux-x64/package.json
+++ b/packages/native-compiler-linux-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vertz/native-compiler-linux-x64",
+  "version": "0.2.65",
+  "private": true,
+  "description": "Vertz native compiler binary for Linux x64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz"
+  },
+  "files": [
+    "vertz-compiler.linux-x64.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "preferUnplugged": true
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/vertz-dev/vertz"
   },
   "bin": {
-    "vertz": "./cli.sh",
     "vtz": "./cli.sh",
     "vtzx": "./cli-exec.sh"
   },

--- a/packages/ui-server/package.json
+++ b/packages/ui-server/package.json
@@ -83,6 +83,9 @@
     "happy-dom": "^20.8.3",
     "typescript": "^5.7.0"
   },
+  "optionalDependencies": {
+    "@vertz/native-compiler": "workspace:^"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/plans/2692-fix-prod-build-pipeline.md
+++ b/plans/2692-fix-prod-build-pipeline.md
@@ -1,0 +1,394 @@
+# Fix Production Build Pipeline (#2692)
+
+**Rev 4** — Quick fix to unblock external users. `vtz build` with Rolldown tracked separately as a future initiative.
+
+## Problem Statement
+
+Vertz apps cannot be built for production. `vtz dev` works perfectly, but `vertz build` fails due to three cascading issues:
+
+1. **Native compiler not published** — `@vertz/native-compiler` is `"private": true` and never published to npm. Without it, UI builds fall back to esbuild's JSX transpiler, which produces broken apps (no signal reactivity, no CSS extraction, no hydration markers). **This is the blocker.**
+2. **Bin link shadowing** — `@vertz/runtime` and `@vertz/cli` both register a `vertz` bin. The runtime's `cli.sh` wins, and it has no `build` subcommand.
+3. **esbuild version mismatch** — `@vertz/cli` depends on `esbuild@^0.25.0`, `@vertz/ui-server` on `esbuild@^0.27.3`.
+
+## API Surface
+
+No new public APIs. The developer-facing commands stay the same:
+
+```bash
+vertz build                      # Full-stack production build
+vertz build --target cloudflare  # Cloudflare Workers bundle
+```
+
+## Manifesto Alignment
+
+- **"If your code builds, it runs"** — Currently it doesn't build at all for production. This fix restores the core promise.
+- **"Production-Ready by Default"** — A framework that can't produce production builds is not production-ready.
+- **"One Way to Do Things"** — The `vertz` bin conflict means there are two `vertz` commands. We need exactly one.
+
+## Non-Goals
+
+- Adding `vtz build` to the Rust binary (tracked separately — requires Rolldown integration, proper POC, and phased rollout).
+- Changing the native compiler's NAPI interface or compilation behavior.
+- Rewriting the build pipeline. The JS build pipeline in `@vertz/cli` is correct — we're fixing distribution.
+- Windows support.
+
+## Unknowns
+
+None. All three issues have clear root causes and fixes within existing patterns (the `@vertz/runtime` platform package pattern is proven).
+
+## Solution
+
+### Fix 1: Publish `@vertz/native-compiler` via platform packages
+
+**Root cause**: `native/vertz-compiler/package.json` has `"private": true` and is never published. The release pipeline builds the `.node` binary on Linux x64 only. External users can't resolve `@vertz/native-compiler`.
+
+**Fix**: Follow the exact pattern used by `@vertz/runtime`:
+
+#### 1a. Create four platform packages
+
+Each contains a single `.node` file for its platform:
+
+```
+packages/native-compiler-darwin-arm64/package.json
+packages/native-compiler-darwin-x64/package.json
+packages/native-compiler-linux-x64/package.json
+packages/native-compiler-linux-arm64/package.json
+```
+
+```jsonc
+// packages/native-compiler-darwin-arm64/package.json
+{
+  "name": "@vertz/native-compiler-darwin-arm64",
+  "version": "0.2.65",
+  "private": true,
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["vertz-compiler.darwin-arm64.node"],
+  "preferUnplugged": true
+}
+```
+
+#### 1b. Convert selector package
+
+The selector package stays at `native/vertz-compiler/` (Rust source, Cargo.toml, build scripts, and parity tests all live there — moving the package.json would break relative paths).
+
+Changes to `native/vertz-compiler/package.json`:
+- Remove `"private": true`
+- Bump version from `0.1.1` to `0.2.65` (sync with monorepo)
+- Add `optionalDependencies` pointing to platform packages
+- Add `postinstall.cjs` that copies the `.node` file from the correct platform package
+- Add `darwin-x64` to exports (currently missing)
+
+```jsonc
+// native/vertz-compiler/package.json
+{
+  "name": "@vertz/native-compiler",
+  "version": "0.2.65",
+  "main": "index.cjs",
+  "scripts": {
+    "postinstall": "node postinstall.cjs",
+    "build": "...",
+    "test": "..."
+  },
+  "optionalDependencies": {
+    "@vertz/native-compiler-darwin-arm64": "0.2.65",
+    "@vertz/native-compiler-darwin-x64": "0.2.65",
+    "@vertz/native-compiler-linux-x64": "0.2.65",
+    "@vertz/native-compiler-linux-arm64": "0.2.65"
+  },
+  "exports": {
+    "./vertz-compiler.darwin-arm64.node": "./vertz-compiler.darwin-arm64.node",
+    "./vertz-compiler.darwin-x64.node": "./vertz-compiler.darwin-x64.node",
+    "./vertz-compiler.linux-x64.node": "./vertz-compiler.linux-x64.node",
+    "./vertz-compiler.linux-arm64.node": "./vertz-compiler.linux-arm64.node"
+  },
+  "files": [
+    "vertz-compiler.*.node",
+    "postinstall.cjs",
+    "index.cjs"
+  ]
+}
+```
+
+#### 1c. Postinstall — copy `.node` from platform package
+
+```js
+// native/vertz-compiler/postinstall.cjs
+// Copies the correct platform .node binary from the platform package
+// into this selector package directory so require.resolve() finds it.
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+const binaryName = `vertz-compiler.${platform}-${arch}.node`;
+const pkgName = `@vertz/native-compiler-${platform}-${arch}`;
+
+try {
+  const pkgDir = path.dirname(require.resolve(`${pkgName}/package.json`));
+  const src = path.join(pkgDir, binaryName);
+  const dest = path.join(__dirname, binaryName);
+  if (fs.existsSync(src) && !fs.existsSync(dest)) {
+    fs.copyFileSync(src, dest);
+  }
+} catch {
+  // Platform package not available — native compiler will fall back gracefully
+}
+```
+
+This mirrors `@vertz/runtime`'s `postinstall.cjs` pattern.
+
+#### 1d. Resolution — no changes needed
+
+The existing `resolveBinaryPath()` in `packages/ui-server/src/compiler/native-compiler.ts` already handles this:
+
+1. `require.resolve('@vertz/native-compiler/vertz-compiler.darwin-arm64.node')` — resolves because `postinstall.cjs` copied the file
+2. Fallback: workspace-relative walk up to `native/vertz-compiler/` — continues to work in the monorepo
+
+#### 1e. Dependency wiring
+
+```jsonc
+// packages/ui-server/package.json — add:
+"optionalDependencies": {
+  "@vertz/native-compiler": "workspace:^"
+}
+```
+
+#### 1f. Production build must hard-fail without native compiler
+
+Add an early `loadNativeCompiler()` guard at the top of `buildUI()` in `ui-build-pipeline.ts`, before `createVertzBunPlugin()` is invoked. The `compile()` convenience function silently falls back to esbuild — production builds must fail loudly instead of producing broken output.
+
+```typescript
+// packages/cli/src/production-build/ui-build-pipeline.ts — top of buildUI()
+import { loadNativeCompiler } from '@vertz/ui-server';
+
+// Fail fast if native compiler is unavailable — the esbuild fallback
+// produces apps without signal reactivity, CSS extraction, or hydration.
+try {
+  loadNativeCompiler();
+} catch {
+  return {
+    success: false,
+    error:
+      'Native compiler not available. Production builds require @vertz/native-compiler.\n' +
+      'Install it: vtz add @vertz/native-compiler\n' +
+      'Or install the platform-specific package: vtz add @vertz/native-compiler-darwin-arm64',
+    durationMs: 0,
+  };
+}
+```
+
+#### 1g. Release pipeline changes
+
+**Extend `build-binaries` matrix** (`.github/workflows/release.yml`):
+
+After building the `vtz` runtime binary in each matrix entry, also build the compiler:
+
+```yaml
+# After the existing cargo build step for vtz:
+- name: Build native compiler
+  run: |
+    cargo build --release --manifest-path native/Cargo.toml -p vertz-compiler --target ${{ matrix.target }}
+    if [[ "${{ matrix.target }}" == *apple* ]]; then
+      cp native/target/${{ matrix.target }}/release/libvertz_compiler.dylib \
+        packages/native-compiler-${{ matrix.pkg_suffix }}/vertz-compiler.${{ matrix.pkg_suffix }}.node
+      codesign -s - packages/native-compiler-${{ matrix.pkg_suffix }}/vertz-compiler.${{ matrix.pkg_suffix }}.node
+    else
+      cp native/target/${{ matrix.target }}/release/libvertz_compiler.so \
+        packages/native-compiler-${{ matrix.pkg_suffix }}/vertz-compiler.${{ matrix.pkg_suffix }}.node
+    fi
+
+- name: Upload compiler artifact
+  uses: actions/upload-artifact@v4
+  with:
+    name: native-compiler-${{ matrix.pkg_suffix }}
+    path: packages/native-compiler-${{ matrix.pkg_suffix }}/
+    retention-days: 1
+```
+
+**macOS code signing**: `codesign -s -` applied to `.node` files same as runtime binaries — without this, macOS Gatekeeper rejects `dlopen` on unsigned shared libraries.
+
+**Remove the linux-only compiler build** from the `release` job (lines 265-269) — it's now handled by the matrix.
+
+#### 1h. Publish script changes
+
+In `scripts/publish.sh`, add phases for native-compiler packages. The existing `packages/runtime-*` glob won't match — add explicit handling:
+
+```bash
+# Phase 1.5: Native compiler platform packages
+echo "Phase 1.5: Publishing native compiler platform packages..."
+for pkg_json in packages/native-compiler-*/package.json; do
+  # Same pattern as Phase 1: strip private, check binary exists, publish
+done
+
+# Phase 2.5: Native compiler selector package
+echo "Phase 2.5: Publishing native compiler selector..."
+# Publish native/vertz-compiler/ (not under packages/, needs explicit path)
+cd native/vertz-compiler
+npm publish --access public --provenance
+cd ../..
+```
+
+#### 1i. Version sync
+
+In `scripts/version.sh`, add sync for native-compiler packages:
+
+```bash
+# After syncing runtime packages:
+# Sync native-compiler package.json version
+jq --arg v "$VERSION" '.version = $v' native/vertz-compiler/package.json > tmp && mv tmp native/vertz-compiler/package.json
+
+# Sync native-compiler platform package versions
+for pkg_json in packages/native-compiler-*/package.json; do
+  jq --arg v "$VERSION" '.version = $v' "$pkg_json" > tmp && mv tmp "$pkg_json"
+done
+
+# Sync native-compiler optionalDependencies
+jq --arg v "$VERSION" '.optionalDependencies |= with_entries(.value = $v)' \
+  native/vertz-compiler/package.json > tmp && mv tmp native/vertz-compiler/package.json
+```
+
+### Fix 2: Remove `vertz` bin from `@vertz/runtime`
+
+Remove the `vertz` key from `@vertz/runtime`'s `bin` field:
+
+```jsonc
+// packages/runtime/package.json
+"bin": {
+  "vtz": "./cli.sh",
+  "vtzx": "./cli-exec.sh"
+  // "vertz" removed — was shadowing @vertz/cli
+}
+```
+
+**Impact**: This **fixes** `vertz` resolution. After this change, `vertz` correctly resolves to `@vertz/cli`'s `dist/vertz.js`, which has `dev`, `build`, `create`, and all other subcommands. The shadowing was the bug.
+
+**Canonical command**: `vertz` is the user-facing CLI command for all workflows (`vertz dev`, `vertz build`, `vertz create`). `vtz` is the native runtime binary used internally and for direct commands (`vtz test`, `vtz install`, `vtz self-update`).
+
+**Consistency fix**: Update `packages/cli/src/commands/create.ts` post-scaffold message from `vtz dev` to `vertz dev` to match the `package.json` template scripts that already say `"dev": "vertz dev"`.
+
+### Fix 3: Align esbuild versions
+
+Update `@vertz/cli` to `esbuild@^0.27.3`:
+
+```jsonc
+// packages/cli/package.json
+"dependencies": {
+  "esbuild": "^0.27.3"  // was "^0.25.0"
+}
+```
+
+**Verification**: The CLI's esbuild usage was inspected (`orchestrator.ts`, `build-cloudflare.ts`). It uses standard `esbuild.build()` with common options only. No exotic APIs or breaking changes between 0.25 and 0.27.
+
+## Type Flow Map
+
+N/A — no generic type parameters. This is tooling/infrastructure.
+
+## E2E Acceptance Test
+
+### Native compiler availability (the blocker)
+
+```bash
+# Given: a fresh project with @vertz/ui-server installed
+# When: running vertz build on a project with src/app.tsx
+npx vertz build
+
+# Then: native compiler loads successfully
+# Expected: NO "Native compiler binary not available" warning
+# Expected: signal transforms, CSS extraction, hydration markers are present
+```
+
+### Native compiler missing = hard error
+
+```bash
+# Given: @vertz/native-compiler NOT installed (wrong platform, install failure)
+# When: running vertz build
+npx vertz build
+
+# Then: build fails with clear error message
+# Expected: "Native compiler not available. Production builds require @vertz/native-compiler."
+# Expected: NOT a silent fallback producing a broken app
+```
+
+### Bin link resolution
+
+```bash
+# Given: @vertz/cli and @vertz/runtime installed
+npm create vertz-app my-app && cd my-app && npm install
+
+# When: running vertz build
+npx vertz build
+# Then: @vertz/cli build command runs (no "unrecognized subcommand" error)
+
+# When: running vertz dev
+npx vertz dev
+# Then: dev server starts successfully
+```
+
+### esbuild compatibility
+
+```bash
+# Given: @vertz/cli and @vertz/ui-server in same project
+npx vertz build
+# Expected: NO "Host version X does not match binary version Y" error
+```
+
+### Automated test
+
+```typescript
+// packages/ui-server/src/compiler/__tests__/native-compiler-resolution.test.ts
+describe('Native compiler resolution', () => {
+  it('loads the native compiler binary', () => {
+    const compiler = loadNativeCompiler();
+    expect(compiler).toBeDefined();
+    expect(typeof compiler.compile).toBe('function');
+  });
+
+  it('compiles JSX with signal transforms', () => {
+    const compiler = loadNativeCompiler();
+    const result = compiler.compile('let x = 0; return <div>{x}</div>', {
+      filename: 'test.tsx',
+    });
+    expect(result.code).toContain('signal');
+  });
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Native compiler platform packages + publish infrastructure
+
+1. Create `packages/native-compiler-{darwin-arm64,darwin-x64,linux-x64,linux-arm64}/package.json`
+2. Update `native/vertz-compiler/package.json`: remove `private`, bump to `0.2.65`, add `optionalDependencies`, add `darwin-x64` export
+3. Write `native/vertz-compiler/postinstall.cjs`
+4. Add `@vertz/native-compiler` as optional dependency of `@vertz/ui-server`
+5. Update `scripts/version.sh` to sync native-compiler versions
+6. Update `scripts/publish.sh` with Phase 1.5 and 2.5 for native-compiler packages
+7. Extend `.github/workflows/release.yml` `build-binaries` matrix to build compiler on all platforms (with macOS code signing)
+
+### Phase 2: Bin link fix + esbuild alignment + hard-fail guard
+
+1. Remove `vertz` from `@vertz/runtime` bin field
+2. Update `@vertz/cli` esbuild dependency to `^0.27.3`
+3. Update `create.ts` post-scaffold message to say `vertz dev`
+4. Add `loadNativeCompiler()` guard at top of `buildUI()` in `ui-build-pipeline.ts`
+5. Grep repo for `vertz dev` vs `vtz dev` inconsistencies and fix
+
+### Phase 3: Tests + changeset
+
+1. Add automated test verifying native compiler loads
+2. Create changesets for `@vertz/runtime`, `@vertz/cli`, `@vertz/ui-server`, `@vertz/native-compiler`
+3. Run full quality gates
+4. Verify `vertz build` works end-to-end on an example app
+
+## Future: `vtz build` with Rolldown
+
+The right long-term architecture is `vtz build` — production builds owned by the Rust binary using Rolldown as an embedded bundler. This eliminates the Bun dependency entirely.
+
+**Tracked separately.** Requires:
+- POC: verify Rolldown compiles alongside vtz's dependency tree (oxc version compatibility)
+- POC: verify Plugin::transform hook works with vertz_compiler_core
+- Measure binary size and compile time impact
+- Plan migration of all JS pipeline features (reactivity manifests, field selection, image transforms, island IDs, route extraction, per-route CSS)
+
+This is a feature, not a bug fix. It should not block unblocking external users.

--- a/reviews/fix-prod-build/phase-01-implementation.md
+++ b/reviews/fix-prod-build/phase-01-implementation.md
@@ -1,0 +1,78 @@
+# Phase 1: Fix Production Build Pipeline
+
+- **Author:** fix-prod-build implementor
+- **Reviewer:** Claude Opus 4.6 (adversarial review)
+- **Commits:** 34c297e15..f44515e2f
+- **Date:** 2026-04-16
+
+## Changes
+
+- `native/vertz-compiler/package.json` (modified)
+- `native/vertz-compiler/postinstall.cjs` (new)
+- `packages/native-compiler-darwin-arm64/package.json` (new)
+- `packages/native-compiler-darwin-x64/package.json` (new)
+- `packages/native-compiler-linux-arm64/package.json` (new)
+- `packages/native-compiler-linux-x64/package.json` (new)
+- `packages/runtime/package.json` (modified)
+- `packages/cli/package.json` (modified)
+- `packages/cli/src/commands/create.ts` (modified)
+- `packages/cli/src/production-build/ui-build-pipeline.ts` (modified)
+- `packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts` (modified)
+- `packages/ui-server/package.json` (modified)
+- `.github/workflows/release.yml` (modified)
+- `scripts/version.sh` (modified)
+- `scripts/publish.sh` (modified)
+- `.changeset/fix-prod-build-pipeline.md` (new)
+
+## CI Status
+
+- [x] Lint passed (oxlint)
+- [x] Rust tests passed (cargo test --all)
+- [x] Rust clippy passed
+- [x] Rust fmt passed
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for
+- [x] TDD compliance (failure-path test added after review)
+- [x] No type gaps or missing edge cases (after review fixes)
+- [x] No security issues
+- [x] Public API changes match design doc
+
+## Findings
+
+### BLOCKER 1: publish.sh Phase 3 double-publish (RESOLVED)
+
+Phase 3 glob matched native-compiler-* after Phase 1.5 removed the `private` flag.
+**Fix:** Added `native-compiler-*` to the basename skip filter in Phase 3.
+
+### BLOCKER 2: postinstall.cjs stale binary on upgrade (RESOLVED)
+
+`!fs.existsSync(dest)` guard prevented overwriting old binaries on upgrade.
+**Fix:** Removed the guard — always overwrite when source exists.
+
+### SHOULD-FIX: Missing failure-path test for buildUI guard (RESOLVED)
+
+Added test verifying `loadNativeCompiler()` throw returns `{ success: false, error: '...', durationMs: 0 }`.
+
+### SHOULD-FIX: No compiler binary verification in CI (RESOLVED)
+
+Added `Verify compiler binary exists` step after copy, before code signing and upload.
+
+### SHOULD-FIX: Changeset missing @vertz/native-compiler (NOT AN ISSUE)
+
+Verified `@vertz/native-compiler` is not published on npm at all — version 0.2.65 is safe.
+`version.sh` handles syncing from the core package version, so changeset coverage is not needed.
+
+### NITPICK: create.ts mixes vtz and vertz (ACKNOWLEDGED)
+
+`vtz install` + `vertz dev` reflects the actual command split: `vtz` is the native runtime
+(install, test), `vertz` is the JS CLI (dev, build, create). Left as-is — both are correct.
+
+### NITPICK: postinstall.cjs maps win32 to linux silently (ACKNOWLEDGED)
+
+Windows is not supported. The try/catch will swallow the error. Low priority.
+
+## Resolution
+
+All blocker and should-fix findings addressed. Approved.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -66,6 +66,44 @@ for pkg_json in packages/runtime-*/package.json; do
   fi
 done
 
+# --- Phase 1.5: Publish native compiler binary packages (packages/native-compiler-*) ---
+echo ""
+echo "=== Publishing native compiler binary packages ==="
+
+for pkg_json in packages/native-compiler-*/package.json; do
+  [ -f "$pkg_json" ] || continue
+
+  dir=$(dirname "$pkg_json")
+  name=$(jq -r '.name' "$pkg_json")
+  version=$(jq -r '.version' "$pkg_json")
+  private=$(jq -r '.private // false' "$pkg_json")
+
+  if [ "$private" = "true" ]; then
+    # Check that a .node binary exists
+    if ! ls "$dir"/vertz-compiler.*.node 1>/dev/null 2>&1; then
+      echo "Skipping $name (no binary)"
+      continue
+    fi
+
+    # Temporarily remove private flag for publishing
+    jq 'del(.private)' "$pkg_json" > "$pkg_json.tmp" && mv "$pkg_json.tmp" "$pkg_json"
+    MODIFIED_PKGS+=("$pkg_json")
+  fi
+
+  if is_published "$name" "$version"; then
+    echo "Skipping $name@$version (already published)"
+    continue
+  fi
+
+  echo "Publishing $name@$version..."
+  if (cd "$dir" && npm publish --access public --provenance); then
+    echo "Published $name@$version"
+  else
+    echo "Failed to publish $name@$version"
+    FAILED+=("$name@$version")
+  fi
+done
+
 # --- Phase 2: Publish selector package (packages/runtime) ---
 echo ""
 echo "=== Publishing runtime selector package ==="
@@ -82,6 +120,25 @@ else
   else
     echo "Failed to publish $name@$version"
     FAILED+=("$name@$version")
+  fi
+fi
+
+# --- Phase 2.5: Publish native compiler selector package ---
+echo ""
+echo "=== Publishing native compiler selector package ==="
+
+compiler_name=$(jq -r '.name' native/vertz-compiler/package.json)
+compiler_version=$(jq -r '.version' native/vertz-compiler/package.json)
+
+if is_published "$compiler_name" "$compiler_version"; then
+  echo "Skipping $compiler_name@$compiler_version (already published)"
+else
+  echo "Publishing $compiler_name@$compiler_version..."
+  if (cd native/vertz-compiler && npm publish --access public --provenance); then
+    echo "Published $compiler_name@$compiler_version"
+  else
+    echo "Failed to publish $compiler_name@$compiler_version"
+    FAILED+=("$compiler_name@$compiler_version")
   fi
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -152,13 +152,13 @@ for pkg_json in packages/*/package.json; do
   version=$(jq -r '.version' "$pkg_json")
   private=$(jq -r '.private // false' "$pkg_json")
 
-  # Skip private, runtime (already published above), and runtime-* packages
+  # Skip private, runtime (already published above), runtime-*, and native-compiler-* packages
   if [ "$private" = "true" ]; then
     continue
   fi
 
   base=$(basename "$dir")
-  if [[ "$base" == runtime || "$base" == runtime-* ]]; then
+  if [[ "$base" == runtime || "$base" == runtime-* || "$base" == native-compiler-* ]]; then
     continue
   fi
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,4 +30,22 @@ jq --arg v "$VERSION" '.optionalDependencies |= with_entries(.value = $v)' \
   packages/runtime/package.json > packages/runtime/package.json.tmp \
   && mv packages/runtime/package.json.tmp packages/runtime/package.json
 
+# Sync native-compiler selector package version
+jq --arg v "$VERSION" '.version = $v' \
+  native/vertz-compiler/package.json > native/vertz-compiler/package.json.tmp \
+  && mv native/vertz-compiler/package.json.tmp native/vertz-compiler/package.json
+
+# Sync native-compiler platform package versions
+for pkg_json in packages/native-compiler-*/package.json; do
+  if [ -f "$pkg_json" ]; then
+    jq --arg v "$VERSION" '.version = $v' "$pkg_json" > "$pkg_json.tmp" \
+      && mv "$pkg_json.tmp" "$pkg_json"
+  fi
+done
+
+# Sync native-compiler optionalDependencies
+jq --arg v "$VERSION" '.optionalDependencies |= with_entries(.value = $v)' \
+  native/vertz-compiler/package.json > native/vertz-compiler/package.json.tmp \
+  && mv native/vertz-compiler/package.json.tmp native/vertz-compiler/package.json
+
 echo "All versions synced to $VERSION"


### PR DESCRIPTION
## Summary

Fixes #2692 — production builds are completely broken for external users.

- **Native compiler platform packages**: 4 new packages (`@vertz/native-compiler-{darwin,linux}-{arm64,x64}`) following the `@vertz/runtime` pattern. `@vertz/native-compiler` becomes a public selector with `optionalDependencies` and `postinstall.cjs` that copies the correct `.node` binary.
- **Bin link fix**: Remove `vertz` from `@vertz/runtime`'s bin field so `@vertz/cli`'s `vertz` binary (dev, build, create) wins.
- **esbuild alignment**: Bump `@vertz/cli` esbuild from `^0.25.0` to `^0.27.3` to match `@vertz/ui-server`.
- **Hard-fail guard**: `loadNativeCompiler()` check at top of `buildUI()` — production builds fail loudly instead of silently falling back to esbuild (which produces broken apps without reactivity).

## Public API Changes

| Change | Impact |
|--------|--------|
| `@vertz/native-compiler` published to npm | Users can `npm install @vertz/native-compiler` for production builds |
| `vertz` bin removed from `@vertz/runtime` | `vertz` now resolves to `@vertz/cli` (the JS CLI with dev/build/create) |
| `vtz`/`vtzx` bins unchanged in `@vertz/runtime` | No impact on native runtime usage |

## Files changed

- [`native/vertz-compiler/package.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/native/vertz-compiler/package.json) — removed private, added optionalDeps + postinstall
- [`native/vertz-compiler/postinstall.cjs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/native/vertz-compiler/postinstall.cjs) — copies platform binary to selector
- [`packages/native-compiler-*/package.json`](https://github.com/vertz-dev/vertz/tree/viniciusdacal/fix-prod-build-2692/packages) — 4 new platform packages
- [`packages/runtime/package.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/packages/runtime/package.json) — removed `vertz` bin
- [`packages/cli/package.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/packages/cli/package.json) — esbuild bump
- [`packages/cli/src/production-build/ui-build-pipeline.ts`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/packages/cli/src/production-build/ui-build-pipeline.ts) — hard-fail guard
- [`packages/ui-server/package.json`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/packages/ui-server/package.json) — added native-compiler optionalDep
- [`.github/workflows/release.yml`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/.github/workflows/release.yml) — build compiler on all 4 platforms
- [`scripts/version.sh`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/scripts/version.sh) — sync native-compiler versions
- [`scripts/publish.sh`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/scripts/publish.sh) — phases 1.5 + 2.5 for compiler packages

## Review

Adversarial review completed — 2 blockers and 3 should-fix items found and resolved:
- Fixed stale binary on upgrade (postinstall always overwrites now)
- Fixed double-publish risk in Phase 3 (added native-compiler-* exclusion)
- Added compiler binary verification step in CI
- Added failure-path test for loadNativeCompiler guard

Review file: [`reviews/fix-prod-build/phase-01-implementation.md`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-prod-build-2692/reviews/fix-prod-build/phase-01-implementation.md)

## Test plan

- [x] Lint passed (oxlint — 0 errors)
- [x] Rust tests passed (cargo test --all — 3,800+ tests, 0 failures)
- [x] Rust clippy passed
- [x] Rust fmt passed
- [x] Build-typecheck passed
- [x] create-vertz-app template tests (118 passed)
- [x] create-vertz-app scaffold tests (90 passed)
- [x] Verified @vertz/native-compiler not published on npm (clean first publish)
- [ ] GitHub CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)