### PR TITLE
fix(db): export EnumSchemaLike named by d.enum overload [#2804]

### DIFF
--- a/.changeset/db-export-enum-schema-like.md
+++ b/.changeset/db-export-enum-schema-like.md
@@ -1,0 +1,15 @@
+---
+'@vertz/db': patch
+---
+
+fix(db): export `EnumSchemaLike` named by the `d.enum(name, schema)` overload
+
+The second overload of `d.enum` accepts any object with a `.values` array (e.g.
+an `EnumSchema` from `@vertz/schema`) via a duck-typed `EnumSchemaLike` interface.
+That interface lived as a file-local declaration in `packages/db/src/d.ts`, so
+consumers who named the function type — for example by emitting `.d.ts` for a
+helper that wraps `d.enum`, or by writing `typeof d.enum` — hit `TS2742` against
+`@vertz/db/dist/d`. `EnumSchemaLike` is now exported from the package entry so
+those references resolve to the public path.
+
+Closes #2804.

--- a/packages/db/src/__tests__/public-exports.test-d.ts
+++ b/packages/db/src/__tests__/public-exports.test-d.ts
@@ -4,6 +4,8 @@ import {
   type ColumnBuilder,
   type ColumnRecord,
   type DefaultMeta,
+  type EnumMeta,
+  type EnumSchemaLike,
   type ManyRelationDef,
   type ModelDef,
   type NumericColumnBuilder,
@@ -82,5 +84,21 @@ describe('Public API exports — issue #2778', () => {
     const model = d.model(todo);
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- {} is the public default for "no relations"
     type _t1 = Expect<Equal<typeof model, ModelDef<typeof todo, {}>>>;
+  });
+
+  // Issue #2804 — EnumSchemaLike is referenced by the d.enum(name, schema) overload.
+  // It must be re-exported so consumers naming `typeof d.enum` (or emitting .d.ts that
+  // pins that overload) don't trip TS2742 against @vertz/db/dist/d.
+  it('EnumSchemaLike names the second-overload parameter shape of d.enum()', () => {
+    const roleSchema: EnumSchemaLike<readonly ['admin', 'member']> = {
+      values: ['admin', 'member'] as const,
+    };
+    const col = d.enum('role', roleSchema);
+    type _t1 = Expect<
+      Equal<
+        typeof col,
+        ColumnBuilder<'admin' | 'member', EnumMeta<'role', readonly ['admin', 'member']>>
+      >
+    >;
   });
 });

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -35,7 +35,9 @@ import { createIndex, createTable } from './schema/table';
 
 // Duck-typing interface so @vertz/db can accept EnumSchema from @vertz/schema
 // without a hard runtime import (keeps the dependency boundary clean).
-interface EnumSchemaLike<T extends readonly string[]> {
+// Exported so consumers naming the d.enum(name, schema) overload (e.g. via
+// `typeof d.enum`) don't trip TS2742 against @vertz/db/dist/d. See #2804.
+export interface EnumSchemaLike<T extends readonly string[]> {
   readonly values: T;
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -58,6 +58,7 @@ export { computeTenantGraph, createDb } from './client';
 export type { createPostgresDriver, PostgresDriver } from './client/postgres-driver';
 // Schema builder
 export { d } from './d';
+export type { EnumSchemaLike } from './d';
 // Update expressions
 export type { DbExpr } from './sql/expr';
 export { isDbExpr } from './sql/expr';


### PR DESCRIPTION
## Summary

- Exports `EnumSchemaLike` from `@vertz/db` so the `d.enum(name, schema)` overload no longer pins a file-local symbol.
- Consumers who named the overload (via `typeof d.enum` or a helper that wraps it and emits `.d.ts`) were tripping `TS2742` against `@vertz/db/dist/d` — same failure mode as #2778, different module.
- Adds a type-level regression test in `packages/db/src/__tests__/public-exports.test-d.ts` that names `EnumSchemaLike` from the public entry and asserts the overload's `ColumnBuilder<…, EnumMeta<…>>` return shape.
- Changeset: `patch`.

Closes #2804.

## Public API Changes

- **Addition:** `EnumSchemaLike<T extends readonly string[]>` is now re-exported from `@vertz/db`.

No breaking changes. No deferred items.

## Design notes

The issue proposed two fix options:

1. Export `EnumSchemaLike` from `src/index.ts` — the symmetric twin of the #2778 fix.
2. Collapse to `SchemaLike` from `./schema/model-schemas`.

Option 2 was rejected: `SchemaLike<T>` requires `parse(value)`, while `EnumSchemaLike<T>` requires `values: T`. They are structurally disjoint, not subsets — the overload exists specifically to extract `TValues` from a `.values`-bearing object (e.g. `@vertz/schema`'s `EnumSchema`), which `SchemaLike` cannot express.

## Completeness sweep

After this fix, every type referenced by a public signature in `packages/db/src/d.ts` is re-exported from `packages/db/src/index.ts`. `EnumSchemaLike` was the last remaining file-local type in `d.ts`.

## Review

Local adversarial review at `reviews/db-enum-schema-like-export/phase-01-export-and-test.md` — approved, no blockers.

## Test plan

- [x] RED verified: `tsgo --noEmit` reported `TS2724: '"../index"' has no exported member named 'EnumSchemaLike'` before the fix.
- [x] GREEN verified: `tsgo --noEmit -p tsconfig.typecheck.json` on `packages/db` — 0 errors.
- [x] `vtz test` on `packages/db` — 1650 passed, 1 skipped.
- [x] `oxlint` + `oxfmt --check` on changed files — clean.
- [x] `vtz run build --filter @vertz/db` — `dist/d.d.ts` emits `export interface EnumSchemaLike<…>`; `dist/index.d.ts` emits `export type { EnumSchemaLike } from './d'`.
- [x] Pre-push lefthook: build-typecheck / lint / test / trojan-source all ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)