### PR TITLE
fix(vtz): unblock build/CI pipeline — scheduler pipe deadlock + changeset/release pipeline

### DIFF
--- a/.changeset/fix-ci-scheduler-pipe-deadlock.md
+++ b/.changeset/fix-ci-scheduler-pipe-deadlock.md
@@ -1,0 +1,9 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): drain child stdout/stderr concurrently in ci scheduler to avoid pipe-buffer deadlock
+
+`vtz ci test` reported packages as `FAILED (exit -1) timeout after 120000ms` even when the underlying test run completed in seconds. Root cause: `execute_command` in the ci scheduler read the child process's piped stdout/stderr only *after* `child.wait()` returned. Once either pipe filled (~16KB on macOS, ~64KB on Linux), the child blocked on its next `write()`, waiting for the parent to drain — which never happened until after `wait()`. Any real test suite emitting more than a few KB of output hit this.
+
+Fixed by draining stdout and stderr concurrently with the wait via `tokio::join!`, including inside the timeout-wrapped branch. Two regression tests generate 512KB of output on stdout and stderr respectively; both complete in ms now.

--- a/.changeset/fix-jwks-jwt-verification.md
+++ b/.changeset/fix-jwks-jwt-verification.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(vtz): resolve JWKS-based JWT verification returning null in full chain

--- a/.changeset/fix-shorthand-method-import.md
+++ b/.changeset/fix-shorthand-method-import.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(compiler): shorthand method definitions no longer trigger false import injection

--- a/.changeset/fix-timer-float-bigint.md
+++ b/.changeset/fix-timer-float-bigint.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(vtz): floor float delay before BigInt conversion in setTimeout/setInterval

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,12 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "ignorePatterns": ["**/.vertz/**", "**/CHANGELOG.md", "**/.tmp-*/**", "**/cli/my-app/**"]
+  "ignorePatterns": [
+    "**/.vertz/**",
+    "**/CHANGELOG.md",
+    "**/.tmp-*/**",
+    "**/cli/my-app/**",
+    "**/coverage/**",
+    "**/dist/**"
+  ]
 }

--- a/native/vtz/src/ci/scheduler.rs
+++ b/native/vtz/src/ci/scheduler.rs
@@ -954,11 +954,31 @@ async fn execute_command(
     let stdout_handle = child.stdout.take();
     let stderr_handle = child.stderr.take();
 
+    // Drain stdout and stderr concurrently with wait(). Otherwise the child
+    // deadlocks once either pipe buffer fills (64KB on Linux, 16KB on macOS)
+    // because the parent isn't reading. This killed `vtz ci test` on any
+    // package emitting more than ~16KB of test output.
+    async fn drain<R: tokio::io::AsyncRead + Unpin>(reader: Option<R>) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        if let Some(mut r) = reader {
+            let _ = r.read_to_end(&mut buf).await;
+        }
+        buf
+    }
+
+    let stdout_fut = drain(stdout_handle);
+    let stderr_fut = drain(stderr_handle);
+
     let result = if let Some(timeout_ms) = timeout {
         let duration = std::time::Duration::from_millis(timeout_ms);
-        match tokio::time::timeout(duration, child.wait()).await {
-            Ok(Ok(status)) => Ok(status),
-            Ok(Err(e)) => Err(e.to_string()),
+        let joined = async {
+            let (status, out, err) = tokio::join!(child.wait(), stdout_fut, stderr_fut);
+            (status, out, err)
+        };
+        match tokio::time::timeout(duration, joined).await {
+            Ok((Ok(status), out, err)) => Ok((status, out, err)),
+            Ok((Err(e), _, _)) => Err(e.to_string()),
             Err(_) => {
                 let _ = child.kill().await;
                 let _ = child.wait().await;
@@ -966,7 +986,8 @@ async fn execute_command(
             }
         }
     } else {
-        child.wait().await.map_err(|e| e.to_string())
+        let (status, out, err) = tokio::join!(child.wait(), stdout_fut, stderr_fut);
+        status.map(|s| (s, out, err)).map_err(|e| e.to_string())
     };
 
     // Unregister PID using the value captured before wait()
@@ -975,25 +996,12 @@ async fn execute_command(
     }
 
     match result {
-        Ok(exit_status) => {
+        Ok((exit_status, stdout_bytes, stderr_bytes)) => {
             let code = exit_status.code();
             let success = exit_status.success();
 
-            let mut stdout_str = String::new();
-            let mut stderr_str = String::new();
-
-            if let Some(mut handle) = stdout_handle {
-                use tokio::io::AsyncReadExt;
-                let mut buf = Vec::new();
-                let _ = handle.read_to_end(&mut buf).await;
-                stdout_str = String::from_utf8_lossy(&buf).to_string();
-            }
-            if let Some(mut handle) = stderr_handle {
-                use tokio::io::AsyncReadExt;
-                let mut buf = Vec::new();
-                let _ = handle.read_to_end(&mut buf).await;
-                stderr_str = String::from_utf8_lossy(&buf).to_string();
-            }
+            let stdout_str = String::from_utf8_lossy(&stdout_bytes).to_string();
+            let stderr_str = String::from_utf8_lossy(&stderr_bytes).to_string();
 
             if success {
                 (TaskStatus::Success, code, stdout_str, stderr_str)
@@ -1148,6 +1156,48 @@ mod tests {
         .await;
         assert_eq!(status, TaskStatus::Success);
         assert!(stderr.contains("error_msg"));
+    }
+
+    #[tokio::test]
+    async fn execute_command_does_not_deadlock_on_large_stdout() {
+        // Regression: child was blocking on stdout write once the pipe buffer
+        // filled (~64KB on Linux, ~16KB on macOS) because the parent only read
+        // the pipes *after* wait(). Any task that emits more than the buffer
+        // size would hang until the task timeout killed it (e.g. `vtz test`
+        // emitting thousands of passing test lines).
+        //
+        // Fix: drain stdout and stderr concurrently with child.wait().
+        //
+        // Produce ~512KB on stdout to exceed the pipe buffer on all platforms.
+        // With a 5s timeout, a deadlocked impl fails with "timeout"; a correct
+        // impl completes in milliseconds.
+        let (status, code, stdout, _) = execute_command_no_signal(
+            "yes 'x' | head -c 524288",
+            Path::new("."),
+            &BTreeMap::new(),
+            Some(5_000),
+            &[],
+        )
+        .await;
+        assert_eq!(status, TaskStatus::Success, "should not hit timeout");
+        assert_eq!(code, Some(0));
+        assert_eq!(stdout.len(), 524_288);
+    }
+
+    #[tokio::test]
+    async fn execute_command_does_not_deadlock_on_large_stderr() {
+        // Same as above but on stderr — both pipes can independently deadlock.
+        let (status, code, _, stderr) = execute_command_no_signal(
+            "yes 'e' | head -c 524288 >&2",
+            Path::new("."),
+            &BTreeMap::new(),
+            Some(5_000),
+            &[],
+        )
+        .await;
+        assert_eq!(status, TaskStatus::Success, "should not hit timeout");
+        assert_eq!(code, Some(0));
+        assert_eq!(stderr.len(), 524_288);
     }
 
     #[tokio::test]

--- a/packages/ui/src/__tests__/subpath-exports.test.ts
+++ b/packages/ui/src/__tests__/subpath-exports.test.ts
@@ -10,6 +10,16 @@ import { resolve } from 'node:path';
  * missing exports and accidental internal symbol leaks.
  */
 
+// The test-mode compiler's spy_exports transform appends this infrastructure
+// export to every compiled module to support spyOn() on ESM live bindings.
+// It's not part of the public API and is absent from production dist builds.
+const COMPILER_INFRA_EXPORTS = ['__vertz_module_id__'];
+function publicExports(mod: object): string[] {
+  return Object.keys(mod)
+    .filter((k) => !COMPILER_INFRA_EXPORTS.includes(k))
+    .sort();
+}
+
 describe('Subpath Exports — @vertz/ui/router', () => {
   const expectedExports = [
     'Link',
@@ -28,7 +38,7 @@ describe('Subpath Exports — @vertz/ui/router', () => {
 
   test('exports exactly the public API (no internal leaks)', async () => {
     const mod = await import('../router/public');
-    const actualExports = Object.keys(mod).sort();
+    const actualExports = publicExports(mod);
     expect(actualExports).toEqual(expectedExports);
   });
 
@@ -74,7 +84,7 @@ describe('Subpath Exports — @vertz/ui/form', () => {
 
   test('exports exactly the public API (no internal leaks)', async () => {
     const mod = await import('../form/public');
-    const actualExports = Object.keys(mod).sort();
+    const actualExports = publicExports(mod);
     expect(actualExports).toEqual(expectedExports);
   });
 
@@ -100,7 +110,7 @@ describe('Subpath Exports — @vertz/ui/query', () => {
 
   test('exports exactly the public API (no internal leaks)', async () => {
     const mod = await import('../query/public');
-    const actualExports = Object.keys(mod).sort();
+    const actualExports = publicExports(mod);
     expect(actualExports).toEqual(expectedExports);
   });
 
@@ -141,7 +151,7 @@ describe('Subpath Exports — @vertz/ui/css', () => {
 
   test('exports exactly the public API (no internal leaks)', async () => {
     const mod = await import('../css/public');
-    const actualExports = Object.keys(mod).sort();
+    const actualExports = publicExports(mod);
     expect(actualExports).toEqual(expectedExports);
   });
 


### PR DESCRIPTION
## Summary

CI on `main` has been broken across ~13 packages. Investigation split the failures into two classes:
1. **Version drift** — CI uses the last published `@vertz/runtime` (0.2.64); source is at 0.2.65 with fixes. Resolves automatically once 0.2.65 publishes.
2. **Real bugs in the build/release pipeline** — fixed in this PR.

## Fixes

### 1. `native/vtz/src/ci/scheduler.rs` — drain stdout/stderr concurrently
`execute_command` read child process pipes only **after** `child.wait()`, so any task emitting >16KB of output (every real test suite) deadlocked on the pipe buffer. `vtz ci test` reported packages as `FAILED (exit -1) timeout after 120000ms` when the underlying run actually completed in seconds.

Fix: drain both pipes concurrently with wait via `tokio::join!`. Two regression tests generate 512KB on stdout and stderr respectively; both complete in ms.

### 2. `.changeset/*` — unblock the Release workflow
Three changesets referenced package `vtz` (not in workspace). `changesets/action@v1` failed every `Release` run with:

```
🦋 error Found changeset fix-jwks-jwt-verification for package vtz which is not in the workspace
```

Renamed to `@vertz/runtime` in the three broken changesets + added one for this PR's scheduler fix.

### 3. `packages/ui/src/__tests__/subpath-exports.test.ts` — filter compiler infra
The test-mode `spy_exports` compiler transform appends `__vertz_module_id__` to every module. The subpath barrel tests did strict `Object.keys` equality, catching infra as an "internal leak". Added a `publicExports()` helper that filters compiler-injected exports. Production dist is unaffected.

### 4. `.oxfmtrc.json` — ignore coverage/ and dist/
`oxfmt --check packages/` in the pre-push hook picked up `packages/ui-canvas/coverage/*.html` (gitignored, but not in oxfmt's ignore list) and blocked pushes whenever a developer ran coverage locally.

## Results

**Before:** `vtz ci test` → 7 packages FAILED exit -1 / 120s timeout.
**After:** 3 pre-existing individual test failures unrelated to this PR (tracked in #2718, #2719, #2720).

## Follow-up: release 0.2.65

Once this merges, the `Release` workflow should open a Version PR including all pending changesets (9 existing + 1 from this PR). Merging that publishes `@vertz/runtime@0.2.66` (or 0.2.65 if the Version PR targets the current `version.txt`), which unblocks CI's version-drift failures automatically.

## Known-fail tests (pre-existing, not in this PR's scope)

- #2718 — `@vertz/ui-server/node-handler.test.ts` + `image-processor.test.ts` (node:http + NAPI/sharp runtime gaps)
- #2719 — `@vertz/cli/docs.test.ts` + `start.test.ts` (vi.mock factory + executor IPC deserialization)
- #2720 — `@vertz/docs/docs-cli-actions.test.ts` (happy-dom GlobalRegistrator state across preload→test)

These all fail on `main` at `ac13a99fe` as well. The pre-push hook was bypassed for this push with explicit authorization — the PR fixes the very pipeline that unblocks CI; the remaining failures are independent.

## Test plan

- [x] `cargo test --package vtz --lib ci::scheduler::tests` — 7/7 pass, including two new deadlock regression tests
- [x] `cargo clippy -p vtz --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `oxlint packages/` + `oxfmt --check packages/` clean
- [x] `vtz ci test --scope @vertz/ui --concurrency 1` — passes in 3.8s (was 120s timeout)
- [x] `vtz test packages/ui/src/__tests__/subpath-exports.test.ts` — 26/26 pass
- [x] Full `vtz ci test --concurrency 4` — only the 3 tracked pre-existing failures remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)