### PR TITLE
fix(vtz): make preload mock.module() effective for module resolution (#2667)

### DIFF
--- a/native/vtz/src/plugin/vertz.rs
+++ b/native/vtz/src/plugin/vertz.rs
@@ -751,6 +751,7 @@ mod tests {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"/* @jsxRuntime classic */
 /* @jsx h */
@@ -783,6 +784,7 @@ export function Card({ title }) {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"/* @jsxRuntime classic */
 /* @jsx h */
@@ -809,6 +811,7 @@ export function Minimal({ title }) {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let output = plugin.compile(
             "export default function App() { return <div>Hello</div>; }",
@@ -830,6 +833,7 @@ export function Minimal({ title }) {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"/* @jsx h */
 import { h } from './h';
@@ -861,6 +865,7 @@ export function Card({ title }: Props) {
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"// @jsx h
 import { h } from './h';
@@ -882,6 +887,7 @@ export function X() { return <div />; }
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"/** @jsx h */
 import { h } from './h';
@@ -903,6 +909,7 @@ export function X() { return <div />; }
             root_dir: Path::new("/project"),
             src_dir: Path::new("/project/src"),
             target: "dom",
+            test_mode: false,
         };
         let source = r#"/*
  * @jsxRuntime classic

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -543,8 +543,14 @@ impl VertzModuleLoader {
                 let trimmed = entry.trim_start_matches("./");
                 // Strip dist/ prefix to get source-relative path
                 if let Some(source_rel) = trimmed.strip_prefix("dist/") {
+                    // Try direct mapping: dist/X → X (handles dist/src/X → src/X)
                     let source_candidate = pkg_dir.join(source_rel);
                     if let Ok(resolved) = self.resolve_with_extensions(&source_candidate) {
+                        return Ok(resolved);
+                    }
+                    // Try src/ prefix: dist/X → src/X (handles dist/auth/public.js → src/auth/public.ts)
+                    let src_candidate = pkg_dir.join("src").join(source_rel);
+                    if let Ok(resolved) = self.resolve_with_extensions(&src_candidate) {
                         return Ok(resolved);
                     }
                 }
@@ -3928,7 +3934,19 @@ impl ModuleLoader for VertzModuleLoader {
             }
         }
 
-        let resolved_path = self.resolve_specifier(specifier, &referrer_path)?;
+        let resolved_path = match self.resolve_specifier(specifier, &referrer_path) {
+            Ok(path) => path,
+            Err(e) => {
+                // If resolution fails but the specifier is mocked (e.g., module doesn't
+                // physically exist — only the mock factory), return a mock URL using the
+                // bare specifier. This supports mocking packages that aren't installed.
+                if is_mocked {
+                    let mock_url = format!("{}bare:{}", VERTZ_MOCK_PREFIX, specifier);
+                    return Ok(ModuleSpecifier::parse(&mock_url)?);
+                }
+                return Err(e);
+            }
+        };
 
         // Canonicalize to ensure same physical file = same module URL.
         // This prevents instanceof failures across ES module boundaries when the
@@ -3975,6 +3993,24 @@ impl ModuleLoader for VertzModuleLoader {
 
             // Handle mocked modules (transitive mocking)
             if let Some(original_path) = specifier.as_str().strip_prefix(VERTZ_MOCK_PREFIX) {
+                // Bare specifier mock: module doesn't physically exist, only the mock
+                // factory was registered (e.g., mocking a package that isn't installed).
+                if let Some(bare_specifier) = original_path.strip_prefix("bare:") {
+                    let export_names = self
+                        .mock_export_names
+                        .borrow()
+                        .get(bare_specifier)
+                        .cloned()
+                        .unwrap_or_default();
+                    let proxy = generate_mock_proxy_module(bare_specifier, &export_names);
+                    return Ok(ModuleSource::new(
+                        ModuleType::JavaScript,
+                        ModuleSourceCode::String(proxy.into()),
+                        &specifier,
+                        None,
+                    ));
+                }
+
                 let path = PathBuf::from(original_path);
                 let mock_specifier = self
                     .mocked_paths
@@ -5172,6 +5208,57 @@ export function Hello() {
             result
         );
         assert_eq!(result.unwrap().to_file_path().unwrap(), canon(&src_entry));
+    }
+
+    #[test]
+    fn test_symlinked_workspace_subpath_resolves_to_source() {
+        // Given a workspace package symlinked in node_modules with subpath exports
+        // pointing to dist/ (e.g., "./auth": "./dist/auth/public.js")
+        // When the dist/ directory doesn't exist but src/auth/public.ts does
+        // Then the resolver should fall back to src/ and resolve correctly (#2667)
+        let tmp = create_temp_dir();
+
+        // Create the real package (e.g., packages/ui)
+        let real_pkg_dir = tmp.path().join("packages").join("ui");
+        let src_dir = real_pkg_dir.join("src").join("auth");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let src_file = src_dir.join("public.ts");
+        std::fs::write(&src_file, "export const AuthProvider = {};").unwrap();
+
+        std::fs::write(
+            real_pkg_dir.join("package.json"),
+            r#"{ "name": "@scope/ui", "exports": { "./auth": { "import": "./dist/auth/public.js" } } }"#,
+        )
+        .unwrap();
+
+        // No dist/ directory — package not built
+
+        // Create a symlink in node_modules (workspace package)
+        let nm_scope = tmp.path().join("node_modules").join("@scope");
+        std::fs::create_dir_all(&nm_scope).unwrap();
+        let nm_pkg = nm_scope.join("ui");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_pkg_dir, &nm_pkg).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&real_pkg_dir, &nm_pkg).unwrap();
+
+        // Create a consumer package (e.g., packages/ui-server)
+        let consumer_dir = tmp.path().join("packages").join("ui-server").join("src");
+        std::fs::create_dir_all(&consumer_dir).unwrap();
+        let test_file = consumer_dir.join("app.test.ts");
+        std::fs::write(&test_file, "import '@scope/ui/auth';").unwrap();
+
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
+        let referrer = ModuleSpecifier::from_file_path(&test_file).unwrap();
+        let result = loader.resolve("@scope/ui/auth", referrer.as_str(), ResolutionKind::Import);
+
+        assert!(
+            result.is_ok(),
+            "Symlinked workspace subpath should resolve to source when dist/ missing: {:?}",
+            result
+        );
+        assert_eq!(result.unwrap().to_file_path().unwrap(), canon(&src_file));
     }
 
     // ---------------------------------------------------------------

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -293,13 +293,14 @@ fn execute_test_file_inner(
             if let Some(ref preamble) = output.mock_preamble {
                 runtime.execute_script_void("[vertz:mock-preamble]", preamble)?;
             }
+        }
 
-            // Collect mock export names from factory return values.
-            // This is needed for proxy generation when the original module has no
-            // ESM exports (e.g., CJS modules like esbuild).
-            let export_names_result = runtime.execute_script(
-                "[vertz:mock-export-names]",
-                r#"(function() {
+        // Collect mock export names from ALL mocked modules (both preload and test file).
+        // This runs unconditionally because preload scripts may have registered mocks
+        // even when the test file itself has no vi.mock() calls. (#2667)
+        let export_names_result = runtime.execute_script(
+            "[vertz:mock-export-names]",
+            r#"(function() {
                     var result = {};
                     var mocks = globalThis.__vertz_mocked_modules || {};
                     for (var spec in mocks) {
@@ -309,20 +310,19 @@ fn execute_test_file_inner(
                     }
                     return result;
                 })()"#,
-            )?;
+        )?;
 
-            if let serde_json::Value::Object(map) = export_names_result {
-                for (specifier, keys) in map {
-                    if let serde_json::Value::Array(arr) = keys {
-                        let names: Vec<String> = arr
-                            .into_iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect();
-                        if !names.is_empty() {
-                            runtime
-                                .loader()
-                                .register_mock_export_names(&specifier, names);
-                        }
+        if let serde_json::Value::Object(map) = export_names_result {
+            for (specifier, keys) in map {
+                if let serde_json::Value::Array(arr) = keys {
+                    let names: Vec<String> = arr
+                        .into_iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect();
+                    if !names.is_empty() {
+                        runtime
+                            .loader()
+                            .register_mock_export_names(&specifier, names);
                     }
                 }
             }
@@ -1000,6 +1000,61 @@ mod tests {
             result.file_error
         );
         assert_eq!(result.passed(), 2, "Both preload mocks should be effective");
+        assert_eq!(result.failed(), 0);
+    }
+
+    #[test]
+    fn test_preload_mock_nonexistent_package() {
+        // Mocking a package that doesn't exist on disk (e.g., @vertz/ui-auth
+        // which is a circular dep not installed). The preload registers the mock
+        // and the test file should be able to import it via bare mock proxy. (#2667)
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        // NO @fake/pkg directory anywhere — it doesn't exist on disk
+
+        // Preload mocks the nonexistent package
+        let preload = write_test_file(
+            base,
+            "preload-phantom.ts",
+            r#"
+            vi.mock('@fake/pkg', () => ({ Widget: () => 'mocked-widget' }));
+            "#,
+        );
+
+        // Test file imports from the nonexistent package — should get mock
+        let test_file = write_test_file(
+            base,
+            "phantom.test.ts",
+            r#"
+            import { Widget } from '@fake/pkg';
+
+            describe('nonexistent package mock', () => {
+                it('receives mocked export from preload', () => {
+                    expect(Widget()).toBe('mocked-widget');
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                preload: vec![preload],
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(
+            result.passed(),
+            1,
+            "Mock of nonexistent package should work"
+        );
         assert_eq!(result.failed(), 0);
     }
 

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -1059,6 +1059,57 @@ mod tests {
     }
 
     #[test]
+    fn test_preload_mock_nonexistent_subpath_package() {
+        // Mocking a subpath specifier that doesn't exist on disk
+        // (e.g., @fake/pkg/auth). The bare mock URL should use the full
+        // specifier including the subpath for lookup. (#2667)
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        let preload = write_test_file(
+            base,
+            "preload-subpath.ts",
+            r#"
+            vi.mock('@fake/pkg/auth', () => ({ Guard: () => 'guarded' }));
+            "#,
+        );
+
+        let test_file = write_test_file(
+            base,
+            "subpath.test.ts",
+            r#"
+            import { Guard } from '@fake/pkg/auth';
+
+            describe('nonexistent subpath mock', () => {
+                it('receives mocked subpath export', () => {
+                    expect(Guard()).toBe('guarded');
+                });
+            });
+            "#,
+        );
+
+        let result = execute_test_file_with_options(
+            &test_file,
+            &ExecuteOptions {
+                preload: vec![preload],
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.file_error.is_none(),
+            "File error: {:?}",
+            result.file_error
+        );
+        assert_eq!(
+            result.passed(),
+            1,
+            "Mock of nonexistent subpath package should work"
+        );
+        assert_eq!(result.failed(), 0);
+    }
+
+    #[test]
     fn test_root_dir_affects_bun_cache_resolution() {
         // The module loader's Bun cache fallback starts from `self.root_dir`.
         // When root_dir is the workspace root (not the test file's parent),


### PR DESCRIPTION
## Summary

Fixes #2667 — `mock.module()` calls from preload scripts were not effective because the test runner only integrated mocks extracted at compile time from the test file itself.

**Three independent root causes fixed:**

- **Bare mock resolution** — When `resolve_specifier()` fails for a mocked-but-unresolvable package (e.g., `@vertz/ui-auth` which doesn't exist on disk), the resolver now falls back to a synthetic `vertz:mock:bare:<specifier>` URL and generates a proxy module from `globalThis.__vertz_mocked_modules`
- **Export names collection** — Moved the mock export names IIFE outside the `if !output.mocked_specifiers.is_empty()` guard so preload-only mocks (where the test file has no `vi.mock()` calls) get their exports registered
- **Workspace subpath `src/` fallback** — Added `pkg_dir/src/<rel>` fallback in `resolve_self_reference_source()` for packages whose export map points to `dist/` but only `src/` exists (e.g., `@vertz/ui` subpath `./auth`)

Also fixes 7 missing `test_mode: false` fields in `vertz.rs` test `CompileContext` initializers (introduced by PR #2711).

## Files Changed

- [`native/vtz/src/runtime/module_loader.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-mock-module-preload/native/vtz/src/runtime/module_loader.rs) — bare mock URL scheme in `resolve()`, bare mock proxy generation in `load()`, `src/` fallback in `resolve_self_reference_source()`
- [`native/vtz/src/test/executor.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-mock-module-preload/native/vtz/src/test/executor.rs) — moved export names collection outside guard, added 2 new tests
- [`native/vtz/src/plugin/vertz.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/fix-mock-module-preload/native/vtz/src/plugin/vertz.rs) — added `test_mode: false` to 7 CompileContext test initializers

## Test Plan

- [x] `test_preload_mock_nonexistent_package` — mocks a bare specifier (`@fake/pkg`) from preload, verifies proxy module works
- [x] `test_preload_mock_nonexistent_subpath_package` — mocks a subpath specifier (`@fake/pkg/sub`) from preload
- [x] `test_symlinked_workspace_subpath_resolves_to_source` — cross-package subpath resolution via symlink when dist/ missing
- [x] All 4900+ Rust tests pass (`cargo test --all`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] 3 of 4 affected TS test files pass (node-handler.test.ts times out due to pre-existing `node:http` issue unrelated to mocks)

## Review

Adversarial review completed: `reviews/fix-mock-module-preload/phase-01-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)