### PR TITLE
feat(scripts): add classname shorthand migration tool

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -12,6 +12,7 @@
     "**/.tmp-*/**",
     "**/cli/my-app/**",
     "**/coverage/**",
-    "**/dist/**"
+    "**/dist/**",
+    "scripts/migrate-classnames/__fixtures__/**"
   ]
 }

--- a/scripts/migrate-classnames/__fixtures__/expected/01-padding.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/01-padding.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  panel: { padding: token.spacing[4], paddingInline: token.spacing[6], paddingTop: token.spacing[2] },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/02-color-with-shade.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/02-color-with-shade.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  card: { backgroundColor: token.color.primary[500], color: token.color.foreground, borderColor: token.color.primary[700] },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/03-color-without-shade.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/03-color-without-shade.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  hero: { backgroundColor: token.color.background, color: token.color.primary, borderColor: token.color.muted },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/04-pseudo-prefixes.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/04-pseudo-prefixes.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  button: { padding: token.spacing[4], '&:hover': { backgroundColor: token.color.primary[500] }, '&:focus': { outline: 'none' }, '&:disabled': { opacity: '0.5' } },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/05-font-variants.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/05-font-variants.tsx
@@ -1,0 +1,6 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  title: { fontSize: token.font.size.xl, fontWeight: token.font.weight.semibold },
+  body: { fontFamily: token.font.family.sans, fontSize: token.font.size.base },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/06-variants-call.ts
+++ b/scripts/migrate-classnames/__fixtures__/expected/06-variants-call.ts
@@ -1,0 +1,15 @@
+import { token, variants } from '@vertz/ui';
+
+export const button = variants({
+  base: { display: 'inline-flex', borderRadius: token.radius.md, fontWeight: token.font.weight.medium },
+  variants: {
+    intent: {
+      primary: { backgroundColor: token.color.primary, color: 'white' },
+      ghost: { backgroundColor: 'transparent', color: token.color.foreground },
+    },
+    size: {
+      sm: { paddingInline: token.spacing[3], fontSize: token.font.size.sm },
+      md: { paddingInline: token.spacing[4], fontSize: token.font.size.base },
+    },
+  },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/07-compound-variants.ts
+++ b/scripts/migrate-classnames/__fixtures__/expected/07-compound-variants.ts
@@ -1,0 +1,10 @@
+import { token, variants } from '@vertz/ui';
+
+export const button = variants({
+  base: { display: 'flex' },
+  variants: {
+    intent: { primary: { backgroundColor: token.color.primary } },
+    size: { sm: { paddingInline: token.spacing[3] } },
+  },
+  compoundVariants: [{ intent: 'primary', size: 'sm', styles: { padding: token.spacing[2], fontWeight: token.font.weight.bold } }],
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/08-keywords.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/08-keywords.tsx
@@ -1,0 +1,6 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  row: { display: 'flex', flexDirection: 'column', alignItems: 'center' },
+  label: { overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/09-raw-values.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/09-raw-values.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  overlay: { cursor: 'pointer', zIndex: '10', opacity: '0.8' },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/10-size-and-border.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/10-size-and-border.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  badge: { width: '100%', height: token.spacing[4], borderWidth: '1px', borderColor: token.color.primary[500] },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/11-mixed-pseudo-groups.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/11-mixed-pseudo-groups.tsx
@@ -1,0 +1,5 @@
+import { css, token } from '@vertz/ui';
+
+export const styles = css({
+  link: { color: token.color.primary, '&:hover': { color: token.color.primary[700], backgroundColor: token.color.primary[100] }, '&:focus': { outline: 'none' }, '&:active': { opacity: '0.8' } },
+});

--- a/scripts/migrate-classnames/__fixtures__/expected/12-import-style-ui-subpath.tsx
+++ b/scripts/migrate-classnames/__fixtures__/expected/12-import-style-ui-subpath.tsx
@@ -1,0 +1,6 @@
+import { css } from '@vertz/ui/css';
+import { token } from '@vertz/ui';
+
+export const styles = css({
+  box: { padding: token.spacing[4], borderRadius: token.radius.md },
+});

--- a/scripts/migrate-classnames/__fixtures__/input/01-padding.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/01-padding.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  panel: ['p:4', 'px:6', 'pt:2'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/02-color-with-shade.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/02-color-with-shade.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  card: ['bg:primary.500', 'text:foreground', 'border:primary.700'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/03-color-without-shade.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/03-color-without-shade.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  hero: ['bg:background', 'text:primary', 'border:muted'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/04-pseudo-prefixes.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/04-pseudo-prefixes.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  button: ['p:4', 'hover:bg:primary.500', 'focus:outline-none', 'disabled:opacity:0.5'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/05-font-variants.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/05-font-variants.tsx
@@ -1,0 +1,6 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  title: ['font:xl', 'weight:semibold'],
+  body: ['font:sans', 'font:base'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/06-variants-call.ts
+++ b/scripts/migrate-classnames/__fixtures__/input/06-variants-call.ts
@@ -1,0 +1,15 @@
+import { variants } from '@vertz/ui';
+
+export const button = variants({
+  base: ['inline-flex', 'rounded:md', 'font:medium'],
+  variants: {
+    intent: {
+      primary: ['bg:primary', 'text:white'],
+      ghost: ['bg:transparent', 'text:foreground'],
+    },
+    size: {
+      sm: ['px:3', 'font:sm'],
+      md: ['px:4', 'font:base'],
+    },
+  },
+});

--- a/scripts/migrate-classnames/__fixtures__/input/07-compound-variants.ts
+++ b/scripts/migrate-classnames/__fixtures__/input/07-compound-variants.ts
@@ -1,0 +1,10 @@
+import { variants } from '@vertz/ui';
+
+export const button = variants({
+  base: ['flex'],
+  variants: {
+    intent: { primary: ['bg:primary'] },
+    size: { sm: ['px:3'] },
+  },
+  compoundVariants: [{ intent: 'primary', size: 'sm', styles: ['p:2', 'font:bold'] }],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/08-keywords.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/08-keywords.tsx
@@ -1,0 +1,6 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  row: ['flex', 'flex-col', 'items:center'],
+  label: ['truncate'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/09-raw-values.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/09-raw-values.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  overlay: ['cursor:pointer', 'z:10', 'opacity:0.8'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/10-size-and-border.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/10-size-and-border.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  badge: ['w:full', 'h:4', 'border:1', 'border:primary.500'],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/11-mixed-pseudo-groups.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/11-mixed-pseudo-groups.tsx
@@ -1,0 +1,11 @@
+import { css } from '@vertz/ui';
+
+export const styles = css({
+  link: [
+    'text:primary',
+    'hover:text:primary.700',
+    'hover:bg:primary.100',
+    'focus:outline-none',
+    'active:opacity:0.8',
+  ],
+});

--- a/scripts/migrate-classnames/__fixtures__/input/12-import-style-ui-subpath.tsx
+++ b/scripts/migrate-classnames/__fixtures__/input/12-import-style-ui-subpath.tsx
@@ -1,0 +1,5 @@
+import { css } from '@vertz/ui/css';
+
+export const styles = css({
+  box: ['p:4', 'rounded:md'],
+});

--- a/scripts/migrate-classnames/fixtures.test.ts
+++ b/scripts/migrate-classnames/fixtures.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@vertz/test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { rewriteSource } from './rewriter';
+
+const FIXTURES_DIR = resolve(import.meta.dir, '__fixtures__');
+const INPUT_DIR = join(FIXTURES_DIR, 'input');
+const EXPECTED_DIR = join(FIXTURES_DIR, 'expected');
+
+function listFixtures(): string[] {
+  return readdirSync(INPUT_DIR)
+    .filter((name) => extname(name) === '.tsx' || extname(name) === '.ts')
+    .sort();
+}
+
+describe('migration fixtures', () => {
+  const fixtures = listFixtures();
+
+  it('has at least 10 fixture pairs', () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const name of fixtures) {
+    it(`rewrites ${name} to match expected output`, () => {
+      const input = readFileSync(join(INPUT_DIR, name), 'utf8');
+      const expected = readFileSync(join(EXPECTED_DIR, name), 'utf8');
+      const result = rewriteSource(input, name);
+      expect(result.code).toBe(expected);
+    });
+
+    it(`is idempotent for ${name} (expected → expected)`, () => {
+      const expected = readFileSync(join(EXPECTED_DIR, name), 'utf8');
+      const result = rewriteSource(expected, name);
+      expect(result.code).toBe(expected);
+      expect(result.changed).toBe(false);
+    });
+  }
+});

--- a/scripts/migrate-classnames/generator.test.ts
+++ b/scripts/migrate-classnames/generator.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from '@vertz/test';
+import { generateStyleBlock } from './generator';
+
+describe('generateStyleBlock — single entries', () => {
+  it('emits a single spacing entry', () => {
+    expect(generateStyleBlock(['p:4'])).toBe('{ padding: token.spacing[4] }');
+  });
+
+  it('emits a single color entry', () => {
+    expect(generateStyleBlock(['bg:primary'])).toBe('{ backgroundColor: token.color.primary }');
+  });
+
+  it('emits a single literal for CSS color keyword', () => {
+    expect(generateStyleBlock(['bg:white'])).toBe("{ backgroundColor: 'white' }");
+  });
+});
+
+describe('generateStyleBlock — multiple base entries', () => {
+  it('joins multiple shorthands in one block', () => {
+    expect(generateStyleBlock(['p:4', 'bg:primary'])).toBe(
+      '{ padding: token.spacing[4], backgroundColor: token.color.primary }',
+    );
+  });
+
+  it('expands multi-declaration keywords (truncate)', () => {
+    expect(generateStyleBlock(['truncate'])).toBe(
+      "{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }",
+    );
+  });
+
+  it('preserves shorthand order', () => {
+    expect(generateStyleBlock(['flex', 'items:center', 'justify:between'])).toBe(
+      "{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }",
+    );
+  });
+});
+
+describe('generateStyleBlock — pseudo grouping', () => {
+  it('groups a single hover shorthand under &:hover', () => {
+    expect(generateStyleBlock(['hover:bg:primary'])).toBe(
+      "{ '&:hover': { backgroundColor: token.color.primary } }",
+    );
+  });
+
+  it('merges multiple shorthands that share the same pseudo', () => {
+    expect(generateStyleBlock(['hover:bg:primary', 'hover:text:white'])).toBe(
+      "{ '&:hover': { backgroundColor: token.color.primary, color: 'white' } }",
+    );
+  });
+
+  it('places base entries before pseudo group', () => {
+    expect(generateStyleBlock(['p:4', 'hover:bg:primary'])).toBe(
+      "{ padding: token.spacing[4], '&:hover': { backgroundColor: token.color.primary } }",
+    );
+  });
+
+  it('emits multiple distinct pseudo groups in first-seen order', () => {
+    expect(
+      generateStyleBlock(['p:4', 'hover:bg:primary', 'focus:outline-none', 'hover:text:white']),
+    ).toBe(
+      "{ padding: token.spacing[4], '&:hover': { backgroundColor: token.color.primary, color: 'white' }, '&:focus': { outline: 'none' } }",
+    );
+  });
+});
+
+describe('generateStyleBlock — edge cases', () => {
+  it('returns {} for an empty array', () => {
+    expect(generateStyleBlock([])).toBe('{}');
+  });
+
+  it('handles a disabled pseudo prefix', () => {
+    expect(generateStyleBlock(['disabled:opacity:0.5'])).toBe(
+      "{ '&:disabled': { opacity: '0.5' } }",
+    );
+  });
+
+  it('handles decimal spacing keys', () => {
+    expect(generateStyleBlock(['mt:0.5'])).toBe("{ marginTop: token.spacing['0.5'] }");
+  });
+});

--- a/scripts/migrate-classnames/generator.ts
+++ b/scripts/migrate-classnames/generator.ts
@@ -1,0 +1,46 @@
+/**
+ * Generates an object-literal source string from an array of shorthand tokens.
+ *
+ *   generateStyleBlock(['p:4', 'hover:bg:primary'])
+ *     -> "{ padding: token.spacing[4], '&:hover': { backgroundColor: token.color.primary } }"
+ *
+ * Base entries render first, pseudo groups render in first-seen order. Output is
+ * single-line; let oxfmt normalize whitespace after the file rewriter runs.
+ */
+
+import type { MappedEntry } from './mapper';
+import { mapShorthand } from './mapper';
+
+export function generateStyleBlock(shorthands: readonly string[]): string {
+  if (shorthands.length === 0) return '{}';
+
+  const baseEntries: MappedEntry[] = [];
+  const pseudoGroups = new Map<string, MappedEntry[]>();
+
+  for (const shorthand of shorthands) {
+    const mapped = mapShorthand(shorthand);
+    if (mapped.pseudo === null) {
+      baseEntries.push(...mapped.entries);
+      continue;
+    }
+    const existing = pseudoGroups.get(mapped.pseudo);
+    if (existing) {
+      existing.push(...mapped.entries);
+    } else {
+      pseudoGroups.set(mapped.pseudo, [...mapped.entries]);
+    }
+  }
+
+  const parts: string[] = [];
+  for (const entry of baseEntries) parts.push(formatEntry(entry));
+  for (const [selector, entries] of pseudoGroups) {
+    const inner = entries.map(formatEntry).join(', ');
+    parts.push(`'${selector}': { ${inner} }`);
+  }
+
+  return `{ ${parts.join(', ')} }`;
+}
+
+function formatEntry(entry: MappedEntry): string {
+  return `${entry.cssKey}: ${entry.valueExpr}`;
+}

--- a/scripts/migrate-classnames/mapper.test.ts
+++ b/scripts/migrate-classnames/mapper.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from '@vertz/test';
+import { mapShorthand } from './mapper';
+
+describe('mapShorthand — spacing', () => {
+  it('maps p:4 to padding + token.spacing[4]', () => {
+    expect(mapShorthand('p:4')).toEqual({
+      entries: [{ cssKey: 'padding', valueExpr: 'token.spacing[4]' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps px:2 to paddingInline + token.spacing[2]', () => {
+    expect(mapShorthand('px:2')).toEqual({
+      entries: [{ cssKey: 'paddingInline', valueExpr: 'token.spacing[2]' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps mt:0.5 to marginTop with decimal spacing', () => {
+    expect(mapShorthand('mt:0.5')).toEqual({
+      entries: [{ cssKey: 'marginTop', valueExpr: "token.spacing['0.5']" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps mx:auto to marginInline + string literal', () => {
+    expect(mapShorthand('mx:auto')).toEqual({
+      entries: [{ cssKey: 'marginInline', valueExpr: "'auto'" }],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — colors', () => {
+  it('maps bg:primary to backgroundColor + token.color.primary', () => {
+    expect(mapShorthand('bg:primary')).toEqual({
+      entries: [{ cssKey: 'backgroundColor', valueExpr: 'token.color.primary' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps bg:primary.500 to backgroundColor + shade', () => {
+    expect(mapShorthand('bg:primary.500')).toEqual({
+      entries: [{ cssKey: 'backgroundColor', valueExpr: 'token.color.primary[500]' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps text:foreground to color token', () => {
+    expect(mapShorthand('text:foreground')).toEqual({
+      entries: [{ cssKey: 'color', valueExpr: 'token.color.foreground' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps bg:white (CSS color keyword) to literal string', () => {
+    expect(mapShorthand('bg:white')).toEqual({
+      entries: [{ cssKey: 'backgroundColor', valueExpr: "'white'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps bg:transparent to literal', () => {
+    expect(mapShorthand('bg:transparent')).toEqual({
+      entries: [{ cssKey: 'backgroundColor', valueExpr: "'transparent'" }],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — keywords', () => {
+  it('maps flex keyword to display', () => {
+    expect(mapShorthand('flex')).toEqual({
+      entries: [{ cssKey: 'display', valueExpr: "'flex'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps flex-col to flexDirection', () => {
+    expect(mapShorthand('flex-col')).toEqual({
+      entries: [{ cssKey: 'flexDirection', valueExpr: "'column'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps truncate (multi-declaration)', () => {
+    expect(mapShorthand('truncate')).toEqual({
+      entries: [
+        { cssKey: 'overflow', valueExpr: "'hidden'" },
+        { cssKey: 'whiteSpace', valueExpr: "'nowrap'" },
+        { cssKey: 'textOverflow', valueExpr: "'ellipsis'" },
+      ],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — pseudo prefixes', () => {
+  it('maps hover:bg:primary with pseudo selector', () => {
+    expect(mapShorthand('hover:bg:primary')).toEqual({
+      entries: [{ cssKey: 'backgroundColor', valueExpr: 'token.color.primary' }],
+      pseudo: '&:hover',
+    });
+  });
+
+  it('maps focus:outline-none keyword with pseudo', () => {
+    expect(mapShorthand('focus:outline-none')).toEqual({
+      entries: [{ cssKey: 'outline', valueExpr: "'none'" }],
+      pseudo: '&:focus',
+    });
+  });
+
+  it('maps disabled:opacity:0.5', () => {
+    expect(mapShorthand('disabled:opacity:0.5')).toEqual({
+      entries: [{ cssKey: 'opacity', valueExpr: "'0.5'" }],
+      pseudo: '&:disabled',
+    });
+  });
+});
+
+describe('mapShorthand — radius / shadow / font', () => {
+  it('maps rounded:md to borderRadius + token.radius.md', () => {
+    expect(mapShorthand('rounded:md')).toEqual({
+      entries: [{ cssKey: 'borderRadius', valueExpr: 'token.radius.md' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps shadow:md to boxShadow + token.shadow.md', () => {
+    expect(mapShorthand('shadow:md')).toEqual({
+      entries: [{ cssKey: 'boxShadow', valueExpr: 'token.shadow.md' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps font:xl to fontSize + token.font.size.xl', () => {
+    expect(mapShorthand('font:xl')).toEqual({
+      entries: [{ cssKey: 'fontSize', valueExpr: 'token.font.size.xl' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps font:bold (weight keyword) to fontWeight', () => {
+    expect(mapShorthand('font:bold')).toEqual({
+      entries: [{ cssKey: 'fontWeight', valueExpr: 'token.font.weight.bold' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps weight:semibold to fontWeight directly', () => {
+    expect(mapShorthand('weight:semibold')).toEqual({
+      entries: [{ cssKey: 'fontWeight', valueExpr: 'token.font.weight.semibold' }],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — alignment + raw', () => {
+  it('maps items:center to alignItems', () => {
+    expect(mapShorthand('items:center')).toEqual({
+      entries: [{ cssKey: 'alignItems', valueExpr: "'center'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps justify:between to justifyContent: space-between', () => {
+    expect(mapShorthand('justify:between')).toEqual({
+      entries: [{ cssKey: 'justifyContent', valueExpr: "'space-between'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps cursor:pointer (raw) to literal', () => {
+    expect(mapShorthand('cursor:pointer')).toEqual({
+      entries: [{ cssKey: 'cursor', valueExpr: "'pointer'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps z:10 (raw numeric) to literal string', () => {
+    expect(mapShorthand('z:10')).toEqual({
+      entries: [{ cssKey: 'zIndex', valueExpr: "'10'" }],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — size / border', () => {
+  it('maps w:full to width: 100%', () => {
+    expect(mapShorthand('w:full')).toEqual({
+      entries: [{ cssKey: 'width', valueExpr: "'100%'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps w:4 to width via spacing', () => {
+    expect(mapShorthand('w:4')).toEqual({
+      entries: [{ cssKey: 'width', valueExpr: 'token.spacing[4]' }],
+      pseudo: null,
+    });
+  });
+
+  it('maps border:1 to borderWidth', () => {
+    expect(mapShorthand('border:1')).toEqual({
+      entries: [{ cssKey: 'borderWidth', valueExpr: "'1px'" }],
+      pseudo: null,
+    });
+  });
+
+  it('maps border:primary.500 to borderColor (color mode)', () => {
+    expect(mapShorthand('border:primary.500')).toEqual({
+      entries: [{ cssKey: 'borderColor', valueExpr: 'token.color.primary[500]' }],
+      pseudo: null,
+    });
+  });
+});
+
+describe('mapShorthand — content', () => {
+  it('maps content:empty to empty CSS string literal', () => {
+    const result = mapShorthand('content:empty');
+    expect(result.entries).toEqual([{ cssKey: 'content', valueExpr: `"''"` }]);
+  });
+
+  it('maps content:none to CSS keyword', () => {
+    const result = mapShorthand('content:none');
+    expect(result.entries).toEqual([{ cssKey: 'content', valueExpr: `"none"` }]);
+  });
+
+  it('throws on invalid content value', () => {
+    expect(() => mapShorthand('content:bogus')).toThrow(/content/i);
+  });
+});
+
+describe('mapShorthand — errors', () => {
+  it('throws on unknown shorthand', () => {
+    expect(() => mapShorthand('bogus:whatever')).toThrow(/unknown/i);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => mapShorthand('')).toThrow();
+  });
+});

--- a/scripts/migrate-classnames/mapper.ts
+++ b/scripts/migrate-classnames/mapper.ts
@@ -1,0 +1,264 @@
+/**
+ * Maps a single shorthand string (e.g. `p:4`, `hover:bg:primary.500`, `truncate`)
+ * to one or more object-form CSS declarations for the migration script.
+ *
+ * Output shape is designed to plug into an object-literal emitter:
+ *   { entries: [{ cssKey: 'padding', valueExpr: 'token.spacing[4]' }], pseudo: null }
+ *
+ * - `cssKey`: camelCase CSS property name (assignable inside a StyleBlock).
+ * - `valueExpr`: a raw expression string ready to be spliced into source code.
+ *     Token paths are bare (`token.color.primary[500]`). String literals are
+ *     quoted (`"'auto'"`).
+ * - `pseudo`: the nested-selector key (`&:hover`, `&:focus`, ...) or null.
+ */
+
+import type { PropertyMapping } from '../../packages/ui/src/css/token-tables';
+import {
+  ALIGNMENT_MAP,
+  COLOR_NAMESPACES,
+  CONTENT_MAP,
+  CSS_COLOR_KEYWORDS,
+  FONT_SIZE_SCALE,
+  FONT_WEIGHT_SCALE,
+  KEYWORD_MAP,
+  PROPERTY_MAP,
+  PSEUDO_MAP,
+  PSEUDO_PREFIXES,
+  SIZE_KEYWORDS,
+  SPACING_SCALE,
+} from '../../packages/ui/src/css/token-tables';
+
+export interface MappedEntry {
+  cssKey: string;
+  valueExpr: string;
+}
+
+export interface MappedShorthand {
+  entries: MappedEntry[];
+  pseudo: string | null;
+}
+
+const FONT_FAMILY_KEYS: ReadonlySet<string> = new Set(['mono', 'sans', 'serif']);
+const TEXT_ALIGN_KEYWORDS: ReadonlySet<string> = new Set([
+  'center',
+  'left',
+  'right',
+  'justify',
+  'start',
+  'end',
+]);
+
+export function mapShorthand(input: string): MappedShorthand {
+  if (!input || input.trim() === '') {
+    throw new TypeError('Empty shorthand string');
+  }
+
+  const trimmed = input.trim();
+  const parts = trimmed.split(':');
+
+  let pseudo: string | null = null;
+  let property: string;
+  let value: string | null;
+
+  if (parts.length === 1) {
+    property = parts[0]!;
+    value = null;
+  } else if (parts.length === 2) {
+    const [first, second] = parts as [string, string];
+    if (PSEUDO_PREFIXES.has(first)) {
+      pseudo = toNestedPseudo(first);
+      property = second;
+      value = null;
+    } else {
+      property = first;
+      value = second;
+    }
+  } else if (parts.length === 3) {
+    const [first, second, third] = parts as [string, string, string];
+    if (!PSEUDO_PREFIXES.has(first)) {
+      throw new TypeError(`Invalid shorthand '${input}': unknown pseudo prefix '${first}'`);
+    }
+    pseudo = toNestedPseudo(first);
+    property = second;
+    value = third;
+  } else {
+    throw new TypeError(`Invalid shorthand '${input}': too many segments`);
+  }
+
+  if (value === null) {
+    const keyword = KEYWORD_MAP[property];
+    if (keyword !== undefined) {
+      return {
+        entries: keyword.map((entry) => ({
+          cssKey: toCamel(entry.property),
+          valueExpr: quote(entry.value),
+        })),
+        pseudo,
+      };
+    }
+    throw new TypeError(`Invalid shorthand '${input}': unknown keyword '${property}'`);
+  }
+
+  const mapping = PROPERTY_MAP[property];
+  if (mapping === undefined) {
+    throw new TypeError(`Invalid shorthand '${input}': unknown property '${property}'`);
+  }
+
+  if (property === 'text') return { entries: mapText(value), pseudo };
+  if (property === 'font') return { entries: mapFont(value), pseudo };
+  if (property === 'border') return { entries: mapBorder(value), pseudo };
+
+  const valueExpr = mapValueForType(value, mapping.valueType, property);
+  const entries = mapping.properties.map((cssProp) => ({
+    cssKey: toCamel(cssProp),
+    valueExpr,
+  }));
+  return { entries, pseudo };
+}
+
+function toNestedPseudo(prefix: string): string {
+  const pseudo = PSEUDO_MAP[prefix];
+  if (pseudo === undefined) {
+    throw new TypeError(`Unknown pseudo prefix '${prefix}'`);
+  }
+  return `&${pseudo}`;
+}
+
+function mapValueForType(
+  value: string,
+  valueType: PropertyMapping['valueType'],
+  property: string,
+): string {
+  switch (valueType) {
+    case 'spacing':
+      return mapSpacing(value, property);
+    case 'color':
+      return mapColor(value, property);
+    case 'radius':
+      return mapRadius(value);
+    case 'shadow':
+      return mapShadow(value);
+    case 'size':
+      return mapSize(value, property);
+    case 'alignment':
+      return mapAlignment(value, property);
+    case 'font-size':
+      return mapFontSize(value);
+    case 'font-weight':
+      return mapFontWeight(value);
+    case 'line-height':
+      return `token.font.lineHeight.${value}`;
+    case 'content':
+      return mapContent(value);
+    case 'ring':
+    case 'display':
+    case 'raw':
+      return quote(value);
+  }
+}
+
+function mapSpacing(value: string, property: string): string {
+  if (value === 'auto') return quote('auto');
+  if (SPACING_SCALE[value] === undefined) {
+    throw new TypeError(`Invalid spacing value '${value}' for '${property}'`);
+  }
+  return spacingAccess(value);
+}
+
+function spacingAccess(key: string): string {
+  return /^\d+$/.test(key) ? `token.spacing[${key}]` : `token.spacing['${key}']`;
+}
+
+function mapColor(value: string, property: string): string {
+  if (CSS_COLOR_KEYWORDS.has(value)) return quote(value);
+
+  const dotIndex = value.indexOf('.');
+  if (dotIndex !== -1) {
+    const namespace = value.substring(0, dotIndex);
+    const shade = value.substring(dotIndex + 1);
+    return `token.color.${namespace}[${shade}]`;
+  }
+  if (COLOR_NAMESPACES.has(value)) return `token.color.${value}`;
+  throw new TypeError(`Invalid color value '${value}' for '${property}'`);
+}
+
+function mapRadius(value: string): string {
+  return `token.radius.${value}`;
+}
+
+function mapShadow(value: string): string {
+  return `token.shadow.${value}`;
+}
+
+function mapSize(value: string, property: string): string {
+  if (SPACING_SCALE[value] !== undefined) return spacingAccess(value);
+  const keyword = SIZE_KEYWORDS[value];
+  if (keyword !== undefined) return quote(keyword);
+  throw new TypeError(`Invalid size value '${value}' for '${property}'`);
+}
+
+function mapAlignment(value: string, property: string): string {
+  const mapped = ALIGNMENT_MAP[value];
+  if (mapped === undefined) {
+    throw new TypeError(`Invalid alignment value '${value}' for '${property}'`);
+  }
+  return quote(mapped);
+}
+
+function mapFontSize(value: string): string {
+  if (FONT_SIZE_SCALE[value] === undefined) {
+    throw new TypeError(`Invalid font-size value '${value}'`);
+  }
+  return `token.font.size.${value}`;
+}
+
+function mapFontWeight(value: string): string {
+  if (FONT_WEIGHT_SCALE[value] === undefined) {
+    throw new TypeError(`Invalid font-weight value '${value}'`);
+  }
+  return `token.font.weight.${value}`;
+}
+
+function mapText(value: string): MappedEntry[] {
+  if (FONT_SIZE_SCALE[value] !== undefined) {
+    return [{ cssKey: 'fontSize', valueExpr: `token.font.size.${value}` }];
+  }
+  if (TEXT_ALIGN_KEYWORDS.has(value)) {
+    return [{ cssKey: 'textAlign', valueExpr: quote(value) }];
+  }
+  return [{ cssKey: 'color', valueExpr: mapColor(value, 'text') }];
+}
+
+function mapFont(value: string): MappedEntry[] {
+  if (FONT_FAMILY_KEYS.has(value)) {
+    return [{ cssKey: 'fontFamily', valueExpr: `token.font.family.${value}` }];
+  }
+  if (FONT_WEIGHT_SCALE[value] !== undefined) {
+    return [{ cssKey: 'fontWeight', valueExpr: `token.font.weight.${value}` }];
+  }
+  return [{ cssKey: 'fontSize', valueExpr: mapFontSize(value) }];
+}
+
+function mapContent(value: string): string {
+  const mapped = CONTENT_MAP[value];
+  if (mapped === undefined) {
+    throw new TypeError(`Invalid content value '${value}'`);
+  }
+  return JSON.stringify(mapped);
+}
+
+function mapBorder(value: string): MappedEntry[] {
+  const num = Number(value);
+  if (!Number.isNaN(num) && num >= 0) {
+    return [{ cssKey: 'borderWidth', valueExpr: quote(`${num}px`) }];
+  }
+  return [{ cssKey: 'borderColor', valueExpr: mapColor(value, 'border') }];
+}
+
+function toCamel(kebab: string): string {
+  return kebab.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase());
+}
+
+function quote(value: string): string {
+  return `'${value}'`;
+}

--- a/scripts/migrate-classnames/rewriter.test.ts
+++ b/scripts/migrate-classnames/rewriter.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from '@vertz/test';
+import { rewriteSource } from './rewriter';
+
+function run(input: string): string {
+  return rewriteSource(input, 'test.tsx').code;
+}
+
+describe('rewriteSource — css() calls', () => {
+  it('rewrites a single array-form block inside css()', () => {
+    const input = [
+      "import { css } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['p:4', 'bg:primary'] });",
+      '',
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain(
+      'const styles = css({ panel: { padding: token.spacing[4], backgroundColor: token.color.primary } });',
+    );
+  });
+
+  it('leaves object-form blocks untouched (idempotent)', () => {
+    const input = [
+      "import { css, token } from '@vertz/ui';",
+      '',
+      'const styles = css({ panel: { padding: token.spacing[4] } });',
+      '',
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toBe(input);
+    expect(rewriteSource(output, 'test.tsx').changed).toBe(false);
+  });
+
+  it('rewrites multiple block keys in one css() call', () => {
+    const input = [
+      "import { css } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['p:4'], title: ['font:xl'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain(
+      'const styles = css({ panel: { padding: token.spacing[4] }, title: { fontSize: token.font.size.xl } });',
+    );
+  });
+
+  it('expands pseudo groups', () => {
+    const input = [
+      "import { css } from '@vertz/ui';",
+      '',
+      "const styles = css({ button: ['p:4', 'hover:bg:primary.500'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain(
+      "const styles = css({ button: { padding: token.spacing[4], '&:hover': { backgroundColor: token.color.primary[500] } } });",
+    );
+  });
+});
+
+describe('rewriteSource — variants() calls', () => {
+  it('rewrites base and per-variant option arrays', () => {
+    const input = [
+      "import { variants } from '@vertz/ui';",
+      '',
+      'const button = variants({',
+      "  base: ['inline-flex', 'rounded:md'],",
+      '  variants: {',
+      '    intent: {',
+      "      primary: ['bg:primary', 'text:white'],",
+      "      ghost: ['bg:transparent'],",
+      '    },',
+      '  },',
+      '});',
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain("base: { display: 'inline-flex', borderRadius: token.radius.md }");
+    expect(output).toContain("primary: { backgroundColor: token.color.primary, color: 'white' }");
+    expect(output).toContain("ghost: { backgroundColor: 'transparent' }");
+  });
+
+  it('rewrites compoundVariants.styles arrays', () => {
+    const input = [
+      "import { variants } from '@vertz/ui';",
+      '',
+      'const button = variants({',
+      "  base: ['flex'],",
+      '  variants: { intent: { primary: {} } },',
+      '  compoundVariants: [',
+      "    { intent: 'primary', styles: ['p:4', 'font:bold'] },",
+      '  ],',
+      '});',
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain(
+      'styles: { padding: token.spacing[4], fontWeight: token.font.weight.bold }',
+    );
+  });
+});
+
+describe('rewriteSource — import management', () => {
+  it('adds token to an existing @vertz/ui named import', () => {
+    const input = [
+      "import { css } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['p:4'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toMatch(/^import \{ css, token \} from '@vertz\/ui';/);
+  });
+
+  it('preserves existing token import (no duplicate)', () => {
+    const input = [
+      "import { css, token } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['p:4'] });",
+    ].join('\n');
+
+    const output = run(input);
+    const tokenOccurrences = output.match(/\btoken\b/g)?.length ?? 0;
+    // token appears once in import + once in generated value = 2
+    expect(tokenOccurrences).toBe(2);
+  });
+
+  it('adds a new import statement when file does not import from @vertz/ui', () => {
+    const input = [
+      "import { css } from '@vertz/ui/css';",
+      '',
+      "const styles = css({ panel: ['p:4'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain("import { token } from '@vertz/ui';");
+  });
+
+  it('does not add token import when no token reference is generated', () => {
+    const input = [
+      "import { css } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['flex', 'bg:white'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).not.toContain('token');
+  });
+
+  it('adds a new token import when existing @vertz/ui import is type-only', () => {
+    const input = [
+      "import type { CSSProps } from '@vertz/ui';",
+      "import { css } from '@vertz/ui/css';",
+      '',
+      "const styles = css({ panel: ['p:4'] });",
+    ].join('\n');
+
+    const output = run(input);
+    expect(output).toContain("import { token } from '@vertz/ui';");
+  });
+
+  it('throws when @vertz/ui imports token under an alias', () => {
+    const input = [
+      "import { css, token as tk } from '@vertz/ui';",
+      '',
+      "const styles = css({ panel: ['p:4'] });",
+    ].join('\n');
+
+    expect(() => rewriteSource(input, 'test.tsx')).toThrow(/token.*aliased.*tk/);
+  });
+});
+
+describe('rewriteSource — changed flag', () => {
+  it('sets changed=true when at least one rewrite occurs', () => {
+    const result = rewriteSource(
+      "import { css } from '@vertz/ui';\nconst s = css({ p: ['p:4'] });\n",
+      'test.tsx',
+    );
+    expect(result.changed).toBe(true);
+  });
+
+  it('sets changed=false for already-migrated files', () => {
+    const result = rewriteSource(
+      "import { css, token } from '@vertz/ui';\nconst s = css({ p: { padding: token.spacing[4] } });\n",
+      'test.tsx',
+    );
+    expect(result.changed).toBe(false);
+  });
+});
+
+describe('rewriteSource — errors', () => {
+  it('throws when an unknown shorthand is encountered', () => {
+    const input = "const s = css({ p: ['bogus:whatever'] });";
+    expect(() => rewriteSource(input, 'test.tsx')).toThrow(/bogus:whatever/);
+  });
+});

--- a/scripts/migrate-classnames/rewriter.ts
+++ b/scripts/migrate-classnames/rewriter.ts
@@ -1,0 +1,188 @@
+/**
+ * Rewrites array-form `css()` / `variants()` call arguments to object form.
+ *
+ * Walks the source AST via `ts.createSourceFile`, edits byte ranges with
+ * `magic-string`. Preserves unrelated code verbatim. Idempotent — running
+ * twice produces identical output because the rewrite only targets array
+ * literals of string shorthands.
+ */
+
+import MagicString from 'magic-string';
+import ts from 'typescript';
+import { generateStyleBlock } from './generator';
+
+export interface RewriteResult {
+  code: string;
+  changed: boolean;
+  tokensUsed: number;
+  rewrittenSites: number;
+}
+
+const TARGET_CALLS: ReadonlySet<string> = new Set(['css', 'variants']);
+
+export function rewriteSource(source: string, filename: string): RewriteResult {
+  const sourceFile = ts.createSourceFile(
+    filename,
+    source,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    filename.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const ms = new MagicString(source);
+  let rewrittenSites = 0;
+
+  visit(sourceFile);
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && isTargetCall(node)) {
+      for (const arg of node.arguments) {
+        if (ts.isObjectLiteralExpression(arg)) {
+          rewriteObjectLiteral(arg);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  function rewriteObjectLiteral(obj: ts.ObjectLiteralExpression): void {
+    for (const prop of obj.properties) {
+      if (!ts.isPropertyAssignment(prop)) continue;
+      const init = prop.initializer;
+
+      if (ts.isArrayLiteralExpression(init) && isShorthandArray(init)) {
+        replaceArrayLiteral(init);
+        continue;
+      }
+
+      if (ts.isObjectLiteralExpression(init)) {
+        rewriteObjectLiteral(init);
+      } else if (ts.isArrayLiteralExpression(init)) {
+        for (const element of init.elements) {
+          if (ts.isObjectLiteralExpression(element)) {
+            rewriteObjectLiteral(element);
+          }
+        }
+      }
+    }
+  }
+
+  function replaceArrayLiteral(array: ts.ArrayLiteralExpression): void {
+    const shorthands: string[] = [];
+    for (const element of array.elements) {
+      if (!ts.isStringLiteralLike(element)) {
+        throw new TypeError(
+          `Array element at ${filename}:${positionOf(element)} is not a string literal — cannot migrate.`,
+        );
+      }
+      shorthands.push(element.text);
+    }
+    const replacement = generateStyleBlock(shorthands);
+    ms.overwrite(array.getStart(sourceFile), array.getEnd(), replacement);
+    rewrittenSites++;
+  }
+
+  function positionOf(node: ts.Node): string {
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    return `${line + 1}:${character + 1}`;
+  }
+
+  const afterBody = ms.toString();
+  const tokensUsed = countTokenReferences(afterBody) - countTokenReferences(source);
+
+  if (rewrittenSites === 0) {
+    return { code: source, changed: false, tokensUsed: 0, rewrittenSites: 0 };
+  }
+
+  const withImport = ensureTokenImport(afterBody, tokensUsed > 0);
+  return {
+    code: withImport,
+    changed: withImport !== source,
+    tokensUsed,
+    rewrittenSites,
+  };
+}
+
+function isTargetCall(call: ts.CallExpression): boolean {
+  const { expression } = call;
+  if (ts.isIdentifier(expression)) return TARGET_CALLS.has(expression.text);
+  return false;
+}
+
+function isShorthandArray(array: ts.ArrayLiteralExpression): boolean {
+  if (array.elements.length === 0) return false;
+  return array.elements.every((el) => ts.isStringLiteralLike(el));
+}
+
+function countTokenReferences(code: string): number {
+  return (code.match(/\btoken\./g) ?? []).length;
+}
+
+/**
+ * Ensure `token` is imported from `@vertz/ui`. If there is already a named
+ * import from `@vertz/ui`, add `token` to its clause. Otherwise insert a new
+ * import statement after the last top-of-file import.
+ */
+function ensureTokenImport(source: string, needsToken: boolean): string {
+  if (!needsToken) return source;
+
+  const sourceFile = ts.createSourceFile(
+    '_.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  let existingVertzUiImport: ts.ImportDeclaration | null = null;
+  let lastImport: ts.ImportDeclaration | null = null;
+
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    lastImport = stmt;
+    const specifier = stmt.moduleSpecifier;
+    if (ts.isStringLiteral(specifier) && specifier.text === '@vertz/ui') {
+      existingVertzUiImport = stmt;
+    }
+  }
+
+  if (existingVertzUiImport) {
+    const clause = existingVertzUiImport.importClause;
+    const namedBindings = clause?.namedBindings;
+    if (namedBindings && ts.isNamedImports(namedBindings) && !clause.isTypeOnly) {
+      const tokenSpec = namedBindings.elements.find((el) => {
+        const original = el.propertyName?.text ?? el.name.text;
+        return original === 'token' && !el.isTypeOnly;
+      });
+      if (tokenSpec) {
+        if (tokenSpec.propertyName === undefined) return source;
+        throw new TypeError(
+          `@vertz/ui imports 'token' aliased as '${tokenSpec.name.text}' — migration script uses unaliased 'token'. Resolve manually.`,
+        );
+      }
+      return insertTokenInNamedImports(source, namedBindings);
+    }
+  }
+
+  const insertPos = lastImport ? lastImport.getEnd() : 0;
+  const prefix = lastImport ? '\n' : '';
+  const suffix = lastImport ? '' : '\n';
+  return (
+    source.slice(0, insertPos) +
+    `${prefix}import { token } from '@vertz/ui';${suffix}` +
+    source.slice(insertPos)
+  );
+}
+
+function insertTokenInNamedImports(source: string, named: ts.NamedImports): string {
+  const elements = named.elements;
+  if (elements.length === 0) {
+    const openBrace = named.getStart() + 1;
+    return source.slice(0, openBrace) + ' token ' + source.slice(openBrace);
+  }
+  const sorted = [...elements.map((el) => el.name.text), 'token'].sort();
+  const start = named.getStart();
+  const end = named.getEnd();
+  const newClause = `{ ${sorted.join(', ')} }`;
+  return source.slice(0, start) + newClause + source.slice(end);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "strict": true,
     "target": "ES2022"
   },
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "scripts/migrate-classnames/__fixtures__"]
 }


### PR DESCRIPTION
## Summary

Task 1 of Phase 3 of the `drop-classname-utilities` feature (#2769 continuation). Builds a programmatic migration tool that rewrites legacy array-form shorthand strings (`['p:4', 'bg:primary.500']`) in `css()` / `variants()` calls to object-form CSS with `token.*` references.

**This PR only delivers the tool + fixtures.** It does NOT run the migration against any application code — that lands in a follow-up PR.

Example transformation:

\`\`\`ts
// BEFORE
css({ panel: ['p:4', 'bg:primary.500'] })

// AFTER
css({ panel: { padding: token.spacing[4], backgroundColor: token.color.primary[500] } })
\`\`\`

## What's in the PR

- \`scripts/migrate-classnames/mapper.ts\` — shorthand → \`MappedShorthand\` (entries + pseudo). Shares token tables with the runtime resolver so semantics stay in sync.
- \`scripts/migrate-classnames/generator.ts\` — array-of-shorthands → object-literal source string. Groups pseudo-prefixed entries (\`hover:…\`) into nested \`'&:hover': {…}\` blocks.
- \`scripts/migrate-classnames/rewriter.ts\` — file-level TypeScript AST walk + \`magic-string\` byte-range edits. Splices \`token\` into existing \`@vertz/ui\` named imports (alphabetized) or inserts a new statement. Idempotent — rerunning produces no-op.
- \`scripts/migrate-classnames/fixtures.test.ts\` + 12 input/expected pairs covering: padding, color with/without shade, pseudo prefixes, font variants, \`variants()\` calls, \`compoundVariants\`, keywords (\`truncate\`, \`flex-col\`), raw values (\`cursor\`, \`z\`), size+border multi-mode, mixed pseudo groups, \`@vertz/ui/css\` subpath imports.
- \`.oxfmtrc.json\` + \`tsconfig.json\` — exclude \`__fixtures__/\` so intentionally-compact fixture output isn't reformatted and fixture TSX files aren't typechecked against the narrow test-scoped token augmentations.

## Review findings addressed

Adversarial review caught four correctness bugs that would produce broken output; all fixed:

- **Aliased \`token\` import** (\`import { token as tk }\`) would emit duplicate imports → now throws with a clear message.
- **\`content:empty\` shorthand** was emitting a quoted literal instead of the CONTENT_MAP value → now routed through \`CONTENT_MAP\` with \`JSON.stringify\` to produce \`\"''\"\`.
- **Type-only \`@vertz/ui\` import** was treated as satisfying the \`token\` dependency → now falls through to insert a separate value import.
- **False-positive token detection** via local name only → now resolves via \`(propertyName ?? name).text\` so aliased bindings are detected correctly.

Tests added for each.

## Public API Changes

None. Scripts-only, not published.

## Test plan

- [x] Unit: mapper (30+), generator (13), rewriter (15), fixtures (25) = 86 tests passing
- [x] Idempotence: rerunning the rewriter on already-migrated output is a no-op
- [x] \`vtz test scripts/migrate-classnames/\` green
- [x] \`vtzx oxlint scripts/migrate-classnames/\` clean
- [x] \`vtzx oxfmt --check scripts/migrate-classnames/\` clean
- [x] No new typecheck errors in migration script

🤖 Generated with [Claude Code](https://claude.com/claude-code)