### PR TITLE
fix(agents): remove broken tool-level `approval` and `execution` fields (#2715, #2716)

### DIFF
--- a/.changeset/fix-agents-remove-broken-fields.md
+++ b/.changeset/fix-agents-remove-broken-fields.md
@@ -1,0 +1,16 @@
+---
+'@vertz/agents': patch
+---
+
+fix(agents): remove broken `approval` and `execution` tool config fields
+
+Both fields were declared on `ToolConfig` / `ToolDefinition` but had no real runtime behavior:
+
+- `approval` was preserved through `tool()` but the ReAct loop never checked it, so an agent that set `approval: { required: true }` on a destructive tool would execute anyway. A security footgun in the type surface.
+- `execution: 'client'` caused the loop to return an error tool message ("cannot be executed on the server") with no protocol for host round-trip. The feature was never implemented.
+
+Both fields are now removed from the public type surface along with the `ToolApprovalConfig` and `ToolExecution` type exports. The misleading "client-side tool" runtime error is replaced with a clearer "tool has no handler" message pointing at the `ToolProvider` option.
+
+Workflow step approval (`StepApprovalConfig` on `workflow().step({ approval })`) is a separate, working feature and is unchanged.
+
+A proper suspend/resume protocol covering human-in-the-loop approval and client-side tool round-trips will be designed alongside the Durable Object runtime work, where per-session persistence is transactional.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -6,7 +6,7 @@ Declarative AI agent framework for Vertz — define agents, tools, and workflows
 
 - **Declarative agents** — Define agents with typed state, tools, and output schemas using `agent()`
 - **ReAct loop** — Built-in Reason-Act-Observe cycle with stuck detection and token budgets
-- **Typed tools** — Input/output schemas validated at runtime, with optional human approval gates
+- **Typed tools** — Input/output schemas validated at runtime
 - **Workflow orchestration** — Multi-step workflows with typed step outputs and approval gates
 - **Session persistence** — Resume conversations with pluggable storage (memory, SQLite, D1)
 - **Agent-to-agent communication** — Tools can invoke other agents for hierarchical flows
@@ -68,7 +68,6 @@ const searchTool = tool({
 - **`description`** — Shown to the LLM to decide when to use the tool
 - **`input` / `output`** — `@vertz/schema` schemas for validation
 - **`handler`** — Receives validated input and a `ToolContext` with agent metadata
-- **`approval`** — Optional human approval gate before execution
 - **`parallel`** — Allow concurrent execution with other tools
 
 ## Defining Agents

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -14,11 +14,9 @@ export type {
   InvokeOptions,
   ModelProvider,
   OnStuckBehavior,
-  ToolApprovalConfig,
   ToolConfig,
   ToolContext,
   ToolDefinition,
-  ToolExecution,
   ToolProvider,
   InferToolProvider,
 } from './types';

--- a/packages/agents/src/loop/react-loop.test.ts
+++ b/packages/agents/src/loop/react-loop.test.ts
@@ -20,7 +20,6 @@ function makeTool(name: string, handler: (input: unknown) => unknown): ToolDefin
     input: s.object({}),
     output: s.unknown(),
     handler: handler as ToolDefinition['handler'],
-    execution: 'server',
   };
 }
 
@@ -184,7 +183,6 @@ describe('reactLoop()', () => {
           input: s.object({}),
           output: s.object({ count: s.number() }),
           handler: async () => ({ count: 'not-a-number' }),
-          execution: 'server',
         };
 
         const llm = mockLLM([
@@ -282,7 +280,6 @@ describe('reactLoop()', () => {
           handler(input: { name: string }) {
             return { greeting: `Hi ${input.name}` };
           },
-          execution: 'server',
         };
 
         const llm = mockLLM([
@@ -1219,7 +1216,6 @@ describe('reactLoop()', () => {
           input: s.object({}),
           output: s.object({}),
           parallel: true,
-          execution: 'server',
           async handler() {
             currentRunning++;
             maxRunning = Math.max(maxRunning, currentRunning);
@@ -1278,7 +1274,6 @@ function makeParallelTool(name: string, handler: (input: unknown) => unknown): T
     input: s.object({}),
     output: s.unknown(),
     handler: handler as ToolDefinition['handler'],
-    execution: 'server',
     parallel: true,
   };
 }

--- a/packages/agents/src/loop/react-loop.ts
+++ b/packages/agents/src/loop/react-loop.ts
@@ -474,7 +474,7 @@ async function executeToolCall(
         toolCallId: callId,
         toolName: toolCall.name,
         content: JSON.stringify({
-          error: `Tool "${toolCall.name}" is a client-side tool and cannot be executed on the server.`,
+          error: `Tool "${toolCall.name}" has no handler. Provide a handler on the tool definition or inject one via the \`tools\` ToolProvider option on run()/runWorkflow().`,
         }),
       },
       success: false,

--- a/packages/agents/src/tool.test.ts
+++ b/packages/agents/src/tool.test.ts
@@ -17,51 +17,7 @@ describe('tool()', () => {
 
         expect(greet.kind).toBe('tool');
         expect(greet.description).toBe('Generate a greeting');
-        expect(greet.execution).toBe('server');
         expect(Object.isFrozen(greet)).toBe(true);
-      });
-    });
-  });
-
-  describe('Given a tool config without a handler (client-side tool)', () => {
-    describe('When tool() is called with execution: "client"', () => {
-      it('Then returns a ToolDefinition with execution "client" and no handler', () => {
-        const screenshot = tool({
-          description: 'Take a screenshot',
-          input: s.object({ selector: s.string().optional() }),
-          output: s.object({ dataUrl: s.string() }),
-          execution: 'client',
-        });
-
-        expect(screenshot.kind).toBe('tool');
-        expect(screenshot.execution).toBe('client');
-        expect(screenshot.handler).toBeUndefined();
-      });
-    });
-  });
-
-  describe('Given a tool config with approval required', () => {
-    describe('When tool() is called', () => {
-      it('Then returns a ToolDefinition with the approval config', () => {
-        const deploy = tool({
-          description: 'Deploy to production',
-          input: s.object({ version: s.string() }),
-          output: s.object({ url: s.string() }),
-          approval: {
-            required: true,
-            message: 'Deploy to production?',
-            timeout: '7d',
-          },
-          handler(input) {
-            return { url: `https://example.com/${input.version}` };
-          },
-        });
-
-        expect(deploy.approval).toEqual({
-          required: true,
-          message: 'Deploy to production?',
-          timeout: '7d',
-        });
       });
     });
   });
@@ -83,17 +39,16 @@ describe('tool()', () => {
     });
   });
 
-  describe('Given a server tool config without a handler', () => {
+  describe('Given a tool config without a handler', () => {
     describe('When tool() is called', () => {
       it('Then creates a valid tool declaration (handler injected at runtime via ToolProvider)', () => {
         const def = tool({
-          description: 'No handler server tool',
+          description: 'No handler tool',
           input: s.object({}),
           output: s.object({}),
         });
 
         expect(def.kind).toBe('tool');
-        expect(def.execution).toBe('server');
         expect(def.handler).toBeUndefined();
       });
     });
@@ -101,41 +56,17 @@ describe('tool()', () => {
 
   describe('Given a tool definition returned by tool()', () => {
     describe('When checking immutability', () => {
-      it('Then nested objects are also frozen (deep freeze)', () => {
+      it('Then the definition is frozen', () => {
         const def = tool({
-          description: 'Deep frozen tool',
+          description: 'Frozen tool',
           input: s.object({}),
           output: s.object({}),
-          approval: { required: true, message: 'Approve?', timeout: '1d' },
           handler() {
             return {};
           },
         });
 
         expect(Object.isFrozen(def)).toBe(true);
-        expect(Object.isFrozen(def.approval)).toBe(true);
-      });
-    });
-  });
-
-  describe('Given a tool config with approval message as a function', () => {
-    describe('When tool() is called', () => {
-      it('Then preserves the function in the approval config', () => {
-        const messageFn = (input: { version: string }) => `Deploy v${input.version}?`;
-        const deploy = tool({
-          description: 'Deploy',
-          input: s.object({ version: s.string() }),
-          output: s.object({ url: s.string() }),
-          approval: {
-            required: true,
-            message: messageFn,
-          },
-          handler(input) {
-            return { url: `https://example.com/${input.version}` };
-          },
-        });
-
-        expect(deploy.approval?.message).toBe(messageFn);
       });
     });
   });

--- a/packages/agents/src/tool.ts
+++ b/packages/agents/src/tool.ts
@@ -6,7 +6,7 @@ import { deepFreeze } from './utils';
  * Define a tool that an agent can use.
  *
  * Tools are typed units of capability: each has a description, input/output schemas,
- * and a handler. All tools in v1 execute on the server.
+ * and a handler. All tools execute on the server.
  */
 export function tool<TInput, TOutput>(
   config: ToolConfig<TInput, TOutput>,
@@ -14,8 +14,6 @@ export function tool<TInput, TOutput>(
   if (!config.description || config.description.trim() === '') {
     throw new Error('tool() description must be a non-empty string.');
   }
-
-  const execution = config.execution ?? 'server';
 
   // Handler-less tools are valid declarations — handlers are injected at runtime
   // via ToolProvider when calling run() or runWorkflow().
@@ -26,8 +24,6 @@ export function tool<TInput, TOutput>(
     input: config.input as SchemaAny,
     output: config.output as SchemaAny,
     handler: config.handler,
-    approval: config.approval,
-    execution,
     parallel: config.parallel,
   };
 

--- a/packages/agents/src/types.test-d.ts
+++ b/packages/agents/src/types.test-d.ts
@@ -35,6 +35,30 @@ tool({
   },
 });
 
+// Tool-level `approval` is not a valid config field (removed — use workflow step approval instead)
+tool({
+  description: 'test',
+  input: s.object({}),
+  output: s.object({}),
+  handler() {
+    return {};
+  },
+  // @ts-expect-error — `approval` is not a valid tool config field
+  approval: { required: true, message: 'Approve?' },
+});
+
+// Tool-level `execution` is not a valid config field (removed — all tools run on the server)
+tool({
+  description: 'test',
+  input: s.object({}),
+  output: s.object({}),
+  handler() {
+    return {};
+  },
+  // @ts-expect-error — `execution` is not a valid tool config field
+  execution: 'client',
+});
+
 // ---------------------------------------------------------------------------
 // Agent type safety
 // ---------------------------------------------------------------------------

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -21,16 +21,6 @@ export type InferAgentOutput<T extends AgentDefinition<any, any, any>> =
 // Tool types
 // ---------------------------------------------------------------------------
 
-/** Configuration for a tool that requires human approval before execution. */
-export interface ToolApprovalConfig<TInput> {
-  readonly required: true;
-  readonly message: string | ((input: TInput) => string);
-  readonly timeout?: string;
-}
-
-/** Where the tool executes. */
-export type ToolExecution = 'server' | 'client';
-
 /** Configuration passed to the `tool()` factory. */
 export interface ToolConfig<
   TInput,
@@ -42,8 +32,6 @@ export interface ToolConfig<
   readonly input: TInputSchema;
   readonly output: TOutputSchema;
   readonly handler?: (input: TInput, ctx: ToolContext) => TOutput | Promise<TOutput>;
-  readonly approval?: ToolApprovalConfig<TInput>;
-  readonly execution?: ToolExecution;
   /** When true, this tool can execute concurrently with other parallel tools. Default: false. */
   readonly parallel?: boolean;
 }
@@ -102,8 +90,6 @@ export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   readonly input: SchemaAny;
   readonly output: SchemaAny;
   readonly handler?: (input: TInput, ctx: ToolContext) => TOutput | Promise<TOutput>;
-  readonly approval?: ToolApprovalConfig<TInput>;
-  readonly execution: ToolExecution;
   /** When true, this tool can execute concurrently with other parallel tools. */
   readonly parallel?: boolean;
 }


### PR DESCRIPTION
## Summary

Both `ToolConfig.approval` and `ToolConfig.execution` were declared on the public type but had no runtime behavior — the types lied to developers. An agent that set `approval: { required: true }` on a destructive tool would execute anyway; an `execution: 'client'` tool errored mid-loop with no host round-trip protocol. Both issues unanimously flagged "declared-but-broken" as a foot-gun class bug during audit.

Closes #2715, #2716.

## Public API Changes

**Breaking type removals** (pre-v1, acceptable per policy):
- Removed `ToolApprovalConfig` and `ToolExecution` type exports from `@vertz/agents`.
- Removed `approval` and `execution` fields from `ToolConfig` and `ToolDefinition`.

**Runtime behavior change:**
- The misleading `"Tool X is a client-side tool and cannot be executed on the server"` error is now `"Tool X has no handler. Provide a handler on the tool definition or inject one via the \`tools\` ToolProvider option on run()/runWorkflow()."`

**Unchanged:**
- Workflow step approval (`StepApprovalConfig`, `workflow().step({ approval })`, `runWorkflow()` pending/resume) is a separate, working feature — fully untouched.

## Why not implement instead of remove

A suspend/resume protocol covering human-in-the-loop approval and client-side tool round-trips was designed (see superseded `plans/agents-tool-suspend-resume.md`). Three adversarial reviews returned changes-requested with non-trivial blockers (store non-atomicity = replay vulnerability, generic erasure, id-uniqueness). The product review concluded implementation was the wrong priority ahead of streaming / OpenAI+Anthropic adapters. Protocol will be revisited alongside the Durable Object runtime when per-session persistence is transactional.

## Test plan
- [x] Negative `.test-d.ts` assertions confirm `approval` and `execution` are rejected on `tool()` config
- [x] `tool.test.ts` rewritten to cover remaining tool() behaviors (description validation, handler-less declarations, immutability)
- [x] Workflow step approval tests unchanged and passing
- [x] `vtz test` green: 195 passed, 13 skipped
- [x] Typecheck clean
- [x] Lint clean (30 pre-existing warnings, 0 new)
- [x] Format clean
- [x] Adversarial review: approved, 0 blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)