### PR TITLE
fix(agents): propagate userId/tenantId to sub-agents via ctx.agents.invoke (#2717)

### DIFF
--- a/.changeset/fix-agents-sub-agent-auth.md
+++ b/.changeset/fix-agents-sub-agent-auth.md
@@ -1,0 +1,11 @@
+---
+'@vertz/agents': patch
+---
+
+fix(agents): propagate `userId`/`tenantId` to sub-agents via `ctx.agents.invoke()`
+
+Previously, `ctx.agents.invoke()` dropped the caller's identity, so every sub-agent ran with `null` `userId` and `tenantId` — a privilege-confusion bug where sub-agent tools saw no authenticated user regardless of the caller's context.
+
+Sub-agents now inherit the parent's identity by default. An optional `as: { userId?, tenantId? }` override on `invoke()` lets a tool handler explicitly rescope a sub-run (set a field to `null` to drop it entirely).
+
+`userId` and `tenantId` are now accepted on all `run()` calls — not only when a store is provided — so stateless callers can also thread identity through.

--- a/packages/agents/src/run.test.ts
+++ b/packages/agents/src/run.test.ts
@@ -762,6 +762,85 @@ describe('run()', () => {
       });
     });
 
+    describe('Given a 3-level chain (A → B → C)', () => {
+      it('Then identity propagates through each level', async () => {
+        let grandchildUserId: string | null | undefined;
+        let grandchildTenantId: string | null | undefined;
+
+        const grandchild = agent('grandchild', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          onStart(ctx) {
+            grandchildUserId = ctx.userId;
+            grandchildTenantId = ctx.tenantId;
+          },
+        });
+
+        const invokeGrandchild = tool({
+          description: 'Invoke grandchild',
+          input: s.object({}),
+          output: s.object({ ok: s.boolean() }),
+          async handler(_input, ctx) {
+            await ctx.agents.invoke(grandchild, { message: 'deep' });
+            return { ok: true };
+          },
+        });
+
+        const child = agent('middle', {
+          state: s.object({}),
+          initialState: {},
+          tools: { invokeGrandchild },
+          model: { provider: 'cloudflare', model: 'test' },
+        });
+
+        const invokeChild = tool({
+          description: 'Invoke middle',
+          input: s.object({}),
+          output: s.object({ ok: s.boolean() }),
+          async handler(_input, ctx) {
+            await ctx.agents.invoke(child, { message: 'middle' });
+            return { ok: true };
+          },
+        });
+
+        const parent = agent('root', {
+          state: s.object({}),
+          initialState: {},
+          tools: { invokeChild },
+          model: { provider: 'cloudflare', model: 'test' },
+        });
+
+        const llm: LLMAdapter = {
+          async chat(messages) {
+            const systemMsg = messages.find((m) => m.role === 'system')?.content ?? '';
+            if (systemMsg.includes('grandchild')) return { text: 'c done', toolCalls: [] };
+            const userMsg = messages.find((m) => m.role === 'user')?.content ?? '';
+            const hasToolResults = messages.some((m) => m.role === 'tool');
+            if (hasToolResults) return { text: 'done', toolCalls: [] };
+            if (systemMsg.includes('middle')) {
+              return { text: '', toolCalls: [{ name: 'invokeGrandchild', arguments: {} }] };
+            }
+            if (userMsg.includes('run')) {
+              return { text: '', toolCalls: [{ name: 'invokeChild', arguments: {} }] };
+            }
+            return { text: 'done', toolCalls: [] };
+          },
+        };
+
+        await run(parent, {
+          message: 'run',
+          llm,
+          userId: 'user-deep',
+          tenantId: 'tenant-deep',
+        });
+
+        expect(grandchildUserId).toBe('user-deep');
+        expect(grandchildTenantId).toBe('tenant-deep');
+      });
+    });
+
     describe('Given a parent run with no identity', () => {
       it('Then the child also has null userId and tenantId (no fabrication)', async () => {
         let childUserId: string | null | undefined;

--- a/packages/agents/src/run.test.ts
+++ b/packages/agents/src/run.test.ts
@@ -640,6 +640,182 @@ describe('run()', () => {
         expect(invokeResult!.response).toBe('I am agent B');
       });
     });
+
+    describe('Given a parent run with userId and tenantId', () => {
+      it('Then the child inherits both by default', async () => {
+        let childUserId: string | null | undefined;
+        let childTenantId: string | null | undefined;
+
+        const childAgent = agent('child', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          onStart(ctx) {
+            childUserId = ctx.userId;
+            childTenantId = ctx.tenantId;
+          },
+        });
+
+        const invokeChild = tool({
+          description: 'Invoke child',
+          input: s.object({}),
+          output: s.object({ ok: s.boolean() }),
+          async handler(_input, ctx) {
+            await ctx.agents.invoke(childAgent, { message: 'go' });
+            return { ok: true };
+          },
+        });
+
+        const parentAgent = agent('parent', {
+          state: s.object({}),
+          initialState: {},
+          tools: { invokeChild },
+          model: { provider: 'cloudflare', model: 'test' },
+        });
+
+        let callCount = 0;
+        const llm: LLMAdapter = {
+          async chat(messages) {
+            callCount++;
+            const systemMsg = messages.find((m) => m.role === 'system')?.content ?? '';
+            if (systemMsg.includes('child')) {
+              return { text: 'child done', toolCalls: [] };
+            }
+            if (callCount === 1) {
+              return { text: '', toolCalls: [{ name: 'invokeChild', arguments: {} }] };
+            }
+            return { text: 'parent done', toolCalls: [] };
+          },
+        };
+
+        await run(parentAgent, {
+          message: 'run',
+          llm,
+          userId: 'user-123',
+          tenantId: 'tenant-A',
+        });
+
+        expect(childUserId).toBe('user-123');
+        expect(childTenantId).toBe('tenant-A');
+      });
+
+      it('Then an explicit `as` override replaces the inherited identity', async () => {
+        let childUserId: string | null | undefined;
+        let childTenantId: string | null | undefined;
+
+        const childAgent = agent('child-override', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          onStart(ctx) {
+            childUserId = ctx.userId;
+            childTenantId = ctx.tenantId;
+          },
+        });
+
+        const invokeChild = tool({
+          description: 'Invoke child with override',
+          input: s.object({}),
+          output: s.object({ ok: s.boolean() }),
+          async handler(_input, ctx) {
+            await ctx.agents.invoke(childAgent, {
+              message: 'go',
+              as: { userId: null, tenantId: 'tenant-B' },
+            });
+            return { ok: true };
+          },
+        });
+
+        const parentAgent = agent('parent-override', {
+          state: s.object({}),
+          initialState: {},
+          tools: { invokeChild },
+          model: { provider: 'cloudflare', model: 'test' },
+        });
+
+        let callCount = 0;
+        const llm: LLMAdapter = {
+          async chat(messages) {
+            callCount++;
+            const systemMsg = messages.find((m) => m.role === 'system')?.content ?? '';
+            if (systemMsg.includes('child-override')) {
+              return { text: 'child done', toolCalls: [] };
+            }
+            if (callCount === 1) {
+              return { text: '', toolCalls: [{ name: 'invokeChild', arguments: {} }] };
+            }
+            return { text: 'parent done', toolCalls: [] };
+          },
+        };
+
+        await run(parentAgent, {
+          message: 'run',
+          llm,
+          userId: 'user-123',
+          tenantId: 'tenant-A',
+        });
+
+        expect(childUserId).toBeNull();
+        expect(childTenantId).toBe('tenant-B');
+      });
+    });
+
+    describe('Given a parent run with no identity', () => {
+      it('Then the child also has null userId and tenantId (no fabrication)', async () => {
+        let childUserId: string | null | undefined;
+        let childTenantId: string | null | undefined;
+
+        const childAgent = agent('child-null', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          onStart(ctx) {
+            childUserId = ctx.userId;
+            childTenantId = ctx.tenantId;
+          },
+        });
+
+        const invokeChild = tool({
+          description: 'Invoke child',
+          input: s.object({}),
+          output: s.object({ ok: s.boolean() }),
+          async handler(_input, ctx) {
+            await ctx.agents.invoke(childAgent, { message: 'go' });
+            return { ok: true };
+          },
+        });
+
+        const parentAgent = agent('parent-null', {
+          state: s.object({}),
+          initialState: {},
+          tools: { invokeChild },
+          model: { provider: 'cloudflare', model: 'test' },
+        });
+
+        let callCount = 0;
+        const llm: LLMAdapter = {
+          async chat(messages) {
+            callCount++;
+            const systemMsg = messages.find((m) => m.role === 'system')?.content ?? '';
+            if (systemMsg.includes('child-null')) {
+              return { text: 'child done', toolCalls: [] };
+            }
+            if (callCount === 1) {
+              return { text: '', toolCalls: [{ name: 'invokeChild', arguments: {} }] };
+            }
+            return { text: 'parent done', toolCalls: [] };
+          },
+        };
+
+        await run(parentAgent, { message: 'run', llm });
+
+        expect(childUserId).toBeNull();
+        expect(childTenantId).toBeNull();
+      });
+    });
   });
 
   describe('Given a ToolProvider with handler implementations', () => {

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -29,6 +29,17 @@ interface RunOptionsBase {
    * extra provider entries are ignored.
    */
   readonly tools?: ToolProvider;
+  /**
+   * Identity of the caller. Propagates to `ctx.userId` inside the agent and to
+   * any sub-agents invoked via `ctx.agents.invoke()`. Also used for session
+   * ownership checks when a store is provided.
+   */
+  readonly userId?: string | null;
+  /**
+   * Tenant of the caller. Propagates to `ctx.tenantId` and is used for session
+   * scoping when a store is provided.
+   */
+  readonly tenantId?: string | null;
 }
 
 /** Stateless mode — no persistence. Same as current behavior. */
@@ -43,10 +54,6 @@ export interface RunOptionsWithStore extends RunOptionsBase {
   readonly sessionId?: string;
   /** Cap per session (default: 200). */
   readonly maxStoredMessages?: number;
-  /** User ID for session ownership. */
-  readonly userId?: string | null;
-  /** Tenant ID for session scoping. */
-  readonly tenantId?: string | null;
 }
 
 export type RunOptions = RunOptionsStateless | RunOptionsWithStore;
@@ -137,8 +144,8 @@ export async function run(
 ): Promise<StatelessLoopResult | SessionLoopResult> {
   const { message, llm, instanceId } = options;
   const agentId = instanceId ?? crypto.randomUUID();
-  const userId = hasStore(options) ? (options.userId ?? null) : null;
-  const tenantId = hasStore(options) ? (options.tenantId ?? null) : null;
+  const userId = options.userId ?? null;
+  const tenantId = options.tenantId ?? null;
 
   // --- Session handling (load or create) ---
   let sessionId: string | undefined;
@@ -213,18 +220,31 @@ export async function run(
     options.tools,
   );
 
-  // Build agent invoker for ctx.agents.invoke()
+  // Build agent invoker for ctx.agents.invoke().
+  // Sub-agents inherit the parent's identity by default; an explicit `as`
+  // override can substitute either field (set to `null` to drop identity).
   const agents = {
     async invoke(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- agent definitions have varying types
       targetAgent: AgentDefinition<any, any, any>,
-      invokeOpts: { message: string; instanceId?: string },
+      invokeOpts: {
+        message: string;
+        instanceId?: string;
+        as?: { userId?: string | null; tenantId?: string | null };
+      },
     ) {
+      const childUserId =
+        invokeOpts.as && 'userId' in invokeOpts.as ? (invokeOpts.as.userId ?? null) : userId;
+      const childTenantId =
+        invokeOpts.as && 'tenantId' in invokeOpts.as ? (invokeOpts.as.tenantId ?? null) : tenantId;
+
       const invokeResult = await run(targetAgent, {
         message: invokeOpts.message,
         llm,
         instanceId: invokeOpts.instanceId,
         tools: options.tools, // inherit tool provider for sub-agents
+        userId: childUserId,
+        tenantId: childTenantId,
       });
       return { response: invokeResult.response };
     },

--- a/packages/agents/src/types.test-d.ts
+++ b/packages/agents/src/types.test-d.ts
@@ -360,3 +360,35 @@ void checkInvoke;
 // InvokeOptions requires message
 const _invokeOpts: InvokeOptions = { message: 'test' };
 void _invokeOpts;
+
+// InvokeOptions accepts `as` identity override
+const _invokeWithAs: InvokeOptions = {
+  message: 'test',
+  as: { userId: 'u', tenantId: 't' },
+};
+void _invokeWithAs;
+
+// `as` fields are nullable (explicit drop of identity)
+const _invokeWithNullAs: InvokeOptions = {
+  message: 'test',
+  as: { userId: null, tenantId: null },
+};
+void _invokeWithNullAs;
+
+// `as` fields are independently optional
+const _invokeWithPartialAs: InvokeOptions = {
+  message: 'test',
+  as: { userId: 'u' },
+};
+void _invokeWithPartialAs;
+
+// @ts-expect-error — userId must be string | null, not number
+const _badAsType: InvokeOptions = { message: 'test', as: { userId: 42 } };
+void _badAsType;
+
+// Top-level run() accepts userId and tenantId on stateless calls
+run(testAgent, { message: 'hi', llm: testLlm, userId: 'u1', tenantId: 't1' });
+run(testAgent, { message: 'hi', llm: testLlm, userId: null, tenantId: null });
+
+// @ts-expect-error — userId must be string | null, not number
+run(testAgent, { message: 'hi', llm: testLlm, userId: 42 });

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -48,10 +48,22 @@ export interface ToolConfig<
   readonly parallel?: boolean;
 }
 
+/** Identity override when invoking a sub-agent. */
+export interface InvokeIdentity {
+  readonly userId?: string | null;
+  readonly tenantId?: string | null;
+}
+
 /** Options for invoking another agent. */
 export interface InvokeOptions {
   readonly message: string;
   readonly instanceId?: string;
+  /**
+   * Override the identity of the sub-run. When omitted, the sub-agent inherits
+   * the caller's `userId` and `tenantId`. Provide `as` to explicitly override
+   * either field (set to `null` to drop the identity entirely).
+   */
+  readonly as?: InvokeIdentity;
 }
 
 /** Agent invocation capability on tool context. */

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -48,7 +48,13 @@ export interface ToolConfig<
   readonly parallel?: boolean;
 }
 
-/** Identity override when invoking a sub-agent. */
+/**
+ * Identity override for a sub-agent run.
+ *
+ * Each field is independently optional: if omitted, the corresponding field is
+ * inherited from the caller. If present (including with value `null`), the
+ * provided value replaces the inherited one.
+ */
 export interface InvokeIdentity {
   readonly userId?: string | null;
   readonly tenantId?: string | null;
@@ -60,8 +66,13 @@ export interface InvokeOptions {
   readonly instanceId?: string;
   /**
    * Override the identity of the sub-run. When omitted, the sub-agent inherits
-   * the caller's `userId` and `tenantId`. Provide `as` to explicitly override
-   * either field (set to `null` to drop the identity entirely).
+   * the caller's `userId` and `tenantId`. Provide `as` to replace either field
+   * (use `null` to drop the identity entirely).
+   *
+   * Note on trust model: tool handlers are server code authored by the agent
+   * owner and treated as trusted. A handler that passes `as: { userId: 'x' }`
+   * is impersonating identity `x` by design — use `as` only when intentionally
+   * scoping a sub-agent to a different (typically lower-privilege) identity.
    */
   readonly as?: InvokeIdentity;
 }


### PR DESCRIPTION
## Summary

Sub-agents invoked via `ctx.agents.invoke()` previously ran with `null` `userId`/`tenantId` regardless of the caller's identity — a privilege-confusion bug where sub-agent tools and access checks saw no authenticated user even when the parent run had one. Closes #2717.

## Public API Changes

**Additions (non-breaking):**
- `RunOptions.userId` and `RunOptions.tenantId` are now accepted on `run()` in **both** stateless and session modes (previously only session mode). Callers without a store can now thread identity through.
- `InvokeOptions.as?: { userId?: string | null; tenantId?: string | null }` — override the inherited identity on a sub-agent invocation. Omit to inherit; set a field to `null` to drop.

**Behavior change (bug fix):**
- `ctx.agents.invoke(childAgent, { message })` now propagates the parent's `userId`/`tenantId` to the child by default. Prior behavior (always `null`) was incorrect.

No breaking type changes — `userId`/`tenantId` moved from `RunOptionsWithStore` up to `RunOptionsBase`, which is additive.

## Test plan
- [x] BDD scenario: parent with `userId`/`tenantId` → child inherits both (`run.test.ts`)
- [x] BDD scenario: explicit `as` override replaces inherited identity, including `null` to drop
- [x] BDD scenario: no parent identity → child has `null`/`null` (no fabrication)
- [x] Deep nesting: A → B → C propagation verified
- [x] Type-level: `as` optional, fields nullable, partial shape accepted, wrong-type rejected
- [x] Local quality gates green: `vtz test` (197 pass, 13 skipped), typecheck clean, lint clean, format clean
- [x] Adversarial review: approved with follow-ups addressed (changeset, 3-level test, trust-model JSDoc)

## Trust model note
`as` lets a tool handler intentionally rescope a sub-run to a different identity. Tool handlers are server code authored by the agent owner and treated as trusted — `as: { userId: 'admin' }` is impersonation by design. Use only when intentionally scoping to a different (typically lower-privilege) identity. Documented on `InvokeOptions.as`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)