### PR TITLE
fix(vtz): make vi.mock()/spyOn() work on ESM module exports (#2700)

### DIFF
--- a/.changeset/fix-esm-mock-spy.md
+++ b/.changeset/fix-esm-mock-spy.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+Fix `vi.mock()` and `spyOn()` on ESM module exports by adding a spy_exports compiler transform that converts `export` declarations to mutable `let` bindings with setter registration, mock proxy generation for CJS/opaque modules, and `mocked_bare_specifiers` to prevent synthetic module intercepts from bypassing `vi.mock()`

--- a/native/vertz-compiler-core/src/lib.rs
+++ b/native/vertz-compiler-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod reactivity_analyzer;
 pub mod route_splitting;
 pub mod signal_api_registry;
 pub mod signal_transformer;
+pub mod spy_exports;
 pub mod ssr_safety_diagnostics;
 pub mod typescript_strip;
 pub mod utils;
@@ -156,6 +157,10 @@ pub struct CompileOptions {
     /// and rewrites imports of mocked modules to `const` destructuring.
     /// Used for test files compiled by the vtz test runner.
     pub mock_hoisting: Option<bool>,
+    /// When true, export declarations are transformed to use `let` bindings with
+    /// setter registration, enabling `spyOn()` on ESM module exports via live
+    /// binding updates. Used for ALL modules when the test runner is active.
+    pub spy_exports: Option<bool>,
 }
 
 /// Per-component AOT compilation result in the output.
@@ -197,6 +202,7 @@ pub fn compile(source: &str, options: CompileOptions) -> CompileResult {
     let enable_prefetch_manifest = options.prefetch_manifest.unwrap_or(false);
     let skip_css = options.skip_css_transform.unwrap_or(false);
     let enable_mock_hoisting = options.mock_hoisting.unwrap_or(false);
+    let enable_spy_exports = options.spy_exports.unwrap_or(false);
 
     let source_type = SourceType::from_path(filename).unwrap_or_default();
     let allocator = Allocator::default();
@@ -282,6 +288,13 @@ pub fn compile(source: &str, options: CompileOptions) -> CompileResult {
     // Strip TypeScript syntax first (interfaces, type aliases, as casts, type annotations, etc.)
     // Must run before JSX transform so that get_transformed_slice() returns clean JavaScript.
     typescript_strip::strip_typescript_syntax(&mut ms, &parser_ret.program, source);
+
+    // Export interposition for spy support — converts `export function/const/class` to `let`
+    // bindings with setter registration, enabling `spyOn()` on ESM module exports.
+    // Must run after TypeScript stripping (needs clean JS) and before component transforms.
+    if enable_spy_exports {
+        spy_exports::transform_spy_exports(&mut ms, &parser_ret.program, source);
+    }
 
     // Route code splitting -- convert static imports in defineRoutes to dynamic imports.
     // Must run before component transforms (it rewrites module-level import/export statements).

--- a/native/vertz-compiler-core/src/spy_exports.rs
+++ b/native/vertz-compiler-core/src/spy_exports.rs
@@ -1,0 +1,721 @@
+//! Export interposition for `spyOn()` support on ESM module exports.
+//!
+//! In test mode, this transform converts export declarations to use `let`
+//! bindings with setter registration. This enables `spyOn()` on ESM module
+//! exports by leveraging ESM live binding semantics — when the setter
+//! reassigns the variable, all importers see the new value.
+//!
+//! ## Transform
+//!
+//! ```text
+//! // Input:
+//! export function createAction(opts) { ... }
+//! export const VERSION = '1.0';
+//!
+//! // Output:
+//! let createAction = function createAction(opts) { ... };
+//! let VERSION = '1.0';
+//! export { createAction, VERSION };
+//! const __vertz_module_id__ = import.meta.url;
+//! export { __vertz_module_id__ };
+//! globalThis.__vertz_module_setters ??= {};
+//! globalThis.__vertz_module_setters[import.meta.url] = {
+//!   createAction: (__v) => { createAction = __v; },
+//!   VERSION: (__v) => { VERSION = __v; },
+//! };
+//! ```
+
+use crate::magic_string::MagicString;
+use oxc_ast::ast::*;
+
+/// Collected export name for setter registration.
+struct ExportName(String);
+
+/// Transform export declarations for spy support.
+///
+/// Converts `export function/const/class` declarations to `let` bindings,
+/// then appends a grouped `export { ... }` statement and setter registration.
+///
+/// Uses targeted MagicString edits rather than copying from the original source,
+/// so prior transforms (e.g., TypeScript stripping) are preserved.
+pub fn transform_spy_exports(ms: &mut MagicString, program: &Program, source: &str) {
+    let mut export_names: Vec<ExportName> = Vec::new();
+
+    // Collect all names bound by import declarations so we can detect conflicts
+    // with re-export transformations.
+    let mut imported_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for stmt in &program.body {
+        if let Statement::ImportDeclaration(import) = stmt {
+            if let Some(ref specifiers) = import.specifiers {
+                for spec in specifiers {
+                    match spec {
+                        ImportDeclarationSpecifier::ImportSpecifier(named) => {
+                            imported_names.insert(named.local.name.to_string());
+                        }
+                        ImportDeclarationSpecifier::ImportDefaultSpecifier(def) => {
+                            imported_names.insert(def.local.name.to_string());
+                        }
+                        ImportDeclarationSpecifier::ImportNamespaceSpecifier(ns) => {
+                            imported_names.insert(ns.local.name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-export that needs to be transformed into import + let binding.
+    struct ReExport {
+        /// The exported (local) name
+        exported_name: String,
+        /// The imported (remote) name (may differ if `export { foo as bar }`)
+        imported_name: String,
+    }
+    /// Names from the original re-export that were skipped (conflict with imports).
+    struct SkippedReExport {
+        exported_name: String,
+        imported_name: String,
+    }
+    /// A single re-export statement to transform.
+    struct ReExportStmt {
+        source: String,
+        names: Vec<ReExport>,
+        /// Names kept as-is in a residual re-export (conflicted with imports)
+        skipped: Vec<SkippedReExport>,
+        span_start: u32,
+        span_end: u32,
+    }
+    let mut reexport_stmts: Vec<ReExportStmt> = Vec::new();
+
+    for stmt in &program.body {
+        let Statement::ExportNamedDeclaration(export) = stmt else {
+            continue;
+        };
+
+        // Handle re-exports: `export { x, y } from './other'`
+        // Transform to: import + let bindings so spyOn setters can intercept
+        if let Some(ref src) = export.source {
+            if export.specifiers.is_empty() {
+                continue;
+            }
+            // Skip `export type { ... } from` (TS type-only re-exports)
+            if matches!(export.export_kind, ImportOrExportKind::Type) {
+                continue;
+            }
+            let mut names = Vec::new();
+            let mut skipped = Vec::new();
+            for spec in &export.specifiers {
+                // Skip type-only specifiers
+                if matches!(spec.export_kind, ImportOrExportKind::Type) {
+                    continue;
+                }
+                let exported_name = spec.exported.name().to_string();
+                let imported_name = spec.local.name().to_string();
+                // Names that already exist as imports can't get a new let binding
+                // (would cause "has already been declared"). Keep them as a residual
+                // re-export so the module's public API is preserved.
+                if imported_names.contains(&exported_name) {
+                    skipped.push(SkippedReExport {
+                        exported_name,
+                        imported_name,
+                    });
+                    continue;
+                }
+                names.push(ReExport {
+                    exported_name,
+                    imported_name,
+                });
+            }
+            if !names.is_empty() || !skipped.is_empty() {
+                reexport_stmts.push(ReExportStmt {
+                    source: src.value.to_string(),
+                    names,
+                    skipped,
+                    span_start: export.span.start,
+                    span_end: export.span.end,
+                });
+            }
+            continue;
+        }
+
+        // Skip `export { x, y }` without declaration (no local binding to intercept)
+        let Some(ref decl) = export.declaration else {
+            continue;
+        };
+
+        match decl {
+            Declaration::FunctionDeclaration(func) => {
+                let Some(ref id) = func.id else { continue };
+                // Skip TypeScript function overload signatures (no body)
+                if func.body.is_none() {
+                    continue;
+                }
+                let name = id.name.to_string();
+
+                // `export function foo(...){}` → `let foo = function foo(...){};\n`
+                // Overwrite `export ` prefix (from export start to function start)
+                // with `let foo = `, preserving the function body as-is in MagicString.
+                ms.overwrite(
+                    export.span.start,
+                    func.span.start,
+                    &format!("let {name} = "),
+                );
+                // Append semicolon after the function (function declarations don't have one)
+                ms.prepend_left(export.span.end, ";");
+
+                export_names.push(ExportName(name));
+            }
+            Declaration::VariableDeclaration(var_decl) => {
+                // Handle `export const foo = expr;` / `export let foo = expr;`
+                // Only single declarators (not `export const a = 1, b = 2;`)
+                if var_decl.declarations.len() != 1 {
+                    continue;
+                }
+                let declarator = &var_decl.declarations[0];
+                let BindingPattern::BindingIdentifier(ref id) = declarator.id else {
+                    continue;
+                };
+                let name = id.name.to_string();
+
+                // Remove `export ` prefix
+                ms.overwrite(export.span.start, var_decl.span.start, "");
+
+                // Change `const`/`var` to `let` if needed
+                let keyword_start = var_decl.span.start as usize;
+                let keyword_src = &source[keyword_start..];
+                if keyword_src.starts_with("const ") {
+                    ms.overwrite(var_decl.span.start, var_decl.span.start + 5, "let");
+                } else if keyword_src.starts_with("var ") {
+                    ms.overwrite(var_decl.span.start, var_decl.span.start + 3, "let");
+                }
+
+                export_names.push(ExportName(name));
+            }
+            Declaration::ClassDeclaration(class) => {
+                let Some(ref id) = class.id else { continue };
+                let name = id.name.to_string();
+
+                // `export class Foo {}` → `let Foo = class Foo {};`
+                ms.overwrite(
+                    export.span.start,
+                    class.span.start,
+                    &format!("let {name} = "),
+                );
+                ms.prepend_left(export.span.end, ";");
+
+                export_names.push(ExportName(name));
+            }
+            _ => {}
+        }
+    }
+
+    // Transform re-export statements into import + let bindings.
+    // Names that conflict with existing imports are kept as-is in a residual
+    // re-export statement.
+    for re in &reexport_stmts {
+        // Nothing to transform — leave original statement unchanged
+        if re.names.is_empty() {
+            continue;
+        }
+
+        let import_specs: Vec<String> = re
+            .names
+            .iter()
+            .map(|n| format!("{} as __re_{}", n.imported_name, n.exported_name))
+            .collect();
+        let let_bindings: Vec<String> = re
+            .names
+            .iter()
+            .map(|n| format!("let {} = __re_{};", n.exported_name, n.exported_name))
+            .collect();
+
+        let mut replacement = format!(
+            "import {{ {} }} from '{}';\n{}",
+            import_specs.join(", "),
+            re.source,
+            let_bindings.join("\n"),
+        );
+
+        // If some names were skipped (conflict with imports), add a residual
+        // re-export so the module's public API is preserved.
+        if !re.skipped.is_empty() {
+            let residual_specs: Vec<String> = re
+                .skipped
+                .iter()
+                .map(|s| {
+                    if s.imported_name == s.exported_name {
+                        s.exported_name.clone()
+                    } else {
+                        format!("{} as {}", s.imported_name, s.exported_name)
+                    }
+                })
+                .collect();
+            replacement.push_str(&format!(
+                "\nexport {{ {} }} from '{}';",
+                residual_specs.join(", "),
+                re.source,
+            ));
+        }
+
+        ms.overwrite(re.span_start, re.span_end, &replacement);
+
+        for n in &re.names {
+            export_names.push(ExportName(n.exported_name.clone()));
+        }
+    }
+
+    if export_names.is_empty() {
+        return;
+    }
+
+    // Append grouped export statement
+    let names: Vec<&str> = export_names.iter().map(|e| e.0.as_str()).collect();
+    let export_stmt = format!("\nexport {{ {} }};", names.join(", "));
+
+    // Append __vertz_module_id__ export and setter registration
+    let setters: Vec<String> = export_names
+        .iter()
+        .map(|e| format!("  {}: (__v) => {{ {} = __v; }}", e.0, e.0))
+        .collect();
+
+    let suffix = format!(
+        "{}\nconst __vertz_module_id__ = import.meta.url;\nexport {{ __vertz_module_id__ }};\nglobalThis.__vertz_module_setters ??= {{}};\nglobalThis.__vertz_module_setters[import.meta.url] = {{\n{}\n}};\n",
+        export_stmt,
+        setters.join(",\n"),
+    );
+
+    ms.append(&suffix);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn transform(source: &str) -> String {
+        let allocator = oxc_allocator::Allocator::default();
+        let source_type = SourceType::from_path("test.ts").unwrap_or_default();
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        let mut ms = MagicString::new(source);
+        transform_spy_exports(&mut ms, &ret.program, source);
+        ms.to_string()
+    }
+
+    #[test]
+    fn transforms_export_function() {
+        let source = "export function createAction(opts) { return opts; }";
+        let result = transform(source);
+        assert!(
+            result.contains("let createAction = function createAction(opts) { return opts; };"),
+            "Should convert to let binding: {}",
+            result
+        );
+        assert!(
+            result.contains("export { createAction"),
+            "Should have grouped export: {}",
+            result
+        );
+        assert!(
+            result.contains("__vertz_module_setters"),
+            "Should have setter registration: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn transforms_export_const() {
+        let source = "export const VERSION = '1.0';";
+        let result = transform(source);
+        assert!(
+            result.contains("let VERSION = '1.0'"),
+            "Should change const to let: {}",
+            result
+        );
+        assert!(
+            result.contains("export { VERSION }"),
+            "Should have grouped export: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn transforms_export_class() {
+        let source = "export class Builder { build() {} }";
+        let result = transform(source);
+        assert!(
+            result.contains("let Builder = class Builder { build() {} };"),
+            "Should convert to let binding: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn transforms_reexports() {
+        let source = "export { foo } from './other';";
+        let result = transform(source);
+        assert!(
+            result.contains("import { foo as __re_foo } from './other'"),
+            "Should import re-exported name: {}",
+            result
+        );
+        assert!(
+            result.contains("let foo = __re_foo;"),
+            "Should create let binding: {}",
+            result
+        );
+        assert!(
+            result.contains("export { foo"),
+            "Should have grouped export: {}",
+            result
+        );
+        assert!(
+            result.contains("foo: (__v) => { foo = __v; }"),
+            "Should register setter: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn transforms_reexports_with_rename() {
+        let source = "export { foo as bar } from './other';";
+        let result = transform(source);
+        assert!(
+            result.contains("import { foo as __re_bar } from './other'"),
+            "Should import with original name: {}",
+            result
+        );
+        assert!(
+            result.contains("let bar = __re_bar;"),
+            "Should create let binding with exported name: {}",
+            result
+        );
+        assert!(
+            result.contains("export { bar"),
+            "Should export the renamed binding: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn transforms_multiple_reexports() {
+        let source = "export { foo, bar } from './other';";
+        let result = transform(source);
+        assert!(
+            result.contains("import { foo as __re_foo, bar as __re_bar } from './other'"),
+            "Should import all re-exported names: {}",
+            result
+        );
+        assert!(
+            result.contains("let foo = __re_foo;"),
+            "Should create let binding for foo: {}",
+            result
+        );
+        assert!(
+            result.contains("let bar = __re_bar;"),
+            "Should create let binding for bar: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn skips_export_without_declaration() {
+        let source = "const x = 1;\nexport { x };";
+        let result = transform(source);
+        // Should be unchanged
+        assert_eq!(result, source);
+    }
+
+    #[test]
+    fn skips_reexport_names_conflicting_with_imports() {
+        // When a name is both imported and re-exported, skip the re-export
+        // transform for that name to avoid "has already been declared" errors.
+        let source = "import { foo } from './bar';\nexport { foo, baz } from './bar';";
+        let result = transform(source);
+        // foo should NOT be transformed (conflicts with import)
+        assert!(
+            !result.contains("let foo = __re_foo"),
+            "Should not create let for conflicting import: {}",
+            result
+        );
+        // baz SHOULD be transformed
+        assert!(
+            result.contains("let baz = __re_baz;"),
+            "Should transform non-conflicting name: {}",
+            result
+        );
+        // foo should be preserved in a residual re-export
+        assert!(
+            result.contains("export { foo } from './bar'"),
+            "Should keep conflicting name in residual re-export: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn skips_all_conflicting_reexport() {
+        // When all re-exported names conflict with imports, the entire
+        // re-export statement is left unchanged.
+        let source = "import { foo, bar } from './baz';\nexport { foo, bar } from './baz';";
+        let result = transform(source);
+        assert_eq!(
+            result, source,
+            "Should be unchanged when all names conflict: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn no_transform_when_no_exports() {
+        let source = "const x = 1;\nfunction foo() {}";
+        let result = transform(source);
+        assert_eq!(result, source);
+    }
+
+    #[test]
+    fn registers_setters_for_all_exports() {
+        let source = "export function foo() {}\nexport const bar = 1;";
+        let result = transform(source);
+        assert!(
+            result.contains("foo: (__v) => { foo = __v; }"),
+            "Should register foo setter: {}",
+            result
+        );
+        assert!(
+            result.contains("bar: (__v) => { bar = __v; }"),
+            "Should register bar setter: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn exports_module_id() {
+        let source = "export function foo() {}";
+        let result = transform(source);
+        assert!(
+            result.contains("const __vertz_module_id__ = import.meta.url"),
+            "Should export module id: {}",
+            result
+        );
+        assert!(
+            result.contains("export { __vertz_module_id__ }"),
+            "Should export __vertz_module_id__: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn handles_export_let() {
+        let source = "export let counter = 0;";
+        let result = transform(source);
+        assert!(
+            result.contains("let counter = 0"),
+            "Should keep let: {}",
+            result
+        );
+        assert!(
+            result.contains("export { counter }"),
+            "Should have grouped export: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn full_compile_function_overloads() {
+        // TypeScript function overloads: two signatures + implementation
+        let source = r#"export function matchError(error: string, handlers: object): string;
+export function matchError(error: number, handlers: object): number;
+export function matchError(error: string | number, handlers: object): string | number {
+  return String(error);
+}"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("overload.ts".to_string()),
+                spy_exports: Some(true),
+                ..Default::default()
+            },
+        );
+        let code = &result.code;
+        // Should have exactly one function binding (not three)
+        assert!(
+            code.contains("let matchError = "),
+            "Should have let binding: {}",
+            code
+        );
+        // Should have valid JS
+        assert!(
+            !code.contains("let matchError = ;"),
+            "Should not have empty let binding: {}",
+            code
+        );
+    }
+
+    #[test]
+    fn full_compile_cli_ts_export_function_with_return_type() {
+        // Minimal reproduction: export function with TS return type
+        let source = r#"import { Command } from 'commander';
+export function createCLI(): Command {
+  const program = new Command();
+  return program;
+}
+"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("cli.ts".to_string()),
+                spy_exports: Some(true),
+                ..Default::default()
+            },
+        );
+        let code = &result.code;
+        // Must not contain TS return type
+        assert!(
+            !code.contains(": Command"),
+            "Should strip TS return type: {}",
+            code
+        );
+        // Must have correct let binding
+        assert!(
+            code.contains("let createCLI = "),
+            "Should have let binding: {}",
+            code
+        );
+        // Must not have syntax issues
+        assert!(!code.contains("};};"), "No double semicolons: {}", code);
+    }
+
+    #[test]
+    fn full_compile_cli_create_ts() {
+        // Exact content from packages/cli/src/commands/create.ts
+        let source = r#"import { resolveOptions, scaffold } from '@vertz/create-vertz-app';
+import { err, ok, type Result } from '@vertz/errors';
+
+export interface CreateOptions {
+  projectName?: string;
+  template?: string;
+  version: string;
+}
+
+export async function createAction(options: CreateOptions): Promise<Result<void, Error>> {
+  const { projectName, version } = options;
+  if (!projectName) {
+    return err(new Error('Project name is required'));
+  }
+  return ok(undefined);
+}
+"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("create.ts".to_string()),
+                spy_exports: Some(true),
+                ..Default::default()
+            },
+        );
+        let code = &result.code;
+        // Should not have TS syntax
+        assert!(
+            !code.contains(": CreateOptions"),
+            "Should strip TS param type: {}",
+            code
+        );
+        assert!(
+            !code.contains("Promise<Result"),
+            "Should strip TS return type: {}",
+            code
+        );
+        assert!(
+            code.contains("let createAction = "),
+            "Should have let binding: {}",
+            code
+        );
+    }
+
+    #[test]
+    fn full_compile_with_export_interface_and_async_fn() {
+        // Matches the pattern from packages/cli/src/commands/create.ts
+        let source = r#"import { err, ok, type Result } from '@vertz/errors';
+
+export interface CreateOptions {
+  projectName?: string;
+  version: string;
+}
+
+export async function createAction(options: CreateOptions): Promise<Result<void, Error>> {
+  return ok(undefined);
+}"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("create.ts".to_string()),
+                spy_exports: Some(true),
+                ..Default::default()
+            },
+        );
+        let code = &result.code;
+        // TypeScript should be stripped, export interposition applied
+        assert!(
+            !code.contains("CreateOptions"),
+            "Interface should be stripped: {}",
+            code
+        );
+        assert!(
+            code.contains("let createAction = "),
+            "Should have let binding: {}",
+            code
+        );
+        // No syntax errors — check for common patterns
+        assert!(
+            code.contains("export { createAction"),
+            "Should have grouped export: {}",
+            code
+        );
+    }
+
+    #[test]
+    fn full_compile_with_typescript() {
+        // Test that spy_exports works correctly when combined with TypeScript stripping
+        // via the full compile() pipeline.
+        let source = r#"export function greet(name: string): string { return `Hello ${name}`; }
+export const VERSION: string = '1.0';
+export class Builder<T> { build(): T { return {} as T; } }"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("test.ts".to_string()),
+                spy_exports: Some(true),
+                ..Default::default()
+            },
+        );
+        let code = &result.code;
+        // TypeScript annotations should be stripped
+        assert!(
+            !code.contains(": string"),
+            "Should strip TS annotations: {}",
+            code
+        );
+        // Export interposition should be applied
+        assert!(
+            code.contains("let greet = "),
+            "Should have let binding for greet: {}",
+            code
+        );
+        assert!(
+            code.contains("export { greet"),
+            "Should have grouped export: {}",
+            code
+        );
+        assert!(
+            code.contains("__vertz_module_setters"),
+            "Should have setter registration: {}",
+            code
+        );
+        // Semicolons should be correct — no syntax errors
+        assert!(
+            !code.contains("};};"),
+            "Should not have double semicolons: {}",
+            code
+        );
+    }
+}

--- a/native/vertz-compiler-core/src/typescript_strip.rs
+++ b/native/vertz-compiler-core/src/typescript_strip.rs
@@ -77,8 +77,8 @@ fn get_removable_statement_span(stmt: &Statement) -> Option<(u32, u32)> {
         Statement::VariableDeclaration(decl) if decl.declare => {
             Some((decl.span.start, decl.span.end))
         }
-        // declare function
-        Statement::FunctionDeclaration(func) if func.declare => {
+        // declare function / function overload signature (no body)
+        Statement::FunctionDeclaration(func) if func.declare || func.body.is_none() => {
             Some((func.span.start, func.span.end))
         }
         // declare class
@@ -108,8 +108,10 @@ fn get_removable_statement_span(stmt: &Statement) -> Option<(u32, u32)> {
                     Declaration::VariableDeclaration(vd) if vd.declare => {
                         Some((export_decl.span.start, export_decl.span.end))
                     }
-                    // export declare function
-                    Declaration::FunctionDeclaration(func) if func.declare => {
+                    // export declare function / export function overload signature
+                    Declaration::FunctionDeclaration(func)
+                        if func.declare || func.body.is_none() =>
+                    {
                         Some((export_decl.span.start, export_decl.span.end))
                     }
                     // export declare class

--- a/native/vertz-compiler/src/lib.rs
+++ b/native/vertz-compiler/src/lib.rs
@@ -244,6 +244,7 @@ fn to_core_options(options: Option<CompileOptions>) -> core::CompileOptions {
             prefetch_manifest: opts.prefetch_manifest,
             skip_css_transform: opts.skip_css_transform,
             mock_hoisting: opts.mock_hoisting,
+            spy_exports: None,
         },
     }
 }

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -141,6 +141,7 @@ impl CompilationPipeline {
             root_dir: &self.root_dir,
             src_dir: &self.src_dir,
             target: "dom",
+            test_mode: false,
         };
         let output = self.plugin.compile(&source, &ctx);
 

--- a/native/vtz/src/plugin/mod.rs
+++ b/native/vtz/src/plugin/mod.rs
@@ -158,6 +158,8 @@ pub struct CompileContext<'a> {
     pub src_dir: &'a Path,
     /// "dom" for browser, "ssr" for server rendering.
     pub target: &'a str,
+    /// Whether the test runner is active — enables spy_exports for all modules.
+    pub test_mode: bool,
 }
 
 /// Result of plugin compilation.
@@ -440,6 +442,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         assert_eq!(plugin.post_process("unchanged", &ctx), "unchanged");
     }
@@ -470,6 +473,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile("const x = 1;", &ctx);
         assert_eq!(output.code, "const x = 1;");

--- a/native/vtz/src/plugin/react.rs
+++ b/native/vtz/src/plugin/react.rs
@@ -275,6 +275,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile("export const x: number = 1;", &ctx);
         assert!(
@@ -304,6 +305,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -341,6 +343,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "import React from 'react';\nexport default function App() { return <div>Hello</div>; }",
@@ -369,6 +372,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let source = r#"
             interface ButtonProps {
@@ -409,6 +413,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export function List() { return <><div>A</div><div>B</div></>; }",
@@ -437,6 +442,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile("export const add = (a, b) => a + b;", &ctx);
         assert!(output.diagnostics.is_empty());
@@ -452,6 +458,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile("export function { broken syntax }", &ctx);
         assert!(!output.diagnostics.is_empty(), "Should have parse errors");
@@ -466,6 +473,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export function Spread(props: any) { return <div {...props} />; }",
@@ -493,6 +501,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let source = r#"
             export function Layout() {
@@ -583,6 +592,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function Counter() { return <div>0</div>; }",
@@ -611,6 +621,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         // Component that uses a hook — should get $RefreshSig$ tracking
         let output = plugin.compile(
@@ -648,6 +659,7 @@ mod tests {
             root_dir: root,
             src_dir: src,
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",

--- a/native/vtz/src/plugin/vertz.rs
+++ b/native/vtz/src/plugin/vertz.rs
@@ -32,6 +32,9 @@ impl FrameworkPlugin for VertzPlugin {
                 fast_refresh: Some(!is_test),
                 skip_css_transform: Some(is_test),
                 mock_hoisting: Some(is_test),
+                // Enable spy_exports for ALL modules in test mode so spyOn()
+                // can replace ESM exports via live binding setters.
+                spy_exports: Some(ctx.test_mode),
                 ..Default::default()
             },
         );
@@ -210,6 +213,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile("export const x = 1;", &ctx);
         assert!(output.code.contains("const x = 1"));
@@ -224,6 +228,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -247,6 +252,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let code = "const x = 1;\nimport.meta.hot.accept();\nconst y = 2;";
         let result = plugin.post_process(code, &ctx);
@@ -263,6 +269,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let code = "const __$moduleId = '/project/src/app.tsx';";
         let result = plugin.post_process(code, &ctx);
@@ -349,6 +356,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "ssr",
+            test_mode: false,
         };
         let source = r#"const styles = css({ root: ['flex', 'p:4'] });"#;
         let output = plugin.compile(source, &ctx);
@@ -371,6 +379,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "ssr",
+            test_mode: false,
         };
         let source = r#"const styles = css({ root: ['flex'] });"#;
         let output = plugin.compile(source, &ctx);
@@ -389,6 +398,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "ssr",
+            test_mode: false,
         };
         let source = r#"const styles = css({ root: ['flex'] });"#;
         let output = plugin.compile(source, &ctx);
@@ -407,6 +417,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "ssr",
+            test_mode: false,
         };
         let source = r#"const styles = css({ root: ['flex'] });"#;
         let output = plugin.compile(source, &ctx);
@@ -444,6 +455,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -469,6 +481,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -489,6 +502,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -509,6 +523,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -529,6 +544,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -549,6 +565,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -569,6 +586,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "ssr",
+            test_mode: false,
         };
         let source = r#"const styles = css({ root: ['flex', 'p:4'] });"#;
         let output = plugin.compile(source, &ctx);

--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -253,14 +253,18 @@ impl VertzJsRuntime {
                 .to_string_lossy()
                 .to_string()
         });
-        let module_loader = Rc::new(VertzModuleLoader::new_with_shared_cache(
+        let mut loader = VertzModuleLoader::new_with_shared_cache(
             &root_dir,
             cache_enabled,
             options.plugin.clone(),
             options.shared_source_cache.clone(),
             options.v8_code_cache.clone(),
             options.resolution_cache.clone(),
-        ));
+        );
+        // Enable test mode so all compiled modules get export interposition
+        // for spyOn() support on ESM exports.
+        loader.set_test_mode(true);
+        let module_loader = Rc::new(loader);
         let snapshot = crate::test::snapshot::get_test_snapshot();
 
         let mut runtime = JsRuntime::new(RuntimeOptions {

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -72,6 +72,18 @@ pub struct VertzModuleLoader {
     /// Key: directory path, Value: `true` if the directory has a package.json with `"type": "module"`.
     /// Missing key means "not yet checked".
     pkg_type_cache: RefCell<HashMap<PathBuf, Option<bool>>>,
+    /// Whether this loader is running in test mode (vtz test).
+    /// When true, all compiled modules get export interposition for spyOn() support.
+    test_mode: bool,
+    /// Export names collected from mock factory return values (JS side).
+    /// Used for proxy generation when `extract_export_names` can't find ESM exports
+    /// (e.g., CJS modules like esbuild).
+    /// Key: raw specifier, Value: export names from the mock factory object.
+    mock_export_names: RefCell<HashMap<String, Vec<String>>>,
+    /// Bare specifiers that are mocked (e.g., "esbuild").
+    /// Checked in resolve() BEFORE synthetic module intercepts, so mocked modules
+    /// take priority over built-in polyfills.
+    mocked_bare_specifiers: RefCell<HashSet<String>>,
 }
 
 impl VertzModuleLoader {
@@ -88,6 +100,9 @@ impl VertzModuleLoader {
             v8_code_cache: None,
             resolution_cache: None,
             pkg_type_cache: RefCell::new(HashMap::new()),
+            test_mode: false,
+            mock_export_names: RefCell::new(HashMap::new()),
+            mocked_bare_specifiers: RefCell::new(HashSet::new()),
         }
     }
 
@@ -109,6 +124,9 @@ impl VertzModuleLoader {
             v8_code_cache: None,
             resolution_cache: None,
             pkg_type_cache: RefCell::new(HashMap::new()),
+            test_mode: false,
+            mock_export_names: RefCell::new(HashMap::new()),
+            mocked_bare_specifiers: RefCell::new(HashSet::new()),
         }
     }
 
@@ -134,7 +152,23 @@ impl VertzModuleLoader {
             v8_code_cache,
             resolution_cache,
             pkg_type_cache: RefCell::new(HashMap::new()),
+            test_mode: false,
+            mock_export_names: RefCell::new(HashMap::new()),
+            mocked_bare_specifiers: RefCell::new(HashSet::new()),
         }
+    }
+
+    /// Enable test mode — all compiled modules get export interposition for spyOn().
+    pub fn set_test_mode(&mut self, enabled: bool) {
+        self.test_mode = enabled;
+    }
+
+    /// Register export names discovered from mock factory return values.
+    /// Used for proxy generation when the original module has no ESM exports.
+    pub fn register_mock_export_names(&self, specifier: &str, names: Vec<String>) {
+        self.mock_export_names
+            .borrow_mut()
+            .insert(specifier.to_string(), names);
     }
 
     /// Register modules that should be mocked (transitive mocking).
@@ -147,6 +181,11 @@ impl VertzModuleLoader {
         test_file_path: &Path,
     ) {
         for specifier in specifiers {
+            // Track bare specifiers so resolve() can skip synthetic module
+            // intercepts for mocked modules (e.g., esbuild).
+            self.mocked_bare_specifiers
+                .borrow_mut()
+                .insert(specifier.clone());
             match self.resolve_specifier(specifier, test_file_path) {
                 Ok(resolved) => {
                     let canonical = self.canonicalize_cached(&resolved);
@@ -181,6 +220,7 @@ impl VertzModuleLoader {
             root_dir: &self.root_dir,
             src_dir: &src_dir,
             target: "ssr",
+            test_mode: self.test_mode,
         };
         self.plugin.compile(source, &ctx)
     }
@@ -638,10 +678,14 @@ impl VertzModuleLoader {
     fn compile_source(&self, source: &str, filename: &str) -> Result<String, AnyError> {
         let target = "ssr";
         let is_test = crate::test::is_test_file(Path::new(filename));
+        // In test mode, enable spy_exports for ALL modules (not just test files)
+        // so spyOn() can replace ESM exports via live binding setters.
+        let spy_exports = self.test_mode;
         let options_hash = format!(
-            "css:{},mock:{}",
-            is_test as u8, // skip_css_transform
-            is_test as u8, // mock_hoisting
+            "css:{},mock:{},spy:{}",
+            is_test as u8,     // skip_css_transform
+            is_test as u8,     // mock_hoisting
+            spy_exports as u8, // spy_exports
         );
         let file_path = PathBuf::from(filename);
 
@@ -701,6 +745,7 @@ impl VertzModuleLoader {
             root_dir: &self.root_dir,
             src_dir: &src_dir,
             target,
+            test_mode: self.test_mode,
         };
 
         let output = self.plugin.compile(source, &ctx);
@@ -2306,11 +2351,6 @@ fn generate_mock_proxy_module(specifier: &str, export_names: &[String]) -> Strin
         }
     }
 
-    // If no default export was extracted but the mock has one, add it
-    if !export_names.iter().any(|n| n == "default") {
-        code.push_str("if ('default' in __m) {{ /* default handled by named exports */ }}\n");
-    }
-
     code
 }
 
@@ -3705,26 +3745,35 @@ impl ModuleLoader for VertzModuleLoader {
         referrer: &str,
         _kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, deno_core::anyhow::Error> {
-        // Intercept @vertz/test and bun:test → synthetic vertz:test module
-        if specifier == "@vertz/test" || specifier == "bun:test" {
-            return Ok(ModuleSpecifier::parse(VERTZ_TEST_SPECIFIER)?);
-        }
+        // If this specifier is mocked, skip ALL synthetic intercepts and fall
+        // through to normal resolution → mocked_paths check. This ensures
+        // vi.mock('esbuild', factory) takes priority over built-in polyfills.
+        let is_mocked = self.mocked_bare_specifiers.borrow().contains(specifier);
 
-        // Intercept vertz:sqlite (canonical), @vertz/sqlite (npm), and bun:sqlite (compat)
-        // → synthetic SQLite module
-        if specifier == "vertz:sqlite" || specifier == "@vertz/sqlite" || specifier == "bun:sqlite"
-        {
-            return Ok(ModuleSpecifier::parse(VERTZ_SQLITE_SPECIFIER)?);
-        }
+        if !is_mocked {
+            // Intercept @vertz/test and bun:test → synthetic vertz:test module
+            if specifier == "@vertz/test" || specifier == "bun:test" {
+                return Ok(ModuleSpecifier::parse(VERTZ_TEST_SPECIFIER)?);
+            }
 
-        // Intercept esbuild → synthetic esbuild module
-        if specifier == "esbuild" {
-            return Ok(ModuleSpecifier::parse(ESBUILD_SPECIFIER)?);
-        }
+            // Intercept vertz:sqlite (canonical), @vertz/sqlite (npm), and bun:sqlite (compat)
+            // → synthetic SQLite module
+            if specifier == "vertz:sqlite"
+                || specifier == "@vertz/sqlite"
+                || specifier == "bun:sqlite"
+            {
+                return Ok(ModuleSpecifier::parse(VERTZ_SQLITE_SPECIFIER)?);
+            }
 
-        // Intercept node:* specifiers → synthetic modules
-        if let Some(synthetic) = node_specifier_to_synthetic(specifier) {
-            return Ok(ModuleSpecifier::parse(synthetic)?);
+            // Intercept esbuild → synthetic esbuild module
+            if specifier == "esbuild" {
+                return Ok(ModuleSpecifier::parse(ESBUILD_SPECIFIER)?);
+            }
+
+            // Intercept node:* specifiers → synthetic modules
+            if let Some(synthetic) = node_specifier_to_synthetic(specifier) {
+                return Ok(ModuleSpecifier::parse(synthetic)?);
+            }
         }
 
         // Internal synthetic module references
@@ -3842,7 +3891,16 @@ impl ModuleLoader for VertzModuleLoader {
 
                 // Read the original source to discover export names
                 let source_text = std::fs::read_to_string(&path).unwrap_or_default();
-                let export_names = extract_export_names(&source_text);
+                let mut export_names = extract_export_names(&source_text);
+
+                // Fallback: use export names from the mock factory object (JS side).
+                // This handles CJS modules (e.g., esbuild) where extract_export_names
+                // can't find ESM exports.
+                if export_names.is_empty() {
+                    if let Some(names) = self.mock_export_names.borrow().get(&mock_specifier) {
+                        export_names = names.clone();
+                    }
+                }
 
                 let proxy = generate_mock_proxy_module(&mock_specifier, &export_names);
                 return Ok(ModuleSource::new(

--- a/native/vtz/src/test/config.rs
+++ b/native/vtz/src/test/config.rs
@@ -78,6 +78,7 @@ pub fn load_test_config(root_dir: &Path) -> Result<TestConfig, AnyError> {
             root_dir,
             src_dir: &src_dir,
             target: "ssr",
+            test_mode: false,
         };
         let output = plugin.compile(&source, &ctx);
         output.code

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -293,6 +293,39 @@ fn execute_test_file_inner(
             if let Some(ref preamble) = output.mock_preamble {
                 runtime.execute_script_void("[vertz:mock-preamble]", preamble)?;
             }
+
+            // Collect mock export names from factory return values.
+            // This is needed for proxy generation when the original module has no
+            // ESM exports (e.g., CJS modules like esbuild).
+            let export_names_result = runtime.execute_script(
+                "[vertz:mock-export-names]",
+                r#"(function() {
+                    var result = {};
+                    var mocks = globalThis.__vertz_mocked_modules || {};
+                    for (var spec in mocks) {
+                        if (mocks.hasOwnProperty(spec) && mocks[spec] && typeof mocks[spec] === 'object') {
+                            result[spec] = Object.keys(mocks[spec]);
+                        }
+                    }
+                    return result;
+                })()"#,
+            )?;
+
+            if let serde_json::Value::Object(map) = export_names_result {
+                for (specifier, keys) in map {
+                    if let serde_json::Value::Array(arr) = keys {
+                        let names: Vec<String> = arr
+                            .into_iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect();
+                        if !names.is_empty() {
+                            runtime
+                                .loader()
+                                .register_mock_export_names(&specifier, names);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -257,12 +257,31 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     }
     const original = obj[method];
     const spy = createMockFunction((...args) => original.apply(obj, args));
-    spy.mockRestore = () => {
-      obj[method] = original;
-      spy.mockReset();
-      return spy;
-    };
-    obj[method] = spy;
+
+    // Check if the target has an ESM module ID (set by spy_exports transform).
+    // If so, use the registered setter for live binding replacement — direct
+    // property assignment on module namespace objects is blocked by V8.
+    const moduleId = obj.__vertz_module_id__;
+    const setter = moduleId
+      && globalThis.__vertz_module_setters
+      && globalThis.__vertz_module_setters[moduleId]
+      && globalThis.__vertz_module_setters[moduleId][method];
+
+    if (setter) {
+      setter(spy);
+      spy.mockRestore = () => {
+        setter(original);
+        spy.mockReset();
+        return spy;
+      };
+    } else {
+      spy.mockRestore = () => {
+        obj[method] = original;
+        spy.mockReset();
+        return spy;
+      };
+      obj[method] = spy;
+    }
     return spy;
   }
 
@@ -1258,6 +1277,7 @@ if (typeof globalThis.HTMLElement === 'undefined') {
   // Dynamic `import()` returns frozen Module namespace objects. spyOn() needs to
   // replace properties on them, which fails. This wrapper delegates reads to the
   // original module (preserving live bindings) while allowing property writes.
+  const __unwrapCache = new WeakMap();
   globalThis.__vertz_unwrap_module = (mod) => {
     if (!mod || typeof mod !== 'object') return mod;
     // Fast path: if already mutable, return as-is
@@ -1266,6 +1286,9 @@ if (typeof globalThis.HTMLElement === 'undefined') {
       const desc = Object.getOwnPropertyDescriptor(mod, keys[0]);
       if (desc && desc.writable && desc.configurable) return mod;
     }
+    // Return cached wrapper if we've seen this module before
+    const cached = __unwrapCache.get(mod);
+    if (cached) return cached;
     // Create mutable wrapper — reads delegate to original, writes stored locally
     const overrides = Object.create(null);
     const wrapper = Object.create(null);
@@ -1277,6 +1300,7 @@ if (typeof globalThis.HTMLElement === 'undefined') {
         enumerable: true,
       });
     }
+    __unwrapCache.set(mod, wrapper);
     return wrapper;
   };
 


### PR DESCRIPTION
## Summary

Fixes #2700 — `vi.mock()` and `spyOn()` were ineffective on ESM module exports in the vtz test runner, breaking ~30 CLI action tests.

### Three changes fix the issue:

- **spy_exports compiler transform** (`native/vertz-compiler-core/src/spy_exports.rs`): Converts `export` declarations to mutable `let` bindings with setter registration on `globalThis.__vertz_module_setters`, enabling `spyOn()` to replace exports on ESM module namespaces. Handles named exports, re-exports from barrel files, and skips conflicting names. Only runs in test mode.

- **Mock proxy generation for CJS/opaque modules**: For modules like `esbuild` whose exports can't be statically analyzed, collects export names from the mock factory return value at runtime and generates proxy modules with those names.

- **`mocked_bare_specifiers` in module loader**: Tracks which bare specifiers are mocked so `resolve()` skips synthetic module intercepts (esbuild, node:* polyfills) for mocked modules, preventing `vi.mock()` from being silently bypassed.

## Public API Changes

None — all changes are internal to the test runner and compiler.

## Files changed

- [`native/vertz-compiler-core/src/spy_exports.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-esm-mock-spy/native/vertz-compiler-core/src/spy_exports.rs) — New spy_exports transform (18 tests)
- [`native/vertz-compiler-core/src/lib.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-esm-mock-spy/native/vertz-compiler-core/src/lib.rs) — Wire spy_exports into compilation pipeline
- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-esm-mock-spy/native/vtz/src/runtime/module_loader.rs) — Mock proxy generation, mocked_bare_specifiers, mock_export_names
- [`native/vtz/src/test/executor.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-esm-mock-spy/native/vtz/src/test/executor.rs) — Pre-compile test files for mock extraction, evaluate preambles
- [`native/vtz/src/test/globals.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-esm-mock-spy/native/vtz/src/test/globals.rs) — Enhanced spyOn() with setter support, __vertz_unwrap_module

## Test plan

- [x] `packages/cli/src/__tests__/cli.test.ts` — 63/63 pass (was 0/63)
- [x] `packages/cli/src/commands/__tests__/build.test.ts` — 19/19 pass
- [x] `packages/cli/src/pipeline/__tests__/orchestrator.test.ts` — 19/19 pass (was 0/19)
- [x] All 3402 Rust unit tests pass
- [x] Cargo clippy clean (0 warnings)
- [x] Cargo fmt clean
- [x] Zero regressions vs main (614 pass / 31 fail — same 31 pre-existing failures)

## Known limitations

- `export default` declarations are not intercepted by spy_exports (spyOn on default exports)
- `export * from` re-exports are not intercepted (requires cross-file analysis)
- These are future enhancements, not regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)