### PR TITLE
fix(compiler): route ref JSX prop through __ref helper [#2788]

### DIFF
--- a/.changeset/fix-ref-callback-compiler.md
+++ b/.changeset/fix-ref-callback-compiler.md
@@ -1,0 +1,19 @@
+---
+'@vertz/ui': patch
+'@vertz/native-compiler': patch
+---
+
+fix(compiler): emit valid code for callback `ref` props on host elements
+
+Previously, the native compiler always emitted `{expr}.current = {el}` for
+the `ref` JSX prop, assuming an object ref. For a callback ref such as
+`ref={(el) => { /* ... */ }}`, the output was the invalid JavaScript
+`(el) => { /* ... */ }.current = __el0` — a member expression cannot
+follow an arrow function with a block body, so the module failed to parse
+with "Unexpected token '.'".
+
+The fix routes both forms through a new `__ref(el, value)` runtime helper
+(matching the existing inline logic in `jsx-runtime/index.ts`) that calls
+the value if it is a function and otherwise assigns to `.current`.
+
+Closes #2788.

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -19,6 +19,7 @@ const DOM_HELPERS: &[&str] = &[
     "__listValue",
     "__on",
     "__prop",
+    "__ref",
     "__pushMountFrame",
     "__show",
     "__spread",

--- a/native/vertz-compiler-core/src/jsx_transformer.rs
+++ b/native/vertz-compiler-core/src/jsx_transformer.rs
@@ -1557,9 +1557,13 @@ fn process_attr(
             let expr_text = ms.get_transformed_slice(*expr_start, *expr_end);
             let use_property = is_idl_property(tag_name, attr_name);
 
-            // Ref
+            // Ref — routed through `__ref(el, value)` so the runtime can
+            // distinguish callback refs from object refs (see issue #2788).
+            // Direct `.current =` emission is invalid for callback refs like
+            // `(el) => { ... }` because a member expression can't follow an
+            // arrow function with a block body.
             if attr_name == "ref" {
-                return Some(format!("{}.current = {}", expr_text, el_var));
+                return Some(format!("__ref({}, {})", el_var, expr_text));
             }
 
             // Form onChange → __formOnChange(el, handler) instead of __on(el, "change", handler)
@@ -2900,7 +2904,44 @@ export function App() {
     return <div ref={myRef}>text</div>;
 }"#,
         );
-        assert!(result.contains(".current = __el0"), "result: {result}");
+        assert!(result.contains("__ref(__el0, myRef)"), "result: {result}");
+    }
+
+    #[test]
+    fn ref_callback_attribute() {
+        // Issue #2788: callback ref must be routed through __ref() so the
+        // compiler doesn't emit invalid code like `(el) => {...}.current = __el0`.
+        let result = transform(
+            r#"export function App() {
+    return <div ref={(el) => { captured = el; }}>text</div>;
+}"#,
+        );
+        assert!(
+            result.contains("__ref(__el0, (el) => { captured = el; })"),
+            "result: {result}"
+        );
+        // Negative: must NOT emit the broken `.current = ` form for callbacks.
+        assert!(
+            !result.contains("}.current = __el0"),
+            "invalid `.current` on arrow body: {result}"
+        );
+    }
+
+    #[test]
+    fn ref_callback_with_inner_html() {
+        // Issue #2788 original repro: ref + innerHTML on the same host
+        // element must produce parseable output.
+        let result = transform(
+            r#"export function App({ html }) {
+    return <div className="foo" innerHTML={html} ref={(el) => { /* noop */ }} />;
+}"#,
+        );
+        assert!(result.contains("__ref(__el0,"), "result: {result}");
+        assert!(result.contains("__html(__el0,"), "result: {result}");
+        assert!(
+            !result.contains("}.current = __el0"),
+            "invalid `.current` on arrow body: {result}"
+        );
     }
 
     // ========== Spread attributes ==========
@@ -3979,7 +4020,7 @@ export function App() {
     return <div ref={myRef}>text</div>;
 }"#,
         );
-        assert!(result.contains(".current ="), "result: {result}");
+        assert!(result.contains("__ref(__el0, myRef)"), "result: {result}");
     }
 
     // ========== Conditional rendering ==========

--- a/native/vertz-compiler-core/src/jsx_transformer.rs
+++ b/native/vertz-compiler-core/src/jsx_transformer.rs
@@ -76,6 +76,15 @@ fn is_idl_attr(attr: &AttrInfo, tag_name: &str) -> bool {
     is_idl_property(tag_name, attr_name)
 }
 
+/// Check if an attribute is the `ref` prop. Spread doesn't count — spread
+/// refs are routed through `__spread()` at runtime.
+fn is_ref_attr(attr: &AttrInfo) -> bool {
+    match attr {
+        AttrInfo::Expression { name, .. } => name == "ref",
+        _ => false,
+    }
+}
+
 /// Check if an attribute is the `innerHTML` prop. Spread doesn't count —
 /// `innerHTML` must be written directly as a JSX attribute to route through
 /// `__html()`.
@@ -1189,7 +1198,7 @@ fn transform_element(
         json_quote(&info.tag_name)
     ));
 
-    // Process attributes — split into normal and deferred IDL property statements.
+    // Process attributes — split into normal and deferred statements.
     // IDL properties (select.value, input.value/checked, textarea.value) are deferred
     // until after children so that e.g. <select>.value is set when <option>s exist.
     //
@@ -1199,11 +1208,20 @@ fn transform_element(
     // Mutual-exclusion with children is enforced at the diagnostic layer
     // (innerhtml_diagnostics); here we simply skip the attribute and emit the
     // helper call.
+    //
+    // `ref` is deferred until after children so callbacks that introspect the
+    // subtree (e.g. querySelector) observe the fully-constructed element —
+    // matching the runtime `jsx()` factory's behavior in jsx-runtime/index.ts.
     let mut deferred_idl_stmts: Vec<String> = Vec::new();
     let mut inner_html_stmt: Option<String> = None;
+    let mut ref_stmt: Option<String> = None;
     for attr in &info.attrs {
         if is_inner_html_attr(attr) {
             inner_html_stmt = build_inner_html_stmt(ms, attr, &el_var);
+            continue;
+        }
+        if is_ref_attr(attr) {
+            ref_stmt = process_attr(ms, attr, &el_var, &info.tag_name, rx);
             continue;
         }
         if let Some(stmt) = process_attr(ms, attr, &el_var, &info.tag_name, rx) {
@@ -1237,6 +1255,12 @@ fn transform_element(
     // IDL property statements after children — <select>.value needs <option>s in DOM first.
     // Also safe for <input>/<textarea> (no meaningful children).
     stmts.extend(deferred_idl_stmts);
+
+    // Ref after IDL properties so the callback sees an element that is fully
+    // attributed and has its children in place.
+    if let Some(stmt) = ref_stmt {
+        stmts.push(stmt);
+    }
 
     format!(
         "(() => {{\n{}\n  return {};\n}})()",
@@ -2941,6 +2965,29 @@ export function App() {
         assert!(
             !result.contains("}.current = __el0"),
             "invalid `.current` on arrow body: {result}"
+        );
+    }
+
+    #[test]
+    fn ref_applied_after_children() {
+        // Ref callbacks must fire after children are in the DOM so they can
+        // introspect the subtree — matches the runtime `jsx()` factory's
+        // behavior (packages/ui/src/jsx-runtime/index.ts). Without this,
+        // `ref={(el) => el.querySelector('.foo')}` would return null.
+        let result = transform(
+            r#"export function App() {
+    return <div ref={(el) => {}}><span className="foo">hi</span></div>;
+}"#,
+        );
+        let ref_idx = result
+            .find("__ref(__el0,")
+            .unwrap_or_else(|| panic!("missing __ref: {result}"));
+        let exit_idx = result
+            .find("__exitChildren()")
+            .unwrap_or_else(|| panic!("missing __exitChildren: {result}"));
+        assert!(
+            ref_idx > exit_idx,
+            "ref must fire after children — got ref_idx={ref_idx}, exit_idx={exit_idx}: {result}"
         );
     }
 

--- a/native/vertz-compiler/__tests__/jsx-transform.test.ts
+++ b/native/vertz-compiler/__tests__/jsx-transform.test.ts
@@ -263,9 +263,20 @@ describe('Feature: JSX element transform', () => {
 
   describe('Given a ref attribute', () => {
     describe('When compiled', () => {
-      it('Then assigns .current on the element variable', () => {
+      it('Then routes the element through the __ref runtime helper', () => {
         const code = compileAndGetCode(`function App() {\n  return <input ref={myRef} />;\n}`);
-        expect(code).toContain('myRef.current');
+        expect(code).toContain('__ref(');
+        expect(code).toContain('myRef');
+      });
+
+      it('Then handles a callback ref without emitting invalid `.current` syntax', () => {
+        // Issue #2788: callback refs combined with a block body must
+        // round-trip through __ref(), not the broken `.current =` form.
+        const code = compileAndGetCode(
+          `function App() {\n  return <div innerHTML={html} ref={(el) => { captured = el; }} />;\n}`,
+        );
+        expect(code).toContain('__ref(');
+        expect(code).not.toMatch(/}\.current\s*=/);
       });
     });
   });

--- a/packages/ui-server/src/__tests__/ref-integration.test.ts
+++ b/packages/ui-server/src/__tests__/ref-integration.test.ts
@@ -1,0 +1,111 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@vertz/test';
+
+beforeAll(() => {
+  GlobalRegistrator.register({ url: 'http://localhost/' });
+});
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+// Imports must follow happy-dom registration so that @vertz/ui's auto-detected
+// DOM adapter picks up the real DOM rather than failing.
+import { __element, __html, __ref } from '@vertz/ui/internals';
+import { ref } from '@vertz/ui';
+import { compile } from '../compiler/native-compiler';
+
+describe('Feature: ref prop across object and callback forms (issue #2788)', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    root.id = 'app';
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    if (root.parentNode) document.body.removeChild(root);
+  });
+
+  describe('Given the __ref runtime helper', () => {
+    it('invokes callback refs with the element', () => {
+      const el = document.createElement('div');
+      let captured: Element | null = null;
+      __ref(el, (node) => {
+        captured = node;
+      });
+      expect(captured).toBe(el);
+    });
+
+    it('assigns element to .current for object refs', () => {
+      const el = document.createElement('span');
+      const r = ref<HTMLElement>();
+      __ref(el, r);
+      expect(r.current).toBe(el);
+    });
+  });
+
+  const hasNativeCompiler = !!(globalThis as Record<string, unknown>).__NATIVE_COMPILER_AVAILABLE__;
+
+  describe.skipIf(!hasNativeCompiler)(
+    'Given JSX with a callback ref alongside innerHTML on the same host element',
+    () => {
+      it('emits __ref() and never the broken `.current =` form on an arrow body', () => {
+        // Exact repro from issue #2788.
+        const source = `
+          export function HighlightedCode({ html }) {
+            return (
+              <div
+                className="foo"
+                innerHTML={html}
+                ref={(el) => { /* noop */ }}
+              />
+            );
+          }
+        `;
+        const result = compile(source, { filename: 'app.tsx', target: 'dom' });
+        expect(result.diagnostics).toEqual([]);
+        expect(result.code).toContain('__ref(');
+        expect(result.code).toContain('__html(');
+        // The old (broken) emission was `(el) => { ... }.current = __el0` —
+        // that member access on an arrow block body is a syntax error.
+        expect(result.code).not.toMatch(/}\.current\s*=/);
+      });
+
+      it('compiles to syntactically valid JavaScript for callback ref + innerHTML', () => {
+        const source = `
+          export function HighlightedCode({ html }) {
+            return (
+              <div
+                className="foo"
+                innerHTML={html}
+                ref={(el) => { /* noop */ }}
+              />
+            );
+          }
+        `;
+        const result = compile(source, { filename: 'app.tsx', target: 'dom' });
+        expect(result.diagnostics).toEqual([]);
+        // `new Function()` parses the string as a Program. If the compiler
+        // emitted `(el) => {...}.current = __el0`, this throws a SyntaxError.
+        // The actual imports don't need to resolve — we only exercise the parser.
+        expect(() => new Function(result.code)).not.toThrow();
+      });
+    },
+  );
+
+  describe.skipIf(!hasNativeCompiler)('Given JSX with only a callback ref (no innerHTML)', () => {
+    it('still routes through __ref() — the bug is not specific to innerHTML', () => {
+      const source = `
+        export function App() {
+          return <div ref={(el) => { captured = el; }} />;
+        }
+      `;
+      const result = compile(source, { filename: 'app.tsx', target: 'dom' });
+      expect(result.diagnostics).toEqual([]);
+      expect(result.code).toContain('__ref(');
+      expect(result.code).not.toMatch(/}\.current\s*=/);
+      expect(() => new Function(result.code)).not.toThrow();
+    });
+  });
+});

--- a/packages/ui/src/dom/__tests__/ref.test.ts
+++ b/packages/ui/src/dom/__tests__/ref.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@vertz/test';
+import { ref } from '../../component/refs';
+import { __ref } from '../ref';
+
+describe('__ref', () => {
+  it('invokes a callback ref with the element', () => {
+    const el = document.createElement('div');
+    let captured: Element | null = null;
+    __ref(el, (node) => {
+      captured = node;
+    });
+    expect(captured).toBe(el);
+  });
+
+  it('assigns .current on an object ref', () => {
+    const el = document.createElement('span');
+    const r = ref<HTMLElement>();
+    __ref(el, r);
+    expect(r.current).toBe(el);
+  });
+
+  it('is a no-op when ref is null or undefined', () => {
+    const el = document.createElement('div');
+    expect(() => __ref(el, null)).not.toThrow();
+    expect(() => __ref(el, undefined)).not.toThrow();
+  });
+
+  it('does not throw when given an object without a current property', () => {
+    const el = document.createElement('div');
+    const emptyRef = {} as { current: HTMLElement };
+    expect(() => __ref(el, emptyRef)).not.toThrow();
+  });
+});

--- a/packages/ui/src/dom/__tests__/spread.test.ts
+++ b/packages/ui/src/dom/__tests__/spread.test.ts
@@ -119,6 +119,17 @@ describe('Feature: Intrinsic element spread attributes', () => {
         __spread(el, { ref: myRef });
         expect(myRef.current).toBe(el);
       });
+
+      it('Then a callback ref is invoked with the element', () => {
+        const el = document.createElement('span');
+        let captured: Element | null = null;
+        __spread(el, {
+          ref: (node: Element) => {
+            captured = node;
+          },
+        });
+        expect(captured).toBe(el);
+      });
     });
   });
 

--- a/packages/ui/src/dom/index.ts
+++ b/packages/ui/src/dom/index.ts
@@ -6,6 +6,7 @@ export { createDOMAdapter } from './dom-adapter';
 export { __child, __element, __text } from './element';
 export { __on } from './events';
 export { __html } from './html';
+export { __ref } from './ref';
 export { clearChildren, insertBefore, removeNode } from './insert';
 export { __list } from './list';
 export { __spread } from './spread';

--- a/packages/ui/src/dom/ref.ts
+++ b/packages/ui/src/dom/ref.ts
@@ -1,0 +1,19 @@
+import type { Ref } from '../component/refs';
+
+/**
+ * Apply a ref to an element. Compiler output target for the JSX `ref` prop.
+ *
+ * Accepts either a callback ref (`(el) => void`) or an object ref
+ * (`{ current: T }`). Mirrors the inline logic in `jsx-runtime/index.ts`
+ * so compiled output matches runtime behavior.
+ */
+export function __ref<T>(el: T, ref: Ref<T> | ((el: T) => void) | null | undefined): void {
+  if (ref == null) return;
+  if (typeof ref === 'function') {
+    ref(el);
+    return;
+  }
+  if (typeof ref === 'object' && 'current' in ref) {
+    ref.current = el;
+  }
+}

--- a/packages/ui/src/dom/spread.ts
+++ b/packages/ui/src/dom/spread.ts
@@ -1,4 +1,5 @@
 import { deferredDomEffect } from '../runtime/signal';
+import { __ref } from './ref';
 import { styleObjectToString } from './style';
 import { normalizeSVGAttr, SVG_NS } from './svg-tags';
 
@@ -49,11 +50,9 @@ export function __spread(
 
     const value = props[key];
 
-    // ref: { current: Element | null }
+    // ref: callback `(el) => void` or object `{ current: T }`.
     if (key === 'ref') {
-      if (value && typeof value === 'object' && 'current' in value) {
-        (value as { current: unknown }).current = el;
-      }
+      __ref(el, value as Parameters<typeof __ref>[1]);
       continue;
     }
 

--- a/packages/ui/src/internals.ts
+++ b/packages/ui/src/internals.ts
@@ -55,6 +55,7 @@ export {
 export { __on } from './dom/events';
 export { __formOnChange } from './dom/form-on-change';
 export { __html } from './dom/html';
+export { __ref } from './dom/ref';
 export { clearChildren, insertBefore, removeNode } from './dom/insert';
 export { __list } from './dom/list';
 export type { ListAnimationHooks } from './dom/list-animation-context';

--- a/reviews/fix-ref-innerhtml-compiler/phase-01-ref-callback.md
+++ b/reviews/fix-ref-innerhtml-compiler/phase-01-ref-callback.md
@@ -1,0 +1,96 @@
+# Phase 1: Route `ref` JSX prop through `__ref` runtime helper
+
+- **Author:** vertz-tech-lead
+- **Reviewer:** adversarial-review-agent
+- **Commits:** af51f48f7
+- **Date:** 2026-04-18
+
+## Changes
+
+- `.changeset/fix-ref-callback-compiler.md` (new)
+- `native/vertz-compiler-core/src/import_injection.rs` (modified — `__ref` added to `DOM_HELPERS`)
+- `native/vertz-compiler-core/src/jsx_transformer.rs` (modified — `process_attr` emits `__ref(el, expr)`; two new Rust tests)
+- `native/vertz-compiler/__tests__/jsx-transform.test.ts` (modified — asserts `__ref(` in output)
+- `packages/ui-server/src/__tests__/ref-integration.test.ts` (new — helper unit tests + compile-parse tests gated on `__NATIVE_COMPILER_AVAILABLE__`)
+- `packages/ui/src/dom/__tests__/ref.test.ts` (new — direct helper tests)
+- `packages/ui/src/dom/index.ts` (modified — export `__ref`)
+- `packages/ui/src/dom/ref.ts` (new — `__ref` helper)
+- `packages/ui/src/internals.ts` (modified — re-export `__ref`)
+
+## CI Status
+
+- [ ] Quality gates not yet confirmed at HEAD (not run as part of this review — author's responsibility before merge).
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for — callback `ref` no longer produces a `SyntaxError`
+- [x] TDD compliance — helper + compiler tests added; negative assertion `!result.contains("}.current = __el0")` is a real regression guard
+- [~] No type gaps — minor: `__ref` generic signature is sound but broader than the JSX intrinsic type (see Nit)
+- [x] No security issues
+- [x] Public API matches design — new internals helper, no public surface change
+
+## Findings
+
+### Blocker — none
+
+### Should fix
+
+**1. Ref fires BEFORE children are appended in compiled output, contradicting the runtime.**
+`native/vertz-compiler-core/src/jsx_transformer.rs:1209` pushes the ref statement into `stmts` alongside the other attribute stmts, which get emitted *before* `__enterChildren(__el0)` / `__append` at lines 1223-1231. Verified by emitting for `<div ref={myRef}><span>hi</span></div>`:
+
+```
+const __el0 = __element("div");
+__ref(__el0, myRef);                     // ← ref invoked with empty element
+__enterChildren(__el0);
+__append(__el0, ... span ...);
+__exitChildren();
+return __el0;
+```
+
+Compare with `packages/ui/src/jsx-runtime/index.ts:253` which explicitly states "Assign ref after element is fully constructed with children" and applies ref only after `applyChildren()` / deferred IDL. This is a divergence between the runtime and the compiled output for any callback ref that measures geometry (`getBoundingClientRect`), runs `focus()`, or reads children. The exact bug #2788 reproducer (`ref + innerHTML`) happens to be fine because `innerHTML` is the last stmt emitted, but the moment the user writes `<div ref={(el) => el.querySelector('.foo')}>…</div>` it silently returns `null`. Fix: treat `ref` like `deferredIdl` and append after `__exitChildren()` / `__html(...)`.
+
+**2. `__spread` still uses the old object-only ref logic.**
+`packages/ui/src/dom/spread.ts:53-58` does `if (value && typeof value === 'object' && 'current' in value)` — callback refs in a spread (`<div {...{ ref: (el) => {} }} />`) are silently dropped. Now that `__ref` exists, `__spread` should delegate to it for parity with the per-attribute path. No test covers spread refs at all.
+
+**3. Integration test actually runs zero compiler assertions on `vtz test`.**
+`packages/ui-server/src/__tests__/ref-integration.test.ts` gates its compile-and-parse tests on `__NATIVE_COMPILER_AVAILABLE__`. The preload at `packages/ui-server/src/__tests__/preload-mock-native-compiler.ts:17-29` sets this to `false` under the vtz runtime (the default for `vtz test`). So the helpful `new Function(result.code)` syntactic-validity test only exercises the bug on Bun CI runs. The Rust-level tests still cover the emission string, so coverage isn't zero — but the doc comment claims "Exact repro from issue #2788" when in reality the ONLY test that compiles-and-parses runs on bun only. Recommendation: add a pure Rust-side test that asserts `new_function_parseable(result)` or at minimum add a comment explaining the gate so future readers don't assume CI is exercising it.
+
+### Nit
+
+**4. Type gap in `__ref` signature.**
+`packages/ui/src/dom/ref.ts:10` uses `Ref<T> | ((el: T) => void)` with `T` inferred from `el`. The JSX intrinsic `ref` prop at `packages/ui/src/jsx-runtime/index.ts:110` is `Ref<unknown> | ((el: Element) => void)` — wider. Doesn't cause bugs because compiler output isn't type-checked, but the two signatures diverging invites drift. Consider aligning with the JSX intrinsic type.
+
+**5. "Does not throw on object without `current`" test is misleading.**
+`packages/ui/src/dom/__tests__/ref.test.ts:28-32` passes `{}` cast to `{ current: HTMLElement }` and asserts `not.toThrow()`. But the implementation has `if ('current' in ref)` — so it silently skips. The test passes because of a *safety guard*, not by design. Either remove the guard (no real user passes `{}`) or document that it's defensive against malformed refs.
+
+**6. `ref_callback_with_inner_html` Rust test doesn't assert ordering.**
+`native/vertz-compiler-core/src/jsx_transformer.rs:2930-2945` checks that both `__ref(` and `__html(` appear but doesn't check order relative to each other or to `__enterChildren`. If finding #1 is fixed, add an ordering assertion here.
+
+## Resolution
+
+Follow-up commit addresses the substantive findings.
+
+**Finding #1 (ref ordering) — FIXED.** `transform_element` now deferrs the
+`ref` stmt (via new `is_ref_attr` helper) and appends it after both
+children and deferred IDL statements, matching the runtime `jsx()`
+factory order. New Rust test `ref_applied_after_children` asserts
+`__ref(__el0, …)` appears after `__exitChildren()` for an element with
+children.
+
+**Finding #2 (spread refs) — FIXED.** `packages/ui/src/dom/spread.ts`
+now delegates to `__ref(el, value)` instead of the inline object-only
+check, so callback refs flow through `{...props}` spreads too. New
+test in `spread.test.ts` asserts the callback is invoked.
+
+**Finding #6 (missing ordering assertion) — RESOLVED** via the new
+`ref_applied_after_children` test.
+
+**Finding #3 (integration test coverage under vtz)** — accepted as a
+documented gap. The Rust tests cover the emission string and ordering.
+The `new Function(result.code)` parse assertion only runs on bun CI —
+same pattern as the existing `inner-html-integration.test.ts`. Not a
+regression introduced by this PR.
+
+**Findings #4, #5 (nits)** — declined. The `__ref` signature is
+deliberately narrower (typed per-call site) and the defensive guard
+for malformed refs is cheap insurance.


### PR DESCRIPTION
## Summary

Fixes #2788: the native Rust compiler emitted invalid JavaScript for callback `ref` props on host elements (`(el) => {}.current = __el0` — fails to parse). Routes both object refs and callback refs through a new `__ref(el, value)` runtime helper that matches the existing runtime `jsx()` factory behavior.

## Public API Changes

- **None.** `__ref` is an internal compiler-runtime contract (exported from `@vertz/ui/internals`), not part of the public surface.

## Changes

- **Phase 1 — Route `ref` through `__ref` helper** (`af51f48f7`)
  - New helper `packages/ui/src/dom/ref.ts` handles both object refs and callback refs
  - Compiler (`native/vertz-compiler-core/src/jsx_transformer.rs`) emits `__ref(__el0, expr)` instead of `{expr}.current = __el0`
  - `__ref` added to `DOM_HELPERS` for auto-import injection
  - Rust + TS unit/integration tests; changeset added

- **Phase 1 review follow-up** (`d35871381`) — addresses adversarial review findings:
  - **Finding #1 (ordering):** `ref` is now deferred in `transform_element` and emitted *after* `__exitChildren()` + deferred IDL stmts, matching the runtime `jsx()` factory. New Rust test `ref_applied_after_children` asserts `__ref(__el0, …)` appears after `__exitChildren()`.
  - **Finding #2 (spread refs):** `packages/ui/src/dom/spread.ts` now delegates to `__ref(el, value)` so callback refs flow through `{...props}` spreads. New `spread.test.ts` test asserts callback invocation.
  - **Finding #6 (ordering assertion):** resolved via the new `ref_applied_after_children` test.

- **Review** (`0cf57a50c`) — adversarial review markdown at `reviews/fix-ref-innerhtml-compiler/phase-01-ref-callback.md`.

## Review findings

See `reviews/fix-ref-innerhtml-compiler/phase-01-ref-callback.md` for the full adversarial review. All substantive findings (ordering, spread parity, missing ordering assertion) are fixed in the commits above. Findings #3 (bun-only parse gate) and #4/#5 (type/test nits) were accepted/declined with documented rationale.

## Test plan

- [x] Rust: `cargo test --all` (all green, including new `ref_callback_attribute`, `ref_callback_with_inner_html`, `ref_applied_after_children`)
- [x] Rust: `cargo clippy --all-targets -- -D warnings`
- [x] Rust: `cargo fmt --all -- --check`
- [x] TS: `vtz test packages/ui/` (2754 pass, 1 pre-existing subpath-exports failure unrelated to this PR)
- [x] TS: `vtzx oxlint` and `vtzx oxfmt --check` on all changed files
- [x] Negative regression test: compiler output for `<div ref={cb} innerHTML={html}>` no longer contains `}.current =` pattern

Closes #2788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)