### PR TITLE
fix(vtz): vi.mock propagates through transitive imports (resolves #2731)

### DIFF
--- a/.changeset/fix-vtz-mock-transitive-propagation.md
+++ b/.changeset/fix-vtz-mock-transitive-propagation.md
@@ -1,0 +1,49 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): vi.mock propagates through transitive imports (resolves #2731)
+
+When a test file did `vi.mock('m', () => ({ fn: ... }))` and then drove
+production code that itself called `await import('m')`, the production code
+got the REAL frozen module namespace — `spyOn` mutations from the test
+didn't propagate. Static imports of mocked modules were fine; only the
+dynamic-import path leaked the real module.
+
+Three concrete fixes, all needed together:
+
+1. **Wrap dynamic `import()` in non-test files when the test runner is
+   active.** The mock-hoisting compiler pass already wrapped dynamic imports
+   in test files via `__vertz_unwrap_module` so frozen ES module namespaces
+   become mutable; this PR extends the same wrap to every module compiled
+   while `spy_exports` is on (i.e., the entire dependency graph during a
+   `vtz test` run). Without it, `cli.ts → await import('@vertz/compiler')`
+   bypassed the spy installed by `cli.test.ts`.
+
+2. **Restore initial impl on `mockRestore()` for `mock(impl)`.** vtz had
+   `mockRestore = mockReset` for plain mocks, which dropped the
+   factory-supplied implementation to `null`. This broke the common pattern
+   `vi.mock('m', () => ({ fn: mock(() => obj) }))` + `vi.restoreAllMocks()`
+   in `afterEach` — the first cleanup nuked `fn`'s impl for every following
+   test. Now matches vitest: "for `vi.fn(impl)`, `mockRestore` reverts to
+   `impl`". `mockReset` still clears, as documented.
+
+3. **Union synthetic-polyfill exports into the mock proxy.** When mocking a
+   bare specifier with a vtz polyfill (esbuild, `node:*`), the proxy module
+   only exported names declared on disk + names returned by the factory.
+   CJS modules like esbuild expose nothing the regex-based extractor can see,
+   so transitive imports of unmocked exports (`import { transformSync } from
+   'esbuild'` in `@vertz/ui-server/bun-plugin`) failed at import time with
+   "module does not provide an export named transformSync" — even when the
+   call path never reached `transformSync()` at runtime. The proxy now
+   advertises the full polyfill surface (values are `undefined` unless the
+   factory supplied them), preserving spec-compliant import resolution.
+
+Unskipped 3 test blocks that had been parked on this:
+`packages/cli/src/__tests__/cli.test.ts` (codegen command action),
+`packages/cli/src/production-build/__tests__/orchestrator.test.ts`
+(BuildOrchestrator), and
+`packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts`
+(buildUI). 133/134 tests pass; one buildUI assertion that expects an actual
+Brotli `.br` sidecar remains skipped because vtz's `node:zlib` polyfill is a
+passthrough — tracked separately as a runtime polyfill gap, not a mock issue.

--- a/native/vertz-compiler-core/src/lib.rs
+++ b/native/vertz-compiler-core/src/lib.rs
@@ -294,6 +294,17 @@ pub fn compile(source: &str, options: CompileOptions) -> CompileResult {
     // Must run after TypeScript stripping (needs clean JS) and before component transforms.
     if enable_spy_exports {
         spy_exports::transform_spy_exports(&mut ms, &parser_ret.program, source);
+
+        // Wrap dynamic `import()` expressions with `.then(__vertz_unwrap_module)` so
+        // that frozen Module namespaces become mutable. Without this, production code
+        // that does `await import('@vertz/foo')` and the test that does `spyOn(mod, 'fn')`
+        // each get their own frozen namespace — mutations in the test don't propagate.
+        // The mock_hoisting transform also wraps dynamic imports for test files; this
+        // is the per-non-test-file equivalent so transitive `spyOn`-on-dynamic-import
+        // works through the entire module graph in test mode (#2731).
+        if !enable_mock_hoisting {
+            mock_hoisting::wrap_dynamic_imports(&mut ms, &parser_ret.program);
+        }
     }
 
     // Route code splitting -- convert static imports in defineRoutes to dynamic imports.
@@ -1306,6 +1317,88 @@ export function App() {
             "Found @vertz/ui imports outside template strings:\n{}\n\nFull output:\n{}",
             outside_imports.join("\n"),
             code
+        );
+    }
+
+    // ── Dynamic import wrapping for transitive spyOn (#2731) ──────────
+
+    /// Production code in test mode (spy_exports on, mock_hoisting off — i.e. the
+    /// non-test files in a test run) must wrap dynamic `import()` with the
+    /// `__vertz_unwrap_module` helper. Without this, `await import(...)` in
+    /// production code returns a frozen Module namespace; the test file's
+    /// `spyOn(mod, 'fn')` mutation can't propagate to the production code's
+    /// own dynamic-import result.
+    #[test]
+    fn spy_exports_wraps_dynamic_imports_in_non_test_files() {
+        let opts = CompileOptions {
+            filename: Some("src/cli.ts".to_string()),
+            spy_exports: Some(true),
+            mock_hoisting: Some(false),
+            ..Default::default()
+        };
+        let source = r#"export async function main() {
+  const mod = await import('@vertz/compiler');
+  return mod.createCompiler();
+}
+"#;
+        let result = compile(source, opts);
+        assert!(
+            result
+                .code
+                .contains("import('@vertz/compiler').then(globalThis.__vertz_unwrap_module)"),
+            "spy_exports must wrap dynamic import() with __vertz_unwrap_module so \
+             spyOn(mod, 'fn') from a test file propagates to production-code \
+             dynamic imports of the same module. Got:\n{}",
+            result.code
+        );
+    }
+
+    /// Without spy_exports the wrapping must NOT be applied — keeps production
+    /// builds clean of test-only runtime helpers.
+    #[test]
+    fn no_dynamic_import_wrap_when_spy_exports_disabled() {
+        let opts = CompileOptions {
+            filename: Some("src/cli.ts".to_string()),
+            spy_exports: Some(false),
+            mock_hoisting: Some(false),
+            ..Default::default()
+        };
+        let source = r#"export async function main() {
+  const mod = await import('@vertz/compiler');
+  return mod.createCompiler();
+}
+"#;
+        let result = compile(source, opts);
+        assert!(
+            !result.code.contains("__vertz_unwrap_module"),
+            "Without spy_exports the dynamic import wrap must not appear. Got:\n{}",
+            result.code
+        );
+    }
+
+    /// Test files (mock_hoisting=true) already wrap dynamic imports inside
+    /// `transform_mock_hoisting`. The spy_exports branch must not wrap a
+    /// SECOND time and produce a double `.then(...)` chain.
+    #[test]
+    fn dynamic_import_wrap_not_duplicated_for_test_files() {
+        let opts = CompileOptions {
+            filename: Some("src/foo.test.ts".to_string()),
+            spy_exports: Some(true),
+            mock_hoisting: Some(true),
+            ..Default::default()
+        };
+        let source = r#"async function setup() {
+  const mod = await import('./util');
+  return mod;
+}
+"#;
+        let result = compile(source, opts);
+        // Exactly one wrap, not two
+        let occurrences = result.code.matches("__vertz_unwrap_module").count();
+        assert_eq!(
+            occurrences, 1,
+            "Test files must not get the dynamic import wrap applied twice. Got {} occurrences in:\n{}",
+            occurrences, result.code
         );
     }
 

--- a/native/vertz-compiler-core/src/mock_hoisting.rs
+++ b/native/vertz-compiler-core/src/mock_hoisting.rs
@@ -670,7 +670,7 @@ fn ms_overwrite(ms: &mut MagicString, start: u32, end: u32, text: &str) {
 
 /// Wrap dynamic `import()` expressions with `.then(globalThis.__vertz_unwrap_module)`
 /// so the returned module namespace is mutable (enabling `spyOn` on ES modules).
-fn wrap_dynamic_imports(ms: &mut MagicString, program: &Program) {
+pub fn wrap_dynamic_imports(ms: &mut MagicString, program: &Program) {
     let mut visitor = DynamicImportVisitor {
         insert_positions: Vec::new(),
     };

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -4047,17 +4047,37 @@ impl ModuleLoader for VertzModuleLoader {
 
                 // Read the original source to discover export names
                 let source_text = std::fs::read_to_string(&path).unwrap_or_default();
-                let mut export_names = extract_export_names(&source_text);
+                let mut export_names_set: std::collections::HashSet<String> =
+                    extract_export_names(&source_text).into_iter().collect();
 
-                // Fallback: use export names from the mock factory object (JS side).
-                // This handles CJS modules (e.g., esbuild) where extract_export_names
-                // can't find ESM exports.
-                if export_names.is_empty() {
-                    if let Some(names) = self.mock_export_names.borrow().get(&mock_specifier) {
-                        export_names = names.clone();
+                // For bare specifiers that have a synthetic polyfill (esbuild, node:*, etc.),
+                // union in those exports too. The CJS module on disk may not declare ESM
+                // exports the regex can find, but the polyfill does. Without this, importing
+                // an export the test factory didn't supply would fail with
+                // "module does not provide an export named X" — even when the consumer's
+                // call path never reaches that import at runtime.
+                let synthetic = node_specifier_to_synthetic(&mock_specifier).or(
+                    match mock_specifier.as_str() {
+                        "esbuild" => Some(ESBUILD_SPECIFIER),
+                        _ => None,
+                    },
+                );
+                if let Some(synthetic) = synthetic {
+                    if let Some(synth_src) = synthetic_module_source(synthetic) {
+                        export_names_set.extend(extract_export_names(synth_src));
                     }
                 }
 
+                // Always merge in export names from the mock factory object (JS side).
+                // This handles CJS modules (e.g., esbuild) where extract_export_names
+                // can't find ESM exports, and ensures any factory-supplied keys are
+                // exported even if they don't appear in the original module's source.
+                if let Some(names) = self.mock_export_names.borrow().get(&mock_specifier) {
+                    export_names_set.extend(names.iter().cloned());
+                }
+
+                let mut export_names: Vec<String> = export_names_set.into_iter().collect();
+                export_names.sort();
                 let proxy = generate_mock_proxy_module(&mock_specifier, &export_names);
                 return Ok(ModuleSource::new(
                     ModuleType::JavaScript,

--- a/native/vtz/src/test/globals.rs
+++ b/native/vtz/src/test/globals.rs
@@ -174,7 +174,15 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     if (impl !== undefined && impl !== null && typeof impl !== 'function') {
       throw new Error('mock() argument must be a function or undefined');
     }
-    let currentImpl = impl || null;
+    // The "original" implementation — captured from the mock() call and
+    // re-applied by mockRestore() so that factory-supplied impls survive
+    // cleanup hooks like vi.restoreAllMocks(). This matches vitest:
+    // "For a mock function created via vi.fn(impl), the implementation
+    // is restored to the one passed to vi.fn()." Critical for
+    // `vi.mock('m', () => ({ fn: mock(() => obj) }))` patterns where
+    // resetting impls between tests would break the factory contract.
+    const initialImpl = impl || null;
+    let currentImpl = initialImpl;
     let onceQueue = [];
     let mockDisplayName = '';
     const mockState = { calls: [], results: [], lastCall: undefined };
@@ -277,9 +285,17 @@ if (typeof globalThis.HTMLElement === 'undefined') {
     };
 
     mockFn.mockRestore = () => {
-      // For plain mock(), mockRestore is the same as mockReset.
-      // spyOn overrides this to restore the original.
-      return mockFn.mockReset();
+      // Restore to the initial impl captured at mock() creation time.
+      // Matches vitest: vi.fn(impl).mockRestore() reverts to `impl`,
+      // not to a fresh no-op. spyOn overrides this to restore the
+      // original target object method.
+      mockState.calls.length = 0;
+      mockState.results.length = 0;
+      mockState.lastCall = undefined;
+      currentImpl = initialImpl;
+      onceQueue.length = 0;
+      mockDisplayName = '';
+      return mockFn;
     };
 
     allMocks.add(mockFn);
@@ -2630,6 +2646,58 @@ mod tests {
             assert_eq!(
                 item["status"], "pass",
                 "getMockImplementation test {} ({}) failed: {:?}",
+                i, item["name"], item["error"]
+            );
+        }
+    }
+
+    /// Regression for #2731: mockRestore on a plain mock(impl) must restore the
+    /// initial impl, not clear it. Critical for vi.mock() factories where the
+    /// factory returns mock(() => obj) — calling vi.restoreAllMocks() in
+    /// afterEach (or any test cleanup) must not break the factory contract for
+    /// subsequent tests.
+    #[test]
+    fn test_mock_restore_preserves_initial_impl() {
+        let mut rt = create_test_runtime();
+        let results = run_test_code(
+            &mut rt,
+            r#"
+            describe('mockRestore semantics', () => {
+                it('restores initial impl on mock(impl).mockRestore()', () => {
+                    const fn = mock(() => 'initial');
+                    fn.mockImplementation(() => 'changed');
+                    expect(fn()).toBe('changed');
+                    fn.mockRestore();
+                    expect(fn()).toBe('initial');
+                });
+                it('clears impl on mock().mockRestore() (no initial impl)', () => {
+                    const fn = mock();
+                    fn.mockReturnValue('temp');
+                    fn.mockRestore();
+                    expect(fn()).toBeUndefined();
+                });
+                it('vi.restoreAllMocks preserves factory impl across tests', () => {
+                    // Simulate a vi.mock() factory pattern: outer mock returns
+                    // an object; the outer mock has an impl, so it survives.
+                    const factory = mock(() => ({ ok: true }));
+                    const result1 = factory();
+                    expect(result1.ok).toBe(true);
+                    vi.restoreAllMocks();
+                    // After restoreAllMocks, factory must still produce the object.
+                    const result2 = factory();
+                    expect(result2).toBeDefined();
+                    expect(result2.ok).toBe(true);
+                });
+            });
+            "#,
+        );
+
+        let arr = results.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        for (i, item) in arr.iter().enumerate() {
+            assert_eq!(
+                item["status"], "pass",
+                "mockRestore semantics test {} ({}) failed: {:?}",
                 i, item["name"], item["error"]
             );
         }

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -394,11 +394,7 @@ describe('createCLI', () => {
     });
   });
 
-  // Skipped under `vtz test` pending #2731. The 3 tests in this block assert
-  // against mocks that drive createCLI's codegen action through @vertz/compiler
-  // + @vertz/codegen mocks. Same underlying mock/resolver interop issue as
-  // production-build/__tests__/orchestrator.test.ts. Fix is tracked with those.
-  describe.skip('codegen command action', () => {
+  describe('codegen command action', () => {
     let exitSpy: MockFunction<(...args: unknown[]) => unknown>;
     let errorSpy: MockFunction<(...args: unknown[]) => unknown>;
     let logSpy: MockFunction<(...args: unknown[]) => unknown>;

--- a/packages/cli/src/production-build/__tests__/orchestrator.test.ts
+++ b/packages/cli/src/production-build/__tests__/orchestrator.test.ts
@@ -23,22 +23,23 @@ import { join } from 'node:path';
 import { BuildOrchestrator, createBuildOrchestrator } from '../orchestrator';
 import type { BuildConfig, BuildManifest } from '../types';
 
-// Mock dependencies
+// Mock dependencies — every mock uses a factory-supplied implementation so it
+// survives `vi.restoreAllMocks()` (vitest semantics: mockRestore returns mocks
+// to their initial state, which means a `mock().mockResolvedValue(x)` mock
+// drops to `undefined`, but `mock(() => Promise.resolve(x))` retains its impl).
 vi.mock('@vertz/compiler', () => {
-  const mockGenerate = mock().mockResolvedValue(undefined);
-
   return {
     createCompiler: mock(() => ({
-      analyze: mock().mockResolvedValue({
+      analyze: mock(async () => ({
         modules: [{ name: 'test', services: [], routes: [], schemas: [] }],
         routes: [],
         schemas: [],
         env: { variables: [] },
         middlewares: [],
-      }),
-      validate: mock().mockResolvedValue([]),
-      compile: mock().mockResolvedValue({ success: true, diagnostics: [] }),
-      getConfig: mock().mockReturnValue({
+      })),
+      validate: mock(async () => []),
+      compile: mock(async () => ({ success: true, diagnostics: [] })),
+      getConfig: mock(() => ({
         strict: false,
         forceGenerate: false,
         compiler: {
@@ -57,37 +58,37 @@ vi.mock('@vertz/compiler', () => {
             detectDeadCode: false,
           },
         },
-      }),
+      })),
     })),
     Compiler: mock(),
     OpenAPIGenerator: class {
-      generate = mockGenerate;
+      generate = mock(async () => undefined);
     },
   };
 });
 
 vi.mock('@vertz/codegen', () => ({
   createCodegenPipeline: mock(() => ({
-    validate: mock().mockReturnValue([]),
-    generate: mock().mockResolvedValue({
+    validate: mock(() => []),
+    generate: mock(async () => ({
       files: [{ path: 'test.ts', content: 'export type Test = string;' }],
       fileCount: 1,
       generators: ['typescript'],
       incremental: { written: ['test.ts'], skipped: [], removed: [] },
-    }),
-    resolveOutputDir: mock().mockReturnValue('.vertz/generated'),
+    })),
+    resolveOutputDir: mock(() => '.vertz/generated'),
     resolveConfig: mock((config) => config),
   })),
-  generate: mock().mockResolvedValue({
+  generate: mock(async () => ({
     files: [{ path: 'test.ts', content: 'export type Test = string;' }],
     fileCount: 1,
     generators: ['typescript'],
-  }),
+  })),
 }));
 
-// Mock esbuild - create a default mock implementation
+// Mock esbuild — factory impl so default behavior survives restoreAllMocks.
 vi.mock('esbuild', () => ({
-  build: mock().mockResolvedValue({
+  build: mock(async () => ({
     errors: [],
     warnings: [],
     metafile: {
@@ -99,22 +100,10 @@ vi.mock('esbuild', () => ({
         },
       },
     },
-  }),
+  })),
 }));
 
-// Skipped under `vtz test` pending #2731.
-//
-// These tests mock @vertz/compiler, @vertz/codegen, and esbuild, then drive the
-// full BuildOrchestrator.build() pipeline. The mocks work in isolation but the
-// pipeline transitively imports @vertz/ui-server/bun-plugin which does its own
-// esbuild resolution — vtz's module loader + vi.mock interaction in this
-// specific transitive chain produces `Cannot read properties of undefined
-// (reading 'analyze')` and `mockCreate.getMockImplementation is not a function`
-// (vtz's mock API doesn't expose getMockImplementation). Fixing properly needs
-// either: (a) splitting these into integration tests that run the real pipeline
-// against a fixture app, or (b) tightening vtz's mock + resolver parity with
-// vitest. Track both in #2731.
-describe.skip('BuildOrchestrator', () => {
+describe('BuildOrchestrator', () => {
   let orchestrator: BuildOrchestrator;
 
   const defaultConfig: BuildConfig = {

--- a/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
+++ b/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts
@@ -103,13 +103,7 @@ function defaultBunBuildImpl(opts: { outdir: string; entrypoints: string[] }) {
 
 // ── Test suite ──────────────────────────────────────────────────────
 
-// Skipped under `vtz test` pending #2731. Assertions drive buildUI through
-// mocked @vertz/compiler + esbuild + @vertz/ui-server/bun-plugin. The
-// transitive resolver interactions produce the same failure class as
-// production-build/__tests__/orchestrator.test.ts — either the mock doesn't
-// propagate into transitive imports, or vitest-only mock APIs (.mockImplementation
-// discovery) aren't available in vtz's @vertz/test surface. Track with #2731.
-describe.skip('buildUI', () => {
+describe('buildUI', () => {
   let tmpDir: string;
   let config: UIBuildConfig;
 
@@ -168,7 +162,10 @@ describe.skip('buildUI', () => {
   });
 
   it('should return failure when native compiler is unavailable', async () => {
-    mockLoadNativeCompiler.mockImplementation(() => {
+    // Use mockImplementationOnce so the throw only affects this test — the
+    // factory-supplied default impl reasserts on the next call, keeping
+    // subsequent tests independent of ordering.
+    mockLoadNativeCompiler.mockImplementationOnce(() => {
       throw new Error('Binary not found');
     });
 
@@ -764,7 +761,12 @@ describe.skip('buildUI', () => {
   // ── Brotli compression ────────────────────────────────────────────
 
   describe('brotli compression', () => {
-    it('should create .br files for eligible files over min size', async () => {
+    // Skipped under vtz: vtz's node:zlib polyfill stub for brotliCompressSync
+    // is a passthrough (returns the input unchanged). buildUI's compressor
+    // only writes .br sidecars when compressed.length < content.length, so
+    // the passthrough never produces output. This is a vtz polyfill gap, not
+    // a buildUI bug — track separately when adding real Brotli to the runtime.
+    it.skip('should create .br files for eligible files over min size', async () => {
       // Override client build to create a large JS file
       mockBunBuild
         .mockImplementationOnce((opts: { outdir: string }) => {


### PR DESCRIPTION
## Summary

Closes #2731. Three layered fixes so `vi.mock('m', factory)` reaches production code that uses `await import('m')` deep in the dependency graph:

1. **Wrap dynamic `import()` in non-test files when `spy_exports` is on.** The mock-hoisting pass already wrapped them in test files via `__vertz_unwrap_module`; extending the wrap to the entire graph means `cli.ts → await import('@vertz/compiler')` no longer bypasses the spy installed by `cli.test.ts`. The `__vertz_unwrap_module` helper caches by the original (frozen) module identity via WeakMap, so the test file and production code resolve to the same mutable wrapper.

2. **`mockRestore` on `mock(impl)` now restores the initial impl** instead of clearing it. Matches vitest semantics ("for `vi.fn(impl)`, mockRestore reverts to `impl`") and unbreaks the common `vi.mock('m', () => ({ fn: mock(() => obj) }))` + `vi.restoreAllMocks()` pattern, where the factory contract was being torn down on first afterEach. `mockReset` still clears.

3. **Mock proxy module unions in synthetic-polyfill exports** for bare specifiers like `esbuild` + `node:*`. Without this, transitive `import { transformSync } from 'esbuild'` in `@vertz/ui-server/bun-plugin` failed at link time even when the call path never invoked it at runtime.

Unskips the 3 test blocks parked on this:

- [packages/cli/src/__tests__/cli.test.ts](https://github.com/vertz-dev/vertz/blob/fix/vtz-mock-transitive-propagation/packages/cli/src/__tests__/cli.test.ts) — codegen command action (3 tests)
- [packages/cli/src/production-build/__tests__/orchestrator.test.ts](https://github.com/vertz-dev/vertz/blob/fix/vtz-mock-transitive-propagation/packages/cli/src/production-build/__tests__/orchestrator.test.ts) — BuildOrchestrator (23 tests)
- [packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts](https://github.com/vertz-dev/vertz/blob/fix/vtz-mock-transitive-propagation/packages/cli/src/production-build/__tests__/ui-build-pipeline.test.ts) — buildUI (47 tests)

Test mocks updated to use factory-supplied impls (`mock(async () => x)`) instead of `mock().mockResolvedValue(x)` so they survive `vi.restoreAllMocks()` under correct vitest semantics — the runtime fix preserves `initialImpl`, but the previous test code also relied on configured impls surviving reset (which neither vitest nor vtz does for `mock()` with no initial impl).

## Public API Changes

- `mockRestore()` on a mock created via `mock(impl)` now restores `impl` instead of clearing the implementation. Behavior change for callers that depended on `mockRestore` being identical to `mockReset` for non-spy mocks. `mockReset()` semantics unchanged. Aligns with vitest.
- Dynamic `import()` in non-test files compiled under `vtz test` is now wrapped with `__vertz_unwrap_module`. Transparent at runtime — the wrapper proxies reads to the original namespace and stores writes locally.
- Mocked modules with synthetic vtz polyfills (esbuild, `node:*`) now expose the union of polyfill exports + factory-returned exports + on-disk ESM exports.

## Test plan

- [x] `cargo test -p vertz-compiler-core` — 1247 passed
- [x] `cargo test --release -p vtz --lib` — 3460 passed (incl. 3 new mock_restore + dynamic-import wrap regression tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `vtz test src/__tests__/cli.test.ts` — 63/63 pass
- [x] `vtz test src/production-build/__tests__/orchestrator.test.ts` — 23/23 pass
- [x] `vtz test src/production-build/__tests__/ui-build-pipeline.test.ts` — 47/47 pass (1 brotli skip, vtz polyfill gap, tracked separately)
- [x] Full workspace `vtz test` — no new regressions vs main; remaining failures (SSR examples, AOT JSX subprocess tests, packages that import `bun`) are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)