### PR TITLE
fix(vtz): default NODE_ENV=test under `vtz test` to match bun/vitest

### DIFF
--- a/.changeset/fix-test-node-env.md
+++ b/.changeset/fix-test-node-env.md
@@ -1,0 +1,12 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): default NODE_ENV=test when unset under `vtz test`
+
+Bun and vitest both set `NODE_ENV=test` automatically when running tests. `vtz test` didn't, so library code that distinguishes production from test (e.g. `@vertz/server`'s JWT issuer/key-pair validation) would take the production branch under `vtz ci test` in CI, where the env is bare. This caused @vertz/server auth tests to fail with:
+
+    JWT issuer is required in production.
+    Key pair is required in production.
+
+Fixed by setting `NODE_ENV=test` at the start of `run_tests()` when NODE_ENV is unset or empty. An explicit `NODE_ENV=production` is preserved. Matches bun/vitest.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/test/runner.rs
+++ b/native/vtz/src/test/runner.rs
@@ -70,10 +70,28 @@ impl TestRunResult {
     }
 }
 
+/// Set `NODE_ENV=test` when unset so libraries that gate on it (e.g. @vertz/server's
+/// production-mode checks) behave correctly under `vtz test`. Matches bun/vitest's
+/// default. Returns the value that was applied, or `None` if NODE_ENV was already set.
+fn ensure_node_env_default() -> Option<&'static str> {
+    match std::env::var("NODE_ENV") {
+        Ok(ref existing) if !existing.is_empty() => None,
+        _ => {
+            std::env::set_var("NODE_ENV", "test");
+            Some("test")
+        }
+    }
+}
+
 /// Run the test suite: discover → execute (parallel) → report.
 ///
 /// Returns a `TestRunResult` with the aggregated results and formatted output.
 pub fn run_tests(config: TestRunConfig) -> (TestRunResult, String) {
+    // Match bun/vitest behavior: default NODE_ENV to "test" when unset so library
+    // code that distinguishes production from test (e.g. @vertz/server auth) takes
+    // the test branch.
+    ensure_node_env_default();
+
     // 1. Discover test files
     let files = discover_test_files(
         &config.root_dir,
@@ -411,6 +429,56 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::Path;
+
+    // Serialize all NODE_ENV-sensitive tests — std::env is process-global.
+    static NODE_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_node_env<T>(initial: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let _lock = NODE_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var("NODE_ENV").ok();
+        match initial {
+            Some(v) => std::env::set_var("NODE_ENV", v),
+            None => std::env::remove_var("NODE_ENV"),
+        }
+        let out = body();
+        match prior {
+            Some(v) => std::env::set_var("NODE_ENV", v),
+            None => std::env::remove_var("NODE_ENV"),
+        }
+        out
+    }
+
+    #[test]
+    fn ensure_node_env_default_sets_test_when_unset() {
+        with_node_env(None, || {
+            let applied = ensure_node_env_default();
+            assert_eq!(applied, Some("test"));
+            assert_eq!(std::env::var("NODE_ENV").as_deref(), Ok("test"));
+        });
+    }
+
+    #[test]
+    fn ensure_node_env_default_sets_test_when_empty() {
+        with_node_env(Some(""), || {
+            let applied = ensure_node_env_default();
+            assert_eq!(applied, Some("test"));
+            assert_eq!(std::env::var("NODE_ENV").as_deref(), Ok("test"));
+        });
+    }
+
+    #[test]
+    fn ensure_node_env_default_preserves_existing_value() {
+        with_node_env(Some("production"), || {
+            let applied = ensure_node_env_default();
+            assert!(applied.is_none());
+            assert_eq!(std::env::var("NODE_ENV").as_deref(), Ok("production"));
+        });
+        with_node_env(Some("development"), || {
+            let applied = ensure_node_env_default();
+            assert!(applied.is_none());
+            assert_eq!(std::env::var("NODE_ENV").as_deref(), Ok("development"));
+        });
+    }
 
     fn create_test_project(dir: &Path) {
         fs::create_dir_all(dir.join("src")).unwrap();


### PR DESCRIPTION
## Summary

Bun and vitest both set `NODE_ENV=test` automatically when running tests. `vtz test` did not, so library code that distinguishes production from test took the wrong branch under `vtz ci test` in CI (where the env is bare).

The most visible symptom was `@vertz/server/auth.test.ts` — 14 of its 31 tests failed with:

```
JWT issuer is required in production.
Key pair is required in production.
```

## Fix

`native/vtz/src/test/runner.rs` — at the start of `run_tests()`, set `NODE_ENV=test` if `NODE_ENV` is unset or empty. An explicit `NODE_ENV=production` is preserved (so coverage runs or deliberate prod-mode tests still work).

## TDD

Three unit tests:
- `ensure_node_env_default_sets_test_when_unset` — NODE_ENV unset → becomes `test`
- `ensure_node_env_default_sets_test_when_empty` — NODE_ENV=`""` → becomes `test`
- `ensure_node_env_default_preserves_existing_value` — NODE_ENV=`production` or `development` is preserved

Verified red-green cycle: neutered the impl locally, saw the tests fail; restored, they pass. Tests use a mutex because `std::env` is process-global (follows the same pattern already in `config.rs`).

## End-to-end verification

With a fresh binary built from this commit and `NODE_ENV` unset:

```bash
$ unset NODE_ENV && vtz test packages/server/src/__tests__/auth/auth.test.ts
Files:  1
Tests:  31 passed (31)
Time:   7524ms
```

(Was 17 pass / 14 fail before.)

## Expected CI impact

Removes the `@vertz/server` auth failures (auth.test.ts, request-handler.test.ts, access-set-jwt.test.ts) from the next CI run once `@vertz/runtime@0.2.67` publishes. Other pre-existing failures (#2718, #2719, #2720, and the @vertz/db 15s timeouts + @vertz/cli assertion failures) are unrelated and tracked separately.

## Test plan

- [x] `cargo test --package vtz --lib test::runner::` — 17/17 pass (was 14/14 + 3 new)
- [x] `cargo clippy -p vtz --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Local verification: @vertz/server/auth.test.ts 31/31 pass against freshly built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)