### PR TITLE
fix(docs): bump test timeout to 60s for build-pipeline.test.ts

### DIFF
--- a/packages/docs/vertz.config.ts
+++ b/packages/docs/vertz.config.ts
@@ -1,5 +1,8 @@
 export default {
   test: {
     preload: ['./happydom.ts', './test-compiler-plugin.ts'],
+    // build-pipeline.test.ts writes temp files and runs the full docs build
+    // per test. Locally ~5s; 3× slower on linux-x64 CI exceeds the default 15s.
+    timeout: 60_000,
   },
 };


### PR DESCRIPTION
## Summary

Re-lands a 3-line test config fix that was originally committed in PR #2729 but did not survive its squash-merge.

`packages/docs/src/__tests__/build-pipeline.test.ts` runs the full docs build against per-test temp directories. Locally it takes ~5s; on linux-x64 CI it's ~3× slower, pushing it past the default 15s per-file timeout. Mirrors the same fix already applied to `@vertz/db`'s PGlite-heavy CLI tests (d146a70d6, PR #2728).

## Public API Changes

None — `vertz.config.ts` is test-only config, not shipped to consumers. No changeset needed.

## Test plan

- [x] `vtz test src/__tests__/build-pipeline.test.ts` passes locally (~5s, well under 60s)
- [ ] GitHub CI goes green on linux-x64