### PR TITLE
fix(theme-shadcn): dialog stack panel + title use foreground color [#2756]

### DIFF
--- a/.changeset/dialog-stack-dark-mode-foreground.md
+++ b/.changeset/dialog-stack-dark-mode-foreground.md
@@ -1,0 +1,15 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+fix(theme-shadcn): dialog stack panel and title render in dark-mode foreground color
+
+`useDialogStack().confirm()` and other stack-rendered dialogs had unreadable
+black title text on dark backgrounds because the global CSS for the
+`dialog[data-dialog-wrapper]` panel did not set `color` explicitly. Native
+`<dialog>` elements render in the top layer and do not inherit `body` color,
+so the panel must set `color: var(--color-foreground)` — the same fix the
+scoped `Dialog.Panel` already applies. The title rule now also sets the
+foreground color explicitly as a defense-in-depth.
+
+Closes #2756.

--- a/packages/theme-shadcn/src/__tests__/styles.test.ts
+++ b/packages/theme-shadcn/src/__tests__/styles.test.ts
@@ -201,6 +201,27 @@ describe('dialog global styles', () => {
     // Dialog wrapper uses margin: auto for native <dialog> centering
     expect(css).toMatch(/dialog\[data-dialog-wrapper\]\s*\{[^}]*margin:\s*auto/);
   });
+
+  it('dialog panel sets explicit foreground color for top-layer rendering', () => {
+    // <dialog> elements in the top-layer may not inherit body color.
+    // The stack-wrapped panel must set color explicitly so confirm() title,
+    // description, and any user-rendered body content are readable in dark mode.
+    const css = createDialogGlobalStyles().css;
+    const panelRules = css
+      .split('}')
+      .filter((rule) => rule.includes('dialog[data-dialog-wrapper] > [data-part="panel"]'));
+    const panelCSS = panelRules.join('}');
+    expect(panelCSS).toMatch(/\bcolor:\s*var\(--color-foreground\)/);
+  });
+
+  it('dialog title sets explicit foreground color', () => {
+    const css = createDialogGlobalStyles().css;
+    const titleRules = css
+      .split('}')
+      .filter((rule) => rule.includes('dialog[data-dialog-wrapper] [data-part="title"]'));
+    const titleCSS = titleRules.join('}');
+    expect(titleCSS).toMatch(/\bcolor:\s*var\(--color-foreground\)/);
+  });
 });
 
 describe('alert', () => {

--- a/packages/theme-shadcn/src/styles/dialog.ts
+++ b/packages/theme-shadcn/src/styles/dialog.ts
@@ -171,6 +171,7 @@ export function createDialogGlobalStyles(): GlobalCSSOutput {
       outline: 'none',
       containerType: 'inline-size',
       backgroundColor: 'var(--color-background)',
+      color: 'var(--color-foreground)',
     },
     // ── Panel open/close animations ──
     'dialog[data-dialog-wrapper][data-state="open"] > [data-part="panel"]': {
@@ -189,6 +190,7 @@ export function createDialogGlobalStyles(): GlobalCSSOutput {
       fontSize: '1rem',
       lineHeight: '1',
       fontWeight: '500',
+      color: 'var(--color-foreground)',
     },
     'dialog[data-dialog-wrapper] [data-part="description"]': {
       fontSize: '0.875rem',


### PR DESCRIPTION
## Summary

- Native `<dialog>` elements render in the browser top layer and do not inherit the body `color`, so stack-rendered dialogs (including `useDialogStack().confirm()`) showed black title and body text in dark mode.
- Added `color: var(--color-foreground)` to `dialog[data-dialog-wrapper] > [data-part="panel"]` (the real root cause — also fixes any custom body content) and to `[data-part="title"]` as defense-in-depth. Matches the scoped `Dialog.Panel` styling that already applies this fix.
- Tests in `packages/theme-shadcn/src/__tests__/styles.test.ts` use the same split-by-`}` + filter-by-selector pattern as the sibling primitive-styles tests.

Closes [#2756](https://github.com/vertz-dev/vertz/issues/2756).

## Public API Changes

- **Additions:** Two new CSS declarations in the `@vertz/theme-shadcn` dialog-stack global styles. Visible behaviour: stack dialogs (`confirm()`, `open()`) now render title + body text in the correct theme-aware foreground color.
- **No breaking changes.** User-level style overrides via higher-specificity selectors or inline `style` still win.

## Test plan

- [x] RED: new tests fail without the panel/title `color` additions.
- [x] GREEN: `vtz test packages/theme-shadcn packages/ui/src/dialog` → 173 passing.
- [x] Lint + format on changed files clean.
- [x] Pre-push hook green (build-typecheck, lint, test, trojan-source all pass).
- [ ] Manual verification in an app with `<ThemeProvider theme="dark">` — title and body text are readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)