### PR TITLE
fix(pm): write dist-tag deps to vertz.lock [#2794]

### DIFF
--- a/.changeset/fix-install-latest-tag.md
+++ b/.changeset/fix-install-latest-tag.md
@@ -1,0 +1,5 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(pm): `vtz install` now writes resolved npm dist-tag specs (`"latest"`, `"next"`, custom tags) to `vertz.lock` instead of silently dropping them (#2794). Previously, a `package.json` dep like `"@types/bun": "latest"` resolved and installed correctly but never landed in the lockfile, causing subsequent `vtz install --frozen` to fail with "lockfile is out of date".

--- a/native/vtz/src/pm/resolver.rs
+++ b/native/vtz/src/pm/resolver.rs
@@ -23,6 +23,47 @@ pub fn version_satisfies_range(version_str: &str, range_str: &str) -> bool {
     range.satisfies(&version)
 }
 
+/// Returns true iff `range_str` is a non-semver dependency specifier that
+/// `graph_to_lockfile` must match by name alone (no semver range check).
+///
+/// Includes `github:` specifiers, `link:` workspace refs, and dist-tag-shaped
+/// strings (`latest`, `next`, `beta`, or custom tags). Excludes semver ranges
+/// (`^1.2.3`, `1.x`, `*`, etc.) and protocol specs (`file:`, `workspace:`,
+/// `npm:`, `http://`) — those are filtered out by `is_dist_tag_shape` and
+/// never reach the graph anyway.
+fn is_non_semver_spec(range_str: &str) -> bool {
+    range_str.starts_with("github:")
+        || range_str.starts_with("link:")
+        || is_dist_tag_shape(range_str)
+}
+
+/// Returns true iff `s` looks like an npm dist-tag name.
+///
+/// Rules:
+/// - Non-empty
+/// - First char is ASCII alphabetic — excludes semver (`1.2.3`), operators (`~1.0`),
+///   and the `*` wildcard.
+/// - All chars are ASCII alphanumeric or `-` / `_` / `.` — excludes protocol
+///   specs (`file:`, `npm:`, `http://`), paths (`./x`), and ranges with
+///   whitespace (`>=1.0.0 <2.0.0`).
+/// - Does not parse as a semver range — rejects `x` / `x.x.x` wildcards that
+///   pass the shape check.
+fn is_dist_tag_shape(s: &str) -> bool {
+    let Some(first) = s.chars().next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return false;
+    }
+    Range::parse(s).is_err()
+}
+
 /// Returns true iff a lockfile entry's pinned version still satisfies `range_str`.
 ///
 /// This guards the lockfile-reuse fast path in `resolve_one_task`: a stale entry
@@ -33,6 +74,12 @@ pub fn version_satisfies_range(version_str: &str, range_str: &str) -> bool {
 ///
 /// GitHub entries (range starts with `github:`) are treated as always-valid here,
 /// because they are pinned by SHA — semver has no meaning for them.
+///
+/// Dist-tag specs (`"latest"`, `"next"`, etc.) intentionally return `false` here
+/// (they fall through to `version_satisfies_range`, which fails on `Range::parse`).
+/// The consequence is that every `vtz install` re-fetches registry metadata for
+/// dist-tag deps to verify the lockfile pin is still current. See #2794 for the
+/// lockfile-write fix and the deferred fast-path optimization.
 pub fn lockfile_entry_satisfies_range(entry: &LockfileEntry, range_str: &str) -> bool {
     if range_str.starts_with("github:") || range_str.starts_with("link:") {
         return true;
@@ -561,9 +608,10 @@ pub fn graph_to_lockfile(
         // Find the resolved version for this dep. Match by name AND by semver range:
         // without the range check, a root dep would get wired to whichever version was
         // hoisted, even if that version doesn't satisfy the declared range (see #2738).
-        // Fall back to name-only for `link:` workspace refs and `github:` specifiers,
-        // which are not semver.
-        let is_non_semver = range.starts_with("github:") || range.starts_with("link:");
+        // Fall back to name-only for non-semver specs — `github:`, `link:`, or
+        // dist-tags like `"latest"` / `"next"` (see #2794). Dist-tag resolution
+        // happens in `resolve_version`; this site just needs to honor the graph.
+        let is_non_semver = is_non_semver_spec(range);
         if let Some(pkg) = graph.packages.values().find(|p| {
             p.name == *name
                 && p.nest_path.is_empty()
@@ -604,8 +652,17 @@ pub fn graph_to_lockfile(
         for (dep_name, dep_range) in all_transitive {
             let key = Lockfile::spec_key(dep_name, dep_range);
             if let std::collections::btree_map::Entry::Vacant(entry) = lockfile.entries.entry(key) {
-                let dep_pkg = if dep_range.starts_with("github:") {
-                    // GitHub dep: match by exact range string equality
+                let dep_pkg = if is_non_semver_spec(dep_range) {
+                    // Non-semver dep (`github:`, `link:`, or dist-tag like `"latest"`):
+                    // match by name only. Dist-tags are resolved upstream in
+                    // `resolve_version`, so a matching name in the graph is the
+                    // correct lockfile target (see #2794).
+                    //
+                    // Known edge: when `graph.packages` holds multiple versions
+                    // of the same name (e.g. sibling dep pulls a different
+                    // range), `find()` returns first-by-key (lexicographically
+                    // lowest version) instead of the dist-tag-resolved version.
+                    // Tracked in #2796.
                     graph.packages.values().find(|p| p.name == *dep_name)
                 } else {
                     // npm dep: match by semver range satisfaction.
@@ -881,6 +938,80 @@ mod tests {
         );
     }
 
+    // #2794: dist-tag classifier — recognizes npm dist-tag specs like "latest",
+    // "next", and custom tags as non-semver, distinct from both `github:`/`link:`
+    // specifiers and semver ranges. Used by `graph_to_lockfile` to match by name
+    // when the range string isn't a valid semver range.
+    #[test]
+    fn test_is_non_semver_spec_dist_tag_latest() {
+        assert!(
+            is_non_semver_spec("latest"),
+            "'latest' must be classified as a non-semver (dist-tag) spec"
+        );
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_github_prefix() {
+        assert!(is_non_semver_spec("github:owner/repo"));
+        assert!(is_non_semver_spec("github:owner/repo#main"));
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_link_prefix() {
+        assert!(is_non_semver_spec("link:../ws-pkg"));
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_other_dist_tags() {
+        // Standard and custom tag names are all dist-tag-shaped.
+        assert!(is_non_semver_spec("next"));
+        assert!(is_non_semver_spec("beta"));
+        assert!(is_non_semver_spec("canary-build"));
+        assert!(is_non_semver_spec("alpha_1"));
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_rejects_semver_ranges() {
+        assert!(!is_non_semver_spec("1.2.3"));
+        assert!(!is_non_semver_spec("^1.2.3"));
+        assert!(!is_non_semver_spec("~1.0.0"));
+        assert!(!is_non_semver_spec(">=1.0.0 <2.0.0"));
+        assert!(!is_non_semver_spec("1.x"));
+        assert!(
+            !is_non_semver_spec("*"),
+            "'*' is a semver wildcard, not a tag"
+        );
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_rejects_protocol_specs() {
+        // Protocol specs (file:, workspace:, npm:) don't reach the graph via
+        // resolve_version. Even if they did, the shape check keeps them out
+        // of the dist-tag class.
+        assert!(!is_non_semver_spec("file:./x"));
+        assert!(!is_non_semver_spec("workspace:*"));
+        assert!(!is_non_semver_spec("npm:react@1.0.0"));
+        assert!(!is_non_semver_spec("http://example.com/pkg.tgz"));
+    }
+
+    #[test]
+    fn test_is_non_semver_spec_edge_cases() {
+        assert!(!is_non_semver_spec(""), "empty string is not a dist-tag");
+        assert!(
+            !is_non_semver_spec("1latest"),
+            "digit-prefixed strings aren't tag-shaped"
+        );
+    }
+
+    #[test]
+    fn test_is_dist_tag_shape_rejects_semver_wildcards() {
+        // `x` and `x.x.x` pass the char shape check but parse as semver
+        // wildcards — Range::parse accepts them, so they must NOT be classified
+        // as dist-tags.
+        assert!(!is_dist_tag_shape("x"));
+        assert!(!is_dist_tag_shape("x.x.x"));
+    }
+
     #[test]
     fn test_graph_to_lockfile_rejects_hoisted_version_outside_range() {
         // Regression for #2738: if the hoisted package version does not satisfy
@@ -997,6 +1128,244 @@ mod tests {
 
         // Single version should remain at root
         assert!(graph.packages["zod@3.24.4"].nest_path.is_empty());
+    }
+
+    // #2794: when the graph has both a root and a nested version of the same
+    // package, a dist-tag root dep must pick the root (hoisted) version.
+    #[test]
+    fn test_graph_to_lockfile_dist_tag_respects_nest_path() {
+        let mut graph = ResolvedGraph::default();
+        graph.packages.insert(
+            "zod@3.24.4".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "3.24.4".to_string(),
+                tarball_url: "root-url".to_string(),
+                integrity: "root-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+        graph.packages.insert(
+            "zod@4.0.0".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "4.0.0".to_string(),
+                tarball_url: "nested-url".to_string(),
+                integrity: "nested-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec!["some-parent".to_string()],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut deps = BTreeMap::new();
+        deps.insert("zod".to_string(), "latest".to_string());
+
+        let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+        let entry = &lockfile.entries["zod@latest"];
+        assert_eq!(
+            entry.version, "3.24.4",
+            "dist-tag root dep must pick the root (nest_path=[]) version, not nested"
+        );
+        assert_eq!(entry.resolved, "root-url");
+    }
+
+    // #2794: a transitive dep declared with a dist-tag spec (e.g. `"bar": "latest"`
+    // inside another package's `dependencies`) must also land in the lockfile.
+    // Separate match site from the root-dep loop — has its own code path.
+    #[test]
+    fn test_graph_to_lockfile_dist_tag_transitive_dep() {
+        let mut graph = ResolvedGraph::default();
+
+        // foo@1.0.0 depends on bar@latest
+        let mut foo_deps = BTreeMap::new();
+        foo_deps.insert("bar".to_string(), "latest".to_string());
+        graph.packages.insert(
+            "foo@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "foo".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "foo-url".to_string(),
+                integrity: "foo-integrity".to_string(),
+                dependencies: foo_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // bar@2.5.0 — what `latest` resolved to
+        graph.packages.insert(
+            "bar@2.5.0".to_string(),
+            ResolvedPackage {
+                name: "bar".to_string(),
+                version: "2.5.0".to_string(),
+                tarball_url: "bar-url".to_string(),
+                integrity: "bar-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut deps = BTreeMap::new();
+        deps.insert("foo".to_string(), "^1.0.0".to_string());
+
+        let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+        let entry = lockfile
+            .entries
+            .get("bar@latest")
+            .expect("transitive dist-tag dep must be written to the lockfile");
+        assert_eq!(entry.version, "2.5.0");
+        assert_eq!(entry.resolved, "bar-url");
+    }
+
+    // #2796: documents the current (wrong) behavior when a transitive dist-tag
+    // dep collides with a sibling that pulls a different version of the same
+    // name. Name-only `find()` returns first-by-key, not the dist-tag-resolved
+    // version. Real fix needs `resolved_from_tag` plumbing — tracked separately.
+    #[test]
+    fn test_graph_to_lockfile_dist_tag_transitive_multi_version_is_first_by_key() {
+        let mut graph = ResolvedGraph::default();
+
+        // foo@1.0.0 declares "bar": "latest" — resolves to bar@2.5.0
+        let mut foo_deps = BTreeMap::new();
+        foo_deps.insert("bar".to_string(), "latest".to_string());
+        graph.packages.insert(
+            "foo@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "foo".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "foo-url".to_string(),
+                integrity: "foo-integrity".to_string(),
+                dependencies: foo_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // baz@1.0.0 declares "bar": "^1.0.0" — resolves to bar@1.0.0
+        let mut baz_deps = BTreeMap::new();
+        baz_deps.insert("bar".to_string(), "^1.0.0".to_string());
+        graph.packages.insert(
+            "baz@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "baz".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "baz-url".to_string(),
+                integrity: "baz-integrity".to_string(),
+                dependencies: baz_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        graph.packages.insert(
+            "bar@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "bar".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "bar-1-url".to_string(),
+                integrity: "bar-1-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        graph.packages.insert(
+            "bar@2.5.0".to_string(),
+            ResolvedPackage {
+                name: "bar".to_string(),
+                version: "2.5.0".to_string(),
+                tarball_url: "bar-2-url".to_string(),
+                integrity: "bar-2-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut deps = BTreeMap::new();
+        deps.insert("foo".to_string(), "^1.0.0".to_string());
+        deps.insert("baz".to_string(), "^1.0.0".to_string());
+
+        let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+        let entry = lockfile
+            .entries
+            .get("bar@latest")
+            .expect("transitive dist-tag entry must exist");
+        // Current behavior: first-by-key wins. Once #2796 is fixed, this should
+        // assert "2.5.0" instead.
+        assert_eq!(
+            entry.version, "1.0.0",
+            "documents #2796 — rewrite when fix lands"
+        );
+    }
+
+    // #2794: a root dep declared with a dist-tag spec (`"latest"`) must land
+    // in the lockfile pinned to the resolved version, not be silently dropped.
+    #[test]
+    fn test_graph_to_lockfile_dist_tag_root_dep() {
+        let mut graph = ResolvedGraph::default();
+        graph.packages.insert(
+            "@types/bun@1.3.12".to_string(),
+            ResolvedPackage {
+                name: "@types/bun".to_string(),
+                version: "1.3.12".to_string(),
+                tarball_url: "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz".to_string(),
+                integrity: "sha512-bun-tag".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut deps = BTreeMap::new();
+        deps.insert("@types/bun".to_string(), "latest".to_string());
+
+        let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+        assert_eq!(
+            lockfile.entries.len(),
+            1,
+            "dist-tag dep must produce a lockfile entry"
+        );
+
+        let entry = &lockfile.entries["@types/bun@latest"];
+        assert_eq!(entry.version, "1.3.12");
+        assert_eq!(
+            entry.resolved,
+            "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz"
+        );
+        assert_eq!(entry.integrity, "sha512-bun-tag");
     }
 
     #[test]

--- a/plans/2794-fix-install-latest-tag.md
+++ b/plans/2794-fix-install-latest-tag.md
@@ -1,0 +1,271 @@
+# Fix: `vtz install` silently drops dependencies with `"latest"` version spec (#2794)
+
+## Problem
+
+`vtz install` silently drops `package.json` entries whose version field is a npm dist-tag like `"latest"`, `"next"`, or `"beta"`.
+
+**Symptoms observed (issue #2794):**
+- Dep resolves and downloads fine (the registry fetch + tarball path is correct)
+- …but no entry is written to `vertz.lock`
+- A later `vtz install --frozen` fails with a misleading `lockfile is out of date`
+- Exposed when migrating CI from `bun install --frozen-lockfile` to `vtz install --frozen` (#2793); worked around by pinning `@types/bun` from `"latest"` to `"^1.3.12"` — the `vtz install` bug remained
+
+## Root Cause
+
+Two helpers in `native/vtz/src/pm/resolver.rs` classify a dep's version range using a narrow hardcoded prefix check:
+
+```rust
+let is_non_semver = range.starts_with("github:") || range.starts_with("link:");
+```
+
+- `resolve_version()` (line 44) correctly handles dist-tags: it checks `dist_tags.get(range_str)` **before** `Range::parse`. So a dep with `"latest"` is resolved and added to the graph. ✓
+- But `graph_to_lockfile()` has **two** match sites that fail on dist-tags:
+  - Root-dep loop, line 566–571: uses `version_satisfies_range(version, range)`. For `range = "latest"`, `Range::parse("latest")` returns `Err`, the function returns `false`, and the dep is silently skipped. ✗
+  - Transitive-dep loop, line 599–622: has a similar `Range::parse` check (no dist-tag handling). A transitive dep declaring `"foo": "latest"` in its `dependencies` hits the same silent-drop path. Rare in practice but has identical failure mode.
+
+A dist-tag is neither a semver range nor a `github:` / `link:` spec, so it slips through.
+
+## Approach
+
+Make dist-tag specs first-class alongside `github:` / `link:` at the two match sites in `graph_to_lockfile`. The `resolve_version` path already resolves dist-tags correctly — this fix only bridges **resolution → lockfile**.
+
+**Invariant:** `resolve_version()` is the single authority for turning a spec into a graph entry. A non-semver spec gets into the graph only via (a) `github:` prefix, (b) `link:` prefix, or (c) `dist_tags.get(range)` returning Some. For cases (a) and (b), `graph_to_lockfile` already matches by name. Case (c) is the gap.
+
+**Minimal change:** introduce a shape-based classifier `is_non_semver_spec` that recognizes dist-tag-shaped strings, apply it at both match sites.
+
+### API Surface (observable behavior)
+
+No new CLI flags. No config changes. Internal behavior change only: the existing user-facing contract (`package.json` → `vtz.lock`) starts honoring dist-tags.
+
+**Before:**
+```bash
+# packages/docs/package.json:
+#   "devDependencies": { "@types/bun": "latest", ... }
+
+vtz install                      # exit 0 — but silently skips @types/bun
+grep '@types/bun' vertz.lock     # no output
+vtz install --frozen             # error: lockfile is out of date
+```
+
+**After:**
+```bash
+vtz install                      # exit 0
+grep '@types/bun' vertz.lock     # @types/bun@latest: { version: "1.3.12", resolved: ..., integrity: ... }
+vtz install --frozen             # exit 0
+```
+
+The lockfile key is `@types/bun@latest` (the user's original spec) and the entry pins to the concrete version the dist-tag resolved to at install time (`"1.3.12"`). Matches bun / npm / yarn semantics.
+
+### The Classifier
+
+Private helpers in `native/vtz/src/pm/resolver.rs`:
+
+```rust
+/// Returns true iff `range_str` is a non-semver dependency specifier that
+/// `graph_to_lockfile` must match by name alone (no semver range check).
+///
+/// Includes:
+/// - `github:owner/repo[#ref]` — pinned by commit SHA
+/// - `link:path` — workspace link
+/// - Dist-tag-shaped strings — `latest`, `next`, `beta`, and custom tags
+///
+/// Deliberately excludes:
+/// - Semver ranges (`^1.2.3`, `~1.0.0`, `>=1.0.0 <2.0.0`, `*`, `1.2.3`, `1.x`)
+/// - Protocol-prefixed specs (`file:`, `workspace:`, `npm:`, `http://`) — these
+///   aren't produced by `resolve_version`, so they won't be in the graph.
+fn is_non_semver_spec(range_str: &str) -> bool {
+    range_str.starts_with("github:")
+        || range_str.starts_with("link:")
+        || is_dist_tag_shape(range_str)
+}
+
+/// Returns true iff `s` looks like a dist-tag name.
+///
+/// Rules:
+/// - Non-empty
+/// - First char is ASCII alphabetic (excludes semver like `1.2.3`, `~1.0`)
+/// - All chars are ASCII alphanumeric or `-` `_` `.` (excludes `:`/`/`/`@`/spaces/operators)
+/// - Does not parse as a semver range (excludes aliases like `x` or `x.x.x` that are
+///   technically valid semver wildcards)
+fn is_dist_tag_shape(s: &str) -> bool {
+    let Some(first) = s.chars().next() else { return false; };
+    if !first.is_ascii_alphabetic() { return false; }
+    if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.') {
+        return false;
+    }
+    Range::parse(s).is_err()
+}
+```
+
+### The Fix
+
+Apply `is_non_semver_spec` at both match sites in `graph_to_lockfile`:
+
+1. **Root-dep loop** (line 566): replace the hardcoded prefix check with `is_non_semver_spec(range)`. When the spec is non-semver, match by `name + nest_path.is_empty()` only (as today for `github:` / `link:`).
+2. **Transitive-dep loop** (line 607 branch): replace the `github:`-only branch with a broader non-semver branch driven by `is_non_semver_spec`. When non-semver, match by name (no `nest_path` restriction for transitives — they can match nested versions).
+
+### Why this is safe
+
+- **Garbage ranges** that coincidentally look dist-tag-shaped (e.g. `"totally-garbage"`): `resolve_version` has no matching dist-tag → returns `None` → resolver aborts with `"No version of 'X' matches range 'Y'"` **before** `graph_to_lockfile` runs. No package in the graph, no entry wired. Same outcome as today.
+- **Overrides + garbage range** (reviewer Finding #2): user writes `"foo": "garbage"` plus override `"foo": "1.0.0"`. Resolver uses `effective_range = "1.0.0"`, graph has `foo@1.0.0`. With this fix, `graph_to_lockfile` classifies `"garbage"` as dist-tag-shaped → matches by name → writes `foo@garbage → 1.0.0`. This is an **intentional improvement**: the user explicitly opted into the override for this name; honoring it at lockfile time is more consistent than silently dropping the entry. Today's behavior (drop, then `--frozen` fails) is strictly worse. If the user didn't intend the override, they'd notice a mismatch and fix `package.json` either way.
+- **Protocol specs** (`file:`, `workspace:`, `npm:`, `http://`): shape check excludes them (contain `:` / `/`). They never appear in the graph via `resolve_version` anyway, so no regression.
+- **Semver ranges** (`^1.2.3`, `*`, `1.x`): shape check excludes them (start with non-alpha, or pass `Range::parse`). Fall through to `version_satisfies_range`. Unchanged behavior. The #2738 regression guard (`test_resolve_version_caret_rejects_lower_minor`, `test_lockfile_entry_satisfies_for_current_range_rejects_stale`) is preserved.
+- **Lockfile fast path** (`lockfile_entry_satisfies_range`, line 36) is **not touched**. For a lockfile entry with `range: "latest"` and a pinned version, the fast path will still return false → the resolver re-fetches registry metadata → `resolve_version` resolves "latest" freshly → `graph_to_lockfile` writes the correct entry. The lockfile reuse is slower for dist-tag deps (one extra registry round-trip) but **correct**. Optimizing this is explicitly out of scope (see Non-Goals).
+
+## Non-Goals
+
+- **Lockfile fast-path optimization for dist-tags.** `lockfile_entry_satisfies_range` stays as-is. Dist-tag deps pay one registry round-trip per install. Tracked as a follow-up — the right fix there is either a `--update`/`--refresh` flag (bun-style) or storing the resolved-from-tag info in `LockfileEntry` to allow trust-based reuse. Both are broader surgery than this bug fix warrants.
+- **Normalize-at-resolution refactor.** Reviewer suggested carrying a `resolved_from_tag` field on `ResolvedPackage` so `graph_to_lockfile` matches via exact tag rather than shape. Correct but blast radius is large (~50 `ResolvedPackage` construction sites across `resolver.rs`, `linker.rs`, `scripts.rs`, `bin.rs`, `mod.rs`). Filing as a follow-up issue; narrow fix first, refactor later.
+- **Rejecting `"latest"` with an error (issue option 2).** Rejected: bun / npm / yarn all resolve dist-tags, including the tree shipped in this very monorepo before the `^1.3.12` workaround.
+- **npm: aliases** (`"foo": "npm:react@18.0.0"`) — distinct behavior, not touched.
+- **Warnings / lint for `"latest"` as a style anti-pattern** — stylistic, not a correctness fix.
+
+## Manifesto Alignment
+
+- **Principle 4 (One right answer)** — dist-tags have a canonical resolution in the npm ecosystem (pin at install time). Silent drop is wrong; we align with every other package manager.
+- **Principle 7 (Fail loud)** — today's silent drop is the worst failure mode. After the fix, success is silent and tag-not-found errors from `resolve_version` as it already does.
+
+## Unknowns
+
+None identified.
+
+## Type Flow Map
+
+N/A — Rust, no generics introduced.
+
+## Follow-up Issues to File Alongside This Fix
+
+1. **Lockfile fast-path for dist-tag entries** — `lockfile_entry_satisfies_range` should trust an entry whose recorded `range` is a dist-tag, to avoid re-fetching metadata on every install. Needs `--update`/`--refresh` flag or schema additions.
+2. **Normalize `resolved_from_tag` at resolution time** — store the tag on `ResolvedPackage` so `graph_to_lockfile` match is exact-tag, not shape-based. Cleaner invariants, larger blast radius.
+
+## Acceptance Criteria (BDD)
+
+```rust
+describe("Feature: is_non_semver_spec classification") {
+  describe("Given a `github:` specifier") {
+    it("Then it's non-semver") {}
+  }
+  describe("Given a `link:` specifier") {
+    it("Then it's non-semver") {}
+  }
+  describe("Given dist-tag-shaped strings") {
+    it("Then 'latest' is non-semver") {}
+    it("Then 'next' is non-semver") {}
+    it("Then 'beta' is non-semver") {}
+    it("Then 'canary-build' is non-semver (hyphen in custom tag)") {}
+    it("Then 'alpha_1' is non-semver (underscore + digit)") {}
+  }
+  describe("Given semver ranges") {
+    it("Then '1.2.3' is semver (starts with digit)") {}
+    it("Then '^1.2.3' is semver (operator prefix)") {}
+    it("Then '~1.0.0' is semver") {}
+    it("Then '>=1.0.0 <2.0.0' is semver (operator + space)") {}
+    it("Then '1.x' is semver (digit prefix)") {}
+    it("Then '*' is semver (operator-only)") {}
+  }
+  describe("Given protocol-prefixed specs that shouldn't reach here") {
+    it("Then 'file:./x' is NOT classified as dist-tag (contains ':' and '/')") {}
+    it("Then 'workspace:*' is NOT classified as dist-tag (contains ':' and '*')") {}
+    it("Then 'npm:react@1.0.0' is NOT classified as dist-tag (contains ':' and '@')") {}
+  }
+  describe("Given edge cases") {
+    it("Then '' (empty) is NOT a dist-tag") {}
+    it("Then '1latest' is NOT a dist-tag (starts with digit)") {}
+  }
+}
+
+describe("Feature: graph_to_lockfile with dist-tag root dep") {
+  describe("Given a graph with @types/bun@1.3.12 and package.json dep @types/bun@latest") {
+    describe("When graph_to_lockfile is called") {
+      it("Then the lockfile contains entry '@types/bun@latest' pinned to 1.3.12") {}
+      it("Then the entry resolved URL matches the graph package tarball") {}
+      it("Then the entry integrity matches the graph package integrity") {}
+    }
+  }
+
+  describe("Given dist-tags 'next' and 'beta' on different packages") {
+    describe("When graph_to_lockfile is called for deps using each tag") {
+      it("Then each tag produces a correctly-keyed lockfile entry") {}
+    }
+  }
+
+  describe("Given two versions of zod in the graph (3.24.4 at root, 4.0.0 nested) and package.json dep zod@latest") {
+    describe("When graph_to_lockfile is called") {
+      it("Then it picks the root (nest_path=[]) version, not the nested one") {}
+    }
+  }
+}
+
+describe("Feature: graph_to_lockfile with dist-tag transitive dep") {
+  describe("Given package foo depends on bar@latest (in bar's packument dist-tags)") {
+    describe("When graph_to_lockfile is called") {
+      it("Then the transitive lockfile entry 'bar@latest' is written with the resolved version") {}
+    }
+  }
+}
+
+describe("Feature: regression — semver ranges still work") {
+  describe("Given zod@^3.24.0 in the graph and package.json") {
+    it("Then graph_to_lockfile writes 'zod@^3.24.0 → 3.24.4' as before") {}
+  }
+  describe("Given a hoisted esbuild@0.25.12 and package.json declares esbuild@^0.27.3") {
+    it("Then graph_to_lockfile does NOT wire the entry (preserves #2738 fix)") {}
+  }
+}
+```
+
+## E2E Acceptance Test
+
+Developer perspective: a `package.json` with a dist-tag dep installs and round-trips through `--frozen`.
+
+```bash
+# Setup: package.json with "@types/bun": "latest"
+vtz install
+grep '@types/bun@latest' vertz.lock   # ← must find a pinned entry
+vtz install --frozen                   # ← must exit 0
+```
+
+The monorepo's own `packages/docs/package.json` was previously pinned to `"^1.3.12"` in #2793 as a workaround. This fix doesn't require reverting that pin — we add regression tests instead. A follow-up PR can optionally revert the workaround after this merges.
+
+## Implementation Plan
+
+Single phase. All changes live in one Rust file.
+
+### Phase 1 — Fix + tests
+
+Files touched (≤5):
+1. `native/vtz/src/pm/resolver.rs` — add `is_non_semver_spec` + `is_dist_tag_shape`, use in root-dep and transitive-dep loops of `graph_to_lockfile`, add tests.
+2. `.changeset/fix-install-latest-tag.md` — patch changeset.
+
+### TDD Order
+
+1. **RED — classifier unit tests**: write tests for each row of the BDD acceptance table for `is_non_semver_spec` / `is_dist_tag_shape`. All fail (helpers don't exist).
+2. **GREEN**: add both helpers.
+3. **RED — root dist-tag → lockfile**: build a `ResolvedGraph` with `@types/bun@1.3.12`, pass deps `{"@types/bun": "latest"}`, assert lockfile has `@types/bun@latest` entry pinned to 1.3.12. Fails with current code.
+4. **GREEN**: swap root-loop prefix check for `is_non_semver_spec`.
+5. **RED — root dist-tag respects nest_path**: graph with root `zod@3.24.4` and nested `zod@4.0.0`, dep `zod: "latest"`, assert root version is picked. (Should already pass from step 4 — the existing `nest_path.is_empty()` filter is retained. Verifies no regression.)
+6. **RED — transitive dist-tag → lockfile**: graph with package `foo@1.0.0` whose `dependencies` declare `"bar": "latest"`, graph also has `bar@2.5.0`. Assert lockfile contains `bar@latest → 2.5.0`. Fails.
+7. **GREEN**: apply `is_non_semver_spec` to the transitive branch.
+8. **Regression guards (keep + verify)**: `test_resolve_version_caret_rejects_lower_minor`, `test_lockfile_entry_satisfies_for_current_range_rejects_stale`, `test_graph_to_lockfile_rejects_hoisted_version_outside_range`, `test_graph_to_lockfile_transitive_matches_by_semver_range` all still green.
+9. **Refactor**: extract docstring, verify no duplication between root and transitive branches.
+
+### Quality Gates
+
+```bash
+cd native
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+All must pass before code review.
+
+### Adversarial Review Targets
+
+- Does the fix handle `"latest"` AND other dist-tags (`next`, `beta`, custom)?
+- Does it preserve the #2738 regression guard (stale lockfile with wrong semver version must still be rejected)?
+- Does it break the `github:` / `link:` paths?
+- Does `resolve_version` still short-circuit garbage ranges before they reach `graph_to_lockfile`?
+- Transitive dist-tag coverage?
+- Shape-check edge cases: empty string, digit prefix, protocol prefix, operator prefix?
+- Does `is_dist_tag_shape` correctly reject semver wildcards like `"x"` / `"x.x.x"` (`Range::parse` parses these → returns false → correct)?

--- a/plans/2794-fix-install-latest-tag/phase-01-classifier-and-lockfile-match.md
+++ b/plans/2794-fix-install-latest-tag/phase-01-classifier-and-lockfile-match.md
@@ -1,0 +1,316 @@
+# Phase 1: Dist-tag classifier + lockfile match
+
+## Context
+
+Fixes GitHub #2794. `vtz install` silently drops `package.json` deps with version spec like `"latest"` (npm dist-tag). The package resolves and installs, but no entry is written to `vertz.lock`; a subsequent `vtz install --frozen` fails with `lockfile is out of date`.
+
+Root cause: `graph_to_lockfile()` in `native/vtz/src/pm/resolver.rs` classifies non-semver specs via a hardcoded `github:`/`link:` prefix check. Dist-tags slip through — `Range::parse("latest")` fails and the dep is silently skipped. Fix lives in two match sites (root-dep loop + transitive-dep loop) inside that one function. See design doc: `plans/2794-fix-install-latest-tag.md`.
+
+## Tasks
+
+### Task 1: Add `is_non_semver_spec` / `is_dist_tag_shape` classifier + unit tests
+
+**Files:** (2)
+- `native/vtz/src/pm/resolver.rs` (modified)
+- `.changeset/fix-install-latest-tag.md` (new)
+
+**What to implement:**
+
+Private helpers inside `resolver.rs`:
+
+```rust
+/// Returns true iff `range_str` is a non-semver dependency specifier that
+/// `graph_to_lockfile` must match by name alone (no semver range check).
+///
+/// Includes:
+/// - `github:owner/repo[#ref]` — pinned by commit SHA
+/// - `link:path` — workspace link
+/// - Dist-tag-shaped strings — `latest`, `next`, `beta`, and custom tags
+///
+/// Deliberately excludes:
+/// - Semver ranges (`^1.2.3`, `~1.0.0`, `>=1.0.0 <2.0.0`, `*`, `1.2.3`, `1.x`)
+/// - Protocol-prefixed specs (`file:`, `workspace:`, `npm:`, `http://`)
+fn is_non_semver_spec(range_str: &str) -> bool {
+    range_str.starts_with("github:")
+        || range_str.starts_with("link:")
+        || is_dist_tag_shape(range_str)
+}
+
+/// Returns true iff `s` looks like a dist-tag name.
+///
+/// Rules:
+/// - Non-empty
+/// - First char is ASCII alphabetic (excludes `1.2.3`, `~1.0`)
+/// - All chars are ASCII alphanumeric or `-` `_` `.` (excludes `:`/`/`/`@`/spaces/operators)
+/// - Does not parse as a semver range (rejects `x` / `x.x.x` semver wildcards)
+fn is_dist_tag_shape(s: &str) -> bool {
+    let Some(first) = s.chars().next() else { return false; };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.') {
+        return false;
+    }
+    Range::parse(s).is_err()
+}
+```
+
+TDD order:
+
+1. **RED — classifier tests** in `#[cfg(test)] mod tests` at the bottom of `resolver.rs`. Write *one* failing test first for `is_non_semver_spec("latest") == true`. Confirm red (helper doesn't exist → won't compile).
+2. **GREEN**: add the two helpers with just enough to pass.
+3. **RED + GREEN + REFACTOR** for the remaining classifier cases — one test at a time:
+   - `is_non_semver_spec("github:owner/repo") == true`
+   - `is_non_semver_spec("link:../ws") == true`
+   - `is_non_semver_spec("next") == true`
+   - `is_non_semver_spec("beta") == true`
+   - `is_non_semver_spec("canary-build") == true`
+   - `is_non_semver_spec("alpha_1") == true`
+   - `is_non_semver_spec("^1.2.3") == false`
+   - `is_non_semver_spec("~1.0.0") == false`
+   - `is_non_semver_spec("1.2.3") == false`
+   - `is_non_semver_spec(">=1.0.0 <2.0.0") == false`
+   - `is_non_semver_spec("1.x") == false`
+   - `is_non_semver_spec("*") == false`
+   - `is_non_semver_spec("") == false`
+   - `is_non_semver_spec("1latest") == false` (digit prefix)
+   - `is_non_semver_spec("file:./x") == false` (contains `:` and `/`)
+   - `is_non_semver_spec("workspace:*") == false`
+   - `is_non_semver_spec("npm:react@1.0.0") == false`
+4. **Changeset**: create `.changeset/fix-install-latest-tag.md` with content:
+   ```markdown
+   ---
+   '@vertz/vtz': patch
+   ---
+
+   fix(pm): `vtz install` now resolves npm dist-tag specs (`"latest"`, `"next"`, etc.) and writes them to `vertz.lock` instead of silently dropping the entry (#2794).
+   ```
+
+**Acceptance criteria:**
+- [ ] `cargo test -p vtz is_non_semver_spec` passes all classifier cases
+- [ ] `cargo test -p vtz is_dist_tag_shape` passes all shape cases
+- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings` from `native/`)
+- [ ] `cargo fmt --all -- --check` clean
+
+---
+
+### Task 2: Use classifier in `graph_to_lockfile` root-dep loop + tests
+
+**Files:** (1 — same `resolver.rs` as Task 1; counts toward the phase file budget but doesn't exceed 5-file-per-task rule)
+- `native/vtz/src/pm/resolver.rs` (modified)
+
+**What to implement:**
+
+TDD order:
+
+1. **RED — root dist-tag integration test**:
+   ```rust
+   #[test]
+   fn test_graph_to_lockfile_dist_tag_root_dep() {
+       let mut graph = ResolvedGraph::default();
+       graph.packages.insert(
+           "@types/bun@1.3.12".to_string(),
+           ResolvedPackage {
+               name: "@types/bun".to_string(),
+               version: "1.3.12".to_string(),
+               tarball_url: "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz".to_string(),
+               integrity: "sha512-abc".to_string(),
+               dependencies: BTreeMap::new(),
+               optional_dependencies: BTreeMap::new(),
+               bin: BTreeMap::new(),
+               nest_path: vec![],
+               os: None,
+               cpu: None,
+           },
+       );
+
+       let mut deps = BTreeMap::new();
+       deps.insert("@types/bun".to_string(), "latest".to_string());
+
+       let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+       assert_eq!(lockfile.entries.len(), 1, "dist-tag dep must produce a lockfile entry");
+
+       let entry = &lockfile.entries["@types/bun@latest"];
+       assert_eq!(entry.version, "1.3.12");
+       assert_eq!(entry.resolved, "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz");
+       assert_eq!(entry.integrity, "sha512-abc");
+   }
+   ```
+   Run: fails (current code silently drops).
+2. **GREEN**: in `graph_to_lockfile()` line 566, replace:
+   ```rust
+   let is_non_semver = range.starts_with("github:") || range.starts_with("link:");
+   ```
+   with:
+   ```rust
+   let is_non_semver = is_non_semver_spec(range);
+   ```
+   The existing `nest_path.is_empty()` filter is preserved.
+3. **RED — nest_path filter for dist-tags**:
+   ```rust
+   #[test]
+   fn test_graph_to_lockfile_dist_tag_respects_nest_path() {
+       let mut graph = ResolvedGraph::default();
+       // Root-level zod 3.24.4
+       graph.packages.insert("zod@3.24.4".to_string(), ResolvedPackage {
+           name: "zod".to_string(),
+           version: "3.24.4".to_string(),
+           nest_path: vec![],
+           tarball_url: "root-url".to_string(),
+           integrity: "root-integrity".to_string(),
+           dependencies: BTreeMap::new(),
+           optional_dependencies: BTreeMap::new(),
+           bin: BTreeMap::new(),
+           os: None, cpu: None,
+       });
+       // Nested zod 4.0.0
+       graph.packages.insert("zod@4.0.0".to_string(), ResolvedPackage {
+           name: "zod".to_string(),
+           version: "4.0.0".to_string(),
+           nest_path: vec!["some-parent".to_string()],
+           tarball_url: "nested-url".to_string(),
+           integrity: "nested-integrity".to_string(),
+           dependencies: BTreeMap::new(),
+           optional_dependencies: BTreeMap::new(),
+           bin: BTreeMap::new(),
+           os: None, cpu: None,
+       });
+
+       let mut deps = BTreeMap::new();
+       deps.insert("zod".to_string(), "latest".to_string());
+
+       let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+       let entry = &lockfile.entries["zod@latest"];
+       assert_eq!(entry.version, "3.24.4", "must pick root (nest_path=[]), not nested");
+       assert_eq!(entry.resolved, "root-url");
+   }
+   ```
+   Should pass after Task 2's GREEN (existing `nest_path.is_empty()` filter).
+4. **REGRESSION**: re-run `test_graph_to_lockfile_rejects_hoisted_version_outside_range` — must still pass (semver range check unchanged).
+
+**Acceptance criteria:**
+- [ ] `test_graph_to_lockfile_dist_tag_root_dep` passes
+- [ ] `test_graph_to_lockfile_dist_tag_respects_nest_path` passes
+- [ ] Existing `test_graph_to_lockfile`, `test_graph_to_lockfile_rejects_hoisted_version_outside_range`, `test_lockfile_entry_satisfies_for_current_range_rejects_stale` still pass
+- [ ] Clippy clean, format clean
+
+---
+
+### Task 3: Use classifier in `graph_to_lockfile` transitive-dep loop + tests
+
+**Files:** (1 — same file)
+- `native/vtz/src/pm/resolver.rs` (modified)
+
+**What to implement:**
+
+TDD order:
+
+1. **RED — transitive dist-tag test**:
+   ```rust
+   #[test]
+   fn test_graph_to_lockfile_dist_tag_transitive_dep() {
+       let mut graph = ResolvedGraph::default();
+
+       // foo@1.0.0 depends on bar@latest
+       let mut foo_deps = BTreeMap::new();
+       foo_deps.insert("bar".to_string(), "latest".to_string());
+       graph.packages.insert("foo@1.0.0".to_string(), ResolvedPackage {
+           name: "foo".to_string(),
+           version: "1.0.0".to_string(),
+           tarball_url: "foo-url".to_string(),
+           integrity: "foo-integrity".to_string(),
+           dependencies: foo_deps,
+           optional_dependencies: BTreeMap::new(),
+           bin: BTreeMap::new(),
+           nest_path: vec![],
+           os: None, cpu: None,
+       });
+
+       // bar@2.5.0 resolved from the `latest` tag
+       graph.packages.insert("bar@2.5.0".to_string(), ResolvedPackage {
+           name: "bar".to_string(),
+           version: "2.5.0".to_string(),
+           tarball_url: "bar-url".to_string(),
+           integrity: "bar-integrity".to_string(),
+           dependencies: BTreeMap::new(),
+           optional_dependencies: BTreeMap::new(),
+           bin: BTreeMap::new(),
+           nest_path: vec![],
+           os: None, cpu: None,
+       });
+
+       let mut deps = BTreeMap::new();
+       deps.insert("foo".to_string(), "^1.0.0".to_string());
+
+       let lockfile = graph_to_lockfile(&graph, &deps, &[], &HashSet::new());
+       let entry = lockfile.entries.get("bar@latest")
+           .expect("transitive dist-tag dep must be in lockfile");
+       assert_eq!(entry.version, "2.5.0");
+       assert_eq!(entry.resolved, "bar-url");
+   }
+   ```
+   Run: fails (current transitive branch at lines 599–622 only handles `github:`).
+2. **GREEN**: in the transitive branch of `graph_to_lockfile`, replace:
+   ```rust
+   let dep_pkg = if dep_range.starts_with("github:") {
+       graph.packages.values().find(|p| p.name == *dep_name)
+   } else {
+       graph.packages.values().find(|p| {
+           p.name == *dep_name
+               && Range::parse(dep_range)
+                   .ok()
+                   .and_then(|r| Version::parse(&p.version).ok().map(|v| r.satisfies(&v)))
+                   .unwrap_or(false)
+       })
+   };
+   ```
+   with:
+   ```rust
+   let dep_pkg = if is_non_semver_spec(dep_range) {
+       // github:, link:, or dist-tag — match by name only.
+       graph.packages.values().find(|p| p.name == *dep_name)
+   } else {
+       graph.packages.values().find(|p| {
+           p.name == *dep_name
+               && Range::parse(dep_range)
+                   .ok()
+                   .and_then(|r| Version::parse(&p.version).ok().map(|v| r.satisfies(&v)))
+                   .unwrap_or(false)
+       })
+   };
+   ```
+3. **REGRESSION**: re-run `test_graph_to_lockfile_transitive_matches_by_semver_range`, `test_graph_to_lockfile_github_transitive_dep`, `test_graph_to_lockfile_with_transitive` — all must still pass.
+
+**Acceptance criteria:**
+- [ ] `test_graph_to_lockfile_dist_tag_transitive_dep` passes
+- [ ] All transitive-related existing tests still pass
+- [ ] Clippy clean, format clean
+- [ ] `cd native && cargo test --all` passes entire crate suite
+- [ ] E2E sanity check: inspect the diff — `graph_to_lockfile` now uses `is_non_semver_spec` at both match sites; no other logic changed
+
+---
+
+## Quality Gates (before review)
+
+From `native/`:
+
+```bash
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+All three must be green.
+
+## Adversarial Review Scope
+
+The review file lands at `reviews/2794-fix-install-latest-tag/phase-01-classifier-and-lockfile-match.md` and must check:
+
+- [ ] All classifier cases covered (dist-tag, semver, protocols, edge)
+- [ ] Both match sites in `graph_to_lockfile` use the classifier (no lingering `range.starts_with("github:")` checks in graph_to_lockfile)
+- [ ] `resolve_version` path unchanged — dist-tag resolution at resolution time still correct
+- [ ] `lockfile_entry_satisfies_range` deliberately untouched (documented as follow-up, verify in the design doc)
+- [ ] #2738 regression guards still green
+- [ ] Transitive test genuinely exercises the transitive branch (not piggybacking on the root path)
+- [ ] Changeset is `patch`
+- [ ] No scope creep — only `resolver.rs` and the changeset touched


### PR DESCRIPTION
## Summary

Fixes #2794 — `vtz install` silently dropped `package.json` deps with non-semver version specs like `"latest"` / `"next"`. The dep resolved and installed fine (tarball + link), but never landed in `vertz.lock`, so `vtz install --frozen` then failed with `lockfile is out of date`.

Root cause in [`native/vtz/src/pm/resolver.rs`](https://github.com/vertz-dev/vertz/blob/viniciusdacal/vtz-install-latest-tag/native/vtz/src/pm/resolver.rs) — `graph_to_lockfile` matched root + transitive deps via `Range::parse(range)`, which errors on dist-tag strings. The hardcoded `github:`/`link:` fallback didn't cover dist-tags, so the resolved package was dropped from the lockfile.

## Fix

- Introduce a shape-based classifier `is_non_semver_spec` (wraps `is_dist_tag_shape`) that routes `github:`, `link:`, AND dist-tag-shaped specs through the name-only match.
- Shape check is tight: first char ASCII letter, only alphanumeric/dash/underscore/dot, AND `Range::parse` fails. Keeps semver wildcards (`x`, `x.x.x`) out and rejects `file:` / `workspace:` / `npm:` protocols that should never reach the graph.
- Both `graph_to_lockfile` match sites updated (root-dep loop + transitive-dep loop).
- `resolve_version` (where dist-tags are actually resolved via the registry's `dist-tags` map) is unchanged.
- `#2738` regression guard preserved — stale semver-range lockfile entries are still rejected.

## Public API Changes

**None.** Behavior-level fix only — `package.json` deps with dist-tag specs now correctly end up in `vertz.lock`.

## Follow-ups (out of scope)

- #2796 — transitive dist-tag may pick wrong version when graph holds multiple versions of the same name. Documented with a regression test guarding current behavior; needs `resolved_from_tag` plumbing through `ResolvedPackage` (~50 construction sites) to fix correctly.
- Lockfile fast-path optimization so dist-tag entries don't re-fetch registry metadata on every install.

## Test plan

- [x] 38 `pm::resolver` tests pass (8 new classifier unit tests, 4 new `graph_to_lockfile` integration tests including regression guards for #2738 and #2796)
- [x] `cargo test --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full TS test suite passed via pre-push hook (2186 passed, 61 skipped)
- [x] Adversarial review at `reviews/2794-fix-install-latest-tag/phase-01-classifier-and-lockfile-match.md` — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)