### PR TITLE
fix(vtz): import rewriter skips JS comments (#2730)

### DIFF
--- a/.changeset/fix-rewriter-comment-apostrophe.md
+++ b/.changeset/fix-rewriter-comment-apostrophe.md
@@ -1,0 +1,13 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): import rewriter now skips JS comments
+
+The `/@deps/` import rewriter did not recognize `//` or `/* */` comments,
+so an apostrophe inside a comment (e.g. `// indicator's data-state`)
+opened a fake string literal that swallowed every `import` statement until
+the next apostrophe. In `@vertz/theme-shadcn@0.2.70/dist/index.js` this
+leaked 5 of 46 bare `@vertz/ui` imports to the browser despite #2740.
+The rewriter and its `from` search now skip line and block comments.
+Closes #2730.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.69"
+version = "0.2.70"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.69"
+version = "0.2.70"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.69"
+version = "0.2.70"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/compiler/import_rewriter.rs
+++ b/native/vtz/src/compiler/import_rewriter.rs
@@ -24,6 +24,37 @@ pub fn rewrite_imports(
     let mut i = 0;
 
     while i < len {
+        // Skip line comments (`// ...`) — apostrophes or `import`/`export` words
+        // inside a comment must not start string scanning or be rewritten.
+        // Regression guard for #2730: comments like `// indicator's data-state`
+        // otherwise opened an unterminated fake string that swallowed real
+        // `import` statements downstream.
+        if chars[i] == '/' && i + 1 < len && chars[i + 1] == '/' {
+            while i < len && chars[i] != '\n' {
+                result.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+
+        // Skip block comments (`/* ... */`) for the same reason.
+        if chars[i] == '/' && i + 1 < len && chars[i + 1] == '*' {
+            result.push(chars[i]);
+            result.push(chars[i + 1]);
+            i += 2;
+            while i < len {
+                if chars[i] == '*' && i + 1 < len && chars[i + 1] == '/' {
+                    result.push(chars[i]);
+                    result.push(chars[i + 1]);
+                    i += 2;
+                    break;
+                }
+                result.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+
         // Skip string literals so we don't match 'import'/'export' inside strings
         if chars[i] == '\'' || chars[i] == '"' {
             let quote = chars[i];
@@ -223,6 +254,28 @@ fn find_from_keyword(chars: &[char], start: usize, len: usize) -> Option<usize> 
     let limit = len.min(start + 2000);
 
     while i < limit {
+        // Skip line comments so apostrophes or `from` inside them don't
+        // derail the search. Mirrors the main loop in `rewrite_imports`.
+        if i + 1 < len && chars[i] == '/' && chars[i + 1] == '/' {
+            while i < len && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Skip block comments for the same reason.
+        if i + 1 < len && chars[i] == '/' && chars[i + 1] == '*' {
+            i += 2;
+            while i < len {
+                if chars[i] == '*' && i + 1 < len && chars[i + 1] == '/' {
+                    i += 2;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
         // Skip string literals to avoid matching 'from' inside strings
         if i < len && (chars[i] == '\'' || chars[i] == '"') {
             let quote = chars[i];
@@ -788,6 +841,79 @@ const msg = `import something`;"#;
         assert_eq!(
             result, code,
             "String literals containing 'import'/'export' must be preserved"
+        );
+    }
+
+    // Regression for #2730: a line comment containing an apostrophe (e.g.
+    // "// indicator's data-state") must not hijack the rewriter into string
+    // mode and swallow real `import` statements that follow. Reproduces the
+    // real-world failure in `@vertz/theme-shadcn/dist/index.js` where 5 bare
+    // `@vertz/ui` imports leaked to the browser downstream of such comments.
+    #[test]
+    fn test_rewrite_imports_ignores_apostrophe_in_line_comment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let code = r#"import { variants } from "@vertz/ui";
+// CSS controls which icon is visible based on the indicator's data-state.
+function foo() { return 42; }
+import { css } from "@vertz/ui";
+export { variants, css, foo };
+"#;
+
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
+
+        assert!(
+            !result.contains("from \"@vertz/ui\""),
+            "bare `@vertz/ui` must not leak past a line comment with an apostrophe:\n{}",
+            result
+        );
+    }
+
+    // Regression for #2730 (block comment variant): apostrophes inside a
+    // `/* ... */` block comment must also be ignored, not treated as the
+    // opening quote of a string literal.
+    #[test]
+    fn test_rewrite_imports_ignores_apostrophe_in_block_comment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let code = r#"import { a } from "pkg-a";
+/* describes the consumer's intent across
+   multiple lines — note the apostrophe */
+import { b } from "pkg-b";
+"#;
+
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
+
+        assert!(
+            !result.contains("from \"pkg-a\"") && !result.contains("from \"pkg-b\""),
+            "bare specifiers must be rewritten across a block comment with an apostrophe:\n{}",
+            result
+        );
+    }
+
+    // The rewriter must preserve comment content verbatim — it must not
+    // mutate text inside `//` or `/* */` (e.g. by trying to rewrite a
+    // bare-looking identifier that happens to live in a comment).
+    #[test]
+    fn test_rewrite_imports_preserves_comment_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let code = r#"// import { x } from "some-pkg"; — this is documentation
+/* import { y } from 'other-pkg'; */
+const x = 1;
+"#;
+
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
+
+        assert_eq!(
+            result, code,
+            "comment text containing import/export syntax must be preserved verbatim"
         );
     }
 

--- a/packages/ui-server/src/__tests__/preload-mock-native-compiler.ts
+++ b/packages/ui-server/src/__tests__/preload-mock-native-compiler.ts
@@ -19,10 +19,13 @@ try {
   const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
   const binaryName = `vertz-compiler.${platform}-${arch}.node`;
-  require.resolve(`@vertz/native-compiler/${binaryName}`);
+  // Actually load the binary — resolving isn't enough because the vtz runtime
+  // cannot currently execute N-API `.node` addons and fails with a UTF-8 read
+  // error. Runtimes that do support `.node` (e.g. bun) succeed here.
+  require(`@vertz/native-compiler/${binaryName}`);
   nativeCompilerAvailable = true;
 } catch {
-  // Binary not available — mock the module
+  // Binary not loadable — mock the module
 }
 
 // Export for tests to use with describe.skipIf


### PR DESCRIPTION
## Summary

Fixes #2730. The `/@deps/` import rewriter did not recognize `//` or `/* */` comments, so an apostrophe inside a comment (e.g. `// indicator's data-state`) opened a fake string literal that swallowed every `import` statement until the next apostrophe.

Verified against published `@vertz/theme-shadcn@0.2.70/dist/index.js`: **5 of 46 bare `@vertz/ui` imports** leaked to the browser despite the #2740 fix. All 5 are downstream of two lines:

- `native/vtz/…/index.js:1445` `// … indicator's data-state.`
- `native/vtz/…/index.js:1888` `// … browser's UA dialog centering.`

After this fix, 0 bare imports leak and the served line count is preserved (4311).

## Public API Changes

None. Internal rewriter fix.

## Root cause

`rewrite_imports` and its `find_from_keyword` helper scanned characters one by one and already handled string/template literals, but had no logic for JS comments. Any apostrophe inside a line or block comment started a phantom single-quoted string that terminated far downstream — typically at another apostrophe or end-of-file — blocking every `import` rewrite in between.

Added comment-skipping to both code paths *before* string-literal handling. See `native/vtz/src/compiler/import_rewriter.rs`.

## Tests

Three regression tests added:
- `test_rewrite_imports_ignores_apostrophe_in_line_comment`
- `test_rewrite_imports_ignores_apostrophe_in_block_comment`
- `test_rewrite_imports_preserves_comment_content`

All 3466 `vtz` lib tests pass; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` clean.

## Secondary change

Also fixed a pre-existing local-only test failure in `packages/ui-server/src/__tests__/preload-mock-native-compiler.ts`. The preload used `require.resolve()` to detect the native compiler binary, but resolve-only succeeds under vtz even though vtz can't actually execute `.node` addons yet. Switched to `require()` so the AOT build-manifest tests skip under vtz (matching CI) and run normally under bun. Without this, every AOT test in that file crashed with "stream did not contain valid UTF-8" when the native-compiler binary was installed locally.

## Test plan

- [x] `cargo test --all` in `native/` passes
- [x] Manual repro against `@vertz/theme-shadcn@0.2.70/dist/index.js` served via `/@deps/` — 0 of 46 bare imports leak
- [x] Pre-push hooks (build-typecheck, lint, test, rust-*) all green
- [ ] GitHub CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)