### PR TITLE
fix(compiler): route innerHTML through AOT content, not HTML attribute [#2790]

### DIFF
--- a/.changeset/inner-html-aot-ssr-fix.md
+++ b/.changeset/inner-html-aot-ssr-fix.md
@@ -1,0 +1,18 @@
+---
+'@vertz/native-compiler': patch
+---
+
+fix(compiler): route `innerHTML` through AOT content, not as an HTML attribute
+
+When a JSX element with an `innerHTML` prop was compiled through the AOT SSR
+path (for example a `<BrandedIcon>` sub-component), the attribute was being
+serialized as the HTML attribute `innerHTML="..."` rather than written into
+the element's content slot. The DOM path (via `__html()`) already handled it
+correctly; the AOT path missed it because `innerHTML` was not in the skip
+list and had no extraction helper.
+
+The AOT transformer now mirrors `dangerouslySetInnerHTML`: it skips
+`innerHTML` during attribute serialization and uses the expression as the
+element's content.
+
+Closes #2790.

--- a/native/vertz-compiler-core/src/aot_string_transformer.rs
+++ b/native/vertz-compiler-core/src/aot_string_transformer.rs
@@ -107,7 +107,10 @@ fn is_boolean_attribute(name: &str) -> bool {
 }
 
 fn is_skip_prop(name: &str) -> bool {
-    matches!(name, "key" | "ref" | "dangerouslySetInnerHTML")
+    matches!(
+        name,
+        "key" | "ref" | "dangerouslySetInnerHTML" | "innerHTML"
+    )
 }
 
 fn is_component_tag(tag: &str) -> bool {
@@ -447,7 +450,8 @@ fn element_to_string(
     let is_void = is_void_element(&tag_name);
     let is_raw_text = is_raw_text_element(&tag_name);
 
-    let dangerous_html = extract_dangerous_inner_html(&elem.opening_element, ms);
+    let dangerous_html = extract_dangerous_inner_html(&elem.opening_element, ms)
+        .or_else(|| extract_inner_html(&elem.opening_element, ms));
     let attrs = attrs_to_string(&elem.opening_element.attributes, ms);
     let hydration_attr = hydration_id
         .map(|id| format!(" data-v-id=\"{id}\""))
@@ -901,6 +905,25 @@ fn attr_to_string(attr: &JSXAttribute, ms: &MagicString) -> Option<String> {
         None => Some(html_name),
         _ => None,
     }
+}
+
+fn extract_inner_html(opening: &JSXOpeningElement, ms: &MagicString) -> Option<String> {
+    for attr in &opening.attributes {
+        if let JSXAttributeItem::Attribute(jsx_attr) = attr {
+            if get_jsx_attr_name(jsx_attr) == "innerHTML" {
+                if let Some(JSXAttributeValue::ExpressionContainer(container)) = &jsx_attr.value {
+                    if let Some(expr) = container.expression.as_expression() {
+                        let span = expr.span();
+                        return Some(ms.get_transformed_slice(span.start, span.end));
+                    }
+                }
+                if let Some(JSXAttributeValue::StringLiteral(s)) = &jsx_attr.value {
+                    return Some(format!("'{}'", escape_string_literal(&s.value)));
+                }
+            }
+        }
+    }
+    None
 }
 
 fn extract_dangerous_inner_html(opening: &JSXOpeningElement, ms: &MagicString) -> Option<String> {
@@ -1806,6 +1829,7 @@ mod tests {
         assert!(is_skip_prop("key"));
         assert!(is_skip_prop("ref"));
         assert!(is_skip_prop("dangerouslySetInnerHTML"));
+        assert!(is_skip_prop("innerHTML"));
         assert!(!is_skip_prop("className"));
         assert!(!is_skip_prop("id"));
     }
@@ -2946,6 +2970,42 @@ export function GameDetail() {
         assert!(
             !ssr.contains("<span>"),
             "children should be ignored with dangerouslySetInnerHTML, ssr: {}",
+            ssr
+        );
+    }
+
+    // ========== innerHTML inside AOT-compiled component (#2790) ==========
+
+    #[test]
+    fn inner_html_is_not_emitted_as_ssr_attribute() {
+        let source = r#"export function BrandedIcon({ providerId }) {
+    return <span innerHTML={getProviderIcon(providerId)} />;
+}"#;
+        let result = compile(source);
+        let ssr = appended_code(&result, source);
+        assert!(
+            !ssr.contains("innerHTML=\""),
+            "innerHTML must not be serialized as an HTML attribute, ssr: {}",
+            ssr
+        );
+        assert!(
+            ssr.contains("getProviderIcon(providerId)"),
+            "innerHTML expression must appear in the SSR string as element content, ssr: {}",
+            ssr
+        );
+    }
+
+    #[test]
+    fn inner_html_overrides_children_in_ssr() {
+        let source = r#"export function Comp() {
+    return <div innerHTML={rawHtml}><span>ignored</span></div>;
+}"#;
+        let result = compile(source);
+        let ssr = appended_code(&result, source);
+        assert!(ssr.contains("rawHtml"), "ssr: {}", ssr);
+        assert!(
+            !ssr.contains("<span>"),
+            "children should be ignored when innerHTML is set, ssr: {}",
             ssr
         );
     }


### PR DESCRIPTION
## Summary

Fix compiler bug #2790: `innerHTML` on a JSX element was being emitted as the HTML attribute `innerHTML="..."` when the element was compiled through the AOT SSR path (e.g. a `<BrandedIcon>` sub-component). The DOM path (`jsx_transformer`) already routed it through `__html()`; the AOT path (`aot_string_transformer`) did not.

The AOT transformer now mirrors how `dangerouslySetInnerHTML` is handled: `innerHTML` is skipped during attribute serialization and its expression is emitted into the element's content slot.

### Public API Changes

- **No public API changes.** Compiler-internal fix.
- **Behavior change:** SSR output for components using `innerHTML` now correctly streams the HTML content between the element's tags instead of on an `innerHTML="..."` attribute. This was unreachable for downstream tests before the fix — e.g. `BrandedIcon` coverage in `@vertz/ui-auth`.

## Changes

- `native/vertz-compiler-core/src/aot_string_transformer.rs`
  - Add `"innerHTML"` to `is_skip_prop()`.
  - Add `extract_inner_html()` helper mirroring `extract_dangerous_inner_html()`.
  - In `element_to_string()`, fall back to the new extractor when `dangerouslySetInnerHTML` is absent.
  - Two new tests: `inner_html_is_not_emitted_as_ssr_attribute`, `inner_html_overrides_children_in_ssr`. Updated `skip_props_are_recognized` to include `innerHTML`.

## Process

Tier 1 internal bug fix per `.claude/rules/design-and-planning.md` — failing test → fix → quality gates → adversarial review → changeset.

- **RED** confirmed both new tests failed with output `'<span innerHTML="' + __esc_attr(...) + '">'`.
- **GREEN** all 1298 compiler-core tests pass.
- Full pre-push gates green: lint, rust-clippy, rust-fmt, rust-test, build-typecheck (all 167 packages), test (2186 passed, 61 skipped), trojan-source.
- Adversarial review in `reviews/compiler-inner-html-nested-jsx/phase-01-aot-inner-html.md` — approved, no blockers. Reviewer verified: string-literal path, both-props precedence, void/raw-text interactions, E0761/E0762 diagnostic compatibility.

## Test plan

- [x] Compiler unit tests pass (`cargo test --all`).
- [x] TS-side `inner-html-integration.test.ts` still green (DOM path unchanged).
- [x] TS-side `oauth-button.test.ts` still green (BrandedIcon runtime behavior).
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean.
- [x] Pre-push hook (lefthook) green on `build-typecheck`, `test`, `lint`, `rust-*`, `trojan-source`.

Closes #2790.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>