### PR TITLE
fix(vtz): semver resolver — `^0.27.3` must not match 0.25.12 (#2738)

### DIFF
--- a/.changeset/fix-vtz-semver-resolver.md
+++ b/.changeset/fix-vtz-semver-resolver.md
@@ -1,0 +1,15 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): semver resolver must not return versions that don't satisfy the range
+
+`vtz install` incorrectly resolved `esbuild: ^0.27.3` to `0.25.12` when a stale
+lockfile entry existed, because the lockfile-reuse fast path trusted the pinned
+version without revalidating that it still satisfied the requested range. The
+companion `graph_to_lockfile` path also wrote root-dep entries by name-only,
+blindly accepting whichever hoisted version was present.
+
+Both paths now verify that the chosen version satisfies the declared range. A
+stale or out-of-range pin falls through to a fresh registry resolve instead of
+silently being reused. Closes #2738.

--- a/native/vtz/src/pm/resolver.rs
+++ b/native/vtz/src/pm/resolver.rs
@@ -8,6 +8,38 @@ use futures_util::stream::{FuturesUnordered, StreamExt};
 use node_semver::{Range, Version};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
+/// Returns true iff `version_str` satisfies `range_str` under npm semver rules.
+///
+/// Both inputs must parse successfully; otherwise returns false (fail-closed).
+/// `"github:..."` specifiers and other non-semver ranges always return false —
+/// callers must route those through their own equality check.
+pub fn version_satisfies_range(version_str: &str, range_str: &str) -> bool {
+    let Ok(version) = Version::parse(version_str) else {
+        return false;
+    };
+    let Ok(range) = Range::parse(range_str) else {
+        return false;
+    };
+    range.satisfies(&version)
+}
+
+/// Returns true iff a lockfile entry's pinned version still satisfies `range_str`.
+///
+/// This guards the lockfile-reuse fast path in `resolve_one_task`: a stale entry
+/// (e.g. `esbuild@^0.27.3` → 0.25.12, left over from a prior install where the
+/// range or registry state differed) must NOT be silently trusted. If the pinned
+/// version no longer satisfies the range, callers must fall through to a fresh
+/// registry resolve.
+///
+/// GitHub entries (range starts with `github:`) are treated as always-valid here,
+/// because they are pinned by SHA — semver has no meaning for them.
+pub fn lockfile_entry_satisfies_range(entry: &LockfileEntry, range_str: &str) -> bool {
+    if range_str.starts_with("github:") || range_str.starts_with("link:") {
+        return true;
+    }
+    version_satisfies_range(&entry.version, range_str)
+}
+
 /// Resolve the best matching version for a range from available versions
 pub fn resolve_version<'a>(
     range_str: &str,
@@ -260,8 +292,12 @@ async fn resolve_one_task<'a>(
     // Check lockfile first for pinned version (use ORIGINAL range for lockfile key)
     let lockfile_key = Lockfile::spec_key(name, range);
     if let Some(entry) = lockfile.entries.get(&lockfile_key) {
-        // If override is active, ignore lockfile version — use override instead
-        if effective_range == *range {
+        // If override is active, ignore lockfile version — use override instead.
+        // Also require the pinned version to still satisfy the requested range.
+        // A stale or corrupted lockfile entry (e.g. `esbuild@^0.27.3` → 0.25.12
+        // left over from an earlier install) must NOT be silently trusted —
+        // fall through to the registry-resolve path so a fresh pick is made.
+        if effective_range == *range && lockfile_entry_satisfies_range(entry, range) {
             let graph_key = ResolvedGraph::key(name, &entry.version);
 
             let resolved = ResolvedPackage {
@@ -522,12 +558,17 @@ pub fn graph_to_lockfile(
 
     for (name, range) in all_deps {
         let key = Lockfile::spec_key(name, range);
-        // Find the resolved version for this dep
-        if let Some(pkg) = graph
-            .packages
-            .values()
-            .find(|p| p.name == *name && p.nest_path.is_empty())
-        {
+        // Find the resolved version for this dep. Match by name AND by semver range:
+        // without the range check, a root dep would get wired to whichever version was
+        // hoisted, even if that version doesn't satisfy the declared range (see #2738).
+        // Fall back to name-only for `link:` workspace refs and `github:` specifiers,
+        // which are not semver.
+        let is_non_semver = range.starts_with("github:") || range.starts_with("link:");
+        if let Some(pkg) = graph.packages.values().find(|p| {
+            p.name == *name
+                && p.nest_path.is_empty()
+                && (is_non_semver || version_satisfies_range(&p.version, range))
+        }) {
             let graph_key = ResolvedGraph::key(name, &pkg.version);
             let scripts = graph.scripts.get(&graph_key).cloned().unwrap_or_default();
             lockfile.entries.insert(
@@ -756,6 +797,181 @@ mod tests {
         );
         let result = resolve_version(">=1.0.0 <2.0.0", &meta.versions, &meta.dist_tags).unwrap();
         assert_eq!(result.version, "1.5.0");
+    }
+
+    // Regression tests for #2738: `^0.27.3` must never match 0.25.12.
+    // Bug: the resolver was trusting stale lockfile entries without revalidating
+    // that the pinned version actually satisfies the range.
+    #[test]
+    fn test_resolve_version_caret_rejects_lower_minor() {
+        // esbuild scenario: range `^0.27.3` must pick 0.27.3, not 0.25.12.
+        let meta = make_metadata(
+            "esbuild",
+            vec![
+                make_version("esbuild", "0.25.12", &[]),
+                make_version("esbuild", "0.27.0", &[]),
+                make_version("esbuild", "0.27.3", &[]),
+            ],
+        );
+        let result = resolve_version("^0.27.3", &meta.versions, &meta.dist_tags).unwrap();
+        assert_eq!(
+            result.version, "0.27.3",
+            "^0.27.3 must pick the highest version in [0.27.3, 0.28.0), not 0.25.12"
+        );
+    }
+
+    #[test]
+    fn test_version_satisfies_range_caret_zero_x() {
+        // Directly validate the bounded-caret semantics we rely on at the lockfile-reuse
+        // path in `resolve_one_task`: a pinned 0.25.12 must NOT be treated as satisfying
+        // `^0.27.3`.
+        assert!(
+            !version_satisfies_range("0.25.12", "^0.27.3"),
+            "0.25.12 must NOT satisfy ^0.27.3"
+        );
+        assert!(
+            version_satisfies_range("0.27.3", "^0.27.3"),
+            "0.27.3 must satisfy ^0.27.3"
+        );
+        assert!(
+            version_satisfies_range("0.27.5", "^0.27.3"),
+            "0.27.5 must satisfy ^0.27.3"
+        );
+        assert!(
+            !version_satisfies_range("0.28.0", "^0.27.3"),
+            "0.28.0 must NOT satisfy ^0.27.3"
+        );
+    }
+
+    #[test]
+    fn test_version_satisfies_range_tilde() {
+        // `~0.27.3` == [0.27.3, 0.28.0)
+        assert!(
+            !version_satisfies_range("0.25.12", "~0.27.3"),
+            "0.25.12 must NOT satisfy ~0.27.3"
+        );
+        assert!(
+            version_satisfies_range("0.27.3", "~0.27.3"),
+            "0.27.3 must satisfy ~0.27.3"
+        );
+        assert!(
+            version_satisfies_range("0.27.5", "~0.27.3"),
+            "0.27.5 must satisfy ~0.27.3"
+        );
+        assert!(
+            !version_satisfies_range("0.28.0", "~0.27.3"),
+            "0.28.0 must NOT satisfy ~0.27.3"
+        );
+    }
+
+    #[test]
+    fn test_version_satisfies_range_explicit() {
+        // Explicit range `>=0.27.3 <0.28.0` accepts 0.27.3 and 0.27.5, rejects 0.25.12.
+        assert!(
+            !version_satisfies_range("0.25.12", ">=0.27.3 <0.28.0"),
+            "0.25.12 must NOT satisfy >=0.27.3 <0.28.0"
+        );
+        assert!(
+            version_satisfies_range("0.27.3", ">=0.27.3 <0.28.0"),
+            "0.27.3 must satisfy >=0.27.3 <0.28.0"
+        );
+        assert!(
+            version_satisfies_range("0.27.5", ">=0.27.3 <0.28.0"),
+            "0.27.5 must satisfy >=0.27.3 <0.28.0"
+        );
+    }
+
+    #[test]
+    fn test_graph_to_lockfile_rejects_hoisted_version_outside_range() {
+        // Regression for #2738: if the hoisted package version does not satisfy
+        // the declared range, `graph_to_lockfile` must NOT wire the lockfile
+        // entry for that range to it. Only a version that actually satisfies
+        // the range should be picked.
+        let mut graph = ResolvedGraph::default();
+        // Pretend hoisting picked an older `esbuild@0.25.12` (maybe from a
+        // stray transitive in a prior state). A newer `0.27.3` is nested.
+        graph.packages.insert(
+            "esbuild@0.25.12".to_string(),
+            ResolvedPackage {
+                name: "esbuild".to_string(),
+                version: "0.25.12".to_string(),
+                tarball_url: "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz".to_string(),
+                integrity: "sha512-stale".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![], // hoisted to root
+                os: None,
+                cpu: None,
+            },
+        );
+        graph.packages.insert(
+            "esbuild@0.27.3".to_string(),
+            ResolvedPackage {
+                name: "esbuild".to_string(),
+                version: "0.27.3".to_string(),
+                tarball_url: "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz".to_string(),
+                integrity: "sha512-correct".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec!["some-parent".to_string()], // nested
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut deps = BTreeMap::new();
+        deps.insert("esbuild".to_string(), "^0.27.3".to_string());
+
+        let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+
+        // Before the fix, the hoisted-by-name lookup picked 0.25.12 and wrote it
+        // under the `esbuild@^0.27.3` key even though it doesn't satisfy the range.
+        // After the fix, the lookup must skip non-matching hoisted versions;
+        // the only entry the test can assert on is that 0.25.12 is NOT wired here.
+        if let Some(entry) = lockfile.entries.get("esbuild@^0.27.3") {
+            assert_ne!(
+                entry.version, "0.25.12",
+                "graph_to_lockfile must not wire ^0.27.3 to a hoisted 0.25.12"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lockfile_entry_satisfies_for_current_range_rejects_stale() {
+        // Simulates a lockfile left over from an earlier install, pinned to 0.25.12
+        // under the key `esbuild@^0.27.3`. On the next install the resolver must NOT
+        // reuse this stale pin; it must re-resolve against the registry.
+        let stale = LockfileEntry {
+            name: "esbuild".to_string(),
+            range: "^0.27.3".to_string(),
+            version: "0.25.12".to_string(),
+            resolved: String::new(),
+            integrity: String::new(),
+            dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            bin: BTreeMap::new(),
+            scripts: BTreeMap::new(),
+            optional: false,
+            overridden: false,
+            os: None,
+            cpu: None,
+        };
+
+        assert!(
+            !lockfile_entry_satisfies_range(&stale, "^0.27.3"),
+            "stale lockfile entry pinned to 0.25.12 must not satisfy ^0.27.3"
+        );
+
+        let fresh = LockfileEntry {
+            version: "0.27.3".to_string(),
+            ..stale
+        };
+        assert!(
+            lockfile_entry_satisfies_range(&fresh, "^0.27.3"),
+            "fresh lockfile entry pinned to 0.27.3 must satisfy ^0.27.3"
+        );
     }
 
     #[test]

--- a/vertz.lock
+++ b/vertz.lock
@@ -1150,19 +1150,19 @@
   resolved "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz"
   integrity "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="
 
-@esbuild/darwin-arm64@0.25.12:
-  version "0.25.12"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz"
-  integrity "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="
-  os:
-    "darwin"
-  cpu:
-    "arm64"
-
 @esbuild/darwin-arm64@0.27.3:
   version "0.27.3"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz"
   integrity "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="
+
+@esbuild/darwin-arm64@0.27.7:
+  version "0.27.7"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz"
+  integrity "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="
+  os:
+    "darwin"
+  cpu:
+    "arm64"
 
 @floating-ui/core@^1.7.5:
   version "1.7.5"
@@ -2646,13 +2646,6 @@
   dependencies:
     "@types/node" "*"
 
-@types/bun@latest:
-  version "1.3.12"
-  resolved "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz"
-  integrity "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="
-  dependencies:
-    "bun-types" "1.3.12"
-
 @types/chai@^5.2.2:
   version "5.2.3"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz"
@@ -2858,7 +2851,7 @@
     "satori" "0.16.0"
 
 @vertz-benchmarks/vertz-app@link:benchmarks/vertz:
-  version "0.0.63"
+  version "0.0.66"
   resolved "link:benchmarks/vertz"
   integrity ""
 
@@ -2873,12 +2866,12 @@
   integrity ""
 
 @vertz-examples/task-manager@link:examples/task-manager:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:examples/task-manager"
   integrity ""
 
 @vertz/agents@link:packages/agents:
-  version "0.2.45"
+  version "0.2.47"
   resolved "link:packages/agents"
   integrity ""
 
@@ -2893,27 +2886,27 @@
   integrity ""
 
 @vertz/cli-runtime@link:packages/cli-runtime:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/cli-runtime"
   integrity ""
 
 @vertz/cli@link:packages/cli:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/cli"
   integrity ""
 
 @vertz/cloudflare@link:packages/cloudflare:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/cloudflare"
   integrity ""
 
 @vertz/codegen@link:packages/codegen:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/codegen"
   integrity ""
 
 @vertz/compiler@link:packages/compiler:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/compiler"
   integrity ""
 
@@ -2923,22 +2916,22 @@
   integrity ""
 
 @vertz/core@link:packages/core:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/core"
   integrity ""
 
 @vertz/create-vertz-app@link:packages/create-vertz-app:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/create-vertz-app"
   integrity ""
 
 @vertz/db@link:packages/db:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/db"
   integrity ""
 
 @vertz/desktop@link:packages/desktop:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/desktop"
   integrity ""
 
@@ -2953,17 +2946,17 @@
   integrity ""
 
 @vertz/errors@link:packages/errors:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/errors"
   integrity ""
 
 @vertz/fetch@link:packages/fetch:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/fetch"
   integrity ""
 
 @vertz/icons@link:packages/icons:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/icons"
   integrity ""
 
@@ -2998,27 +2991,27 @@
   integrity ""
 
 @vertz/native-compiler-darwin-arm64@link:packages/native-compiler-darwin-arm64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/native-compiler-darwin-arm64"
   integrity ""
 
 @vertz/native-compiler-darwin-x64@link:packages/native-compiler-darwin-x64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/native-compiler-darwin-x64"
   integrity ""
 
 @vertz/native-compiler-linux-arm64@link:packages/native-compiler-linux-arm64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/native-compiler-linux-arm64"
   integrity ""
 
 @vertz/native-compiler-linux-x64@link:packages/native-compiler-linux-x64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/native-compiler-linux-x64"
   integrity ""
 
 @vertz/native-compiler@link:native/vertz-compiler:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:native/vertz-compiler"
   integrity ""
 
@@ -3033,37 +3026,37 @@
   integrity ""
 
 @vertz/runtime-darwin-arm64@link:packages/runtime-darwin-arm64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/runtime-darwin-arm64"
   integrity ""
 
 @vertz/runtime-darwin-x64@link:packages/runtime-darwin-x64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/runtime-darwin-x64"
   integrity ""
 
 @vertz/runtime-linux-arm64@link:packages/runtime-linux-arm64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/runtime-linux-arm64"
   integrity ""
 
 @vertz/runtime-linux-x64@link:packages/runtime-linux-x64:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/runtime-linux-x64"
   integrity ""
 
 @vertz/runtime@link:packages/runtime:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/runtime"
   integrity ""
 
 @vertz/schema@link:packages/schema:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/schema"
   integrity ""
 
 @vertz/server@link:packages/server:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/server"
   integrity ""
 
@@ -3078,22 +3071,22 @@
   integrity ""
 
 @vertz/test@link:packages/test:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/test"
   integrity ""
 
 @vertz/testing@link:packages/testing:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/testing"
   integrity ""
 
 @vertz/theme-shadcn@link:packages/theme-shadcn:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/theme-shadcn"
   integrity ""
 
 @vertz/tui@link:packages/tui:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/tui"
   integrity ""
 
@@ -3103,22 +3096,22 @@
   integrity ""
 
 @vertz/ui-canvas@link:packages/ui-canvas:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/ui-canvas"
   integrity ""
 
 @vertz/ui-primitives@link:packages/ui-primitives:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/ui-primitives"
   integrity ""
 
 @vertz/ui-server@link:packages/ui-server:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/ui-server"
   integrity ""
 
 @vertz/ui@link:packages/ui:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/ui"
   integrity ""
 
@@ -3647,7 +3640,7 @@ cookie@^1.0.2:
   integrity "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
 
 create-vertz@link:packages/create-vertz:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/create-vertz"
   integrity ""
 
@@ -3977,36 +3970,36 @@ esbuild@^0.27.0:
     "esbuild" "bin/esbuild"
 
 esbuild@^0.27.3:
-  version "0.25.12"
-  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz"
-  integrity "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="
+  version "0.27.7"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz"
+  integrity "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="
   optionalDependencies:
-    "@esbuild/aix-ppc64" "0.25.12"
-    "@esbuild/android-arm" "0.25.12"
-    "@esbuild/android-arm64" "0.25.12"
-    "@esbuild/android-x64" "0.25.12"
-    "@esbuild/darwin-arm64" "0.25.12"
-    "@esbuild/darwin-x64" "0.25.12"
-    "@esbuild/freebsd-arm64" "0.25.12"
-    "@esbuild/freebsd-x64" "0.25.12"
-    "@esbuild/linux-arm" "0.25.12"
-    "@esbuild/linux-arm64" "0.25.12"
-    "@esbuild/linux-ia32" "0.25.12"
-    "@esbuild/linux-loong64" "0.25.12"
-    "@esbuild/linux-mips64el" "0.25.12"
-    "@esbuild/linux-ppc64" "0.25.12"
-    "@esbuild/linux-riscv64" "0.25.12"
-    "@esbuild/linux-s390x" "0.25.12"
-    "@esbuild/linux-x64" "0.25.12"
-    "@esbuild/netbsd-arm64" "0.25.12"
-    "@esbuild/netbsd-x64" "0.25.12"
-    "@esbuild/openbsd-arm64" "0.25.12"
-    "@esbuild/openbsd-x64" "0.25.12"
-    "@esbuild/openharmony-arm64" "0.25.12"
-    "@esbuild/sunos-x64" "0.25.12"
-    "@esbuild/win32-arm64" "0.25.12"
-    "@esbuild/win32-ia32" "0.25.12"
-    "@esbuild/win32-x64" "0.25.12"
+    "@esbuild/aix-ppc64" "0.27.7"
+    "@esbuild/android-arm" "0.27.7"
+    "@esbuild/android-arm64" "0.27.7"
+    "@esbuild/android-x64" "0.27.7"
+    "@esbuild/darwin-arm64" "0.27.7"
+    "@esbuild/darwin-x64" "0.27.7"
+    "@esbuild/freebsd-arm64" "0.27.7"
+    "@esbuild/freebsd-x64" "0.27.7"
+    "@esbuild/linux-arm" "0.27.7"
+    "@esbuild/linux-arm64" "0.27.7"
+    "@esbuild/linux-ia32" "0.27.7"
+    "@esbuild/linux-loong64" "0.27.7"
+    "@esbuild/linux-mips64el" "0.27.7"
+    "@esbuild/linux-ppc64" "0.27.7"
+    "@esbuild/linux-riscv64" "0.27.7"
+    "@esbuild/linux-s390x" "0.27.7"
+    "@esbuild/linux-x64" "0.27.7"
+    "@esbuild/netbsd-arm64" "0.27.7"
+    "@esbuild/netbsd-x64" "0.27.7"
+    "@esbuild/openbsd-arm64" "0.27.7"
+    "@esbuild/openbsd-x64" "0.27.7"
+    "@esbuild/openharmony-arm64" "0.27.7"
+    "@esbuild/sunos-x64" "0.27.7"
+    "@esbuild/win32-arm64" "0.27.7"
+    "@esbuild/win32-ia32" "0.27.7"
+    "@esbuild/win32-x64" "0.27.7"
   bin:
     "esbuild" "bin/esbuild"
 
@@ -6875,7 +6868,7 @@ uuid@^13.0.0:
     "uuid" "dist-node/bin/uuid"
 
 vertz@link:packages/vertz:
-  version "0.2.65"
+  version "0.2.68"
   resolved "link:packages/vertz"
   integrity ""
 


### PR DESCRIPTION
## Summary

Fixes #2738. `vtz install`'s semver resolver was producing lockfile entries like `esbuild@^0.27.3 → 0.25.12`, even though `0.25.12` clearly does not satisfy `^0.27.3`. This caused every esbuild spawn across the monorepo to fail with *Host version "0.27.3" does not match binary version "0.25.12"* because the optional platform binaries still pinned to 0.27.3 while the host library resolved to 0.25.12.

## Root Cause

Two fail-open paths in `native/vtz/src/pm/resolver.rs`:

1. **Lockfile fast path** in `resolve_one_task` (~line 262) trusted any pinned version under the matching `name@range` key without verifying the pin still satisfies the range. A stale entry left over from a prior install or registry-state change was silently reused.
2. **Root-dep wiring** in `graph_to_lockfile` (~line 526) looked up the hoisted package by **name only**, then wrote a lockfile entry pointing at whatever hoisted version happened to be present — even if it was out of range.

The low-level `resolve_version()` and `node_semver` itself were already correct — the bug was purely in the reuse / wiring glue that bypassed the satisfies-check.

## Fix

Two new helpers, both in `resolver.rs`:

- `version_satisfies_range(version, range)` — thin wrapper over `Range::parse(...).satisfies(Version::parse(...))` returning `false` on parse failure (fail-closed).
- `lockfile_entry_satisfies_range(entry, range)` — same, but treats `github:` and `link:` specs as always-valid since they're pinned outside semver.

Applied at both bug sites:
- The lockfile fast path now also requires `lockfile_entry_satisfies_range(entry, range)` before reusing a pinned version. A failing check falls through to a fresh registry resolve.
- `graph_to_lockfile`'s hoisted-by-name lookup is replaced with hoisted-by-name-and-range.

## Test Strategy (TDD)

All tests in `native/vtz/src/pm/resolver.rs`, ran `cargo test -p vtz --lib` to confirm red → green.

- `test_version_satisfies_range_caret_zero_x` — `^0.27.3` must reject 0.25.12 / 0.28.0 and accept 0.27.3 / 0.27.5.
- `test_version_satisfies_range_tilde` — same bounds for `~0.27.3`.
- `test_version_satisfies_range_explicit` — `>=0.27.3 <0.28.0` accept/reject.
- `test_resolve_version_caret_rejects_lower_minor` — `^0.27.3` against a version list containing 0.25.12 must pick 0.27.3.
- `test_lockfile_entry_satisfies_for_current_range_rejects_stale` — a pinned 0.25.12 under the `^0.27.3` key must fail the guard; 0.27.3 passes.
- `test_graph_to_lockfile_rejects_hoisted_version_outside_range` — confirmed RED on the prior code path; GREEN with the fix.

## E2E Verification

Rebuilt the release binary (`cargo build --release -p vtz`), linked via `scripts/link-runtime.sh`, cleared `~/.vertz/cache/npm/store/esbuild*` + `@esbuild+*`, ran `vtz install`:

Before: `esbuild@^0.27.3: version "0.25.12"` (WRONG)
After:  `esbuild@^0.27.3: version "0.27.7"` (CORRECT — highest in [0.27.3, 0.28.0))

And `node_modules/.bin/esbuild --version` now prints `0.27.7`, matching the installed package version.

## Quality Gates

- `cargo test -p vtz --lib` — 3456 passed, 0 failed
- `cargo clippy -p vtz --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Test Plan

- [x] Rust unit tests pass
- [x] Rust clippy clean with `-D warnings`
- [x] Rust fmt clean
- [x] Live `vtz install` produces correct `esbuild@^0.27.3 → 0.27.x` lockfile entry
- [x] `node_modules/.bin/esbuild` matches installed package version
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)