### PR TITLE
fix(compiler,ui): emit numeric/boolean raw CSS declarations [#2783]

### DIFF
--- a/.changeset/css-raw-decl-numeric-extraction.md
+++ b/.changeset/css-raw-decl-numeric-extraction.md
@@ -1,0 +1,34 @@
+---
+'@vertz/ui': patch
+'@vertz/native-compiler': patch
+---
+
+fix(ui,compiler): emit numeric/boolean raw CSS declarations from `css()` and `variants()`
+
+Raw object declarations inside nested selectors used to silently drop
+non-string values. Numeric values now flow through the same kebab-case +
+unitless/`px` rules as shorthand tokens, in both the runtime and the AOT
+compiler.
+
+```ts
+css({
+  card: [
+    {
+      '&:hover': {
+        fontSize: 16,        // → font-size: 16px
+        opacity: 0.8,        // → opacity: 0.8 (unitless)
+        marginTop: -8,       // → margin-top: -8px
+        '--my-tone': 1,      // → --my-tone: 1 (custom prop, no unit)
+        padding: 0,          // → padding: 0 (zero is unitless)
+      },
+    },
+  ],
+});
+```
+
+`UnaryExpression(-, NumericLiteral)` and `BooleanLiteral` are also accepted.
+The unitless property list is shared between `packages/ui/src/css/unitless-properties.ts`
+and `native/vertz-compiler-core/src/css_unitless.rs`, with a parity test
+already enforcing they stay in sync.
+
+Closes #2783.

--- a/native/vertz-compiler-core/src/css_transform.rs
+++ b/native/vertz-compiler-core/src/css_transform.rs
@@ -195,7 +195,9 @@ fn extract_style_block_key(key: &PropertyKey) -> Option<String> {
 
 fn is_static_scalar_value(expr: &Expression) -> bool {
     match expr {
-        Expression::StringLiteral(_) | Expression::NumericLiteral(_) => true,
+        Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_) => true,
         Expression::UnaryExpression(u) if u.operator == UnaryOperator::UnaryNegation => {
             matches!(&u.argument, Expression::NumericLiteral(_))
         }
@@ -251,6 +253,7 @@ fn extract_scalar_value(expr: &Expression) -> Option<StyleDeclValue> {
     match expr {
         Expression::StringLiteral(s) => Some(StyleDeclValue::String(s.value.to_string())),
         Expression::NumericLiteral(n) => Some(StyleDeclValue::Number(n.value)),
+        Expression::BooleanLiteral(b) => Some(StyleDeclValue::String(b.value.to_string())),
         Expression::UnaryExpression(u) if u.operator == UnaryOperator::UnaryNegation => {
             if let Expression::NumericLiteral(n) = &u.argument {
                 Some(StyleDeclValue::Number(-n.value))
@@ -792,5 +795,87 @@ const b = css({ root: { display: 'grid' } });
         let source = r#"const s = css({ card: { marginTop: -8 } });"#;
         let (_, css) = transform(source);
         assert!(css.contains("margin-top: -8px;"), "css: {}", css);
+    }
+
+    // ── Nested raw declarations: numeric values parity contract [#2783] ──────────
+
+    #[test]
+    fn nested_raw_declarations_numeric_dimensional_gets_px() {
+        let source = r#"const s = css({ card: { '&:hover': { fontSize: 16 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains(":hover"), "css: {}", css);
+        assert!(css.contains("font-size: 16px;"), "css: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_unitless_no_px() {
+        let source = r#"const s = css({ card: { '&:hover': { opacity: 1, lineHeight: 1.5, zIndex: 10 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("opacity: 1;"), "css: {}", css);
+        assert!(css.contains("line-height: 1.5;"), "css: {}", css);
+        assert!(css.contains("z-index: 10;"), "css: {}", css);
+        assert!(!css.contains("opacity: 1px"), "unitless got px: {}", css);
+        assert!(
+            !css.contains("line-height: 1.5px"),
+            "unitless got px: {}",
+            css
+        );
+        assert!(!css.contains("z-index: 10px"), "unitless got px: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_negative_numeric_via_unary() {
+        let source = r#"const s = css({ card: { '&:hover': { marginTop: -8 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("margin-top: -8px;"), "css: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_zero_no_px() {
+        let source = r#"const s = css({ card: { '&:hover': { padding: 0 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("padding: 0;"), "css: {}", css);
+        assert!(!css.contains("0px"), "0 got px: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_custom_property_passthrough() {
+        let source = r#"const s = css({ card: { '&:hover': { '--my-tone': 1 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("--my-tone: 1;"), "css: {}", css);
+        assert!(!css.contains("1px"), "custom prop got px: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_boolean_value() {
+        let source = r#"const s = css({ card: { '&:hover': { someFlag: false } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("some-flag: false;"), "css: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_string_still_works() {
+        let source = r#"const s = css({ card: { '&:hover': { color: 'red' } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("color: red;"), "css: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_mixed_string_and_numeric() {
+        let source =
+            r#"const s = css({ card: { '&:focus': { color: 'red', padding: 8, opacity: 1 } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains("color: red;"), "css: {}", css);
+        assert!(css.contains("padding: 8px;"), "css: {}", css);
+        assert!(css.contains("opacity: 1;"), "css: {}", css);
+    }
+
+    #[test]
+    fn nested_raw_declarations_deeply_nested_numeric() {
+        let source = r#"const s = css({ card: { '&:hover': { '& > span': { fontSize: 16, opacity: 1 } } } });"#;
+        let (_, css) = transform(source);
+        assert!(css.contains(":hover > span"), "css: {}", css);
+        assert!(css.contains("font-size: 16px;"), "css: {}", css);
+        assert!(css.contains("opacity: 1;"), "css: {}", css);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2783. Raw object declarations inside `css({...})` and `variants({...})` selectors used to silently drop non-string values. Numeric, unary-negative, and boolean values now flow through the same kebab-case + unitless/`px` formatting in both the AOT compiler and the runtime.

```ts
css({
  card: [
    {
      '&:hover': {
        fontSize: 16,    // → font-size: 16px
        opacity: 0.8,    // → opacity: 0.8 (unitless)
        marginTop: -8,   // → margin-top: -8px
        '--my-tone': 1,  // → --my-tone: 1 (custom property)
        padding: 0,      // → padding: 0 (zero is unitless)
      },
    },
  ],
});
```

## Public API Changes

**Additions** — none. The fix removes a silent data loss in an existing API path; no signatures change.

**Breaking** — none.

## What changed

- `native/vertz-compiler-core/src/css_transform.rs`
  - `is_static_scalar_value` and `is_static_css_declarations` now accept `BooleanLiteral` alongside `StringLiteral`, `NumericLiteral`, and `UnaryExpression(-, NumericLiteral)`.
  - `extract_scalar_value` adds a `BooleanLiteral → StyleDeclValue::String(b.value.to_string())` arm.
  - `extract_css_declarations` was rewritten to use `extract_scalar_value` + `format_style_value` (instead of the StringLiteral-only path), and skips empty property keys.
  - 9 new tests under "Array-form raw declarations: numeric values [#2783]".

- `packages/ui/src/css/css.ts`
  - New `formatRawDeclaration()` helper that mirrors the AOT compiler's `extract_css_declarations` (camelCase → kebab-case, `formatStyleValue` for `px`/unitless rules, custom-property passthrough).
  - Both the array-form raw-decl path and the direct-object form path now route through it. The runtime previously emitted `fontSize: 16` (no kebab, no `px`) inside nested raw decls — fixed.

- `packages/ui/src/css/__tests__/css-raw-declarations.test.ts`
  - 6 new TS parity tests covering the same matrix as the Rust tests.

- `.changeset/css-raw-decl-numeric-extraction.md` (patch).

## Test Plan

- [x] Rust: `cargo test --all` green (74 tests in `css_transform`)
- [x] Rust: `cargo clippy --all-targets -- -D warnings` clean
- [x] Rust: `cargo fmt --all -- --check` clean
- [x] TS: full test suite green (2186/2247 passing, rest pre-existing skips)
- [x] TS: `oxlint packages/` clean on changed files
- [x] TS: `oxfmt --check packages/` clean
- [x] Existing TS↔Rust unitless parity test passes
- [x] Adversarial review at `reviews/issue-2783/phase-01-numeric-extraction.md` — no blockers, both should-fix items addressed

Closes #2783.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>