### PR TITLE
fix(native): resolve clippy warnings for Rust 1.95 CI

### DIFF
--- a/native/vertz-compiler-core/src/aot_string_transformer.rs
+++ b/native/vertz-compiler-core/src/aot_string_transformer.rs
@@ -1555,10 +1555,8 @@ impl ReactiveDetector<'_> {
             return;
         }
         match expr {
-            Expression::Identifier(id) => {
-                if self.reactive_names.contains(id.name.as_str()) {
-                    self.found = true;
-                }
+            Expression::Identifier(id) if self.reactive_names.contains(id.name.as_str()) => {
+                self.found = true;
             }
             Expression::StaticMemberExpression(member) => {
                 self.check_expr(&member.object);

--- a/native/vertz-compiler-core/src/component_analyzer.rs
+++ b/native/vertz-compiler-core/src/component_analyzer.rs
@@ -131,20 +131,16 @@ fn check_expression_for_component<'a>(
 ) {
     match expr {
         // const Foo = () => <div/>;
-        Expression::ArrowFunctionExpression(arrow) => {
-            if arrow_contains_jsx(arrow) {
-                let (start, end) = arrow_body_range(arrow);
-                components.push(ComponentInfo {
-                    name: name.to_string(),
-                    body_start: start,
-                    body_end: end,
-                    is_arrow_expression: arrow.expression,
-                    props_param: extract_props_param_from_items(&arrow.params.items),
-                    destructured_prop_names: extract_destructured_props_from_items(
-                        &arrow.params.items,
-                    ),
-                });
-            }
+        Expression::ArrowFunctionExpression(arrow) if arrow_contains_jsx(arrow) => {
+            let (start, end) = arrow_body_range(arrow);
+            components.push(ComponentInfo {
+                name: name.to_string(),
+                body_start: start,
+                body_end: end,
+                is_arrow_expression: arrow.expression,
+                props_param: extract_props_param_from_items(&arrow.params.items),
+                destructured_prop_names: extract_destructured_props_from_items(&arrow.params.items),
+            });
         }
 
         // const Foo = function() { return <div/>; };

--- a/native/vertz-compiler-core/src/css_transform.rs
+++ b/native/vertz-compiler-core/src/css_transform.rs
@@ -49,7 +49,7 @@ pub fn transform_css(ms: &mut MagicString, program: &Program, file_path: &str) -
 
     // Process in reverse order so positions remain valid
     let mut sorted_calls = calls;
-    sorted_calls.sort_by(|a, b| b.start.cmp(&a.start));
+    sorted_calls.sort_by_key(|b| std::cmp::Reverse(b.start));
 
     for call in &sorted_calls {
         if call.kind != CssCallKind::Static {

--- a/native/vertz-compiler-core/src/mutation_transformer.rs
+++ b/native/vertz-compiler-core/src/mutation_transformer.rs
@@ -9,7 +9,7 @@ pub fn transform_mutations(ms: &mut MagicString, mutations: &[MutationInfo]) {
 
     // Process mutations in reverse order (end-to-start) to preserve positions
     let mut sorted: Vec<&MutationInfo> = mutations.iter().collect();
-    sorted.sort_by(|a, b| b.start.cmp(&a.start));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.start));
 
     for mutation in sorted {
         let original_text = ms.slice(mutation.start, mutation.end);

--- a/native/vertz-compiler-core/src/route_splitting.rs
+++ b/native/vertz-compiler-core/src/route_splitting.rs
@@ -538,10 +538,8 @@ fn visit_identifiers_in_expr(
     }
 
     match expr {
-        Expression::Identifier(ident) => {
-            if ident.name == symbol_name {
-                *found = true;
-            }
+        Expression::Identifier(ident) if ident.name == symbol_name => {
+            *found = true;
         }
         Expression::CallExpression(call) => {
             visit_identifiers_in_call_expr(call, symbol_name, factory_spans, found);
@@ -589,15 +587,11 @@ fn visit_identifiers_in_expr(
         Expression::JSXElement(jsx) => {
             // Check tag name
             match &jsx.opening_element.name {
-                JSXElementName::Identifier(ident) => {
-                    if ident.name == symbol_name {
-                        *found = true;
-                    }
+                JSXElementName::Identifier(ident) if ident.name == symbol_name => {
+                    *found = true;
                 }
-                JSXElementName::IdentifierReference(ident) => {
-                    if ident.name == symbol_name {
-                        *found = true;
-                    }
+                JSXElementName::IdentifierReference(ident) if ident.name == symbol_name => {
+                    *found = true;
                 }
                 _ => {}
             }

--- a/native/vtz/src/ci/changes.rs
+++ b/native/vtz/src/ci/changes.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::{Path, PathBuf};
 
@@ -218,7 +219,7 @@ pub fn map_files_to_packages(files: &[PathBuf], workspace: &ResolvedWorkspace) -
         pkg_paths.push((cr.path.as_path(), name.as_str()));
     }
     // Sort by path length descending so longest prefix matches first.
-    pkg_paths.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+    pkg_paths.sort_by_key(|a| Reverse(a.0.components().count()));
 
     let mut directly_changed = BTreeSet::new();
     let mut root_changed = false;

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -755,15 +755,11 @@ fn strip_leftover_typescript(code: &str) -> String {
         // Track nesting context with a stack
         match chars[i] {
             '(' | '{' => nesting_stack.push(chars[i]),
-            ')' => {
-                if nesting_stack.last() == Some(&'(') {
-                    nesting_stack.pop();
-                }
+            ')' if nesting_stack.last() == Some(&'(') => {
+                nesting_stack.pop();
             }
-            '}' => {
-                if nesting_stack.last() == Some(&'{') {
-                    nesting_stack.pop();
-                }
+            '}' if nesting_stack.last() == Some(&'{') => {
+                nesting_stack.pop();
             }
             _ => {}
         }

--- a/native/vtz/src/deps/resolve.rs
+++ b/native/vtz/src/deps/resolve.rs
@@ -215,10 +215,8 @@ fn resolve_condition_value(
     for key in &["import", "node", "module", "default", "require"] {
         if let Some(val) = conditions.get(*key) {
             match val {
-                serde_json::Value::String(s) => {
-                    if is_safe_export_target(s) {
-                        return Some(s.clone());
-                    }
+                serde_json::Value::String(s) if is_safe_export_target(s) => {
+                    return Some(s.clone());
                 }
                 serde_json::Value::Object(nested) => {
                     // Nested conditions (e.g., import: { types: "...", default: "..." })

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -3093,7 +3093,7 @@ async fn discover_stale_optional_deps(
     }
 
     // Batch-fetch metadata concurrently (ETag-cached, no network cost for cached entries)
-    let results: Vec<_> = stream::iter(candidates.into_iter())
+    let results: Vec<_> = stream::iter(candidates)
         .map(|(name, version)| {
             let reg = registry;
             async move {

--- a/native/vtz/src/pm/overrides.rs
+++ b/native/vtz/src/pm/overrides.rs
@@ -133,7 +133,7 @@ pub fn parse_overrides(
     }
 
     // Sort by specificity: longer parent_path first (more specific wins during matching)
-    rules.sort_by(|a, b| b.parent_path.len().cmp(&a.parent_path.len()));
+    rules.sort_by_key(|r| std::cmp::Reverse(r.parent_path.len()));
 
     Ok(OverrideMap { rules })
 }

--- a/native/vtz/src/runtime/signal_graph.rs
+++ b/native/vtz/src/runtime/signal_graph.rs
@@ -580,16 +580,14 @@ impl SignalGraph {
     /// Effect subscribers are queued for batch flush.
     fn schedule_notify(&mut self, subscriber_id: u32) {
         match self.nodes.get(subscriber_id as usize) {
-            Some(SignalNode::Computed { state, .. }) => {
-                if *state != ComputedState::Dirty {
-                    self.mark_computed_dirty(subscriber_id);
-                }
+            Some(SignalNode::Computed { state, .. }) if *state != ComputedState::Dirty => {
+                self.mark_computed_dirty(subscriber_id);
             }
-            Some(SignalNode::Effect { disposed, .. }) => {
-                if !disposed && !self.effect_scheduled[subscriber_id as usize] {
-                    self.effect_scheduled.set(subscriber_id as usize, true);
-                    self.pending_effects.push(subscriber_id);
-                }
+            Some(SignalNode::Effect { disposed, .. })
+                if !disposed && !self.effect_scheduled[subscriber_id as usize] =>
+            {
+                self.effect_scheduled.set(subscriber_id as usize, true);
+                self.pending_effects.push(subscriber_id);
             }
             _ => {}
         }

--- a/native/vtz/src/server/api_proxy.rs
+++ b/native/vtz/src/server/api_proxy.rs
@@ -99,7 +99,7 @@ impl ProxyConfig {
         }
 
         // Sort by prefix length descending so longest match wins.
-        rules.sort_by(|a, b| b.prefix.len().cmp(&a.prefix.len()));
+        rules.sort_by_key(|r| std::cmp::Reverse(r.prefix.len()));
 
         let client = reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(5))

--- a/native/vtz/src/server/inspector.rs
+++ b/native/vtz/src/server/inspector.rs
@@ -208,6 +208,8 @@ async fn handle_ws_connection(state: InspectorState, socket: WebSocket) {
     let mut forward_task = tokio::spawn(async move {
         while let Some(Ok(msg)) = ws_receiver.next().await {
             match msg {
+                // Cannot collapse into match guard: `text` is moved by unbounded_send()
+                #[allow(clippy::collapsible_match)]
                 Message::Text(text) => {
                     if forward_tx.unbounded_send(text).is_err() {
                         break;


### PR DESCRIPTION
## Summary

Fixes clippy warnings that appear on CI (Rust 1.95.0) but not with older local toolchains. Both `vertz-compiler-core` and `vtz` crates affected.

- Collapse `if`-in-`match` to match guards — `clippy::collapsible_match` (8 instances, 1 allowed where value is moved)
- Use `sort_by_key` with `Reverse` instead of `sort_by` — `clippy::unnecessary_sort_by` (5 instances)
- Remove unnecessary `.into_iter()` — `clippy::useless_conversion` (1 instance)

Discovered while working on #2713.

## Files Changed

**vertz-compiler-core:**
- `native/vertz-compiler-core/src/aot_string_transformer.rs`
- `native/vertz-compiler-core/src/component_analyzer.rs`
- `native/vertz-compiler-core/src/css_transform.rs`
- `native/vertz-compiler-core/src/mutation_transformer.rs`
- `native/vertz-compiler-core/src/route_splitting.rs`

**vtz:**
- `native/vtz/src/ci/changes.rs`
- `native/vtz/src/compiler/pipeline.rs`
- `native/vtz/src/deps/resolve.rs`
- `native/vtz/src/pm/mod.rs`
- `native/vtz/src/pm/overrides.rs`
- `native/vtz/src/runtime/signal_graph.rs`
- `native/vtz/src/server/api_proxy.rs`
- `native/vtz/src/server/inspector.rs`

## Test plan

- [x] `cargo test --all` — all Rust tests pass
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)