### PR TITLE
fix(vtz): preserve executable mode when `vtz install` extracts tarballs

### DIFF
--- a/.changeset/fix-vtz-install-preserve-executable.md
+++ b/.changeset/fix-vtz-install-preserve-executable.md
@@ -1,0 +1,23 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): preserve executable mode from tar headers during `vtz install`
+
+npm package tarballs encode `bin/*` files with mode 0o755 in their tar
+headers. The extractor in `native/vtz/src/pm/tarball.rs` was creating
+each file via `File::create` and copying bytes, but never applying the
+header mode — so every extracted file came out at the process umask
+(typically 0o644). This made shipped binaries non-executable and spawn
+failed with `EACCES`, e.g. `@esbuild/linux-x64/bin/esbuild`, which
+blocked any build that shelled out to esbuild after `vtz install
+--frozen` in CI.
+
+Fix: read `entry.header().mode()` before writing, and apply the masked
+file-permission bits (0o777, excluding setuid/sticky for safety) via
+`set_permissions` after the write completes. Applied to both
+`extract_tarball` (npm) and `extract_github_tarball` (GitHub refs).
+
+No-op on Windows (permissions are gated by `#[cfg(unix)]`). Regression
+test builds a tar with a 0o755 exec file and a 0o644 data file,
+extracts, and asserts both modes are preserved.

--- a/native/vtz/src/pm/tarball.rs
+++ b/native/vtz/src/pm/tarball.rs
@@ -372,13 +372,40 @@ pub fn extract_tarball(
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
+            let mode = entry.header().mode().ok();
             let mut output = std::fs::File::create(&target)?;
             // Read with size limit enforcement
             let mut limited = entry.take(MAX_FILE_SIZE);
             std::io::copy(&mut limited, &mut output)?;
+            // Drop the handle before touching permissions on Windows (noop on Unix).
+            drop(output);
+            apply_entry_mode(&target, mode)?;
         }
     }
 
+    Ok(())
+}
+
+/// Preserve the file mode recorded in the tar header.
+///
+/// npm package tarballs include binaries at mode 0o755; without applying the
+/// header mode they land as 0o644 and spawn fails with EACCES (seen with
+/// `@esbuild/linux-x64/bin/esbuild` after `vtz install` in CI).
+fn apply_entry_mode(target: &Path, mode: Option<u32>) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Some(mode) = mode {
+            // Mask to file-permission bits; ignore setuid/sticky to avoid
+            // introducing elevated bits from an untrusted archive.
+            let safe = mode & 0o777;
+            std::fs::set_permissions(target, std::fs::Permissions::from_mode(safe))?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (target, mode);
+    }
     Ok(())
 }
 
@@ -474,9 +501,12 @@ pub fn extract_github_tarball(
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
+            let mode = entry.header().mode().ok();
             let mut output = std::fs::File::create(&target)?;
             let mut limited = entry.take(MAX_FILE_SIZE);
             std::io::copy(&mut limited, &mut output)?;
+            drop(output);
+            apply_entry_mode(&target, mode)?;
         }
     }
 
@@ -754,6 +784,71 @@ mod tests {
         // Verify
         let extracted = std::fs::read_to_string(dest.join("index.js")).unwrap();
         assert_eq!(extracted, "console.log('hello');");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_extract_tarball_preserves_executable_mode() {
+        // Regression: `vtz install` was extracting npm tarballs without
+        // preserving the executable bit, so binaries like
+        // @esbuild/linux-x64/bin/esbuild came out non-executable and spawn
+        // failed with EACCES. npm package tarballs include binaries at mode
+        // 0o755, and we must preserve that.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("extract");
+        std::fs::create_dir_all(&dest).unwrap();
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let exec_content = b"#!/bin/sh\necho hi\n";
+        let mut exec_header = tar::Header::new_gnu();
+        exec_header.set_size(exec_content.len() as u64);
+        exec_header.set_mode(0o755);
+        exec_header.set_cksum();
+        builder
+            .append_data(&mut exec_header, "package/bin/cli", &exec_content[..])
+            .unwrap();
+
+        let data_content = b"plain data\n";
+        let mut data_header = tar::Header::new_gnu();
+        data_header.set_size(data_content.len() as u64);
+        data_header.set_mode(0o644);
+        data_header.set_cksum();
+        builder
+            .append_data(&mut data_header, "package/README.md", &data_content[..])
+            .unwrap();
+
+        let tar_bytes = builder.into_inner().unwrap();
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&tar_bytes).unwrap();
+        let gz_bytes = encoder.finish().unwrap();
+
+        extract_tarball(&gz_bytes, &dest).unwrap();
+
+        let exec_perms = std::fs::metadata(dest.join("bin/cli"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            exec_perms & 0o777,
+            0o755,
+            "executable file should retain 0o755, got {:o}",
+            exec_perms & 0o777
+        );
+
+        let data_perms = std::fs::metadata(dest.join("README.md"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            data_perms & 0o777,
+            0o644,
+            "regular file should retain 0o644, got {:o}",
+            data_perms & 0o777
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

npm package tarballs encode `bin/*` files with mode 0o755 in their tar headers. `extract_tarball` in `native/vtz/src/pm/tarball.rs` was writing file contents via `File::create` + `io::copy` but never applying the header mode, so every extracted file came out at the process umask (typically 0o644). Shipped binaries came out non-executable.

Discovered while testing #2733 (replacing \`bun install\` with \`vtz install --frozen\` on CI):

\`\`\`
Build failed: The service was stopped: spawn
/home/runner/work/vertz/vertz/node_modules/@esbuild/linux-x64/bin/esbuild
EACCES
\`\`\`

## Fix

Read `entry.header().mode()` before writing, then apply masked file-permission bits via `set_permissions` after the write completes. Applied to both `extract_tarball` (npm) and `extract_github_tarball` (GitHub refs).

Masking to 0o777 (dropping setuid/sticky) so an untrusted archive can't elevate via setuid bit.

No-op on Windows (`#[cfg(unix)]` guards the `set_permissions` call).

## TDD

New regression test `test_extract_tarball_preserves_executable_mode`:
- Builds a tar with two entries — one at 0o755, one at 0o644
- Extracts via `extract_tarball`
- Asserts both modes round-trip correctly

Verified red → green locally:
- Before fix: exec file extracted at 0o644 (red, assertion fails with "got 644")
- After fix: both files extract at the right mode (green)

## Blast radius

- All \`vtz install\` calls that extract tarballs with executable files benefit. Previously any bin would fail at spawn time unless something else chmod'd it.
- Linker's scoped-bin-stub path already chmod'd its own stubs — unaffected.
- Windows: unchanged (no-op).

## Unblocks

- #2733 — CI can now use \`vtz install --frozen\` in place of \`bun install --frozen-lockfile\`

## Test plan

- [x] \`cargo test -p vtz --lib pm::tarball::\` — 20/20 pass including the new regression
- [x] \`cargo clippy -p vtz --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [ ] After merge + 0.2.68 release, re-run CI on #2733 to confirm \`vtz install --frozen\` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)