### PR TITLE
fix(db): re-export column/table/relation types from entry [#2778]

### DIFF
--- a/.changeset/db-export-column-types.md
+++ b/.changeset/db-export-column-types.md
@@ -1,0 +1,15 @@
+---
+'@vertz/db': patch
+---
+
+fix(db): re-export column/table/relation types referenced by public `d.*` signatures
+
+Consumers writing `export const myTable = d.table(...)` with `declaration: true`
+previously hit `TS2742` because the inferred return types referenced internal
+modules like `@vertz/db/dist/schema/column`. The following types are now
+re-exported from the package entry: `DefaultMeta`, `SerialMeta`, `VectorMeta`
+(from `./schema/column`), `ColumnRecord`, `TableOptions` (from `./schema/table`),
+`ValidateOneRelationFKs` (from `./schema/model`), `ThroughDef`, `ManyRelationDef`
+(from `./schema/relation`).
+
+Closes #2778.

--- a/packages/db/src/__tests__/public-exports.test-d.ts
+++ b/packages/db/src/__tests__/public-exports.test-d.ts
@@ -1,0 +1,86 @@
+import { describe, it } from '@vertz/test';
+import {
+  d,
+  type ColumnBuilder,
+  type ColumnRecord,
+  type DefaultMeta,
+  type ManyRelationDef,
+  type ModelDef,
+  type NumericColumnBuilder,
+  type RelationDef,
+  type SerialMeta,
+  type TableDef,
+  type TableOptions,
+  type ThroughDef,
+  type ValidateOneRelationFKs,
+  type VectorMeta,
+} from '../index';
+import type { Equal, Expect } from './_type-helpers';
+
+// ---------------------------------------------------------------------------
+// Issue #2778 — every type referenced by a public return signature of `d.*`
+// must be re-exported from the package entry. Otherwise consumers emitting
+// declaration files hit TS2742 ("cannot be named without a reference to an
+// internal module like @vertz/db/dist/schema/column").
+//
+// The `import type { ... } from '../index'` block below is itself the primary
+// regression guard: removing any of these from `src/index.ts` fails the import
+// with TS2305 before the body of any test runs. The per-test `Equal<...>` blocks
+// additionally pin the structural contract each type names.
+// ---------------------------------------------------------------------------
+
+describe('Public API exports — issue #2778', () => {
+  it('DefaultMeta covers d.uuid() / d.text() / d.boolean() return metadata', () => {
+    type UuidReturn = ReturnType<typeof d.uuid>;
+    type BooleanReturn = ReturnType<typeof d.boolean>;
+    type _t1 = Expect<Equal<UuidReturn, ColumnBuilder<string, DefaultMeta<'uuid'>>>>;
+    type _t2 = Expect<Equal<BooleanReturn, ColumnBuilder<boolean, DefaultMeta<'boolean'>>>>;
+  });
+
+  it('SerialMeta names the return metadata of d.serial()', () => {
+    type SerialReturn = ReturnType<typeof d.serial>;
+    type _t1 = Expect<Equal<SerialReturn, NumericColumnBuilder<number, SerialMeta>>>;
+  });
+
+  it('VectorMeta names the return metadata of d.vector()', () => {
+    const col = d.vector(3);
+    type Meta = (typeof col)['_meta'];
+    type _t1 = Expect<Equal<Meta, VectorMeta<3>>>;
+  });
+
+  it('ColumnRecord and TableOptions are accepted by d.table()', () => {
+    const cols = { id: d.uuid().primary(), title: d.text() };
+    type Cols = typeof cols;
+    // Constraint check: Cols must satisfy ColumnRecord.
+    type _t1 = Expect<Equal<Cols extends ColumnRecord ? true : false, true>>;
+
+    const opts: TableOptions = {};
+    const table = d.table('t', cols, opts);
+    type _t2 = Expect<Equal<typeof table extends TableDef<Cols> ? true : false, true>>;
+  });
+
+  it('ValidateOneRelationFKs shape matches d.model() relation constraints', () => {
+    const user = d.table('user', { id: d.uuid().primary() });
+    const post = d.table('post', { id: d.uuid().primary(), userId: d.uuid() });
+    const relations = { author: d.ref.one(() => user, 'userId') };
+    type Validated = ValidateOneRelationFKs<typeof post, typeof relations>;
+    // The validated shape exposes the relation keys from the input record.
+    type _t1 = Expect<Equal<keyof Validated, 'author'>>;
+  });
+
+  it('ThroughDef and ManyRelationDef are nameable from the public entry', () => {
+    const tag = d.table('tag', { id: d.uuid().primary() });
+    const manyRef = d.ref.many(() => tag);
+    type _t1 = Expect<Equal<typeof manyRef, ManyRelationDef<typeof tag>>>;
+    // ThroughDef is the element type of RelationDef['_through'].
+    type Through = NonNullable<RelationDef['_through']>;
+    type _t2 = Expect<Equal<Through, ThroughDef>>;
+  });
+
+  it('d.model() return type is nameable via ModelDef + ColumnRecord', () => {
+    const todo = d.table('todo', { id: d.uuid().primary(), title: d.text() });
+    const model = d.model(todo);
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- {} is the public default for "no relations"
+    type _t1 = Expect<Equal<typeof model, ModelDef<typeof todo, {}>>>;
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -137,13 +137,16 @@ export type {
   ColumnBuilder,
   ColumnMetadata,
   DecimalMeta,
+  DefaultMeta,
   EnumMeta,
   FormatMeta,
   InferColumnType,
   JsonbValidator,
   NumericColumnBuilder,
+  SerialMeta,
   StringColumnBuilder,
   VarcharMeta,
+  VectorMeta,
 } from './schema/column';
 export { defineAnnotations } from './schema/define-annotations';
 export type { RegisteredEnum } from './schema/enum-registry';
@@ -163,16 +166,18 @@ export type {
   SelectOption,
   UpdateInput,
 } from './schema/inference';
-export type { ModelDef } from './schema/model';
+export type { ModelDef, ValidateOneRelationFKs } from './schema/model';
 export type { ModelSchemas, SchemaLike } from './schema/model-schemas';
 export { createRegistry } from './schema/registry';
-export type { RelationDef } from './schema/relation';
+export type { ManyRelationDef, RelationDef, ThroughDef } from './schema/relation';
 export type {
+  ColumnRecord,
   IndexDef,
   IndexOptions,
   IndexType,
   MarkAsPrimary,
   TableDef,
+  TableOptions,
   TableOptionsWithPK,
 } from './schema/table';
 export type {


### PR DESCRIPTION
Closes #2778.

## Public API Changes

**Additions** (all `export type { ... } from './schema/*'` from `@vertz/db` entry — no runtime cost):

- `DefaultMeta`, `SerialMeta`, `VectorMeta` (from `./schema/column`)
- `ColumnRecord`, `TableOptions` (from `./schema/table`)
- `ValidateOneRelationFKs` (from `./schema/model`)
- `ThroughDef`, `ManyRelationDef` (from `./schema/relation`)

**Breaking:** none.
**Deferred:** none.

## Summary

Consumers writing `export const myTable = d.table(...)` with TypeScript's `declaration: true` hit [TS2742](https://typescript.tv/errors/#ts2742) because the inferred return types of `d.*` builders referenced internal modules (`@vertz/db/dist/schema/column`, etc.) that were not part of the package entry.

This PR re-exports every type referenced in the public return signatures of `d.uuid`, `d.text`, `d.serial`, `d.vector`, `d.table`, `d.model`, `d.ref.one`, `d.ref.many`, so declaration emit resolves to `@vertz/db` rather than `@vertz/db/dist/schema/*`.

Zero runtime impact — only `.d.ts` output changes.

## Test plan

- [x] `packages/db/src/__tests__/public-exports.test-d.ts` — `import type { ... } from '../index'` block is the regression guard (removing any entry fails TS2305); per-test `Equal<>` assertions pin the structural contract for each builder.
- [x] `turbo run typecheck --filter=@vertz/db --filter=@vertz/server` — green.
- [x] `turbo run test --filter=@vertz/db` — 1650 passed, 1 skipped.
- [x] `turbo run build --filter=@vertz/db` — verified the eight types appear in `dist/index.d.ts`.
- [x] `vtzx oxlint packages/db/` — 0 errors.

## Adversarial review

Self-review spawned one agent. Findings:

- **B1 (blocker)** — Missing changeset → fixed: `.changeset/db-export-column-types.md` added (`patch`).
- **B2** — Reviewer worried `ReturnType<typeof d.xxx>` checks alone wouldn't catch a regression; however the `import type { … } from '../index'` block fails with TS2305 before any `Equal<>` test body runs. Confirmed experimentally: removing any export from `src/index.ts` yields eight `TS2305` errors and eight cascading `Type 'false' does not satisfy the constraint 'true'` errors. Clarifying comment added to the test file.
- **S1 (sibling leak, out of scope)** — `packages/db/src/d.ts:38` declares `interface EnumSchemaLike<T>` module-local and uses it in a `d.enum()` overload parameter. Tracked as #2804.

## Follow-ups

- #2804 — `d.enum()` overload references file-local `EnumSchemaLike`.