### PR TITLE
fix(docs): bump test timeout to 60s for build-pipeline.test.ts

### DIFF
--- a/packages/docs/vertz.config.ts
+++ b/packages/docs/vertz.config.ts
@@ -1,5 +1,8 @@
 export default {
   test: {
     preload: ['./happydom.ts', './test-compiler-plugin.ts'],
+    // build-pipeline.test.ts writes temp files and runs the full docs build
+    // per test. Locally ~5s; 3× slower on linux-x64 CI exceeds the default 15s.
+    timeout: 60_000,
   },
 };


### PR DESCRIPTION
## Symptom

`@vertz/docs/src/__tests__/build-pipeline.test.ts` fails in CI with:

```
docs/src/__tests__/build-pipeline.test.ts FAIL (load error)
  Error: Test execution timed out after 15000ms
```

## Root cause

The test writes temp files and runs the full docs build per test. Locally ~5s; 3× slower on linux-x64 CI, exceeds the default 15s per-file timeout.

Same pattern as the PGlite-heavy `@vertz/db` CLI tests that were fixed in d146a70d6.

## Fix

Set `test.timeout: 60_000` in `packages/docs/vertz.config.ts`. 4× local headroom.

## History

This exact config change was included in the branches for #2729 and #2735 but got dropped by squash-merges each time. Isolating in its own single-commit PR so it actually lands on main.

## What this does NOT fix

`@vertz/cli` still has 3 real assertion failures on main (`cli.test.ts`, `orchestrator.test.ts`, `ui-build-pipeline.test.ts`) tracked in #2731. Those need actual code fixes, not a timeout bump.

## Test plan

- [x] Locally: `vtz test packages/docs/src/__tests__/build-pipeline.test.ts` → 19/19 pass in ~5s
- [ ] CI green for @vertz/docs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)