### PR TITLE
fix(db): bump test timeout to 60s for PGlite-backed CLI tests

### DIFF
--- a/packages/db/vertz.config.ts
+++ b/packages/db/vertz.config.ts
@@ -1,6 +1,10 @@
 export default {
   test: {
     preload: ['../../test-preload.ts'],
+    // PGlite-backed CLI tests (migrate-dev, status, request-scope) spin up a
+    // WASM Postgres per test. On linux-x64 CI each test is 2–3× slower than
+    // local macOS/arm64, pushing files of 20+ tests past the default 15s.
+    timeout: 60_000,
     coveragePathIgnorePatterns: [
       '**/errors/dist/**',
       '**/schema/dist/**',


### PR DESCRIPTION
## Symptom

Three `@vertz/db` test files fail in CI with per-file timeouts, but all pass locally in under 8s:

```
db/src/cli/__tests__/migrate-dev.test.ts    FAIL (load error)  Test execution timed out after 15000ms
db/src/cli/__tests__/status.test.ts         FAIL (load error)  Test execution timed out after 15000ms
db/src/client/__tests__/request-scope.test.ts FAIL (load error) Test execution timed out after 15000ms
```

## Root cause

All three tests instantiate a PGlite WASM Postgres instance per test. With 20–30 tests per file and ~500ms per test on linux-x64 CI (vs ~250ms locally on macOS arm64), cumulative runtime exceeds the default 15s per-file timeout.

Local measurement (migrate-dev): 7.2s total, 28/28 pass, slowest test 678ms. 2× slowdown on CI pushes it past 15s.

## Fix

Set `test.timeout: 60_000` in `packages/db/vertz.config.ts`. 4× local headroom.

## Followup (not in this PR)

A proper fix shares a PGlite instance across tests (or swaps to better-sqlite3 for tests that don't exercise Postgres-specific behavior). That's invasive — track separately if flakiness recurs.

## Test plan

- [x] `vtz test packages/db/src/cli/__tests__/migrate-dev.test.ts` — 28/28 pass in 7.2s
- [ ] CI — confirm the three timing-out files now pass under 60s
- [ ] This PR's CI will also be the first to run against `@vertz/runtime@0.2.67`, so should surface whether the NODE_ENV fix resolved the `@vertz/server` auth + `@vertz/core/ctx-builder` failures from the previous CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)