### PR TITLE
fix(native-compiler): add repository field to enable npm publish with provenance

### DIFF
--- a/.changeset/fix-native-compiler-repository.md
+++ b/.changeset/fix-native-compiler-repository.md
@@ -1,0 +1,14 @@
+---
+'@vertz/native-compiler': patch
+---
+
+fix(native-compiler): add repository/license/description fields to package.json
+
+npm publish with `--provenance` rejected the 0.2.66 publish with:
+
+    npm error code E422
+    Error verifying sigstore provenance bundle: Failed to validate
+    repository information: package.json: "repository.url" is "",
+    expected to match "https://github.com/vertz-dev/vertz" from provenance
+
+The `@vertz/native-compiler` package had never been published before, and its package.json was missing `repository`, `license`, and `description`. npm's provenance attestation requires the manifest's `repository.url` to match the source repo recorded in the provenance bundle. Added all three fields matching the pattern used by the other `@vertz/*` packages.

--- a/native/vertz-compiler/package.json
+++ b/native/vertz-compiler/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@vertz/native-compiler",
   "version": "0.2.66",
+  "description": "Native Rust compiler for Vertz (signal transforms, JSX, CSS)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vertz-dev/vertz.git",
+    "directory": "native/vertz-compiler"
+  },
   "exports": {
     "./vertz-compiler.darwin-arm64.node": "./vertz-compiler.darwin-arm64.node",
     "./vertz-compiler.darwin-x64.node": "./vertz-compiler.darwin-x64.node",


### PR DESCRIPTION
## Summary

Previous release run (#2723 merge) published @vertz/runtime@0.2.66 and all platform binaries successfully, but failed partway through on @vertz/native-compiler (first-time publish to npm):

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "",
expected to match "https://github.com/vertz-dev/vertz" from provenance
```

## Why

The @vertz/native-compiler package has never been published — nobody noticed its manifest was missing the fields npm publishing with `--provenance` requires: `repository.url` must match the source repo in the provenance attestation.

## Fix

Added `repository`, `license`, and `description` to `native/vertz-compiler/package.json`, matching the conventional layout of every other @vertz/* package.

## Status of the partial release

- @vertz/runtime@0.2.66 → published ✓ (this is what CI needs)
- @vertz/runtime-{darwin,linux}-{arm64,x64}@0.2.66 → published ✓
- @vertz/native-compiler-{darwin,linux}-{arm64,x64}@0.2.66 → published ✓
- @vertz/native-compiler@0.2.66 → **failed** ✗
- @vertz/cli, @vertz/server, @vertz/ui, @vertz/errors, etc @0.2.66 → published ✓ (after the native-compiler failure, publishing continued)
- GitHub release `v0.2.66` → **not created** (workflow exited before the "Upload binaries" step)

So CI version-drift failures from the 7-package meltdown should be **largely resolved** as of now, since @vertz/runtime@0.2.66 is live. The remaining broken piece is tooling that tries to install @vertz/native-compiler@0.2.66.

## Next steps after merging

1. The Release workflow re-runs, assembles a Version PR that bumps to 0.2.67 including this fix.
2. Merging that Version PR retries the publish, this time completing @vertz/native-compiler too.
3. GitHub release `v0.2.67` gets created with all four platform runtime binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)