### PR TITLE
fix(changesets): add missing CHANGELOG.md to native-compiler platform packages

### DIFF
--- a/packages/native-compiler-darwin-arm64/CHANGELOG.md
+++ b/packages/native-compiler-darwin-arm64/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @vertz/native-compiler-darwin-arm64
+
+## 0.2.65

--- a/packages/native-compiler-darwin-x64/CHANGELOG.md
+++ b/packages/native-compiler-darwin-x64/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @vertz/native-compiler-darwin-x64
+
+## 0.2.65

--- a/packages/native-compiler-linux-arm64/CHANGELOG.md
+++ b/packages/native-compiler-linux-arm64/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @vertz/native-compiler-linux-arm64
+
+## 0.2.65

--- a/packages/native-compiler-linux-x64/CHANGELOG.md
+++ b/packages/native-compiler-linux-x64/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @vertz/native-compiler-linux-x64
+
+## 0.2.65


### PR DESCRIPTION
## Summary

Release workflow on `main` was failing with:

```
Error: ENOENT: no such file or directory, open
'/home/runner/work/vertz/vertz/packages/native-compiler-darwin-arm64/CHANGELOG.md'
```

`changesets/action@v1` opens the CHANGELOG.md of every workspace package when preparing a Version PR. The four `@vertz/native-compiler-*` platform packages didn't have one (unlike `@vertz/runtime-*` platform packages, which did).

## Why this blocked the Version PR

After #2721 landed and fixed the `'vtz' not in workspace` changeset issue, the release action got further — far enough to start reading CHANGELOG.md files for every package in the workspace. Four missing files → ENOENT → Version PR never created.

## Fix

Added a starter CHANGELOG.md to each of:
- `packages/native-compiler-darwin-arm64/CHANGELOG.md`
- `packages/native-compiler-darwin-x64/CHANGELOG.md`
- `packages/native-compiler-linux-arm64/CHANGELOG.md`
- `packages/native-compiler-linux-x64/CHANGELOG.md`

Matches the format of the existing `packages/runtime-*` CHANGELOGs. `scripts/version.sh` already syncs the platform packages' version numbers out-of-band, so no `fixed`-group change is needed.

## Test plan

- [ ] Release workflow succeeds after merge
- [ ] Version PR is opened with all ~10 pending changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)