### PR TITLE
fix(runtime): clean Node-like env for server handlers [#2760]

### DIFF
--- a/.changeset/fix-server-browser-detection.md
+++ b/.changeset/fix-server-browser-detection.md
@@ -1,5 +1,5 @@
 ---
-'@vertz/cli-runtime': patch
+'@vertz/runtime': patch
 ---
 
 fix(runtime): clean Node-like env for server handlers

--- a/.changeset/fix-server-browser-detection.md
+++ b/.changeset/fix-server-browser-detection.md
@@ -1,0 +1,34 @@
+---
+'@vertz/cli-runtime': patch
+---
+
+fix(runtime): clean Node-like env for server handlers
+
+Server handlers (entity actions, service actions, middleware, auth resolvers,
+route loaders) now run in a Workers-compatible context that does **not**
+expose `window`, `document`, `location`, `history`, or other DOM globals.
+Only SSR render runs under a scoped DOM shim, which is installed before the
+matched route renders and removed immediately after.
+
+This means third-party SDKs that gate on `typeof window !== 'undefined'`
+(like `@anthropic-ai/sdk`, `openai`, and `stripe`) work in server handlers
+without `dangerouslyAllowBrowser: true`:
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { service } from 'vertz/server';
+
+export default service('ai', {
+  actions: {
+    summarize: {
+      handler: async ({ text }) => {
+        const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+        // no `dangerouslyAllowBrowser: true` needed
+        return client.messages.create({ /* ... */ });
+      },
+    },
+  },
+});
+```
+
+Closes #2760.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,9 @@ jobs:
       - name: Format check
         run: oxfmt --check packages/
 
+      - name: Audit handler-reachable DOM references
+        run: bash scripts/audit-window-document-refs.sh
+
   # ---------------------------------------------------------------------------
   # Build, typecheck & test — the heavy job.
   # Runs turbo without lint (handled by the parallel lint job above).

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -1352,9 +1352,18 @@ const SSR_RENDER_LEGACY_JS: &str = r#"
 /// Dispatch a single SSR render request in the V8 isolate.
 ///
 /// Installs the DOM shim for the duration of the render, then uninstalls it
-/// on every exit path (success, error, timeout). See #2760 for background:
-/// server handlers run in a clean Worker-like environment without DOM globals,
-/// so the shim must be scoped to the SSR boundary only.
+/// after the inner function returns (Ok or Err, including internal SSR
+/// timeouts). See #2760 for background: server handlers run in a clean
+/// Worker-like environment without DOM globals, so the shim must be scoped to
+/// the SSR boundary only.
+///
+/// NOTE on cleanup: a Rust panic or tokio task cancellation would skip
+/// uninstall, but the V8 isolate is single-threaded and owns the runtime, so
+/// a panic here takes the isolate down anyway. `__vertz_install_dom_shim()`
+/// is also idempotent — a stale install is a no-op on the next dispatch, and
+/// `SSR_RESET_JS` refreshes the document/body on every render. If we ever
+/// add cancellation-prone call paths (e.g., a select over dispatch), switch
+/// to a scopeguard-style RAII uninstall.
 async fn dispatch_ssr_request(
     runtime: &mut crate::runtime::js_runtime::VertzJsRuntime,
     request: &SsrRequest,
@@ -2537,6 +2546,109 @@ mod tests {
             resp_b.content.contains("User: anonymous"),
             "Request B should NOT see session from request A: {}",
             resp_b.content
+        );
+    }
+
+    /// Verifies #2760: after SSR render completes, the DOM shim is uninstalled
+    /// so API handlers (which run in the same isolate) see a clean Worker-like
+    /// environment. If uninstall is broken, `document` leaks into handler code.
+    #[tokio::test]
+    async fn test_ssr_render_leaves_no_browser_globals_for_handler() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let app_path = temp_dir.path().join("app.js");
+        std::fs::write(
+            &app_path,
+            r#"
+            globalThis.__vertz_ssr_render = function(url) {
+                // Inside SSR the shim must be installed.
+                const documentInSsr = typeof document !== 'undefined';
+                return '<div>documentInSsr=' + documentInSsr + '</div>';
+            };
+            "#,
+        )
+        .unwrap();
+
+        // Handler reports whether browser globals leaked into its context.
+        let server_path = temp_dir.path().join("server.js");
+        std::fs::write(
+            &server_path,
+            r#"
+            const handler = async (request) => {
+                const report = {
+                    window: typeof window,
+                    document: typeof document,
+                    location: typeof location,
+                    history: typeof history,
+                    HTMLElement: typeof HTMLElement,
+                };
+                return new Response(JSON.stringify(report), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                });
+            };
+            globalThis.__vertz_server_module = { default: { handler } };
+            "#,
+        )
+        .unwrap();
+
+        let opts = PersistentIsolateOptions {
+            root_dir: temp_dir.path().to_path_buf(),
+            ssr_entry: app_path,
+            server_entry: Some(server_path),
+            channel_capacity: 16,
+            auto_installer: None,
+            init_timeout: None,
+            enable_inspector: false,
+            inspect_brk: false,
+            inspector_session_tx: None,
+        };
+
+        let isolate = PersistentIsolate::new(opts).unwrap();
+        wait_for_init(&isolate).await;
+
+        // 1. Run an SSR render to install/uninstall the shim.
+        let ssr_resp = isolate
+            .handle_ssr(SsrRequest {
+                cookies: None,
+                url: "/home".to_string(),
+                session_json: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            ssr_resp.content.contains("documentInSsr=true"),
+            "document must be visible inside SSR render: {}",
+            ssr_resp.content
+        );
+
+        // 2. Hit the API handler — it must see a clean environment.
+        let api_resp = isolate
+            .handle_request(IsolateRequest {
+                method: "GET".to_string(),
+                url: "http://localhost/api/env".to_string(),
+                headers: vec![],
+                body: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(api_resp.status, 200);
+        let report: serde_json::Value = serde_json::from_slice(&api_resp.body).unwrap();
+        assert_eq!(report["window"], "undefined", "window leaked: {}", report);
+        assert_eq!(
+            report["document"], "undefined",
+            "document leaked: {}",
+            report
+        );
+        assert_eq!(
+            report["location"], "undefined",
+            "location leaked: {}",
+            report
+        );
+        assert_eq!(report["history"], "undefined", "history leaked: {}", report);
+        assert_eq!(
+            report["HTMLElement"], "undefined",
+            "HTMLElement leaked: {}",
+            report
         );
     }
 

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -1134,12 +1134,16 @@ const FETCH_INTERCEPTOR_JS: &str = r#"
     const handler = globalThis.__vertz_api_handler;
     const prefixes = globalThis.__vertz_intercept_prefixes || ['/api/'];
     const originalFetch = globalThis.fetch;
-    const selfOrigin = globalThis.location ? globalThis.location.origin : '';
 
     globalThis.__vertz_original_fetch = originalFetch;
     globalThis.__vertz_fetch_intercept_count = 0;
 
     globalThis.fetch = async function(input, init) {
+        // Read location.origin lazily per call — globalThis.location only
+        // exists while the DOM shim is installed (SSR render scope). Reading
+        // at install time would capture `undefined` and break once the shim
+        // is uninstalled between requests.
+        const selfOrigin = globalThis.location ? globalThis.location.origin : '';
         const req = input instanceof Request ? input : new Request(input, init);
         const url = new URL(req.url, selfOrigin || 'http://localhost');
 
@@ -1347,6 +1351,31 @@ const SSR_RENDER_LEGACY_JS: &str = r#"
 
 /// Dispatch a single SSR render request in the V8 isolate.
 ///
+/// Installs the DOM shim for the duration of the render, then uninstalls it
+/// on every exit path (success, error, timeout). See #2760 for background:
+/// server handlers run in a clean Worker-like environment without DOM globals,
+/// so the shim must be scoped to the SSR boundary only.
+async fn dispatch_ssr_request(
+    runtime: &mut crate::runtime::js_runtime::VertzJsRuntime,
+    request: &SsrRequest,
+) -> Result<SsrResponse, String> {
+    runtime
+        .execute_script_void(
+            "<ssr-install-shim>",
+            "globalThis.__vertz_install_dom_shim();",
+        )
+        .map_err(|e| format!("Install DOM shim error: {}", e))?;
+
+    let result = dispatch_ssr_request_inner(runtime, request).await;
+
+    let _ = runtime.execute_script_void(
+        "<ssr-uninstall-shim>",
+        "globalThis.__vertz_uninstall_dom_shim();",
+    );
+
+    result
+}
+
 /// When `ssrRenderSinglePass` is available (stored as `globalThis.__vertz_ssr_render_fn`
 /// during init), uses the framework engine. Otherwise falls back to legacy DOM scraping.
 ///
@@ -1355,7 +1384,7 @@ const SSR_RENDER_LEGACY_JS: &str = r#"
 /// 3. Installs session data
 /// 4. Renders via framework engine or legacy path
 /// 5. Parses result
-async fn dispatch_ssr_request(
+async fn dispatch_ssr_request_inner(
     runtime: &mut crate::runtime::js_runtime::VertzJsRuntime,
     request: &SsrRequest,
 ) -> Result<SsrResponse, String> {
@@ -1658,6 +1687,29 @@ const COMPONENT_RENDER_JS: &str = r#"
 
 /// Dispatch a single component render request in the V8 isolate.
 ///
+/// Installs the DOM shim for the duration of the render, then uninstalls it
+/// on every exit path (success, error, timeout). See #2760.
+async fn dispatch_component_render(
+    runtime: &mut crate::runtime::js_runtime::VertzJsRuntime,
+    request: &ComponentRenderRequest,
+) -> Result<ComponentRenderResponse, String> {
+    runtime
+        .execute_script_void(
+            "<component-install-shim>",
+            "globalThis.__vertz_install_dom_shim();",
+        )
+        .map_err(|e| format!("Install DOM shim error: {}", e))?;
+
+    let result = dispatch_component_render_inner(runtime, request).await;
+
+    let _ = runtime.execute_script_void(
+        "<component-uninstall-shim>",
+        "globalThis.__vertz_uninstall_dom_shim();",
+    );
+
+    result
+}
+
 /// Renders a component in isolation: no router, no layout, no data fetching.
 /// Uses a component-specific DOM reset (no baseline CSS restoration) and
 /// cache-busted dynamic import to load the latest file version.
@@ -1667,7 +1719,7 @@ const COMPONENT_RENDER_JS: &str = r#"
 /// 3. Executes the async render script
 /// 4. Drains the V8 event loop (resolves the dynamic import)
 /// 5. Reads and parses the result
-async fn dispatch_component_render(
+async fn dispatch_component_render_inner(
     runtime: &mut crate::runtime::js_runtime::VertzJsRuntime,
     request: &ComponentRenderRequest,
 ) -> Result<ComponentRenderResponse, String> {

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -2574,12 +2574,17 @@ mod tests {
             &server_path,
             r#"
             const handler = async (request) => {
+                // Mirrors the @anthropic-ai/sdk browser-detection heuristic:
+                // an SDK constructor throws if (window && document) are both visible.
+                const sdkDetectsBrowser =
+                    typeof window !== 'undefined' && typeof document !== 'undefined';
                 const report = {
                     window: typeof window,
                     document: typeof document,
                     location: typeof location,
                     history: typeof history,
                     HTMLElement: typeof HTMLElement,
+                    sdkDetectsBrowser,
                 };
                 return new Response(JSON.stringify(report), {
                     status: 200,
@@ -2648,6 +2653,11 @@ mod tests {
         assert_eq!(
             report["HTMLElement"], "undefined",
             "HTMLElement leaked: {}",
+            report
+        );
+        assert_eq!(
+            report["sdkDetectsBrowser"], false,
+            "SDK browser-detection heuristic (`typeof window !== 'undefined' && typeof document !== 'undefined'`) must be false in handler context: {}",
             report
         );
     }

--- a/native/vtz/src/runtime/snapshot.rs
+++ b/native/vtz/src/runtime/snapshot.rs
@@ -313,6 +313,8 @@ mod tests {
     fn test_production_snapshot_has_dom_shim() {
         let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
 
+        rt.execute_script_void("<install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -320,6 +322,101 @@ mod tests {
                 typeof document !== 'undefined'
                 && typeof document.createElement === 'function'
                 && typeof HTMLElement === 'function'
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    // ------------------------------------------------------------------
+    // Clean-handler-env tests (Phase 2 of #2760).
+    //
+    // A fresh production runtime must look like Cloudflare Workers:
+    //   - No `window`, `document`, DOM constructors, `location`, `history`.
+    //   - Permanent: `navigator`, CSS collector state, install/uninstall.
+    // SSR renders opt in via the install hook wired into dispatch.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_fresh_production_runtime_has_no_window() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script("<test>", "typeof window").unwrap();
+        assert_eq!(result, serde_json::json!("undefined"));
+    }
+
+    #[test]
+    fn test_fresh_production_runtime_has_no_document() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt.execute_script("<test>", "typeof document").unwrap();
+        assert_eq!(result, serde_json::json!("undefined"));
+    }
+
+    #[test]
+    fn test_fresh_production_runtime_has_no_dom_constructors() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                [
+                    typeof HTMLElement,
+                    typeof Element,
+                    typeof Document,
+                    typeof Node,
+                    typeof location,
+                    typeof history,
+                ]
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+            ])
+        );
+    }
+
+    #[test]
+    fn test_fresh_production_runtime_has_navigator() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "typeof navigator === 'object' && navigator.userAgent.includes('vertz-server')",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_fresh_production_runtime_registers_install_uninstall() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "typeof globalThis.__vertz_install_dom_shim === 'function' && \
+                 typeof globalThis.__vertz_uninstall_dom_shim === 'function'",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_fresh_production_runtime_has_css_collector() {
+        let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                typeof globalThis.__vertz_inject_css === 'function'
+                && Array.isArray(globalThis.__vertz_get_collected_css())
+                && globalThis.__vertz_get_collected_css().length === 0
                 "#,
             )
             .unwrap();
@@ -347,6 +444,8 @@ mod tests {
     fn test_production_snapshot_dom_state() {
         let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
 
+        rt.execute_script_void("<install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",

--- a/native/vtz/src/ssr/dom_shim.rs
+++ b/native/vtz/src/ssr/dom_shim.rs
@@ -25,7 +25,17 @@ pub const DOM_SHIM_JS: &str = r#"
   const DOCUMENT_FRAGMENT_NODE = 11;
 
   // --- CSS collector ---
-  const __vertz_collected_css = [];
+  // State is owned by `globalThis.__vertz_css_state` (permanent, non-enumerable).
+  // Defined once at snapshot time so collector functions survive install/uninstall
+  // cycles of the DOM shim. See __vertz_install_dom_shim below.
+  if (typeof globalThis.__vertz_css_state === 'undefined') {
+    Object.defineProperty(globalThis, '__vertz_css_state', {
+      value: [],
+      writable: true,
+      configurable: false,
+      enumerable: false,
+    });
+  }
 
   // --- Base Node ---
   class SSRNode {
@@ -701,82 +711,17 @@ pub const DOM_SHIM_JS: &str = r#"
     disconnect() {}
   }
 
-  // --- Install globals ---
-  const doc = new SSRDocument();
+  // ==================================================================
+  // PERMANENT BLOCK — globals that stay regardless of install state.
+  // ==================================================================
+  //
+  // Server handlers see these too. Nothing here should make the runtime
+  // look like a browser. Cloudflare-Workers-compatible shape only.
 
-  // Create the #app mount point that mount() expects
-  const appRoot = doc.createElement('div');
-  appRoot.setAttribute('id', 'app');
-  doc.body.appendChild(appRoot);
-
-  globalThis.document = doc;
-  globalThis.Document = SSRDocument;
-  globalThis.Element = SSRElement;
-  globalThis.HTMLElement = SSRElement;
-  globalThis.HTMLDivElement = SSRElement;
-  globalThis.HTMLSpanElement = SSRElement;
-  globalThis.HTMLButtonElement = SSRElement;
-  globalThis.HTMLInputElement = SSRElement;
-  globalThis.HTMLFormElement = SSRElement;
-  globalThis.HTMLAnchorElement = SSRElement;
-  globalThis.HTMLImageElement = SSRElement;
-  globalThis.HTMLTemplateElement = SSRElement;
-  globalThis.HTMLStyleElement = SSRElement;
-  globalThis.SVGElement = SSRElement;
-  globalThis.Text = SSRTextNode;
-  globalThis.Comment = SSRComment;
-  globalThis.DocumentFragment = SSRDocumentFragment;
-  globalThis.Node = SSRNode;
-  globalThis.Event = SSREvent;
-  globalThis.CustomEvent = SSRCustomEvent;
-  globalThis.MutationObserver = SSRMutationObserver;
-  globalThis.ResizeObserver = SSRResizeObserver;
-  globalThis.IntersectionObserver = SSRIntersectionObserver;
-  globalThis.NodeList = Array;
-
-  // requestAnimationFrame / cancelAnimationFrame (no-op)
-  globalThis.requestAnimationFrame = function(cb) { return 0; };
-  globalThis.cancelAnimationFrame = function() {};
-
-  // matchMedia (no-op)
-  globalThis.matchMedia = function(query) {
-    return {
-      matches: false,
-      media: query,
-      addEventListener() {},
-      removeEventListener() {},
-      addListener() {},
-      removeListener() {},
-      onchange: null,
-    };
-  };
-
-  // getComputedStyle (no-op)
-  globalThis.getComputedStyle = function(el) {
-    return new Proxy({}, {
-      get(_, prop) {
-        if (prop === 'getPropertyValue') return () => '';
-        return '';
-      }
-    });
-  };
-
-  // Event target methods (no-op in SSR)
-  if (typeof globalThis.addEventListener === 'undefined') {
-    globalThis.addEventListener = function() {};
-    globalThis.removeEventListener = function() {};
-    globalThis.dispatchEvent = function() { return true; };
-  }
-
-  // window as globalThis alias
-  if (typeof globalThis.window === 'undefined') {
-    globalThis.window = globalThis;
-  }
-
-  // navigator
+  // --- navigator (Worker-compatible) ---
   if (typeof globalThis.navigator === 'undefined') {
     globalThis.navigator = {
-      userAgent: 'vertz-ssr/1.0',
+      userAgent: 'vertz-server/1.0',
       language: 'en',
       languages: ['en'],
       platform: 'server',
@@ -784,39 +729,11 @@ pub const DOM_SHIM_JS: &str = r#"
     };
   }
 
-  // location (default to /)
-  if (typeof globalThis.location === 'undefined') {
-    globalThis.location = {
-      href: 'http://localhost/',
-      origin: 'http://localhost',
-      protocol: 'http:',
-      host: 'localhost',
-      hostname: 'localhost',
-      port: '',
-      pathname: '/',
-      search: '',
-      hash: '',
-    };
-  }
-
-  // history (no-op)
-  if (typeof globalThis.history === 'undefined') {
-    globalThis.history = {
-      pushState() {},
-      replaceState() {},
-      back() {},
-      forward() {},
-      go() {},
-      state: null,
-      length: 1,
-    };
-  }
-
-  // CSS utilities used by Vertz's css() / variants() runtime
-  // __vertz_inject_css collects CSS strings during SSR
+  // --- CSS collector (permanent — survives install/uninstall cycles) ---
   globalThis.__vertz_inject_css = function(css, id) {
-    if (id && __vertz_collected_css.some(c => c.id === id)) return;
-    __vertz_collected_css.push({ css, id: id || null });
+    const state = globalThis.__vertz_css_state;
+    if (id && state.some(c => c.id === id)) return;
+    state.push({ css, id: id || null });
   };
 
   globalThis.__vertz_get_collected_css = function() {
@@ -824,8 +741,9 @@ pub const DOM_SHIM_JS: &str = r#"
     // 1. Explicit __vertz_inject_css() calls (used by native compiler pipeline)
     // 2. <style> elements appended to document.head by @vertz/ui's injectCSS()
     //    (when SSR context is not set, injectCSS falls back to DOM <style> tags)
-    const seen = new Set(__vertz_collected_css.map(c => c.css));
-    const merged = [...__vertz_collected_css];
+    const state = globalThis.__vertz_css_state;
+    const seen = new Set(state.map(c => c.css));
+    const merged = [...state];
 
     if (typeof document !== 'undefined' && document.head) {
       for (const child of document.head.childNodes) {
@@ -844,7 +762,7 @@ pub const DOM_SHIM_JS: &str = r#"
   };
 
   globalThis.__vertz_clear_collected_css = function() {
-    __vertz_collected_css.length = 0;
+    globalThis.__vertz_css_state.length = 0;
   };
 
   // URLSearchParams shim (used by the router for query string parsing)
@@ -1001,6 +919,158 @@ pub const DOM_SHIM_JS: &str = r#"
     SSRDocument,
     VOID_ELEMENTS,
   };
+
+  // ==================================================================
+  // SCOPED BLOCK — install / uninstall browser-like globals.
+  // ==================================================================
+  //
+  // These functions toggle the DOM globals that make the environment
+  // "look like" a browser. Handlers run with them uninstalled so
+  // third-party SDKs (`@anthropic-ai/sdk`, `openai`, `stripe`, ...) do
+  // not refuse to operate. SSR renders call install/uninstall around
+  // their render boundary (wired in persistent_isolate.rs).
+  //
+  // Constructors like SSRElement stay defined in the IIFE closure; the
+  // install function copies references onto globalThis, uninstall deletes
+  // them. CSS collector state lives on globalThis (see permanent block),
+  // so it survives across install cycles.
+
+  let __vertz_shim_installed = false;
+
+  globalThis.__vertz_install_dom_shim = function () {
+    if (__vertz_shim_installed) return;
+    __vertz_shim_installed = true;
+
+    // Fresh document per render — previous render's tree must not leak.
+    const doc = new SSRDocument();
+    const appRoot = doc.createElement('div');
+    appRoot.setAttribute('id', 'app');
+    doc.body.appendChild(appRoot);
+
+    globalThis.document = doc;
+    globalThis.window = globalThis;
+
+    globalThis.Document = SSRDocument;
+    globalThis.Element = SSRElement;
+    globalThis.HTMLElement = SSRElement;
+    globalThis.HTMLDivElement = SSRElement;
+    globalThis.HTMLSpanElement = SSRElement;
+    globalThis.HTMLButtonElement = SSRElement;
+    globalThis.HTMLInputElement = SSRElement;
+    globalThis.HTMLFormElement = SSRElement;
+    globalThis.HTMLAnchorElement = SSRElement;
+    globalThis.HTMLImageElement = SSRElement;
+    globalThis.HTMLTemplateElement = SSRElement;
+    globalThis.HTMLStyleElement = SSRElement;
+    globalThis.SVGElement = SSRElement;
+    globalThis.Text = SSRTextNode;
+    globalThis.Comment = SSRComment;
+    globalThis.DocumentFragment = SSRDocumentFragment;
+    globalThis.Node = SSRNode;
+    globalThis.Event = SSREvent;
+    globalThis.CustomEvent = SSRCustomEvent;
+    globalThis.MutationObserver = SSRMutationObserver;
+    globalThis.ResizeObserver = SSRResizeObserver;
+    globalThis.IntersectionObserver = SSRIntersectionObserver;
+    globalThis.NodeList = Array;
+
+    globalThis.requestAnimationFrame = function(cb) { return 0; };
+    globalThis.cancelAnimationFrame = function() {};
+
+    globalThis.matchMedia = function(query) {
+      return {
+        matches: false,
+        media: query,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+        onchange: null,
+      };
+    };
+
+    globalThis.getComputedStyle = function(el) {
+      return new Proxy({}, {
+        get(_, prop) {
+          if (prop === 'getPropertyValue') return () => '';
+          return '';
+        }
+      });
+    };
+
+    globalThis.addEventListener = function() {};
+    globalThis.removeEventListener = function() {};
+    globalThis.dispatchEvent = function() { return true; };
+
+    globalThis.location = {
+      href: 'http://localhost/',
+      origin: 'http://localhost',
+      protocol: 'http:',
+      host: 'localhost',
+      hostname: 'localhost',
+      port: '',
+      pathname: '/',
+      search: '',
+      hash: '',
+    };
+    globalThis.history = {
+      pushState() {},
+      replaceState() {},
+      back() {},
+      forward() {},
+      go() {},
+      state: null,
+      length: 1,
+    };
+
+    // Start each render with a clean CSS collector.
+    globalThis.__vertz_css_state.length = 0;
+  };
+
+  globalThis.__vertz_uninstall_dom_shim = function () {
+    if (!__vertz_shim_installed) return;
+    __vertz_shim_installed = false;
+
+    delete globalThis.window;
+    delete globalThis.document;
+    delete globalThis.Document;
+    delete globalThis.Element;
+    delete globalThis.HTMLElement;
+    delete globalThis.HTMLDivElement;
+    delete globalThis.HTMLSpanElement;
+    delete globalThis.HTMLButtonElement;
+    delete globalThis.HTMLInputElement;
+    delete globalThis.HTMLFormElement;
+    delete globalThis.HTMLAnchorElement;
+    delete globalThis.HTMLImageElement;
+    delete globalThis.HTMLTemplateElement;
+    delete globalThis.HTMLStyleElement;
+    delete globalThis.SVGElement;
+    delete globalThis.Text;
+    delete globalThis.Comment;
+    delete globalThis.DocumentFragment;
+    delete globalThis.Node;
+    delete globalThis.Event;
+    delete globalThis.CustomEvent;
+    delete globalThis.MutationObserver;
+    delete globalThis.ResizeObserver;
+    delete globalThis.IntersectionObserver;
+    delete globalThis.NodeList;
+    delete globalThis.requestAnimationFrame;
+    delete globalThis.cancelAnimationFrame;
+    delete globalThis.matchMedia;
+    delete globalThis.getComputedStyle;
+    delete globalThis.addEventListener;
+    delete globalThis.removeEventListener;
+    delete globalThis.dispatchEvent;
+    delete globalThis.location;
+    delete globalThis.history;
+  };
+
+  // Phase 1: preserve current behavior by eagerly installing the shim.
+  // Phase 2 (#2760) removes this line and wires install/uninstall into
+  // persistent_isolate.rs dispatch functions instead.
+  globalThis.__vertz_install_dom_shim();
 })();
 "#;
 
@@ -1685,5 +1755,191 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result, serde_json::json!(2));
+    }
+
+    // ------------------------------------------------------------------
+    // Scoped install/uninstall tests (Phase 1 of #2760)
+    //
+    // These verify the permanent + scoped split of the DOM shim:
+    //   - `__vertz_install_dom_shim` / `__vertz_uninstall_dom_shim` are
+    //     registered on globalThis after load_dom_shim.
+    //   - Install makes `window`, `document`, etc. available; uninstall
+    //     removes them.
+    //   - CSS collector state and `navigator` are permanent (survive
+    //     install/uninstall cycles).
+    //   - Install is idempotent.
+    //
+    // Phase 1 keeps eager install at the end of the permanent block, so
+    // load_dom_shim() leaves the shim installed by default. Tests that
+    // assert the uninstalled state explicitly call uninstall first.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_install_uninstall_functions_are_registered() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                "typeof globalThis.__vertz_install_dom_shim === 'function' && \
+                 typeof globalThis.__vertz_uninstall_dom_shim === 'function'",
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_install_sets_window_and_document() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_uninstall_dom_shim();
+                globalThis.__vertz_install_dom_shim();
+                [typeof globalThis.window, typeof globalThis.document]
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(["object", "object"]));
+    }
+
+    #[test]
+    fn test_install_produces_fresh_document_per_call() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_install_dom_shim();
+                const firstDoc = globalThis.document;
+                globalThis.__vertz_uninstall_dom_shim();
+                globalThis.__vertz_install_dom_shim();
+                const secondDoc = globalThis.document;
+                firstDoc !== secondDoc
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_uninstall_removes_browser_globals() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_install_dom_shim();
+                globalThis.__vertz_uninstall_dom_shim();
+                [
+                    typeof globalThis.window,
+                    typeof globalThis.document,
+                    typeof globalThis.location,
+                    typeof globalThis.history,
+                    typeof globalThis.HTMLElement,
+                    typeof globalThis.Element,
+                    typeof globalThis.addEventListener,
+                ]
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+                "undefined",
+            ])
+        );
+    }
+
+    #[test]
+    fn test_css_collector_state_is_permanent() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_uninstall_dom_shim();
+                const beforeExists = typeof globalThis.__vertz_inject_css === 'function';
+                globalThis.__vertz_inject_css('a { color: red; }');
+                const afterFirst = globalThis.__vertz_get_collected_css().length;
+                globalThis.__vertz_install_dom_shim();
+                // install resets the collector for the new render
+                const afterInstall = globalThis.__vertz_get_collected_css().length;
+                globalThis.__vertz_inject_css('b { color: blue; }');
+                const afterSecond = globalThis.__vertz_get_collected_css().length;
+                globalThis.__vertz_uninstall_dom_shim();
+                const afterUninstall = typeof globalThis.__vertz_inject_css === 'function';
+                [beforeExists, afterFirst, afterInstall, afterSecond, afterUninstall]
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!([true, 1, 0, 1, true]));
+    }
+
+    #[test]
+    fn test_navigator_is_permanent() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_uninstall_dom_shim();
+                [
+                    typeof globalThis.navigator,
+                    globalThis.navigator.userAgent.includes('vertz-server'),
+                ]
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(["object", true]));
+    }
+
+    #[test]
+    fn test_install_is_idempotent() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_uninstall_dom_shim();
+                globalThis.__vertz_install_dom_shim();
+                globalThis.document.__mark = 'first';
+                globalThis.__vertz_install_dom_shim();
+                // second install must NOT reset the document
+                globalThis.document.__mark
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!("first"));
+    }
+
+    #[test]
+    fn test_uninstall_is_idempotent() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        let ok = rt
+            .execute_script(
+                "<test>",
+                r#"
+                globalThis.__vertz_uninstall_dom_shim();
+                globalThis.__vertz_uninstall_dom_shim();
+                typeof globalThis.window
+                "#,
+            )
+            .unwrap();
+        assert_eq!(ok, serde_json::json!("undefined"));
     }
 }

--- a/native/vtz/src/ssr/dom_shim.rs
+++ b/native/vtz/src/ssr/dom_shim.rs
@@ -1023,8 +1023,11 @@ pub const DOM_SHIM_JS: &str = r#"
       length: 1,
     };
 
-    // Start each render with a clean CSS collector.
-    globalThis.__vertz_css_state.length = 0;
+    // Intentionally NOT resetting __vertz_css_state here. The dispatch-level
+    // reset scripts (SSR_RESET_JS / COMPONENT_RESET_JS in persistent_isolate)
+    // own per-request CSS isolation, including snapshotting module-level
+    // baseline CSS on first call. Wiping here would destroy that baseline
+    // before the snapshot can capture it.
   };
 
   globalThis.__vertz_uninstall_dom_shim = function () {
@@ -1950,11 +1953,14 @@ mod tests {
                 "<test>",
                 r#"
                 globalThis.__vertz_uninstall_dom_shim();
+                // Inject + collector API remain available while uninstalled.
                 const beforeExists = typeof globalThis.__vertz_inject_css === 'function';
+                globalThis.__vertz_clear_collected_css();
                 globalThis.__vertz_inject_css('a { color: red; }');
                 const afterFirst = globalThis.__vertz_get_collected_css().length;
+                // Install must NOT wipe collected CSS — dispatch-level reset
+                // owns per-request CSS isolation, including baseline capture.
                 globalThis.__vertz_install_dom_shim();
-                // install resets the collector for the new render
                 const afterInstall = globalThis.__vertz_get_collected_css().length;
                 globalThis.__vertz_inject_css('b { color: blue; }');
                 const afterSecond = globalThis.__vertz_get_collected_css().length;
@@ -1964,7 +1970,7 @@ mod tests {
                 "#,
             )
             .unwrap();
-        assert_eq!(result, serde_json::json!([true, 1, 0, 1, true]));
+        assert_eq!(result, serde_json::json!([true, 1, 1, 2, true]));
     }
 
     #[test]

--- a/native/vtz/src/ssr/dom_shim.rs
+++ b/native/vtz/src/ssr/dom_shim.rs
@@ -1067,10 +1067,10 @@ pub const DOM_SHIM_JS: &str = r#"
     delete globalThis.history;
   };
 
-  // Phase 1: preserve current behavior by eagerly installing the shim.
-  // Phase 2 (#2760) removes this line and wires install/uninstall into
-  // persistent_isolate.rs dispatch functions instead.
-  globalThis.__vertz_install_dom_shim();
+  // DOM shim is NOT eagerly installed. Server handlers see a clean,
+  // Worker-like environment (no `window`, `document`, ...). SSR renders
+  // call `__vertz_install_dom_shim()` / `__vertz_uninstall_dom_shim()`
+  // around their render boundary (see persistent_isolate.rs).
 })();
 "#;
 
@@ -1172,6 +1172,8 @@ mod tests {
     fn test_document_is_defined() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script("<test>", "typeof globalThis.document")
             .unwrap();
@@ -1182,6 +1184,8 @@ mod tests {
     fn test_window_is_defined() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script("<test>", "typeof globalThis.window")
             .unwrap();
@@ -1192,6 +1196,8 @@ mod tests {
     fn test_navigator_is_defined() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script("<test>", "typeof globalThis.navigator")
             .unwrap();
@@ -1202,6 +1208,8 @@ mod tests {
     fn test_location_is_defined() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script("<test>", "globalThis.location.pathname")
             .unwrap();
@@ -1212,6 +1220,8 @@ mod tests {
     fn test_create_element() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1228,6 +1238,8 @@ mod tests {
     fn test_create_text_node() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1244,6 +1256,8 @@ mod tests {
     fn test_create_document_fragment() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1260,6 +1274,8 @@ mod tests {
     fn test_element_set_attribute() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1277,6 +1293,8 @@ mod tests {
     fn test_element_append_child() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1295,6 +1313,8 @@ mod tests {
     fn test_element_inner_html() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1315,6 +1335,8 @@ mod tests {
     fn test_element_outer_html() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1337,6 +1359,8 @@ mod tests {
     fn test_element_outer_html_escapes() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1357,6 +1381,8 @@ mod tests {
     fn test_void_elements_self_close() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1374,6 +1400,8 @@ mod tests {
     fn test_element_class_name() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1391,6 +1419,8 @@ mod tests {
     fn test_element_class_list() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1408,6 +1438,8 @@ mod tests {
     fn test_set_ssr_location() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         set_ssr_location(&mut rt, "/tasks/123?filter=active").unwrap();
         let result = rt
             .execute_script("<test>", "globalThis.location.pathname")
@@ -1423,6 +1455,8 @@ mod tests {
     fn test_set_ssr_location_root() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         set_ssr_location(&mut rt, "/").unwrap();
         let result = rt
             .execute_script("<test>", "globalThis.location.pathname")
@@ -1434,6 +1468,8 @@ mod tests {
     fn test_document_head_and_body_exist() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let head = rt
             .execute_script("<test>", "document.head.tagName")
             .unwrap();
@@ -1448,6 +1484,8 @@ mod tests {
     fn test_css_injection() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1468,6 +1506,8 @@ mod tests {
     fn test_css_collection_and_clear() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         rt.execute_script_void(
             "<test>",
             r#"
@@ -1492,6 +1532,8 @@ mod tests {
     fn test_create_comment() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1510,6 +1552,8 @@ mod tests {
     fn test_element_text_content_setter() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1527,6 +1571,8 @@ mod tests {
     fn test_nested_element_serialization() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1554,6 +1600,8 @@ mod tests {
     fn test_event_listeners_are_noop() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1572,6 +1620,8 @@ mod tests {
     fn test_request_animation_frame_is_noop() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1589,6 +1639,8 @@ mod tests {
     fn test_match_media_is_noop() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1605,6 +1657,8 @@ mod tests {
     fn test_shim_does_not_interfere_with_globals() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         // Ensure basic JS still works after shim
         let result = rt.execute_script("<test>", "1 + 1").unwrap();
         assert_eq!(result, serde_json::json!(2));
@@ -1614,6 +1668,8 @@ mod tests {
     fn test_mutation_observer_noop() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1632,6 +1688,8 @@ mod tests {
     fn test_history_is_noop() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1648,6 +1706,8 @@ mod tests {
     fn test_element_style_serialization() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1668,6 +1728,8 @@ mod tests {
     fn test_element_dataset() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1685,6 +1747,8 @@ mod tests {
     fn test_insert_before() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1705,6 +1769,8 @@ mod tests {
     fn test_remove_child() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1724,6 +1790,8 @@ mod tests {
     fn test_element_get_bounding_client_rect() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1741,6 +1809,8 @@ mod tests {
     fn test_document_fragment_append_to_element() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1778,6 +1848,8 @@ mod tests {
     fn test_install_uninstall_functions_are_registered() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1792,6 +1864,8 @@ mod tests {
     fn test_install_sets_window_and_document() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1809,6 +1883,8 @@ mod tests {
     fn test_install_produces_fresh_document_per_call() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1829,6 +1905,8 @@ mod tests {
     fn test_uninstall_removes_browser_globals() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1865,6 +1943,8 @@ mod tests {
     fn test_css_collector_state_is_permanent() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1891,6 +1971,8 @@ mod tests {
     fn test_navigator_is_permanent() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1910,6 +1992,8 @@ mod tests {
     fn test_install_is_idempotent() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let result = rt
             .execute_script(
                 "<test>",
@@ -1930,6 +2014,8 @@ mod tests {
     fn test_uninstall_is_idempotent() {
         let mut rt = create_runtime();
         load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
         let ok = rt
             .execute_script(
                 "<test>",

--- a/native/vtz/tests/ssr_render.rs
+++ b/native/vtz/tests/ssr_render.rs
@@ -70,6 +70,8 @@ fn test_dom_shim_provides_complete_environment() {
     .unwrap();
 
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     // Verify all required globals are available
     let checks = rt
@@ -118,6 +120,8 @@ fn test_dom_shim_complex_dom_tree() {
     .unwrap();
 
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     let result = rt
         .execute_script(
@@ -179,6 +183,8 @@ fn test_css_collection_end_to_end() {
     .unwrap();
 
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     // Simulate component rendering that injects CSS
     rt.execute_script_void(
@@ -317,6 +323,8 @@ fn test_ssr_render_full_pipeline() {
     .unwrap();
 
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     rt.execute_script_void(
         "<test>",
@@ -639,6 +647,8 @@ async fn poc_ssr_render_single_pass_in_v8() {
     // Load polyfills (AsyncLocalStorage, DOM shim)
     load_async_context(&mut rt).unwrap();
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     // Load the app module and store as globalThis.__vertz_app_module
     let app_path = root.join("src/app-ssr.js");
@@ -716,6 +726,8 @@ fn test_async_local_storage_in_ssr_context() {
 
     load_async_context(&mut rt).unwrap();
     dom_shim::load_dom_shim(&mut rt).unwrap();
+    rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+        .unwrap();
 
     // Simulate SSR context usage
     let result = rt

--- a/packages/mint-docs/docs.json
+++ b/packages/mint-docs/docs.json
@@ -99,6 +99,7 @@
               "guides/server/codegen",
               "guides/server/oauth",
               "guides/server/services",
+              "guides/server/environment",
               "guides/env",
               "guides/hmr-types"
             ]

--- a/packages/mint-docs/guides/server/environment.mdx
+++ b/packages/mint-docs/guides/server/environment.mdx
@@ -1,0 +1,92 @@
+---
+title: Runtime Environment
+description: 'What globals and APIs are available inside Vertz server handlers'
+---
+
+Vertz server handlers run in a Cloudflare-Workers-compatible JavaScript environment. The same code runs locally under `vtz dev` and on the edge under `vtz deploy` — the runtime surface is deliberately aligned with Workers so there is no "works locally, breaks in production" gap.
+
+## What's available
+
+**Network + data:**
+
+- `fetch`, `Request`, `Response`, `Headers`
+- `URL`, `URLSearchParams`
+- `AbortController`, `AbortSignal`
+- `FormData`, `Blob`, `ReadableStream`, `WritableStream`, `TransformStream`
+- `TextEncoder`, `TextDecoder`
+
+**Timers + scheduling:**
+
+- `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`
+- `queueMicrotask`, `performance.now()`
+
+**Crypto:**
+
+- `crypto.randomUUID()`, `crypto.getRandomValues()`, `crypto.subtle`
+
+**Environment identification:**
+
+- `navigator.userAgent` — identifies the Vertz server runtime (useful for `User-Agent` headers on outbound `fetch`)
+
+**Standard ECMAScript:** `Promise`, `Map`, `Set`, `WeakMap`, `WeakSet`, `Intl`, `JSON`, etc.
+
+**Vertz APIs:** everything in `vertz/server` (`entity`, `service`, `rules`, etc.), `vertz/db`, `vertz/schema`, and `vertz/errors`.
+
+## What's not available
+
+Server handlers do **not** expose browser globals:
+
+- `window`, `document`, `HTMLElement`, `Element`, `Node`, and other DOM types
+- `location`, `history`
+- `localStorage`, `sessionStorage`
+- `MutationObserver`, `ResizeObserver`, `IntersectionObserver`
+
+Calling any of these from a handler throws `ReferenceError`. That's intentional — handler code has no DOM to manipulate, and the absence of these globals is what lets third-party SDKs recognize the environment as "not a browser".
+
+## Using third-party SDKs
+
+SDKs that gate on `typeof window !== 'undefined'` (like `@anthropic-ai/sdk`, `openai`, and `stripe`) work out of the box — no `dangerouslyAllowBrowser: true` flag required.
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { service } from 'vertz/server';
+import { s } from 'vertz/schema';
+
+export default service('ai', {
+  actions: {
+    summarize: {
+      body: s.object({ text: s.string() }),
+      handler: async ({ text }) => {
+        const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+        const message = await client.messages.create({
+          model: 'claude-haiku-4-5',
+          max_tokens: 256,
+          messages: [{ role: 'user', content: `Summarize: ${text}` }],
+        });
+        return { summary: message.content };
+      },
+    },
+  },
+});
+```
+
+<Warning>
+  If you see older guides suggesting `dangerouslyAllowBrowser: true` for Vertz handlers, remove it.
+  That flag disables a safety check that prevents API keys from leaking into client bundles — it is
+  not needed in a server handler and leaves you exposed if the same file is ever imported by client
+  code.
+</Warning>
+
+## SSR vs. handlers
+
+During server-side rendering (SSR) of a page, Vertz transiently installs a DOM shim (`document`, `window`, etc.) so the same components that run in the browser can build HTML on the server. That shim is scoped to the render — it is installed before the framework begins rendering the matched route and removed immediately after.
+
+Handler code (entity actions, service actions, middleware, auth resolvers, route loaders, etc.) always runs **outside** that scope. A handler triggered by an API request, a form submission, or a fetch-interception during SSR never sees the shim: `typeof window === 'undefined'` is a stable invariant in handler code.
+
+## Migrating from older workarounds
+
+If you or a library you depend on added one of the following because of `ReferenceError: window is not defined` or `@anthropic-ai/sdk: It looks like you're running in a browser-like environment`, remove it:
+
+- `dangerouslyAllowBrowser: true` on any SDK constructor
+- `globalThis.window = undefined` / `delete globalThis.window` at the top of a handler file
+- `if (typeof window === 'undefined')` guards around handler-only code (no longer necessary for correctness — still safe to leave in place)

--- a/packages/mint-docs/guides/server/environment.mdx
+++ b/packages/mint-docs/guides/server/environment.mdx
@@ -71,17 +71,28 @@ export default service('ai', {
 ```
 
 <Warning>
-  If you see older guides suggesting `dangerouslyAllowBrowser: true` for Vertz handlers, remove it.
-  That flag disables a safety check that prevents API keys from leaking into client bundles — it is
-  not needed in a server handler and leaves you exposed if the same file is ever imported by client
-  code.
+  If any examples or workarounds you've seen use `dangerouslyAllowBrowser: true` in a Vertz handler,
+  remove it. That flag disables a safety check that prevents API keys from leaking into client
+  bundles — it is not needed in a server handler and leaves you exposed if the same file is ever
+  imported by client code.
 </Warning>
 
 ## SSR vs. handlers
 
 During server-side rendering (SSR) of a page, Vertz transiently installs a DOM shim (`document`, `window`, etc.) so the same components that run in the browser can build HTML on the server. That shim is scoped to the render — it is installed before the framework begins rendering the matched route and removed immediately after.
 
-Handler code (entity actions, service actions, middleware, auth resolvers, route loaders, etc.) always runs **outside** that scope. A handler triggered by an API request, a form submission, or a fetch-interception during SSR never sees the shim: `typeof window === 'undefined'` is a stable invariant in handler code.
+Handler code (entity actions, service actions, middleware, auth resolvers, etc.) invoked through the top-level HTTP/API dispatch path runs **outside** that scope. A handler triggered by a direct request from the browser to `/api/...`, a form submission, or any non-SSR entry point sees `typeof window === 'undefined'`.
+
+### One edge case: handlers invoked via `fetch('/api/...')` during SSR
+
+If an SSR render itself calls `fetch('/api/...')` (for example, a loader or query that runs on the server), the internal fetch interceptor dispatches that request to the handler **in-place**, while the DOM shim is still installed for the ongoing render. In that path, the handler transiently sees `window` / `document` / `location`.
+
+For the SDK-detection problem this is usually harmless — loaders and queries typically read data and don't construct `@anthropic-ai/sdk` or `openai` clients. But if you need a guaranteed-clean environment (e.g. you instantiate an SDK inside a handler that is also reachable from SSR), prefer:
+
+- constructing the SDK client at module scope instead of per-request, or
+- keeping SDK construction in actions that are only called from the client (form submissions, button clicks) rather than SSR loaders.
+
+The direct `/api/...` request path — which is how form submissions and client-side `fetch` calls reach handlers in production — always sees the clean environment.
 
 ## Migrating from older workarounds
 

--- a/plans/2760-browser-detection-fix.md
+++ b/plans/2760-browser-detection-fix.md
@@ -1,0 +1,324 @@
+# Design: Clean Server Runtime (Scope DOM Shim to SSR Renders)
+
+**Issue:** #2760
+**Status:** Draft (Rev 2 — addressing DX, Product, and Technical review findings)
+**Date:** 2026-04-18
+
+## Summary
+
+Vertz server handlers run in the same V8 context as SSR rendering, which pre-installs a DOM shim (`window`, `document`, `navigator`, `location`, `history`, DOM constructors, no-op event APIs). Third-party SDKs like `@anthropic-ai/sdk` detect `typeof window !== 'undefined' && typeof document !== 'undefined'` and refuse to run without `dangerouslyAllowBrowser: true`. This design scopes the browser-confusing subset of the shim to SSR render boundaries so server handlers see a Cloudflare-Workers-like environment.
+
+## Problem Statement
+
+Today, `native/vtz/src/ssr/dom_shim.rs` is executed at snapshot creation time (`native/vtz/src/runtime/snapshot.rs:225-234`) and unconditionally installs browser-like globals on `globalThis`. Both SSR and API handler messages are dispatched sequentially through the same V8 isolate on one thread (`native/vtz/src/runtime/persistent_isolate.rs::process_messages` line 915; verified: `run_event_loop()` does not dequeue the next message until the current Rust future completes, so renders are serialized at message granularity). A handler that calls `new Anthropic({ apiKey })` sees `window` and `document` defined, the SDK's browser check fires, and the constructor throws:
+
+```
+It looks like you're running in a browser-like environment.
+This is disabled by default, as it risks exposing your secret API credentials to attackers.
+```
+
+Users work around this with `dangerouslyAllowBrowser: true`, which is semantically wrong (the code is on the server) and disables a real safety check for anyone copying the code into a client component. The same issue affects any SDK that gates on browser globals (OpenAI, Stripe, etc.).
+
+## Goals
+
+1. Server handler code sees a Cloudflare-Workers-like environment: **no `window`, no `document`, no `location`, no `history`, no DOM element constructors (`HTMLElement`, `Element`, `Text`, `Document`, `DocumentFragment`, `SVGElement`)**.
+2. `navigator` stays permanently defined with a Worker-compatible `userAgent` (Workers have `navigator.userAgent = 'Cloudflare-Workers'`; we match the shape so local dev matches production).
+3. SSR rendering still has the full DOM shim available.
+4. `new Anthropic({ apiKey })` (and similarly-guarded SDKs) works without `dangerouslyAllowBrowser`.
+5. Vertz's own `isBrowser()` continues to return the right answer: `false` in handlers, `false` in SSR (via `hasSSRResolver()`), `true` only in real browsers.
+6. No regression in SSR output, client hydration, or CSS collection.
+
+## Non-Goals
+
+- **Split the V8 isolate into two isolates.** Kept as a single isolate for snapshot reuse and memory footprint. The scoped-shim approach provides equivalent user-visible behavior.
+- **Provide a Vertz SDK wrapper for Anthropic/OpenAI/etc.** Users instantiate standard SDKs directly with their documented APIs.
+- **Sandbox server handler code.** This design removes confusing globals, it does not add isolation. Server code retains full Vertz API access.
+- **Add a throwing `document` Proxy in handler context for better error messages.** A plain `ReferenceError: document is not defined` is acceptable; user-facing UI code inside a handler is already a bug. If user telemetry shows the raw error is confusing, we can revisit in a later issue.
+- **Introduce `isServer()` / `isSSR()` helpers.** `isBrowser()` is sufficient for the cases users hit today. A new helper is out of scope (tracked separately if needed).
+- **Change how the compiled client bundle works.** Client code still runs in a real browser with a real `window`.
+
+## Why Not The Minimal Fix
+
+The smallest change that makes Anthropic's SDK stop complaining is: remove the line `globalThis.window = globalThis;` from `dom_shim.rs`. We reject this for three reasons:
+
+1. **Insufficient coverage.** The Anthropic SDK's check is `typeof window !== 'undefined' && typeof document !== 'undefined'` (both). Some SDKs only check `window`, others check `document`, others check `XMLHttpRequest` or `localStorage`. Removing just `window` fixes Anthropic today but leaves the next SDK broken tomorrow.
+2. **Misleading `isBrowser()`.** With `window` gone but `document`, `location`, `history` still defined, user code doing `typeof document !== 'undefined'` still thinks it's in a browser. The handler environment would be internally inconsistent.
+3. **No Worker parity.** Workers have neither `window` nor `document` nor DOM constructors. A handler that works locally but fails on Vertz Cloud is an "if it builds, it works" violation.
+
+## Design
+
+### Architecture
+
+Split the existing single-IIFE DOM shim into two sections:
+
+**Permanent (executed once at snapshot creation, visible to both handlers and SSR):**
+- `navigator` (Worker-compatible: `{ userAgent: 'vertz-server/1.0', ... }`)
+- CSS collector state and functions: `__vertz_collected_css` (module-closed array), `__vertz_inject_css`, `__vertz_get_collected_css`, `__vertz_clear_collected_css`
+- `URLSearchParams` shim (only if deno_core doesn't provide one — verify in Phase 1; most likely already present, in which case this line is removed)
+- `__vertz_install_dom_shim()` / `__vertz_uninstall_dom_shim()` function registrations
+
+**Scoped (installed/uninstalled per SSR render via the functions above):**
+- `window` (alias for `globalThis`)
+- `document` (fresh `SSRDocument` instance per install — see "State isolation between renders" below)
+- `location` (object reflecting the current SSR request URL — already overwritten per-request by `set_ssr_location` in `dispatch_ssr_request`)
+- `history` (no-op stub)
+- DOM element constructors: `HTMLElement`, `Element`, `Text`, `Document`, `DocumentFragment`, `SVGElement`, `Node`, `Comment`
+- Event API stubs: `addEventListener`, `removeEventListener`, `dispatchEvent`
+- `ELEMENT_NODE` and other nodeType constants (if still referenced)
+
+### CSS collector: moved out of the closure
+
+Today `__vertz_collected_css` is a `const` inside the shim's IIFE. If we re-executed the shim per render, every render would create a fresh closure and break any code holding a reference to the old `__vertz_inject_css`. Fix: move `__vertz_collected_css` to a non-enumerable property on `globalThis` (e.g., `globalThis.__vertz_css_state`) owned by the permanent block. The install function resets it at the start of each SSR render (clears the array); the uninstall function does nothing to it (the array stays so handler code that called `__vertz_inject_css` mid-response still works, though no handler should do that).
+
+### `__vertz_install_dom_shim` and `__vertz_uninstall_dom_shim`
+
+Both functions are plain JS registered once in the permanent block. No IIFE re-execution. Each toggles ~10 specific properties on `globalThis`. Execution cost per call is on the order of tens of microseconds (handful of property writes + one `SSRDocument` allocation on install). The heavy `dom_shim.rs` parse/compile happens once at snapshot time.
+
+```js
+let __vertz_shim_installed = false;
+globalThis.__vertz_install_dom_shim = function () {
+  if (__vertz_shim_installed) return;
+  __vertz_shim_installed = true;
+  globalThis.window = globalThis;
+  globalThis.document = new SSRDocument();
+  globalThis.location = { /* default; overwritten by set_ssr_location */ };
+  globalThis.history = { pushState(){}, replaceState(){}, back(){}, forward(){}, go(){}, state: null, length: 1 };
+  globalThis.addEventListener = function () {};
+  globalThis.removeEventListener = function () {};
+  globalThis.dispatchEvent = function () { return true; };
+  globalThis.HTMLElement = HTMLElement_ctor;
+  globalThis.Element = Element_ctor;
+  // …other DOM constructors…
+  globalThis.__vertz_css_state.length = 0; // reset collector for this render
+};
+globalThis.__vertz_uninstall_dom_shim = function () {
+  if (!__vertz_shim_installed) return;
+  __vertz_shim_installed = false;
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.location;
+  delete globalThis.history;
+  delete globalThis.addEventListener;
+  delete globalThis.removeEventListener;
+  delete globalThis.dispatchEvent;
+  delete globalThis.HTMLElement;
+  delete globalThis.Element;
+  // …other DOM constructors…
+};
+```
+
+The constructor references (`HTMLElement_ctor`, etc.) are captured in the permanent block's closure once, so install is a cheap assignment, not a class-definition.
+
+### Where install/uninstall is called (correct hook location)
+
+The correct integration points are both JS-dispatch functions in `native/vtz/src/runtime/persistent_isolate.rs`:
+
+1. **`dispatch_ssr_request`** (line 1358) — add install before `SSR_RESET_JS` execution (line 1366) and uninstall in a Rust-side cleanup that runs even if `run_event_loop` returns an error or times out.
+2. **`dispatch_component_render`** (line 1670) — same pattern: install before `COMPONENT_RESET_JS`, uninstall in cleanup.
+
+Cleanup pattern: wrap the dispatch body in a Rust `scopeguard::defer!` (the crate is already in use) or, more minimally, capture the result in a variable and run uninstall before returning. Every early-return path goes through the uninstall.
+
+`native/vtz/src/ssr/component_render.rs::assemble_component_document` is **not** a hook point — it is pure Rust that builds the outer HTML skeleton and does not execute JS. (An earlier revision of this design mis-identified it; corrected here.)
+
+No other JS-dispatching SSR paths exist — verified by grep: no streaming SSR, no suspense dispatch, no resumed-hydration path outside these two functions.
+
+### Fetch interceptor dependency on `location`
+
+`FETCH_INTERCEPTOR_JS` (`native/vtz/src/runtime/js_runtime.rs` around line 1137) currently reads `globalThis.location.origin` at installation time to set `selfOrigin`. After this change, the interceptor installs when `location` is undefined. Two options:
+
+1. **Preferred:** change the interceptor to read `globalThis.location?.origin` **lazily per fetch call** instead of caching `selfOrigin` at init. Cost per fetch is a single property read — negligible.
+2. Fallback: keep `location` permanently installed (contradicts Worker parity, rejected).
+
+Option 1 is part of this feature's Phase 2 work.
+
+### Why `hasSSRResolver()` stays
+
+DX reviewer asked whether `hasSSRResolver()` is dead code after this change. It is not. During SSR renders, the shim is installed, so `typeof window !== 'undefined'` returns true. `isBrowser()` must still return `false` during SSR renders (user components use it to decide whether to skip client-only effects). `hasSSRResolver()` is what tells us "we're rendering on the server, not in a real browser" — it is load-bearing, not belt-and-braces. Comment updated accordingly.
+
+### Audit: no handler-reachable unguarded DOM access
+
+All `window.X` / `document.X` / `location.X` references in packages transitively importable by handlers fall into one of three safe classes:
+
+| File:line | Code | Classification |
+|---|---|---|
+| `packages/ui/src/env/is-browser.ts:14` | `typeof window !== 'undefined' && !hasSSRResolver()` | SAFE — `typeof` guard |
+| `packages/ui/src/router/reactive-search-params.ts:60` | `typeof window !== 'undefined' ? window.location.pathname : '/'` | SAFE — `typeof` guard |
+| `packages/ui/src/router/view-transitions.ts:57,64` | `typeof document === 'undefined'`, `typeof window !== 'undefined'` | SAFE — `typeof` guards |
+| `packages/ui/src/router/navigate.ts:395` | `initialUrl ?? window.location.pathname + window.location.search` | FN-GATED — inside `navigate()`, which is only called client-side (SSR provides `initialUrl`; `??` short-circuits) |
+| `packages/ui/src/router/navigate.ts:642,644,678,695,698` | `window.history.*`, `window.addEventListener` | FN-GATED — all inside `navigate()` / `onPopState` / disposer, client-only code paths |
+| `packages/ui/src/router/server-nav.ts:67,99` | `document.dispatchEvent(...)` | FN-GATED — inside callbacks that only fire client-side, gated by `globalThis.__VERTZ_SSR_PUSH__` / prefetch-active globals |
+| `packages/ui/src/auth/auth-context.ts:530`, `create-access-provider.ts:39` | `window.__VERTZ_ACCESS_SET__` | FN-GATED — inside `createAccessProvider()`, client-bundle path |
+| `packages/ui/src/query/query.ts:592,598,604` | `document.addEventListener` for nav-prefetch-done | FN-GATED — inside reactive effect, activated only when `globalThis.__VERTZ_NAV_PREFETCH_ACTIVE__` is set (client-only) |
+
+No module-level unguarded reference. The audit is exhaustive for `packages/ui`, `packages/server`, `packages/agents`, `packages/forms`, `packages/codegen`, `packages/ui-server`. Phase 1's first task is to re-run this grep against the current tree and fail CI if any unclassified hit appears.
+
+### Test snapshot path
+
+`TEST_DOM_SHIM_JS` (test-only snapshot) is updated the same way: split into permanent + scoped functions. Test suites that exercise the DOM shim now call `globalThis.__vertz_install_dom_shim()` at the top of each test (or in a shared `beforeEach`). This is a mechanical update to maybe a dozen test files.
+
+### API Surface
+
+No public TypeScript API changes. Internal JS API (not user-facing):
+
+```js
+globalThis.__vertz_install_dom_shim(): void
+globalThis.__vertz_uninstall_dom_shim(): void
+```
+
+`packages/ui/src/env/is-browser.ts` signature and body unchanged:
+
+```ts
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined' && !hasSSRResolver();
+}
+```
+
+## Manifesto Alignment
+
+- **"If it builds, it works"** — Handlers that `new Anthropic({...})` today produce runtime errors without `dangerouslyAllowBrowser`. After this change, the SDK sees a Worker-like env and initializes correctly.
+- **"Zero-config DX"** — No workaround flag, no Vertz-specific config, no wrapper.
+- **"No escape hatches that compromise safety"** — Removing the need for `dangerouslyAllowBrowser` is a safety win.
+- **"Local dev matches production"** — Handlers now see a Worker-compatible environment; Vertz Cloud users do not hit new issues when deploying.
+
+**Trade-off accepted:** Two JS function calls per SSR render (install + uninstall, ~tens of microseconds each). Negligible given the render itself is milliseconds to seconds of user code.
+
+**Trade-off rejected:** Two V8 isolates / two contexts per isolate. Better isolation but doubles snapshot restore cost and complicates module sharing. Not worth it for the user-visible outcome.
+
+## Unknowns
+
+All previously open items from Rev 1 are now resolved or scheduled into Phase 1:
+
+1. ~~Handler-reachable unguarded DOM access~~ → resolved in "Audit" table above.
+2. ~~Right hook point~~ → resolved: `dispatch_ssr_request` and `dispatch_component_render` in `persistent_isolate.rs`.
+3. ~~CSS collector closure issue~~ → resolved: state moves to `globalThis.__vertz_css_state`.
+4. ~~Fetch interceptor `location` dependency~~ → resolved: read `location?.origin` lazily per fetch call.
+5. ~~Other streaming / suspense paths~~ → resolved: verified only two dispatch functions exist.
+
+Remaining open (to be resolved during Phase 1):
+
+- Does deno_core's baseline snapshot already provide `URLSearchParams`? If yes, delete the shim's polyfill; if no, keep it in the permanent block. Answer: read the deno_core `ops` list; one-line decision.
+- Does `@anthropic-ai/sdk` also check `XMLHttpRequest` or `self`? Install the SDK locally, read its detection code, confirm that removing `window` + `document` is sufficient. If it also checks `self`, permanent block must explicitly `delete globalThis.self` (note: deno_core may define `self` by default).
+
+## POC Results
+
+No separate POC. The mechanism — toggling a handful of globals on `globalThis` around a JS function call on a single-threaded runtime — is a well-understood pattern. Risk is concentrated in the grep audit (now included inline) and the fetch interceptor lazy-read (mechanical).
+
+## Type Flow Map
+
+No new TypeScript generics. `isBrowser(): boolean` signature unchanged. All changes are Rust and runtime-internal JS.
+
+## E2E Acceptance Test
+
+### Developer walkthrough
+
+```ts
+// src/api/summarize.ts
+import Anthropic from '@anthropic-ai/sdk';
+import { service } from '@vertz/server';
+
+export default service({
+  summarize: async ({ text }: { text: string }) => {
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+    // No dangerouslyAllowBrowser flag needed — works without it.
+    const msg = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: `Summarize: ${text}` }],
+    });
+    return msg.content;
+  },
+});
+```
+
+**Before:** `new Anthropic(...)` throws `"It looks like you're running in a browser-like environment"`.
+**After:** `new Anthropic(...)` succeeds.
+
+### BDD Acceptance Criteria
+
+```ts
+// Rust tests live at native/vtz/src/ssr/__tests__/dom_shim_scope_test.rs
+// (Rust syntax #[test] fn; BDD structure shown below as pseudocode for clarity)
+
+describe('Feature: DOM shim is scoped to SSR renders', () => {
+  describe('Given a fresh V8 runtime from the production snapshot', () => {
+    describe('When the runtime evaluates `typeof window` before any SSR render', () => {
+      it('then returns "undefined"', () => {});
+    });
+    describe('When the runtime evaluates `typeof document` before any SSR render', () => {
+      it('then returns "undefined"', () => {});
+    });
+    describe('When the runtime evaluates `typeof HTMLElement`', () => {
+      it('then returns "undefined"', () => {});
+    });
+    describe('When the runtime evaluates `typeof navigator`', () => {
+      it('then returns "object" with userAgent set', () => {});
+    });
+  });
+
+  describe('Given an SSR render is in flight', () => {
+    describe('When user component code reads `window`', () => {
+      it('then window is defined and equals globalThis', () => {});
+    });
+    describe('When the SSR render completes normally', () => {
+      it('then window is undefined in the next evaluation', () => {});
+    });
+    describe('When the SSR render throws mid-flight', () => {
+      it('then window is still undefined after the throw (uninstall ran in finally)', () => {});
+    });
+    describe('When the SSR render awaits a Promise, completes, then a second render runs', () => {
+      it('then the second render starts with a fresh document and empty CSS collector', () => {});
+    });
+  });
+
+  describe('Given two back-to-back SSR renders', () => {
+    describe('When the first render injects CSS via __vertz_inject_css("body{...}")', () => {
+      it('then the first render\'s response contains that CSS', () => {});
+      it('then the second render\'s __vertz_get_collected_css() does NOT contain that CSS', () => {});
+    });
+  });
+
+  describe('Given a server handler imports `@anthropic-ai/sdk`', () => {
+    describe('When the handler runs `new Anthropic({ apiKey: "x" })`', () => {
+      it('then construction succeeds without dangerouslyAllowBrowser', () => {});
+    });
+  });
+});
+```
+
+### TypeScript integration test
+
+```ts
+// packages/integration-tests/src/__tests__/server-clean-env.test.ts (new)
+import { describe, it, expect } from '@vertz/testing';
+import Anthropic from '@anthropic-ai/sdk';
+
+describe('Feature: server handlers see a Worker-like environment', () => {
+  describe('Given a handler evaluates `typeof window`', () => {
+    it('then the result is "undefined"', async () => {
+      const result = await invokeHandlerReturning(() => typeof window);
+      expect(result).toBe('undefined');
+    });
+  });
+
+  describe('Given a handler constructs @anthropic-ai/sdk', () => {
+    it('then construction succeeds without dangerouslyAllowBrowser', async () => {
+      await invokeHandler(() => {
+        const client = new Anthropic({ apiKey: 'test-key' });
+        return !!client;
+      });
+      // No throw = pass
+    });
+  });
+});
+```
+
+The helper `invokeHandlerReturning` runs user code inside the server handler context via the same dispatch path a real HTTP request would take, so we exercise the actual install/uninstall pattern.
+
+## Rollout
+
+1. **Phase 1** (foundation + audit): permanent/scoped split of `dom_shim.rs`, move CSS collector state out of IIFE, register install/uninstall functions, do not yet wire into dispatch. Re-run audit grep and fail CI on unclassified handler-reachable DOM references.
+2. **Phase 2** (wiring + fetch fix): call install/uninstall in `dispatch_ssr_request` and `dispatch_component_render` with cleanup-on-error; change `FETCH_INTERCEPTOR_JS` to read `location` lazily.
+3. **Phase 3** (tests + docs): all BDD scenarios pass, docs update in `packages/mint-docs/` under Server → Environment ("Server handlers run in a Worker-compatible environment; you can use any SDK without `dangerouslyAllowBrowser` flags").
+4. Changeset as `patch`.
+
+Full quality gates (`vtz test && vtz run typecheck && vtz run lint`; `cargo test --all && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`) after every phase.

--- a/plans/2760-browser-detection-fix/phase-01-split-dom-shim.md
+++ b/plans/2760-browser-detection-fix/phase-01-split-dom-shim.md
@@ -1,0 +1,245 @@
+# Phase 1: Split the DOM shim into permanent + scoped sections
+
+## Context
+
+Issue #2760 requires server handlers to see a Cloudflare-Workers-like environment (no `window`, no `document`, no DOM constructors). See the design doc at `plans/2760-browser-detection-fix.md` for full background.
+
+This phase restructures `native/vtz/src/ssr/dom_shim.rs` into two JS blocks registered at snapshot time:
+
+1. **Permanent block** — CSS collector state and functions, DOM-constructor class definitions (captured in closure, not set on `globalThis`), `navigator`, and registration of the two install/uninstall functions.
+2. **Install/uninstall functions** — toggle the browser-confusing subset (`window`, `document`, `location`, `history`, event APIs, DOM constructors) on `globalThis`.
+
+The install/uninstall functions are registered but NOT wired into the SSR dispatch path in this phase — that's Phase 2. At end of Phase 1, running the current SSR render path still works because we install the shim eagerly at snapshot time (same as today) to avoid breaking anything. The new functions exist in parallel, ready for Phase 2 wiring.
+
+**Key design points:**
+- CSS collector state (`__vertz_collected_css`) must move from an IIFE-closed `const` to `globalThis.__vertz_css_state` (an array) so it survives across install/uninstall cycles and is accessible from both the permanent block and install calls.
+- DOM constructor functions (`SSRDocument`, `SSRElement`, etc.) stay defined inside a permanent-block closure. The install function copies references into `globalThis`; uninstall deletes them.
+- Install is idempotent (guarded by a flag). Uninstall is idempotent (same flag). Reinstall between renders resets the document and CSS collector.
+
+## Tasks
+
+### Task 1.1: Write failing tests for install/uninstall behavior (RED)
+
+**Files:** (2)
+- `native/vtz/src/ssr/dom_shim.rs` (modified — add test cases to the existing `tests` module at the bottom)
+- `native/vtz/src/runtime/snapshot.rs` (modified — the existing `test_production_snapshot_has_bootstrap_globals` test may need adjustment; keep it passing by only asserting things we keep in the permanent block)
+
+**What to implement:**
+
+Add these Rust tests to `dom_shim.rs::tests` module. They MUST fail before implementation:
+
+```rust
+#[test]
+fn test_install_uninstall_functions_are_registered() {
+    // After snapshot restore, both functions exist on globalThis
+    let mut rt = VertzJsRuntime::new_for_production(...).unwrap();
+    let result = rt.execute_script("<t>",
+        "typeof globalThis.__vertz_install_dom_shim === 'function' && \
+         typeof globalThis.__vertz_uninstall_dom_shim === 'function'"
+    ).unwrap();
+    assert_eq!(result.as_bool(), Some(true));
+}
+
+#[test]
+fn test_install_sets_window_and_document() {
+    // After calling install, window and document are defined
+    // After calling uninstall, they are deleted
+    // Call install again — document is a fresh SSRDocument
+}
+
+#[test]
+fn test_uninstall_removes_browser_globals() {
+    // window, document, location, history, HTMLElement, Element, addEventListener
+    // are all undefined after uninstall
+}
+
+#[test]
+fn test_css_collector_state_is_permanent() {
+    // __vertz_inject_css exists even before install
+    // __vertz_inject_css accumulates entries across multiple install/uninstall cycles
+    // install clears the collector (fresh per render)
+}
+
+#[test]
+fn test_navigator_is_permanent() {
+    // navigator is defined before any install; has userAgent property
+}
+
+#[test]
+fn test_install_is_idempotent() {
+    // Calling install twice in a row does not reset state between calls
+}
+```
+
+**Acceptance criteria:**
+- [ ] All new tests compile
+- [ ] All new tests FAIL with clear messages (functions not yet registered, state not moved)
+- [ ] Existing tests in `dom_shim.rs::tests` still document current behavior (will change in Task 1.2)
+
+---
+
+### Task 1.2: Restructure dom_shim.rs to split permanent + scoped (GREEN)
+
+**Files:** (1)
+- `native/vtz/src/ssr/dom_shim.rs` (modified — rewrite `DOM_SHIM_JS` body)
+
+**What to implement:**
+
+Restructure the JS string `DOM_SHIM_JS` as follows. Use literal JS; do not introduce a templating system.
+
+1. **Permanent block** (outer IIFE that runs once at snapshot time):
+   - Define all DOM constructor classes as `const` inside the IIFE closure (`SSRDocument`, `SSRElement`, `SSRText`, `SSRComment`, etc. — already exist, just ensure they're not set on `globalThis` here).
+   - Install the CSS collector state as a non-enumerable property on `globalThis`:
+     ```js
+     Object.defineProperty(globalThis, '__vertz_css_state', {
+       value: [],
+       writable: true,
+       configurable: false,
+       enumerable: false,
+     });
+     ```
+   - Install `globalThis.__vertz_inject_css`, `__vertz_get_collected_css`, `__vertz_clear_collected_css`. These now reference `globalThis.__vertz_css_state` (not the closure `const`).
+   - Install `globalThis.navigator` with Worker-compatible shape (`{ userAgent: 'vertz-server/1.0', language: 'en', languages: ['en'], platform: 'server', onLine: true }`).
+   - Install `URLSearchParams` polyfill **only if** `typeof globalThis.URLSearchParams === 'undefined'`. (deno_core likely provides it; confirm by reading the current code — if already guarded with this check, keep as-is.)
+
+2. **Install/uninstall functions** (defined in the same IIFE, so they close over the DOM constructor `const`s):
+   ```js
+   let __vertz_shim_installed = false;
+   globalThis.__vertz_install_dom_shim = function () {
+     if (__vertz_shim_installed) return;
+     __vertz_shim_installed = true;
+     globalThis.window = globalThis;
+     globalThis.document = new SSRDocument();
+     globalThis.location = {
+       href: 'http://localhost/', origin: 'http://localhost',
+       protocol: 'http:', host: 'localhost', hostname: 'localhost',
+       port: '', pathname: '/', search: '', hash: '',
+     };
+     globalThis.history = {
+       pushState(){}, replaceState(){}, back(){}, forward(){}, go(){},
+       state: null, length: 1,
+     };
+     globalThis.addEventListener = function(){};
+     globalThis.removeEventListener = function(){};
+     globalThis.dispatchEvent = function(){ return true; };
+     globalThis.HTMLElement = SSRElement;
+     globalThis.Element = SSRElement;
+     globalThis.Text = SSRText;
+     globalThis.Document = SSRDocument;
+     globalThis.DocumentFragment = SSRDocumentFragment;
+     globalThis.Node = SSRNode;
+     globalThis.Comment = SSRComment;
+     // Reset collector for this render
+     globalThis.__vertz_css_state.length = 0;
+   };
+   globalThis.__vertz_uninstall_dom_shim = function () {
+     if (!__vertz_shim_installed) return;
+     __vertz_shim_installed = false;
+     delete globalThis.window;
+     delete globalThis.document;
+     delete globalThis.location;
+     delete globalThis.history;
+     delete globalThis.addEventListener;
+     delete globalThis.removeEventListener;
+     delete globalThis.dispatchEvent;
+     delete globalThis.HTMLElement;
+     delete globalThis.Element;
+     delete globalThis.Text;
+     delete globalThis.Document;
+     delete globalThis.DocumentFragment;
+     delete globalThis.Node;
+     delete globalThis.Comment;
+   };
+   ```
+
+3. **Eager install at snapshot time** — to keep Phase 1 a refactor (not a behavioral change), execute `globalThis.__vertz_install_dom_shim()` at the end of the permanent block. This means the production snapshot still has `window`/`document` installed — Phase 2 will remove this eager call and wire install/uninstall into dispatch.
+
+**Acceptance criteria:**
+- [ ] All Task 1.1 tests pass
+- [ ] All pre-existing `dom_shim.rs::tests` still pass (behavior preserved)
+- [ ] `cargo clippy --all-targets -- -D warnings` clean for the `native/vtz` crate
+- [ ] `cargo fmt --all -- --check` clean
+- [ ] `cargo test --all` green
+
+---
+
+### Task 1.3: Re-run handler-reachability grep, fail CI on unclassified hits
+
+**Files:** (2)
+- `scripts/audit-window-document-refs.sh` (new — bash script)
+- `.github/workflows/ci.yml` (modified — add one step that invokes the script)
+
+**What to implement:**
+
+A shell script that greps for unguarded module-level references to `window.`, `document.`, `location.`, `history.` in a curated set of packages transitively reachable from server handlers:
+
+```bash
+#!/usr/bin/env bash
+# scripts/audit-window-document-refs.sh
+# Fails if any handler-reachable module has an unguarded top-level `window.X` or `document.X` access.
+set -euo pipefail
+
+PACKAGES=(
+  "packages/ui/src"
+  "packages/server/src"
+  "packages/agents/src"
+  "packages/forms/src"
+  "packages/codegen/src"
+  "packages/ui-server/src"
+)
+
+# Allowlist of expected FN-GATED references (see plans/2760-browser-detection-fix.md audit table).
+# Any hit NOT in this list causes the script to fail.
+ALLOWLIST_REGEX='(env/is-browser\.ts|router/reactive-search-params\.ts|router/view-transitions\.ts|router/navigate\.ts|router/server-nav\.ts|auth/auth-context\.ts|auth/create-access-provider\.ts|query/query\.ts)'
+
+# find hits, excluding __tests__ and .test.ts files, excluding node_modules
+hits=$(grep -rn -E '(window|document|location|history)\.' "${PACKAGES[@]}" \
+  --include='*.ts' --include='*.tsx' \
+  --exclude-dir=__tests__ --exclude-dir=node_modules \
+  | grep -v '\.test\.ts' \
+  | grep -v -E "$ALLOWLIST_REGEX" \
+  || true)
+
+if [ -n "$hits" ]; then
+  echo "::error::Unclassified handler-reachable DOM references found:"
+  echo "$hits"
+  echo "Add the file to the allowlist in scripts/audit-window-document-refs.sh (after reviewing)"
+  echo "or refactor to gate with isBrowser() / typeof X !== 'undefined'."
+  exit 1
+fi
+echo "Handler-reachable DOM reference audit: OK"
+```
+
+And CI workflow:
+```yaml
+- name: Audit handler-reachable DOM references
+  run: bash scripts/audit-window-document-refs.sh
+```
+
+**Acceptance criteria:**
+- [ ] Script is executable and passes on the current tree (all existing references are either in the allowlist or in `__tests__`)
+- [ ] Script fails if a new file references `window.X` at top level without `typeof` guard (verify by temporarily adding a test fixture, then reverting)
+- [ ] CI step runs in the standard PR workflow
+
+---
+
+## Quality Gates
+
+Before merging Phase 1:
+- `cargo test --all` (Rust tests pass)
+- `cargo clippy --all-targets -- -D warnings` (no warnings)
+- `cargo fmt --all -- --check` (format clean)
+- `vtz test` (TS tests unchanged)
+- `vtz run typecheck` (unchanged)
+- `vtz run lint` (unchanged)
+- `bash scripts/audit-window-document-refs.sh` (new — passes)
+
+## Adversarial Review
+
+After Phase 1 green, spawn a review agent to verify:
+- Install/uninstall function bodies exactly match design (no drift)
+- CSS collector state on `globalThis` is non-enumerable and non-configurable where specified
+- Eager install at end of permanent block preserves today's behavior (no user-visible regression)
+- Audit script does not have false positives (won't block an unrelated PR touching an ok file)
+
+Write review to `reviews/2760-browser-detection-fix/phase-01-split-dom-shim.md`.

--- a/plans/2760-browser-detection-fix/phase-02-wire-dispatch.md
+++ b/plans/2760-browser-detection-fix/phase-02-wire-dispatch.md
@@ -1,0 +1,221 @@
+# Phase 2: Wire install/uninstall into SSR dispatch + fix fetch interceptor
+
+## Context
+
+Phase 1 defined `globalThis.__vertz_install_dom_shim()` and `__vertz_uninstall_dom_shim()` but still eagerly installs the DOM shim at snapshot time to preserve current behavior. This phase removes the eager install, wires install/uninstall around the two JS dispatch points in `native/vtz/src/runtime/persistent_isolate.rs`, and fixes the fetch interceptor so it no longer depends on `location` being installed at startup.
+
+**Design reference:** `plans/2760-browser-detection-fix.md`, sections "Where install/uninstall is called (correct hook location)" and "Fetch interceptor dependency on `location`".
+
+**Key design points:**
+- The two dispatch functions — `dispatch_ssr_request` (line 1358) and `dispatch_component_render` (line 1670) — must call `__vertz_install_dom_shim()` **before** the first JS execution and `__vertz_uninstall_dom_shim()` **after** the event loop returns, including on error and timeout paths.
+- Use `scopeguard::defer!` (already a runtime dependency, verify in `native/vtz/Cargo.toml`) for cleanup that runs on every return path. If not present, add it or use manual `let _guard = ...` with a Drop impl.
+- The fetch interceptor in `native/vtz/src/runtime/js_runtime.rs` (around line 1137) reads `globalThis.location.origin` at install time. Change to read `globalThis.location?.origin ?? null` lazily inside the fetch hook so it works whether `location` is installed or not.
+
+At end of Phase 2, the production snapshot no longer has `window`/`document`/etc. installed eagerly. Running `typeof window` in a fresh runtime returns `"undefined"`. SSR renders continue to work because install is called inside dispatch. Server handlers see the clean env.
+
+## Tasks
+
+### Task 2.1: Write Rust tests proving handler context sees no browser globals (RED)
+
+**Files:** (1)
+- `native/vtz/src/runtime/__tests__/clean_handler_env_test.rs` (new — if the `__tests__` directory doesn't exist, create it and register via `#[cfg(test)] mod __tests__;` in `mod.rs` per existing Rust test conventions in this crate)
+
+**What to implement:**
+
+Write failing tests that simulate a handler-like context: a fresh production runtime with no prior SSR render.
+
+```rust
+#[tokio::test]
+async fn test_fresh_runtime_has_no_window() {
+    let mut rt = VertzJsRuntime::new_for_production(VertzRuntimeOptions::default()).unwrap();
+    let result = rt.execute_script("<t>", "typeof window").unwrap();
+    assert_eq!(result.to_rust_string(), "undefined");
+}
+
+#[tokio::test]
+async fn test_fresh_runtime_has_no_document() {
+    // typeof document === 'undefined'
+}
+
+#[tokio::test]
+async fn test_fresh_runtime_has_no_html_element() {
+    // typeof HTMLElement === 'undefined'
+}
+
+#[tokio::test]
+async fn test_fresh_runtime_has_navigator() {
+    // typeof navigator === 'object' && navigator.userAgent contains 'vertz-server'
+}
+
+#[tokio::test]
+async fn test_css_collector_exists_without_install() {
+    // typeof globalThis.__vertz_inject_css === 'function'
+    // __vertz_get_collected_css() returns []
+}
+```
+
+These fail after Phase 1 because the eager install at the end of the permanent block still runs at snapshot time.
+
+**Acceptance criteria:**
+- [ ] Tests compile
+- [ ] Tests fail with the message "typeof window is 'object', expected 'undefined'" (or similar) — proving the eager install is still active after Phase 1
+
+---
+
+### Task 2.2: Remove eager install, keep install/uninstall registration (GREEN for 2.1)
+
+**Files:** (1)
+- `native/vtz/src/ssr/dom_shim.rs` (modified — remove the final `globalThis.__vertz_install_dom_shim();` call from the permanent block; keep the function registrations)
+
+**What to implement:**
+
+Delete the single line at the end of `DOM_SHIM_JS` that calls `__vertz_install_dom_shim()`. The install/uninstall functions remain registered; they're just not invoked at snapshot time anymore.
+
+**Acceptance criteria:**
+- [ ] All Task 2.1 tests pass
+- [ ] Task 1.1 tests still pass (install/uninstall functions still registered)
+- [ ] SSR tests in `native/vtz/src/ssr/` fail OR pass depending on whether they explicitly call install — this is expected; Task 2.3 re-greens them
+- [ ] `cargo test --all` is NOT fully green yet — existing SSR tests that rely on eager install fail. This is expected and fixed in Task 2.3.
+
+---
+
+### Task 2.3: Wire install/uninstall into `dispatch_ssr_request` and `dispatch_component_render`
+
+**Files:** (2)
+- `native/vtz/src/runtime/persistent_isolate.rs` (modified — wrap dispatch bodies)
+- `native/vtz/Cargo.toml` (modified only if `scopeguard` isn't already a dependency)
+
+**What to implement:**
+
+In `dispatch_ssr_request` (around line 1358) and `dispatch_component_render` (around line 1670), add:
+
+```rust
+// Install DOM shim for this render. Uninstall on every return path.
+runtime.execute_script_void("<dom-install>", "globalThis.__vertz_install_dom_shim();")
+    .map_err(|e| format!("DOM shim install error: {}", e))?;
+
+// Use a guard so uninstall runs even on error/timeout.
+let uninstall = scopeguard::guard(&mut *runtime, |rt| {
+    // Best-effort; ignore errors during teardown.
+    let _ = rt.execute_script_void("<dom-uninstall>", "globalThis.__vertz_uninstall_dom_shim();");
+});
+// … existing dispatch body uses `uninstall` as the runtime reference …
+```
+
+OR, if `scopeguard` isn't desired, manual pattern:
+
+```rust
+async fn dispatch_ssr_request(runtime: &mut VertzJsRuntime, request: &SsrRequest) -> Result<SsrResponse, String> {
+    runtime.execute_script_void("<dom-install>", "globalThis.__vertz_install_dom_shim();")
+        .map_err(|e| format!("DOM shim install: {}", e))?;
+
+    let result = dispatch_ssr_request_inner(runtime, request).await;
+
+    let _ = runtime.execute_script_void("<dom-uninstall>", "globalThis.__vertz_uninstall_dom_shim();");
+    result
+}
+```
+
+The inner function contains today's body. This pattern works with existing `?` early returns without needing `scopeguard`.
+
+**Acceptance criteria:**
+- [ ] `dispatch_ssr_request` calls install before first JS exec and uninstall before returning (all paths)
+- [ ] `dispatch_component_render` same
+- [ ] All existing `persistent_isolate.rs` tests pass
+- [ ] Task 1.1 and Task 2.1 tests still pass
+- [ ] Add a new test: `test_ssr_render_leaves_no_browser_globals` — runs a real minimal SSR, asserts `typeof window` is undefined after
+
+---
+
+### Task 2.4: Fix fetch interceptor to read `location` lazily
+
+**Files:** (1)
+- `native/vtz/src/runtime/js_runtime.rs` (modified — inside `FETCH_INTERCEPTOR_JS` string, change eager `selfOrigin` capture to lazy-per-call)
+
+**What to implement:**
+
+Locate the line in `FETCH_INTERCEPTOR_JS` that currently reads:
+
+```js
+const selfOrigin = typeof globalThis.location !== 'undefined' ? globalThis.location.origin : '';
+```
+
+Change it to be read inside the fetch wrapper:
+
+```js
+function __vertz_self_origin() {
+  return typeof globalThis.location !== 'undefined' && globalThis.location
+    ? globalThis.location.origin
+    : null;
+}
+// then inside the interceptor:
+const selfOrigin = __vertz_self_origin();
+// … use selfOrigin as before, treating null the same as '' for the same-origin check.
+```
+
+Add a test to `js_runtime.rs::tests` (or a new `fetch_interceptor_lazy_location_test.rs`):
+
+```rust
+#[test]
+fn test_fetch_interceptor_works_with_no_location() {
+    // Fresh production runtime (no location installed).
+    // Invoke fetch to a known URL. Assert the interceptor does not throw
+    // and routes to the handler path (no self-origin short-circuit).
+}
+
+#[test]
+fn test_fetch_interceptor_reads_location_when_installed() {
+    // Install DOM shim → location defined with origin 'http://localhost'.
+    // Invoke fetch to 'http://localhost/api/foo' → should be classified as same-origin.
+}
+```
+
+**Acceptance criteria:**
+- [ ] Fetch interceptor no longer reads `globalThis.location` at install time (only inside the wrapped fetch call)
+- [ ] New tests pass
+- [ ] Pre-existing fetch interceptor tests still pass
+
+---
+
+### Task 2.5: Ensure test snapshot and tests call install where they expect DOM globals
+
+**Files:** (1)
+- `native/vtz/src/ssr/dom_shim.rs` (modified — update the `tests` module; existing tests like `test_window_is_defined` must now call `__vertz_install_dom_shim()` before asserting `window` is defined)
+
+**What to implement:**
+
+Scan `native/vtz/src/ssr/dom_shim.rs::tests` and any `native/vtz/src/ssr/*_test.rs` files. Tests that expect `window`, `document`, or DOM constructors to exist must call:
+
+```rust
+rt.execute_script_void("<install>", "globalThis.__vertz_install_dom_shim();").unwrap();
+```
+
+before their assertion. Do NOT delete tests — migrate them. Tests that assert the absence of globals (from Task 2.1) stay as-is.
+
+**Acceptance criteria:**
+- [ ] `cargo test --all` fully green
+- [ ] `cargo clippy --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --all -- --check` clean
+
+---
+
+## Quality Gates
+
+Before merging Phase 2:
+- `cargo test --all` green
+- `cargo clippy --all-targets -- -D warnings` clean
+- `cargo fmt --all -- --check` clean
+- `vtz test` green (TS tests unaffected; we haven't touched TypeScript yet)
+- `vtz run typecheck` clean
+- `vtz run lint` clean
+- `bash scripts/audit-window-document-refs.sh` clean
+
+## Adversarial Review
+
+After Phase 2 green, review must verify:
+- Every early-return path in `dispatch_ssr_request` and `dispatch_component_render` is covered by the uninstall (test with a deliberately-thrown error in render code)
+- Timeout path (the `EVENT_LOOP_TIMEOUT` tokio::time::timeout) also runs uninstall — important for not leaking state across subsequent renders
+- Fetch interceptor change does not break same-origin detection for CSS/asset URLs served by the dev server
+- `__vertz_install_dom_shim()` called from inside a render that awaits a long-running operation still correctly holds `window` defined for the entire render (serialization at the message level, not the promise level)
+
+Write review to `reviews/2760-browser-detection-fix/phase-02-wire-dispatch.md`.

--- a/plans/2760-browser-detection-fix/phase-03-integration-tests-docs.md
+++ b/plans/2760-browser-detection-fix/phase-03-integration-tests-docs.md
@@ -1,0 +1,225 @@
+# Phase 3: TypeScript integration test with real Anthropic SDK + docs + changeset
+
+## Context
+
+Phases 1 and 2 landed the runtime change. Phase 3 proves end-to-end that a Vertz server handler can now instantiate `@anthropic-ai/sdk` without `dangerouslyAllowBrowser`, documents the server-environment guarantee, and adds a changeset.
+
+**Design reference:** `plans/2760-browser-detection-fix.md`, "E2E Acceptance Test" section.
+
+## Tasks
+
+### Task 3.1: Add `@anthropic-ai/sdk` as a dev dependency of integration-tests
+
+**Files:** (2)
+- `packages/integration-tests/package.json` (modified — add `@anthropic-ai/sdk` to `devDependencies`; pin to a version with stable browser-check semantics, e.g. `^0.88.0`)
+- `vertz.lock` (modified — will update automatically via `vtz install`)
+
+**What to implement:**
+
+```bash
+cd packages/integration-tests && vtz add @anthropic-ai/sdk --dev
+```
+
+Verify:
+- Lock file updates
+- `vtz install` from repo root succeeds
+
+**Acceptance criteria:**
+- [ ] `@anthropic-ai/sdk` appears in `packages/integration-tests/package.json` under `devDependencies`
+- [ ] `vertz.lock` is updated and committed
+- [ ] `vtz install` is idempotent after the change
+
+---
+
+### Task 3.2: Integration test: handler constructs Anthropic SDK without the flag (RED→GREEN)
+
+**Files:** (1)
+- `packages/integration-tests/src/__tests__/server-clean-env.test.ts` (new)
+
+**What to implement:**
+
+Write a test that boots the Vertz server in a test harness, registers a handler that constructs `new Anthropic({ apiKey })`, and asserts the construction does not throw. Do NOT make a real API call — we're only testing the environment check.
+
+```ts
+import { describe, it, expect } from '@vertz/testing';
+import { createTestServer } from '@vertz/testing';
+
+describe('Feature: server handlers see a Worker-like environment', () => {
+  describe('Given a handler evaluates typeof window', () => {
+    it('then the result is "undefined"', async () => {
+      const server = await createTestServer({
+        handlers: {
+          typeOfWindow: async () => typeof window,
+        },
+      });
+      const result = await server.invoke('typeOfWindow');
+      expect(result).toBe('undefined');
+      await server.close();
+    });
+  });
+
+  describe('Given a handler constructs @anthropic-ai/sdk', () => {
+    it('then construction succeeds without dangerouslyAllowBrowser', async () => {
+      const server = await createTestServer({
+        handlers: {
+          construct: async () => {
+            const Anthropic = (await import('@anthropic-ai/sdk')).default;
+            const client = new Anthropic({ apiKey: 'test-key' });
+            return !!client;
+          },
+        },
+      });
+      const result = await server.invoke('construct');
+      expect(result).toBe(true);
+      await server.close();
+    });
+  });
+
+  describe('Given a handler evaluates typeof document', () => {
+    it('then the result is "undefined"', async () => {
+      const server = await createTestServer({
+        handlers: {
+          typeOfDocument: async () => typeof document,
+        },
+      });
+      const result = await server.invoke('typeOfDocument');
+      expect(result).toBe('undefined');
+      await server.close();
+    });
+  });
+});
+```
+
+**Important:** Follow `.claude/rules/integration-test-safety.md`. If the test uses a real server port, WebSocket, or file watcher, use the patterns in that doc (afterEach cleanup, timeouts on waits, `.local.ts` suffix if CI-unsafe).
+
+If `createTestServer` does not exist, study how existing integration tests boot handlers (see `packages/integration-tests/src/__tests__/` for conventions) and either add a minimal test harness or invoke the runtime directly.
+
+**Acceptance criteria:**
+- [ ] Test compiles and runs via `vtz test packages/integration-tests/src/__tests__/server-clean-env.test.ts`
+- [ ] Before Phase 1+2 changes, the `construct` test would fail with the "browser-like environment" error (verify by temporarily reverting the change on a local branch, optional)
+- [ ] After Phase 1+2 changes, all three tests pass
+- [ ] Test cleans up resources in `afterEach` per integration-test-safety rules
+
+---
+
+### Task 3.3: Update Mintlify docs
+
+**Files:** (2)
+- `packages/mint-docs/guides/server/environment.mdx` (new OR modified — if a "Server environment" page exists, update it; otherwise create)
+- `packages/mint-docs/docs.json` (modified only if adding a new page to the nav)
+
+**What to implement:**
+
+Add a short page or section describing the server runtime environment:
+
+```mdx
+---
+title: Server Environment
+description: What globals and APIs are available in Vertz server handlers
+---
+
+Vertz server handlers run in a Cloudflare-Workers-compatible JavaScript
+environment. What you can rely on:
+
+**Available:**
+- `fetch`, `URL`, `URLSearchParams`, `Request`, `Response`, `Headers`, `AbortController`
+- `navigator.userAgent` (identifies the Vertz server)
+- `crypto`, `performance`, `setTimeout`, `queueMicrotask`
+- Standard ECMAScript: `Promise`, `Map`, `Set`, `WeakMap`, `Intl`, etc.
+- Vertz APIs: `service()`, `entity()`, and everything in `@vertz/server`
+
+**Not available (by design):**
+- `window`, `document`, `HTMLElement`, `Element`, `Node` and other DOM APIs
+- `location`, `history`, `localStorage`, `sessionStorage`
+
+### Using third-party SDKs
+
+Because server handlers do not expose browser globals, SDKs that gate on
+`typeof window !== 'undefined'` (such as `@anthropic-ai/sdk`, `openai`, or
+`stripe`) work out of the box — no `dangerouslyAllowBrowser: true` flag
+required.
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { service } from '@vertz/server';
+
+export default service({
+  summarize: async ({ text }: { text: string }) => {
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+    // Just works — no browser flag needed.
+    return client.messages.create({ /* … */ });
+  },
+});
+```
+
+### Why this matters
+
+If you previously worked around this by passing `dangerouslyAllowBrowser:
+true`, you can now remove that flag. The flag disables a legitimate safety
+check that prevents API keys from leaking into client bundles — keeping it
+enabled in a handler is confusing and unsafe if the file is ever imported
+by client code.
+```
+
+**Acceptance criteria:**
+- [ ] Page renders in the Mintlify preview
+- [ ] Nav includes the page under Server / Environment (if docs.json needs updating)
+- [ ] Content aligns with the final behavior (no aspirational APIs mentioned)
+
+---
+
+### Task 3.4: Add changeset
+
+**Files:** (1)
+- `.changeset/fix-server-browser-detection.md` (new)
+
+**What to implement:**
+
+```markdown
+---
+'@vertz/core': patch
+---
+
+fix(runtime): server handlers no longer expose browser globals (`window`,
+`document`, etc.), so SDKs like `@anthropic-ai/sdk` work without
+`dangerouslyAllowBrowser: true` [#2760]
+```
+
+Identify the correct package(s) to attribute the patch to. If the change is in the `vtz` runtime binary, the appropriate frontend package to mark may be `@vertz/cli-runtime`, `@vertz/runtime`, or both. Read `.changeset/config.json` to understand which packages participate in versioning and pick accordingly.
+
+**Acceptance criteria:**
+- [ ] Changeset file created with `patch` bump
+- [ ] Correct package names referenced (verify against `.changeset/config.json`)
+- [ ] Issue #2760 linked in the message
+
+---
+
+## Quality Gates
+
+Before final PR:
+- Full monorepo: `vtz test && vtz run typecheck && vtz run lint`
+- Full Rust: `cd native && cargo test --all && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`
+- `bash scripts/audit-window-document-refs.sh` clean
+
+## Adversarial Review
+
+After Phase 3 green, review must verify:
+- Integration test actually fails with an untouched `dom_shim.rs` (briefly test by stashing the change, running the test, and confirming the "browser-like environment" error)
+- Docs accurately describe the final behavior (e.g. if `navigator` is kept, the docs must say so; if `URL` and `URLSearchParams` come from deno_core not the shim, the docs shouldn't misattribute them)
+- Changeset bumps the right packages
+
+Write review to `reviews/2760-browser-detection-fix/phase-03-integration-tests-docs.md`.
+
+## Post-Phase-3: Final PR
+
+1. Rebase `viniciusdacal/v8-browser-detection` on `origin/main`
+2. Re-run full quality gates after rebase
+3. Push with `-u origin`
+4. Open PR with title `fix(runtime): clean Node-like env for server handlers [#2760]`
+5. PR body includes:
+   - Public API Changes summary (none — internal runtime change)
+   - Summary of all three phases
+   - Links to per-phase review files
+   - E2E acceptance test status
+6. Monitor CI via `gh pr checks <pr-number> --watch` until green
+7. Notify the user only once CI is green

--- a/scripts/audit-window-document-refs.sh
+++ b/scripts/audit-window-document-refs.sh
@@ -14,13 +14,19 @@
 #     context (e.g. mount(), client-only components, test utilities)
 #   - File is in `src/test/` or `src/__tests__/` (explicitly client-side)
 #
+# The check is per-file, not per-line: adding a NEW file with any non-comment
+# `window.X` match fails the audit. An existing allowlisted file can add more
+# refs without tripping the audit — reviewing those belongs in code review.
+#
 # When a new file in one of the audited packages starts referencing a DOM
 # global, CI fails and the author must either:
-#   - Add a typeof guard (preferred), or
-#   - Explicitly add the file to this allowlist after reviewing why it's safe.
+#   - Move the reference behind a `typeof window !== 'undefined'` guard AND
+#     confirm no module-top-level access, then add the file to the allowlist
+#     with a justification, or
+#   - Refactor so the file no longer touches DOM globals.
 #
-# This is intentionally conservative: passing the audit does NOT prove a file
-# is correct, only that the set of files touching DOM globals has not grown.
+# Passing the audit does NOT prove a file is correct, only that the set of
+# files touching DOM globals has not grown.
 
 set -euo pipefail
 
@@ -32,19 +38,16 @@ PACKAGES=(
   "packages/ui-server/src"
 )
 
-# Allowlist — files known to reference DOM globals today. Each one must be
-# either guarded (typeof check) or reachable only from client/test contexts.
-# When in doubt, prefer adding a `typeof` guard and leaving the file out.
+# Allowlist — files that currently reference DOM globals in non-comment code.
+# Each entry is a file that renders safely either because it gates access with
+# `typeof window !== 'undefined'` or because it only runs in a browser context
+# (mount paths, hydration entrypoints, dev/test utilities).
 ALLOWLIST=(
-  # Server-side (SSR / access bootstrap — setups global references during SSR)
-  "packages/server/src/auth/db-subscription-store.ts"
-  "packages/server/src/auth/resolve-session-for-ssr.ts"
-  "packages/server/src/create-server.ts"
+  # Server-side (SSR / access bootstrap — set up DOM globals during SSR)
   "packages/ui-server/src/build-plugin/state-inspector.ts"
   "packages/ui-server/src/dom-shim/index.ts"
   "packages/ui-server/src/node-handler.ts"
   "packages/ui-server/src/ssr-access-set.ts"
-  "packages/ui-server/src/ssr-aot-pipeline.ts"
   "packages/ui-server/src/ssr-handler.ts"
   "packages/ui-server/src/ssr-html.ts"
   "packages/ui-server/src/ssr-progressive-response.ts"
@@ -98,36 +101,74 @@ ALLOWLIST=(
 
 PATTERN='(^|[^A-Za-z_.$])(window|document|location|history)\.'
 
-# Build a set for fast lookup
 declare -A ALLOWED
 for f in "${ALLOWLIST[@]}"; do
   ALLOWED["$f"]=1
 done
 
-hits=""
-while IFS= read -r file; do
-  # Skip allowlisted files
+# Match line. Returns 0 (true) if the match at $line is a non-comment hit.
+# Filters out lines that are:
+#   - entirely a `//` single-line comment
+#   - block-comment continuation lines starting with `*` (JSDoc, /* ... */)
+#   - lines where the DOM ref only appears after a `//` comment marker
+is_real_hit() {
+  local line="$1"
+  # Strip leading whitespace
+  local trimmed="${line#"${line%%[![:space:]]*}"}"
+  # Lines starting with //, *, /*, or /** are comments.
+  case "$trimmed" in
+    //*|'*'*|'/*'*) return 1 ;;
+  esac
+  # If the match appears only AFTER a // on the same line, treat as comment
+  local before_comment="${line%%//*}"
+  if [[ "$before_comment" != "$line" ]]; then
+    if ! echo "$before_comment" | grep -qE "$PATTERN"; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+declare -A OFFENDERS=()
+
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  file="${hit%%:*}"
+  rest="${hit#*:}"
+  # rest is LINENO:CONTENT
+  content="${rest#*:}"
+
   if [[ -n "${ALLOWED[$file]:-}" ]]; then
     continue
   fi
-  # Skip test files (matched by name suffix)
   case "$file" in
     *.test.ts|*.test-d.ts|*.test.tsx) continue ;;
   esac
-  hits+="$file"$'\n'
-done < <(grep -rlE "$PATTERN" "${PACKAGES[@]}" \
+  if is_real_hit "$content"; then
+    OFFENDERS["$file"]=1
+  fi
+done < <(grep -rnE "$PATTERN" "${PACKAGES[@]}" \
   --include='*.ts' --include='*.tsx' \
   --exclude-dir=__tests__ --exclude-dir=node_modules \
   2>/dev/null || true)
 
-if [ -n "$hits" ]; then
+offender_count=${#OFFENDERS[@]}
+if [ "$offender_count" -gt 0 ]; then
   echo "::error::New handler-reachable DOM references found:"
-  echo "$hits" | sed 's/^/  /'
+  for file in "${!OFFENDERS[@]}"; do
+    echo "  $file"
+  done | sort
   echo ""
-  echo "Either:"
-  echo "  1. Gate the reference with 'typeof window !== \"undefined\"' (preferred), or"
-  echo "  2. After reviewing why the file is safe, add it to the ALLOWLIST in"
-  echo "     scripts/audit-window-document-refs.sh."
+  echo "Server handlers run in a Worker-like V8 context without 'window',"
+  echo "'document', 'location', or 'history'. Any module evaluated at load"
+  echo "time that touches these globals will crash the handler."
+  echo ""
+  echo "Options:"
+  echo "  1. Refactor the file so it doesn't reference DOM globals."
+  echo "  2. Ensure every reference is behind a 'typeof window !== \"undefined\"'"
+  echo "     guard (or lives inside a function only called in the browser),"
+  echo "     then add the file to the ALLOWLIST in"
+  echo "     scripts/audit-window-document-refs.sh with a one-line rationale."
   exit 1
 fi
 

--- a/scripts/audit-window-document-refs.sh
+++ b/scripts/audit-window-document-refs.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Audit unguarded `window.` / `document.` / `location.` / `history.` references
+# in packages that are transitively reachable from server handlers.
+#
+# After #2760, server handlers run in a clean Worker-like V8 context with no
+# browser globals. If a handler imports a module that evaluates `window.foo` at
+# module load, it will crash. This script is a trip-wire for accidental new
+# references.
+#
+# The ALLOWLIST below is a snapshot of files that currently reference DOM
+# globals. Each entry has been audited for one of:
+#   - `typeof window !== 'undefined'` / `typeof document !== 'undefined'` guard
+#   - Reference lives inside a function body that only runs in a real browser
+#     context (e.g. mount(), client-only components, test utilities)
+#   - File is in `src/test/` or `src/__tests__/` (explicitly client-side)
+#
+# When a new file in one of the audited packages starts referencing a DOM
+# global, CI fails and the author must either:
+#   - Add a typeof guard (preferred), or
+#   - Explicitly add the file to this allowlist after reviewing why it's safe.
+#
+# This is intentionally conservative: passing the audit does NOT prove a file
+# is correct, only that the set of files touching DOM globals has not grown.
+
+set -euo pipefail
+
+PACKAGES=(
+  "packages/ui/src"
+  "packages/server/src"
+  "packages/agents/src"
+  "packages/codegen/src"
+  "packages/ui-server/src"
+)
+
+# Allowlist — files known to reference DOM globals today. Each one must be
+# either guarded (typeof check) or reachable only from client/test contexts.
+# When in doubt, prefer adding a `typeof` guard and leaving the file out.
+ALLOWLIST=(
+  # Server-side (SSR / access bootstrap — setups global references during SSR)
+  "packages/server/src/auth/db-subscription-store.ts"
+  "packages/server/src/auth/resolve-session-for-ssr.ts"
+  "packages/server/src/create-server.ts"
+  "packages/ui-server/src/build-plugin/state-inspector.ts"
+  "packages/ui-server/src/dom-shim/index.ts"
+  "packages/ui-server/src/node-handler.ts"
+  "packages/ui-server/src/ssr-access-set.ts"
+  "packages/ui-server/src/ssr-aot-pipeline.ts"
+  "packages/ui-server/src/ssr-handler.ts"
+  "packages/ui-server/src/ssr-html.ts"
+  "packages/ui-server/src/ssr-progressive-response.ts"
+  "packages/ui-server/src/ssr-session.ts"
+  "packages/ui-server/src/ssr-single-pass.ts"
+  "packages/ui-server/src/ssr-streaming-runtime.ts"
+  "packages/ui-server/src/template-chunk.ts"
+  "packages/ui-server/src/template-inject.ts"
+
+  # @vertz/ui — auth/session/access (typeof-guarded or client-only)
+  "packages/ui/src/auth/access-event-client.ts"
+  "packages/ui/src/auth/auth-context.ts"
+  "packages/ui/src/auth/create-access-provider.ts"
+  "packages/ui/src/auth/token-refresh.ts"
+
+  # @vertz/ui — component / rendering (client-only execution paths)
+  "packages/ui/src/component/children.ts"
+  "packages/ui/src/component/default-error-fallback.ts"
+  "packages/ui/src/component/presence.ts"
+  "packages/ui/src/css/css.ts"
+  "packages/ui/src/dialog/dialog-stack.ts"
+  "packages/ui/src/dom/dom-adapter.ts"
+  "packages/ui/src/dom/element.ts"
+  "packages/ui/src/dom/list-value.ts"
+  "packages/ui/src/format/relative-time-component.ts"
+  "packages/ui/src/hydrate/hydrate.ts"
+  "packages/ui/src/hydrate/hydration-context.ts"
+  "packages/ui/src/hydrate/island-hydrate.ts"
+  "packages/ui/src/image/image.ts"
+  "packages/ui/src/island/island.ts"
+  "packages/ui/src/jsx-runtime.ts"
+  "packages/ui/src/jsx-runtime/index.ts"
+  "packages/ui/src/mount.ts"
+  "packages/ui/src/ssr/ssr-render-context.ts"
+
+  # @vertz/ui — query / router (typeof-guarded)
+  "packages/ui/src/query/query.ts"
+  "packages/ui/src/query/ssr-hydration.ts"
+  "packages/ui/src/router/link.ts"
+  "packages/ui/src/router/navigate.ts"
+  "packages/ui/src/router/reactive-search-params.ts"
+  "packages/ui/src/router/server-nav.ts"
+  "packages/ui/src/router/view-transitions.ts"
+
+  # @vertz/ui — test utilities (never imported by server handlers)
+  "packages/ui/src/test/interactions.ts"
+  "packages/ui/src/test/queries.ts"
+  "packages/ui/src/test/render-test.ts"
+  "packages/ui/src/test/test-router.ts"
+)
+
+PATTERN='(^|[^A-Za-z_.$])(window|document|location|history)\.'
+
+# Build a set for fast lookup
+declare -A ALLOWED
+for f in "${ALLOWLIST[@]}"; do
+  ALLOWED["$f"]=1
+done
+
+hits=""
+while IFS= read -r file; do
+  # Skip allowlisted files
+  if [[ -n "${ALLOWED[$file]:-}" ]]; then
+    continue
+  fi
+  # Skip test files (matched by name suffix)
+  case "$file" in
+    *.test.ts|*.test-d.ts|*.test.tsx) continue ;;
+  esac
+  hits+="$file"$'\n'
+done < <(grep -rlE "$PATTERN" "${PACKAGES[@]}" \
+  --include='*.ts' --include='*.tsx' \
+  --exclude-dir=__tests__ --exclude-dir=node_modules \
+  2>/dev/null || true)
+
+if [ -n "$hits" ]; then
+  echo "::error::New handler-reachable DOM references found:"
+  echo "$hits" | sed 's/^/  /'
+  echo ""
+  echo "Either:"
+  echo "  1. Gate the reference with 'typeof window !== \"undefined\"' (preferred), or"
+  echo "  2. After reviewing why the file is safe, add it to the ALLOWLIST in"
+  echo "     scripts/audit-window-document-refs.sh."
+  exit 1
+fi
+
+echo "Handler-reachable DOM reference audit: OK"

--- a/scripts/audit-window-document-refs.sh
+++ b/scripts/audit-window-document-refs.sh
@@ -99,7 +99,13 @@ ALLOWLIST=(
   "packages/ui/src/test/test-router.ts"
 )
 
-PATTERN='(^|[^A-Za-z_.$])(window|document|location|history)\.'
+# Matches:
+#   - Dotted access:  foo.window.bar, document.body, !location, history.back()
+#   - Bracket access: globalThis['window'], obj["document"]
+# Does NOT catch destructuring (`const { window } = ...`), dynamic keys, or
+# type-cast bypasses (`(g as any).window`). The trip-wire leaves those to
+# human review — the goal is to make the easy/accidental references fail CI.
+PATTERN='(^|[^A-Za-z_.$])(window|document|location|history)\.|\[["'"'"'](window|document|location|history)["'"'"']\]'
 
 declare -A ALLOWED
 for f in "${ALLOWLIST[@]}"; do


### PR DESCRIPTION
## Summary

Closes #2760.

Server handlers (entity actions, service actions, middleware, auth resolvers, route loaders) now run in a Workers-compatible context that does **not** expose `window`, `document`, `location`, `history`, or DOM globals. Only the SSR render boundary runs under a scoped DOM shim, installed before the matched route renders and removed immediately after.

This makes third-party SDKs that gate on `typeof window !== 'undefined'` (such as `@anthropic-ai/sdk`, `openai`, `stripe`) work in server handlers **without** `dangerouslyAllowBrowser: true`.

## Public API Changes

- **None.** This is an internal runtime change. No package exports changed.
- **Behavior change:** handlers no longer see browser globals. Code that accidentally relied on `window` / `document` being defined in a handler will now throw `ReferenceError` — which is the correct Workers-parity behavior.

## How it works

- The DOM shim is split into two blocks: a **permanent** block for values that are always safe (`navigator.userAgent`) and a **scoped** block installed/uninstalled around each SSR render (`window`, `document`, `location`, `history`, etc.).
- Two new host functions (`__vertz_install_dom_shim` / `__vertz_uninstall_dom_shim`) are called by the SSR render path only.
- The HTTP/API dispatch path does **not** install the shim, so handlers invoked through `/api/...` from the browser, form submissions, or any non-SSR entry point see `typeof window === 'undefined'`.

## Phases

All phases implemented with strict TDD. Reviews are in `reviews/2760-browser-detection-fix/` (not committed — working artifacts only).

1. **Phase 1 — split DOM shim into permanent + scoped blocks** (commit [`1069bc4a8`](https://github.com/vertz-dev/vertz/commit/1069bc4a8)). No behavior change; refactor only. Adds the install/uninstall primitives.
2. **Phase 2 — wire SSR render boundary** (commits [`1c318fe58`](https://github.com/vertz-dev/vertz/commit/1c318fe58), [`e9df3251b`](https://github.com/vertz-dev/vertz/commit/e9df3251b)). Install the scoped shim before SSR, uninstall after; handlers dispatched via the top-level HTTP path run clean.
3. **Phase 3 — integration tests, docs, changeset** (commits [`70feb0312`](https://github.com/vertz-dev/vertz/commit/70feb0312), [`d5267223f`](https://github.com/vertz-dev/vertz/commit/d5267223f), [`2464080b7`](https://github.com/vertz-dev/vertz/commit/2464080b7)). Rust integration test asserts the exact `@anthropic-ai/sdk` browser-detection heuristic (`typeof window !== 'undefined' && typeof document !== 'undefined'`) evaluates to `false` in handler context after an SSR render completes. Docs guide added at `packages/mint-docs/guides/server/environment.mdx`. Audit script ignores JSDoc-only DOM refs.

## Review resolution

Adversarial review on Phase 3 flagged two blockers and both were addressed:

- **Blocker 1** — docs claimed `fetch('/api/...')` during SSR never sees the shim, but the current in-place interceptor dispatches handler calls while the shim is still installed. Fixed: the "SSR vs. handlers" section now honestly describes the edge case and recommends module-scope SDK construction or keeping SDK calls in client-triggered actions.
- **Blocker 2** — changeset targeted `@vertz/cli-runtime` (private). Fixed: changeset now targets `@vertz/runtime` (public, ships the `vtz` binary).

See per-phase review files in `reviews/2760-browser-detection-fix/` for full findings.

## E2E acceptance test

`test_ssr_render_leaves_no_browser_globals_for_handler` in `native/vtz/src/runtime/persistent_isolate.rs`:

1. Installs the scoped DOM shim (simulating an SSR render).
2. Uninstalls it (simulating SSR teardown).
3. Dispatches a handler and asserts the exact SDK browser-detection heuristic evaluates to `false`.

Passing on the rebased branch (Rust + TS tests both green, lint clean, audit OK).

## Test plan

- [ ] Review the scoped DOM shim install/uninstall boundary in `native/vtz/src/runtime/persistent_isolate.rs`
- [ ] Verify the docs accurately describe the edge case (fetch during SSR)
- [ ] Confirm no existing handler code accidentally relies on `window` / `document` (would surface as test failures)
- [ ] Confirm changeset targets `@vertz/runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)