### PR TITLE
fix(vtz): isolate process.env per V8 isolate

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.68"
+version = "0.2.69"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.68"
+version = "0.2.69"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.68"
+version = "0.2.69"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -177,6 +177,7 @@ impl VertzJsRuntime {
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
                 state.put(http_serve::HttpServeState::default());
+                state.put(env::IsolateEnv::from_process_env());
             })),
             ..Default::default()
         };
@@ -242,6 +243,7 @@ impl VertzJsRuntime {
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
                 state.put(http_serve::HttpServeState::default());
+                state.put(env::IsolateEnv::from_process_env());
             })),
             ..Default::default()
         };
@@ -451,6 +453,7 @@ impl VertzJsRuntime {
                 state.put(crypto_subtle::CryptoKeyStore::default());
                 state.put(sqlite::SqliteStore::default());
                 state.put(http_serve::HttpServeState::default());
+                state.put(env::IsolateEnv::from_process_env());
             })),
             ..Default::default()
         };

--- a/native/vtz/src/runtime/ops/env.rs
+++ b/native/vtz/src/runtime/ops/env.rs
@@ -1,31 +1,59 @@
 use deno_core::op2;
 use deno_core::OpDecl;
+use deno_core::OpState;
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Per-isolate environment variable store.
+///
+/// Seeded from `std::env::vars()` when the isolate is created, then diverges
+/// independently. JS mutations to `process.env` operate on this store and do
+/// NOT touch the process-global `std::env` — this prevents parallel isolates
+/// (e.g. `vtz test` worker threads running multiple files in one process) from
+/// racing on shared OS env state.
+///
+/// Matches the isolation semantics of bun/vitest test workers, where each
+/// worker has its own `process.env` copy.
+#[derive(Default)]
+pub struct IsolateEnv(pub Rc<RefCell<HashMap<String, String>>>);
+
+impl IsolateEnv {
+    /// Seed from the current process environment. Called once per isolate at
+    /// creation time.
+    pub fn from_process_env() -> Self {
+        Self(Rc::new(RefCell::new(std::env::vars().collect())))
+    }
+}
 
 /// Get an environment variable. Returns null if not set.
 #[op2]
 #[string]
-pub fn op_env_get(#[string] key: String) -> Option<String> {
-    std::env::var(&key).ok()
+pub fn op_env_get(state: &mut OpState, #[string] key: String) -> Option<String> {
+    let env = state.borrow::<IsolateEnv>();
+    env.0.borrow().get(&key).cloned()
 }
 
 /// Set an environment variable.
 #[op2(fast)]
-pub fn op_env_set(#[string] key: String, #[string] value: String) {
-    std::env::set_var(&key, &value);
+pub fn op_env_set(state: &mut OpState, #[string] key: String, #[string] value: String) {
+    let env = state.borrow::<IsolateEnv>();
+    env.0.borrow_mut().insert(key, value);
 }
 
 /// Remove an environment variable.
 #[op2(fast)]
-pub fn op_env_remove(#[string] key: String) {
-    std::env::remove_var(&key);
+pub fn op_env_remove(state: &mut OpState, #[string] key: String) {
+    let env = state.borrow::<IsolateEnv>();
+    env.0.borrow_mut().remove(&key);
 }
 
 /// List all environment variable names.
 #[op2]
 #[serde]
-pub fn op_env_keys() -> Vec<String> {
-    std::env::vars().map(|(k, _)| k).collect()
+pub fn op_env_keys(state: &mut OpState) -> Vec<String> {
+    let env = state.borrow::<IsolateEnv>();
+    env.0.borrow().keys().cloned().collect()
 }
 
 /// Get the current working directory.
@@ -419,6 +447,44 @@ mod tests {
             .unwrap();
         assert_eq!(result, serde_json::json!(true));
         std::env::remove_var("VERTZ_KEYS_TEST");
+    }
+
+    #[test]
+    fn test_process_env_isolated_across_isolates() {
+        // Regression: under `vtz test`, parallel test files each get their own
+        // V8 isolate but used to share process.env via std::env, causing env
+        // mutations (e.g. NODE_ENV=production) to race across files.
+        // Each isolate must have its own process.env.
+        let mut rt1 = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+        let mut rt2 = VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap();
+
+        rt1.execute_script(
+            "<test>",
+            "process.env.VERTZ_ISOLATION_TEST = 'isolate_one'; null",
+        )
+        .unwrap();
+        rt2.execute_script(
+            "<test>",
+            "process.env.VERTZ_ISOLATION_TEST = 'isolate_two'; null",
+        )
+        .unwrap();
+
+        let r1 = rt1
+            .execute_script("<test>", "process.env.VERTZ_ISOLATION_TEST")
+            .unwrap();
+        let r2 = rt2
+            .execute_script("<test>", "process.env.VERTZ_ISOLATION_TEST")
+            .unwrap();
+
+        assert_eq!(r1, serde_json::json!("isolate_one"));
+        assert_eq!(r2, serde_json::json!("isolate_two"));
+
+        // Mutations must NOT leak to the process-global std::env either —
+        // otherwise other tests running in the same cargo test process race.
+        assert!(
+            std::env::var("VERTZ_ISOLATION_TEST").is_err(),
+            "JS mutations to process.env should not leak to std::env"
+        );
     }
 
     #[test]

--- a/native/vtz/src/runtime/ops/process.rs
+++ b/native/vtz/src/runtime/ops/process.rs
@@ -1,8 +1,37 @@
 use deno_core::op2;
 use deno_core::OpDecl;
+use deno_core::OpState;
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
+
+use super::env::IsolateEnv;
+
+/// Apply an env policy to `cmd`:
+/// - If `env_override` is `Some`, replace the child's env entirely with it
+///   (matches Node.js semantics when `opts.env` is set).
+/// - Otherwise, replace with the isolate's env store (so JS mutations to
+///   `process.env` are visible to child processes, matching Node's "child
+///   inherits parent's env" default).
+fn apply_child_env(
+    cmd: &mut Command,
+    isolate_env: &IsolateEnv,
+    env_override: Option<HashMap<String, String>>,
+) {
+    cmd.env_clear();
+    match env_override {
+        Some(map) => {
+            for (k, v) in map {
+                cmd.env(k, v);
+            }
+        }
+        None => {
+            for (k, v) in isolate_env.0.borrow().iter() {
+                cmd.env(k, v);
+            }
+        }
+    }
+}
 
 /// Synchronously spawn a child process and capture its output.
 ///
@@ -11,6 +40,7 @@ use std::sync::{Mutex, OnceLock};
 #[op2]
 #[serde]
 pub fn op_command_output_sync(
+    state: &mut OpState,
     #[string] file: String,
     #[serde] args: Vec<String>,
     #[string] cwd: Option<String>,
@@ -23,13 +53,8 @@ pub fn op_command_output_sync(
         cmd.current_dir(dir);
     }
 
-    if let Some(env_map) = env {
-        // Node.js replaces the entire environment when opts.env is set.
-        cmd.env_clear();
-        for (key, value) in env_map {
-            cmd.env(key, value);
-        }
-    }
+    let isolate_env = state.borrow::<IsolateEnv>();
+    apply_child_env(&mut cmd, isolate_env, env);
 
     let output = cmd.output().map_err(|e| {
         deno_core::error::type_error(format!("Failed to execute command '{file}': {e}"))
@@ -94,6 +119,7 @@ fn known_pids() -> &'static Mutex<std::collections::HashSet<u32>> {
 #[op2]
 #[serde]
 pub fn op_process_spawn(
+    state: &mut OpState,
     #[string] file: String,
     #[serde] args: Vec<String>,
     #[string] cwd: Option<String>,
@@ -107,12 +133,8 @@ pub fn op_process_spawn(
         cmd.current_dir(dir);
     }
 
-    if let Some(env_map) = env {
-        cmd.env_clear();
-        for (key, value) in env_map {
-            cmd.env(key, value);
-        }
-    }
+    let isolate_env = state.borrow::<IsolateEnv>();
+    apply_child_env(&mut cmd, isolate_env, env);
 
     match stdio.as_deref() {
         Some("inherit") => {


### PR DESCRIPTION
## Summary

Under `vtz test`, parallel test files each run in their own V8 isolate but share the process. Previously `op_env_{get,set,remove,keys}` operated on `std::env`, which is process-global — so two parallel files both mutating `process.env.NODE_ENV` raced, giving whichever wrote last.

This broke `@vertz/core` `env-validator.test.ts`: it sets `NODE_ENV='production'` and asserts, but a concurrent `ctx-builder.test.ts` sets `NODE_ENV='development'`, so the assertion fails with _"expected development to be production"_ — the main-branch CI failure.

## Fix

Per-isolate `IsolateEnv` in `OpState`, seeded from `std::env::vars()` at isolate creation. JS mutations operate on the isolate's HashMap, not `std::env`. Matches bun/vitest worker-isolation semantics.

`child_process.spawn`/`exec` also updated: when `opts.env` is null, children inherit the _isolate's_ env (not the process env), so a JS mutation like `process.env.NODE_ENV = 'production'` is visible to spawned children — matches Node.js parent-env-inheritance semantics.

## Regression test

`test_process_env_isolated_across_isolates` — two isolates set the same key to different values, read it back, and verify no leak to `std::env`. Without the fix this fails with `"isolate_two" != "isolate_one"`.

## Test plan

- [x] `cargo test -p vtz` — all 3463+ tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `@vertz/core` test suite (311/311 pass, including previously failing `env-validator`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)