### PR TITLE
fix(vtz): trigger HMR and clean module graph on file delete

### DIFF
--- a/.changeset/fix-hmr-on-delete.md
+++ b/.changeset/fix-hmr-on-delete.md
@@ -1,0 +1,21 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): trigger HMR and clean module graph on file delete
+
+The dev server's file-change loop called `compile_for_browser` on every
+event, which fails for a deleted file — pushing the flow into the
+compilation-error branch and skipping graph/cache cleanup. Dependents of
+the deleted file were never HMR-invalidated, so clients kept using stale
+modules.
+
+`process_file_change` now cleans the module graph on `Remove` events
+(under a single write lock, so a concurrent browser fetch can't re-add
+the deleted node between the read and write phases). Deleting a
+standalone CSS file escalates past `CssUpdate` (whose URL would 404) to
+`ModuleUpdate`. The server loop branches on `Remove` to skip compilation
+while still invalidating dependents, so HMR broadcasts an `Update` (or
+`FullReload` when the entry file is deleted).
+
+Closes #2764.

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -1750,51 +1750,62 @@ pub async fn start_server_with_lifecycle(
                                         .clear_category(ErrorCategory::Runtime)
                                         .await;
 
-                                    // Attempt recompilation for error recovery
-                                    let compile_result = watcher_state.pipeline
-                                        .compile_for_browser(&change.path);
+                                    // For delete events: skip compilation and import-graph
+                                    // rewriting — the file is gone. process_file_change still
+                                    // cleans up the graph entry and invalidates dependents.
+                                    let is_remove = matches!(
+                                        change.kind,
+                                        crate::watcher::file_watcher::FileChangeKind::Remove,
+                                    );
 
-                                    // Check if compilation produced an error module
-                                    if compile_result.code.contains("console.error(`[vertz] Compilation error:") {
-                                        // Read the source to provide a snippet
+                                    if !is_remove {
+                                        // Attempt recompilation for error recovery
+                                        let compile_result = watcher_state.pipeline
+                                            .compile_for_browser(&change.path);
+
+                                        // Check if compilation produced an error module
+                                        if compile_result.code.contains("console.error(`[vertz] Compilation error:") {
+                                            // Read the source to provide a snippet
+                                            let source = std::fs::read_to_string(&change.path)
+                                                .unwrap_or_default();
+                                            let snippet = if !source.is_empty() {
+                                                Some(extract_snippet(&source, 1, 3))
+                                            } else {
+                                                None
+                                            };
+
+                                            let mut error = DevError::build(
+                                                format!("Compilation failed: {}", file_str)
+                                            ).with_file(file_str.clone());
+
+                                            if let Some(s) = snippet {
+                                                error = error.with_snippet(s);
+                                            }
+
+                                            watcher_state.error_broadcaster
+                                                .report_error(error)
+                                                .await;
+
+                                            continue;
+                                        }
+
+                                        // Update module graph with this file's imports
+                                        // so transitive dependents are invalidated correctly.
                                         let source = std::fs::read_to_string(&change.path)
                                             .unwrap_or_default();
-                                        let snippet = if !source.is_empty() {
-                                            Some(extract_snippet(&source, 1, 3))
-                                        } else {
-                                            None
-                                        };
-
-                                        let mut error = DevError::build(
-                                            format!("Compilation failed: {}", file_str)
-                                        ).with_file(file_str.clone());
-
-                                        if let Some(s) = snippet {
-                                            error = error.with_snippet(s);
-                                        }
-
-                                        watcher_state.error_broadcaster
-                                            .report_error(error)
-                                            .await;
-
-                                        continue;
-                                    }
-
-                                    // Update module graph with this file's imports
-                                    // so transitive dependents are invalidated correctly.
-                                    let source = std::fs::read_to_string(&change.path)
-                                        .unwrap_or_default();
-                                    if !source.is_empty() {
-                                        let deps = crate::deps::scanner::scan_local_dependencies(
-                                            &source,
-                                            &change.path,
-                                        );
-                                        if let Ok(mut graph) = watcher_state.module_graph.write() {
-                                            graph.update_module(&change.path, deps);
+                                        if !source.is_empty() {
+                                            let deps = crate::deps::scanner::scan_local_dependencies(
+                                                &source,
+                                                &change.path,
+                                            );
+                                            if let Ok(mut graph) = watcher_state.module_graph.write() {
+                                                graph.update_module(&change.path, deps);
+                                            }
                                         }
                                     }
 
-                                    // Compilation succeeded — process the change normally
+                                    // Process the change — invalidates cache, computes dependents,
+                                    // and for Remove events also cleans the graph.
                                     let result = watcher::process_file_change(
                                         change,
                                         watcher_state.pipeline.cache(),

--- a/native/vtz/src/watcher/mod.rs
+++ b/native/vtz/src/watcher/mod.rs
@@ -63,7 +63,8 @@ pub fn process_file_change(
 
     let is_entry_file = change.path == entry_file;
 
-    // Get transitive dependents from the module graph
+    // Get transitive dependents from the module graph BEFORE any structural
+    // mutation — so deleted nodes still contribute their dependents here.
     let invalidated_files: Vec<PathBuf> = {
         let graph = graph.read().unwrap();
         let affected = graph.get_transitive_dependents(&change.path);
@@ -78,6 +79,13 @@ pub fn process_file_change(
     // If the changed file is new (not in graph yet), just invalidate it
     if invalidated_files.is_empty() {
         cache.invalidate(&change.path);
+    }
+
+    // On delete, drop the module from the graph so its ghost edges don't
+    // contaminate future invalidation cascades.
+    if matches!(change.kind, FileChangeKind::Remove) {
+        let mut graph = graph.write().unwrap();
+        graph.remove_module(&change.path);
     }
 
     InvalidationResult {
@@ -292,6 +300,64 @@ mod tests {
         assert!(!result
             .invalidated_files
             .contains(&PathBuf::from("/src/Input.tsx")));
+    }
+
+    #[test]
+    fn test_process_file_change_remove_cleans_graph_and_invalidates_dependents() {
+        let cache = CompilationCache::new();
+        let graph = new_shared_module_graph();
+        let entry = PathBuf::from("/src/app.tsx");
+
+        // app depends on utils
+        {
+            let mut g = graph.write().unwrap();
+            g.update_module(
+                Path::new("/src/app.tsx"),
+                vec![PathBuf::from("/src/utils.ts")],
+            );
+        }
+        cache.insert(PathBuf::from("/src/utils.ts"), make_cached_module("utils"));
+        cache.insert(PathBuf::from("/src/app.tsx"), make_cached_module("app"));
+
+        let change = FileChange {
+            kind: FileChangeKind::Remove,
+            path: PathBuf::from("/src/utils.ts"),
+        };
+
+        let result = process_file_change(&change, &cache, &graph, &entry);
+
+        // Deleted file must be gone from the graph
+        {
+            let g = graph.read().unwrap();
+            assert!(
+                !g.has_module(Path::new("/src/utils.ts")),
+                "deleted module must be removed from graph"
+            );
+            // app should no longer reference utils as a dependency
+            let app_deps = g.get_dependencies(Path::new("/src/app.tsx"));
+            assert!(
+                !app_deps.contains(&PathBuf::from("/src/utils.ts")),
+                "reverse edges must be cleaned on remove"
+            );
+        }
+
+        // Dependents must be in the invalidation result so HMR can notify them
+        assert!(
+            result
+                .invalidated_files
+                .contains(&PathBuf::from("/src/app.tsx")),
+            "dependents must be invalidated on remove"
+        );
+
+        // Cache must not retain stale entries for the deleted file or its dependents
+        assert!(
+            cache.get_unchecked(Path::new("/src/utils.ts")).is_none(),
+            "cache entry for deleted file must be removed"
+        );
+        assert!(
+            cache.get_unchecked(Path::new("/src/app.tsx")).is_none(),
+            "cache entry for dependent must be invalidated"
+        );
     }
 
     #[test]

--- a/native/vtz/src/watcher/mod.rs
+++ b/native/vtz/src/watcher/mod.rs
@@ -45,30 +45,38 @@ pub fn process_file_change(
     graph: &SharedModuleGraph,
     entry_file: &Path,
 ) -> InvalidationResult {
-    // A CSS file is "CSS-only" if it has no JS dependents in the module graph.
-    // When a CSS file is imported by JS (`import './styles.css'`), it's served
-    // as a JS module — so changes should trigger a module update, not a CSS update.
-    let is_css_only = if change
-        .path
-        .extension()
-        .map(|ext| ext == "css")
-        .unwrap_or(false)
-    {
-        let g = graph.read().unwrap();
-        let dependents = g.get_dependents(&change.path);
-        dependents.is_empty()
-    } else {
-        false
-    };
-
     let is_entry_file = change.path == entry_file;
+    let is_remove = matches!(change.kind, FileChangeKind::Remove);
 
-    // Get transitive dependents from the module graph BEFORE any structural
-    // mutation — so deleted nodes still contribute their dependents here.
-    let invalidated_files: Vec<PathBuf> = {
-        let graph = graph.read().unwrap();
-        let affected = graph.get_transitive_dependents(&change.path);
-        affected.into_iter().collect()
+    // Snapshot dependents and (for Remove) clean up the graph under a single
+    // write lock so a concurrent module_server fetch can't add a dependent
+    // between the read and write phases.
+    let (invalidated_files, is_css_only) = {
+        let mut g = graph.write().unwrap();
+
+        // A CSS file is "CSS-only" if it has no JS dependents in the module
+        // graph. When a CSS file is imported by JS (`import './styles.css'`),
+        // it's served as a JS module — so changes should trigger a module
+        // update, not a CSS update. A deleted CSS file is never CSS-only:
+        // re-fetching the URL would 404, so we must escalate to a module
+        // update / full reload.
+        let is_css = change
+            .path
+            .extension()
+            .map(|ext| ext == "css")
+            .unwrap_or(false);
+        let is_css_only = is_css && !is_remove && g.get_dependents(&change.path).is_empty();
+
+        let invalidated: Vec<PathBuf> = g
+            .get_transitive_dependents(&change.path)
+            .into_iter()
+            .collect();
+
+        if is_remove {
+            g.remove_module(&change.path);
+        }
+
+        (invalidated, is_css_only)
     };
 
     // Invalidate all affected files in the compilation cache
@@ -79,13 +87,6 @@ pub fn process_file_change(
     // If the changed file is new (not in graph yet), just invalidate it
     if invalidated_files.is_empty() {
         cache.invalidate(&change.path);
-    }
-
-    // On delete, drop the module from the graph so its ghost edges don't
-    // contaminate future invalidation cascades.
-    if matches!(change.kind, FileChangeKind::Remove) {
-        let mut graph = graph.write().unwrap();
-        graph.remove_module(&change.path);
     }
 
     InvalidationResult {
@@ -357,6 +358,27 @@ mod tests {
         assert!(
             cache.get_unchecked(Path::new("/src/app.tsx")).is_none(),
             "cache entry for dependent must be invalidated"
+        );
+    }
+
+    #[test]
+    fn test_process_file_change_standalone_css_delete_is_not_css_only() {
+        // A standalone CSS file with no JS dependents would normally be treated
+        // as CSS-only (HMR re-fetches the stylesheet URL). On delete, that URL
+        // 404s — so Remove events must escalate past CssUpdate.
+        let cache = CompilationCache::new();
+        let graph = new_shared_module_graph();
+        let entry = PathBuf::from("/src/app.tsx");
+
+        let change = FileChange {
+            kind: FileChangeKind::Remove,
+            path: PathBuf::from("/src/styles.css"),
+        };
+
+        let result = process_file_change(&change, &cache, &graph, &entry);
+        assert!(
+            !result.is_css_only,
+            "deleted CSS file must not be treated as css_only (would 404 on re-fetch)"
         );
     }
 

--- a/native/vtz/tests/parity/hmr.rs
+++ b/native/vtz/tests/parity/hmr.rs
@@ -1,11 +1,17 @@
 use crate::common::*;
 use futures_util::StreamExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time::timeout;
+use vertz_runtime::compiler::cache::CompilationCache;
 use vertz_runtime::hmr::protocol::HmrMessage;
-use vertz_runtime::watcher::file_watcher::{FileChangeKind, FileWatcher, FileWatcherConfig};
+use vertz_runtime::plugin::vertz::VertzPlugin;
+use vertz_runtime::plugin::{hmr_action_to_message, FrameworkPlugin, HmrAction};
+use vertz_runtime::watcher::file_watcher::{
+    FileChange, FileChangeKind, FileWatcher, FileWatcherConfig,
+};
 use vertz_runtime::watcher::module_graph::ModuleGraph;
+use vertz_runtime::watcher::{new_shared_module_graph, process_file_change};
 
 /// Parity #37: File change triggers module update message on WebSocket.
 /// Uses direct `hmr_hub.broadcast()` for deterministic testing (Tier 1).
@@ -127,6 +133,96 @@ async fn entry_file_change_triggers_full_reload() {
         "Expected Modify or Create, got: {:?}",
         change.kind
     );
+}
+
+/// Parity #41: Deleting a file broadcasts an HMR Update for its dependents
+/// and cleans the module graph so future invalidations are not contaminated.
+#[tokio::test]
+async fn file_delete_triggers_hmr_update_and_cleans_graph() {
+    let root = Path::new("/project");
+    let entry = PathBuf::from("/project/src/app.tsx");
+    let deleted = PathBuf::from("/project/src/utils.ts");
+
+    let cache = CompilationCache::new();
+    let graph = new_shared_module_graph();
+
+    // app.tsx imports utils.ts
+    {
+        let mut g = graph.write().unwrap();
+        g.update_module(&entry, vec![deleted.clone()]);
+    }
+
+    let result = process_file_change(
+        &FileChange {
+            kind: FileChangeKind::Remove,
+            path: deleted.clone(),
+        },
+        &cache,
+        &graph,
+        &entry,
+    );
+
+    // Deleted file must be gone from the graph.
+    assert!(
+        !graph.read().unwrap().has_module(&deleted),
+        "deleted file must be removed from graph"
+    );
+
+    // Dependent must be in the invalidation result.
+    assert!(
+        result.invalidated_files.contains(&entry),
+        "dependent must be invalidated after delete"
+    );
+
+    // Plugin strategy must produce a ModuleUpdate (not a no-op) for the dependent.
+    let action = VertzPlugin.hmr_strategy(&result);
+    let modules = match action {
+        HmrAction::ModuleUpdate(m) => m,
+        other => panic!("expected ModuleUpdate for delete with dependents, got {other:?}"),
+    };
+    assert!(
+        modules.iter().any(|p| p == &entry),
+        "update modules must include the dependent"
+    );
+
+    // Message serialized through the plugin pipeline is an Update with the
+    // dependent's root-relative URL.
+    let msg = hmr_action_to_message(&HmrAction::ModuleUpdate(modules.clone()), root);
+    match msg {
+        HmrMessage::Update { modules: mods, .. } => {
+            assert!(
+                mods.iter().any(|m| m == "/src/app.tsx"),
+                "broadcast update must include the dependent's URL, got: {mods:?}"
+            );
+        }
+        other => panic!("expected Update HMR message, got {other:?}"),
+    }
+}
+
+/// Parity #42: Deleting the entry file triggers a FullReload.
+#[tokio::test]
+async fn entry_file_delete_triggers_full_reload() {
+    let entry = PathBuf::from("/project/src/app.tsx");
+
+    let cache = CompilationCache::new();
+    let graph = new_shared_module_graph();
+    graph.write().unwrap().update_module(&entry, vec![]);
+
+    let result = process_file_change(
+        &FileChange {
+            kind: FileChangeKind::Remove,
+            path: entry.clone(),
+        },
+        &cache,
+        &graph,
+        &entry,
+    );
+
+    assert!(result.is_entry_file);
+    match VertzPlugin.hmr_strategy(&result) {
+        HmrAction::FullReload(_) => {}
+        other => panic!("expected FullReload for entry-file delete, got {other:?}"),
+    }
 }
 
 /// Parity #40: Module graph tracks transitive dependents.


### PR DESCRIPTION
## Summary

- Dev server's change loop called `compile_for_browser` on every event, which fails for deleted files — pushing flow into the compile-error branch and skipping graph/cache cleanup. Dependents of deleted files kept serving stale modules.
- `process_file_change` now cleans the module graph on `Remove` events under a single write lock (prevents race with concurrent `graph.update_module` from browser fetches), and the server loop branches on `Remove` to skip compilation while still invalidating dependents. HMR broadcasts `Update` for a dependent delete, `FullReload` for entry-file delete.
- Standalone CSS delete escalates past `CssUpdate` (whose URL would 404) to `ModuleUpdate`, unit-tested. Follow-ups filed as #2765, #2766, #2767.

## Test plan

- [x] `cargo test --all` — green (new unit + parity tests for Remove path)
- [x] `cargo clippy --all-targets -- -D warnings` — green
- [x] `cargo fmt --all -- --check` — green
- [ ] GitHub CI green
- [ ] Manual: delete a `.tsx` file in a dev-server session; confirm dependents hot-update without stale modules

Closes #2764.