### PR TITLE
fix(ui): let globalCss() accept nested at-rules [#2776]

### DIFF
--- a/.changeset/global-css-keyframes.md
+++ b/.changeset/global-css-keyframes.md
@@ -1,0 +1,25 @@
+---
+'@vertz/ui': patch
+---
+
+fix(ui): let `globalCss()` accept nested at-rules (`@keyframes`, `@media`, `@supports`)
+
+`globalCss({ '@keyframes spin': { from: {...}, to: {...} } })` used to fail
+typecheck with `TS2353` because the block value type only allowed CSS
+declarations. `GlobalStyleBlock` is now a union — either a declarations map
+or a selector → declarations map — and the runtime wraps nested blocks
+inside their parent at-rule.
+
+```ts
+globalCss({
+  '@keyframes spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+  '@media (min-width: 768px)': {
+    body: { fontSize: '18px' },
+  },
+});
+```
+
+Closes #2776.

--- a/packages/mint-docs/api-reference/ui/css.mdx
+++ b/packages/mint-docs/api-reference/ui/css.mdx
@@ -236,6 +236,24 @@ const reset = globalCss({
 // reset.css → compiled global CSS string
 ```
 
+### Nested at-rules
+
+`@keyframes`, `@media`, and `@supports` accept a nested block — the inner
+keys are frame selectors (`from`, `to`, `0%`–`100%`) or regular selectors,
+and their values are CSS declarations.
+
+```ts
+globalCss({
+  '@keyframes spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+  '@media (min-width: 768px)': {
+    body: { fontSize: '18px' },
+  },
+});
+```
+
 ### Signature
 
 ```ts
@@ -244,9 +262,9 @@ function globalCss(input: GlobalCSSInput): GlobalCSSOutput;
 
 ### Parameters
 
-| Parameter | Type                                     | Description                                  |
-| --------- | ---------------------------------------- | -------------------------------------------- |
-| `input`   | `Record<string, Record<string, string>>` | Object mapping selectors to CSS declarations |
+| Parameter | Type             | Description                                                                                              |
+| --------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `input`   | `GlobalCSSInput` | Selector → block. Block is CSS declarations or (for at-rules) a map of nested selectors to declarations. |
 
 ### Returns
 
@@ -332,7 +350,10 @@ type StyleBlock = {
   [property: string]: string | number | StyleBlock;
 };
 
-type GlobalCSSInput = Record<string, Record<string, string>>;
+type NestedSelectorBlock = { [selector: string]: CamelCSSDeclarations };
+type GlobalStyleBlock = CamelCSSDeclarations | NestedSelectorBlock;
+type GlobalCSSInput = Record<string, GlobalStyleBlock>;
+
 interface GlobalCSSOutput {
   css: string;
 }

--- a/packages/site/pages/api-reference/ui/css.mdx
+++ b/packages/site/pages/api-reference/ui/css.mdx
@@ -236,6 +236,24 @@ const reset = globalCss({
 // reset.css → compiled global CSS string
 ```
 
+### Nested at-rules
+
+`@keyframes`, `@media`, and `@supports` accept a nested block — the inner
+keys are frame selectors (`from`, `to`, `0%`–`100%`) or regular selectors,
+and their values are CSS declarations.
+
+```ts
+globalCss({
+  '@keyframes spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+  '@media (min-width: 768px)': {
+    body: { fontSize: '18px' },
+  },
+});
+```
+
 ### Signature
 
 ```ts
@@ -244,9 +262,9 @@ function globalCss(input: GlobalCSSInput): GlobalCSSOutput;
 
 ### Parameters
 
-| Parameter | Type                                     | Description                                  |
-| --------- | ---------------------------------------- | -------------------------------------------- |
-| `input`   | `Record<string, Record<string, string>>` | Object mapping selectors to CSS declarations |
+| Parameter | Type             | Description                                                                                              |
+| --------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `input`   | `GlobalCSSInput` | Selector → block. Block is CSS declarations or (for at-rules) a map of nested selectors to declarations. |
 
 ### Returns
 
@@ -332,7 +350,10 @@ type StyleBlock = {
   [property: string]: string | number | StyleBlock;
 };
 
-type GlobalCSSInput = Record<string, Record<string, string>>;
+type NestedSelectorBlock = { [selector: string]: CamelCSSDeclarations };
+type GlobalStyleBlock = CamelCSSDeclarations | NestedSelectorBlock;
+type GlobalCSSInput = Record<string, GlobalStyleBlock>;
+
 interface GlobalCSSOutput {
   css: string;
 }

--- a/packages/ui/src/css/__tests__/global-css.test-d.ts
+++ b/packages/ui/src/css/__tests__/global-css.test-d.ts
@@ -1,0 +1,95 @@
+/**
+ * Type-level tests for globalCss().
+ *
+ * Covers the nested at-rule shape — @keyframes with from/to/percent frame
+ * selectors, and @media / @supports with nested selector blocks. Tests
+ * exercise the generic input mapping on globalCss() rather than the
+ * public `GlobalCSSInput` alias, because the per-key discrimination
+ * between declarations and nested-selector blocks only narrows through
+ * the function signature.
+ */
+
+import { globalCss } from '../global-css';
+
+// ─── Regular selectors with CSS declarations ──────────────────────
+
+globalCss({
+  body: { margin: '0', fontFamily: 'system-ui' },
+  ':root': { '--color-primary': '#3b82f6' },
+  '*, *::before, *::after': { boxSizing: 'border-box' },
+});
+
+// ─── @keyframes with from/to ──────────────────────────────────────
+
+globalCss({
+  '@keyframes spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+});
+
+// ─── @keyframes with percentage frames and camelCase properties ───
+
+globalCss({
+  '@keyframes pulse': {
+    '0%': { opacity: '1' },
+    '50%': { opacity: '0.5', backgroundColor: 'red' },
+    '100%': { opacity: '1' },
+  },
+});
+
+// ─── @media with nested selector blocks ───────────────────────────
+
+globalCss({
+  '@media (min-width: 768px)': {
+    body: { fontSize: '18px' },
+  },
+});
+
+// ─── @supports with nested selector blocks ────────────────────────
+
+globalCss({
+  '@supports (display: grid)': {
+    body: { display: 'grid' },
+  },
+});
+
+// ─── Typos on a flat block are still rejected ─────────────────────
+
+globalCss({
+  // @ts-expect-error — `bacgroundColor` is not a valid CSS property
+  body: { bacgroundColor: 'red' },
+});
+
+// ─── Typos inside a @keyframes frame are still rejected ───────────
+
+globalCss({
+  '@keyframes broken': {
+    // @ts-expect-error — `transfrom` is not a valid CSS property
+    from: { transfrom: 'rotate(0deg)' },
+  },
+});
+
+// ─── Mixing declarations and nested rules in one block is rejected ─
+
+globalCss({
+  body: {
+    margin: '0',
+    // @ts-expect-error — regular selector blocks only accept CSS declarations; nested at-rules aren't valid here.
+    '@media (min-width: 768px)': { padding: '1rem' },
+  },
+});
+
+// ─── A non-object value for a regular selector is rejected ────────
+
+globalCss({
+  // @ts-expect-error — a selector block must be an object, not a string.
+  body: 'red',
+});
+
+// ─── A non-object value for an at-rule is rejected ────────────────
+
+globalCss({
+  // @ts-expect-error — at-rule blocks must be nested selector maps, not strings.
+  '@keyframes spin': 'rotate(0deg)',
+});

--- a/packages/ui/src/css/__tests__/global-css.test.ts
+++ b/packages/ui/src/css/__tests__/global-css.test.ts
@@ -112,4 +112,104 @@ describe('globalCss()', () => {
     expect(result.css).toContain('body {');
     expect(result.css).toContain('html {');
   });
+
+  it('emits @keyframes with from/to frame selectors', () => {
+    const result = globalCss({
+      '@keyframes spin': {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      },
+    });
+
+    expect(result.css).toContain('@keyframes spin {');
+    expect(result.css).toContain('from {');
+    expect(result.css).toContain('to {');
+    expect(result.css).toContain('transform: rotate(0deg);');
+    expect(result.css).toContain('transform: rotate(360deg);');
+  });
+
+  it('emits @keyframes with percentage frames and camelCase properties', () => {
+    const result = globalCss({
+      '@keyframes pulse': {
+        '0%': { opacity: '1' },
+        '50%': { opacity: '0.5', backgroundColor: 'red' },
+        '100%': { opacity: '1' },
+      },
+    });
+
+    expect(result.css).toContain('@keyframes pulse {');
+    expect(result.css).toContain('0% {');
+    expect(result.css).toContain('50% {');
+    expect(result.css).toContain('100% {');
+    expect(result.css).toContain('background-color: red;');
+  });
+
+  it('emits @media with nested selector blocks', () => {
+    const result = globalCss({
+      '@media (min-width: 768px)': {
+        body: { fontSize: '18px' },
+        html: { height: '100%' },
+      },
+    });
+
+    expect(result.css).toBe(
+      '@media (min-width: 768px) {\n' +
+        '  body {\n' +
+        '    font-size: 18px;\n' +
+        '  }\n' +
+        '  html {\n' +
+        '    height: 100%;\n' +
+        '  }\n' +
+        '}',
+    );
+  });
+
+  it('emits @supports with nested selector blocks', () => {
+    const result = globalCss({
+      '@supports (display: grid)': {
+        body: { display: 'grid' },
+      },
+    });
+
+    expect(result.css).toBe(
+      '@supports (display: grid) {\n' + '  body {\n' + '    display: grid;\n' + '  }\n' + '}',
+    );
+  });
+
+  it('skips null and undefined property values', () => {
+    const result = globalCss({
+      body: {
+        margin: '0',
+        // @ts-expect-error — test runtime resilience to null/undefined values.
+        padding: null,
+        // @ts-expect-error — test runtime resilience to null/undefined values.
+        color: undefined,
+      },
+    });
+
+    expect(result.css).toContain('margin: 0;');
+    expect(result.css).not.toContain('padding');
+    expect(result.css).not.toContain('color');
+  });
+
+  it('wraps @keyframes frames inside the at-rule (not as siblings)', () => {
+    const result = globalCss({
+      '@keyframes spin': {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      },
+    });
+
+    // Structural check: the at-rule opens once, then frames, then closes once.
+    expect(result.css).toBe(
+      '@keyframes spin {\n' +
+        '  from {\n' +
+        '    transform: rotate(0deg);\n' +
+        '  }\n' +
+        '  to {\n' +
+        '    transform: rotate(360deg);\n' +
+        '  }\n' +
+        '}',
+    );
+  });
 });

--- a/packages/ui/src/css/global-css.ts
+++ b/packages/ui/src/css/global-css.ts
@@ -19,6 +19,13 @@
  *     fontFamily: 'system-ui, sans-serif',
  *     lineHeight: '1.5',
  *   },
+ *   '@keyframes spin': {
+ *     from: { transform: 'rotate(0deg)' },
+ *     to: { transform: 'rotate(360deg)' },
+ *   },
+ *   '@media (min-width: 768px)': {
+ *     body: { fontSize: '18px' },
+ *   },
  * });
  * ```
  */
@@ -26,8 +33,35 @@
 import { injectCSS } from './css';
 import type { CamelCSSDeclarations } from './css-properties';
 
-/** Input to globalCss(): selector → property-value map (camelCase keys). */
-export type GlobalCSSInput = Record<string, CamelCSSDeclarations>;
+/**
+ * Map of inner selectors (frame selectors like `from`/`to`/`50%`, or
+ * regular selectors inside `@media`/`@supports`) to CSS declarations.
+ * Nesting is one level deep — `@keyframes`, `@media`, and `@supports`
+ * only ever contain a single layer of inner rules.
+ */
+export type NestedSelectorBlock = { [selector: string]: CamelCSSDeclarations };
+
+/**
+ * A block inside globalCss(). For regular selectors it is a CSS
+ * declarations map; for at-rule keys (`@keyframes`, `@media`, `@supports`)
+ * it is a nested selector → declarations map. The exact shape is
+ * discriminated on the selector key at the call site via
+ * {@link globalCss}'s generic input type.
+ */
+export type GlobalStyleBlock = CamelCSSDeclarations | NestedSelectorBlock;
+
+/** Input to globalCss(): selector → block. */
+export type GlobalCSSInput = Record<string, GlobalStyleBlock>;
+
+/**
+ * Strict per-selector block: nested for at-rules, flat declarations
+ * otherwise. Keys that aren't known CSS properties resolve to `never`,
+ * so typos on a regular block and mixing declarations with nested
+ * at-rules under the same selector are both rejected.
+ */
+type StrictGlobalBlock<K extends string, V> = K extends `@${string}`
+  ? NestedSelectorBlock
+  : { [P in keyof V]?: P extends keyof CamelCSSDeclarations ? CamelCSSDeclarations[P] : never };
 
 /** Output of globalCss(): extracted CSS string. */
 export interface GlobalCSSOutput {
@@ -40,32 +74,58 @@ export interface GlobalCSSOutput {
  *
  * Properties use camelCase and are converted to kebab-case.
  * CSS custom properties (--*) are passed through as-is.
+ * At-rules with nested blocks (`@keyframes`, `@media`, `@supports`) are
+ * emitted with their inner selector blocks wrapped one level deep.
  *
- * @param input - Selector-to-properties map.
+ * @param input - Selector-to-block map.
  * @returns Extracted CSS.
  */
-export function globalCss(input: GlobalCSSInput): GlobalCSSOutput {
+export function globalCss<const T extends Record<string, object>>(input: {
+  [K in keyof T & string]: StrictGlobalBlock<K, T[K]>;
+}): GlobalCSSOutput {
   const rules: string[] = [];
 
-  for (const [selector, properties] of Object.entries(input)) {
-    const declarations = Object.entries(properties)
-      .map(([prop, value]) => {
-        const cssProperty = prop.startsWith('--') ? prop : camelToKebab(prop);
-        return `  ${cssProperty}: ${value};`;
-      })
-      .join('\n');
-
-    rules.push(`${selector} {\n${declarations}\n}`);
+  for (const [selector, block] of Object.entries(input as GlobalCSSInput)) {
+    rules.push(renderBlock(selector, block));
   }
 
   const cssText = rules.join('\n');
 
-  // Auto-inject into the DOM, matching the behavior of css().
   injectCSS(cssText);
 
   return {
     css: cssText,
   };
+}
+
+/**
+ * Render a selector → block pair. If any value in the block is a plain
+ * object, it is treated as a nested selector (e.g. `@keyframes` frames,
+ * `@media` inner selectors); otherwise it is treated as a CSS declaration.
+ */
+function renderBlock(selector: string, block: GlobalStyleBlock): string {
+  const declarations: string[] = [];
+  const nestedRules: string[] = [];
+
+  for (const [key, value] of Object.entries(block)) {
+    if (value == null) continue;
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      nestedRules.push(renderBlock(key, value as CamelCSSDeclarations));
+      continue;
+    }
+    const cssProperty = key.startsWith('--') ? key : camelToKebab(key);
+    declarations.push(`  ${cssProperty}: ${value};`);
+  }
+
+  const parts: string[] = [];
+  if (declarations.length > 0) {
+    parts.push(`${selector} {\n${declarations.join('\n')}\n}`);
+  }
+  if (nestedRules.length > 0) {
+    const indented = nestedRules.map((rule) => rule.replace(/^/gm, '  ')).join('\n');
+    parts.push(`${selector} {\n${indented}\n}`);
+  }
+  return parts.join('\n');
 }
 
 /** Convert camelCase property name to kebab-case. */

--- a/packages/ui/src/css/index.ts
+++ b/packages/ui/src/css/index.ts
@@ -41,7 +41,12 @@ export type {
 export { compileFonts, font } from './font';
 export type { GoogleFontOptions } from './google-font';
 export { googleFont } from './google-font';
-export type { GlobalCSSInput, GlobalCSSOutput } from './global-css';
+export type {
+  GlobalCSSInput,
+  GlobalCSSOutput,
+  GlobalStyleBlock,
+  NestedSelectorBlock,
+} from './global-css';
 export { globalCss } from './global-css';
 export { keyframes } from './keyframes';
 export { type ColorPalette, palettes } from './palettes';

--- a/packages/ui/src/css/public.ts
+++ b/packages/ui/src/css/public.ts
@@ -29,7 +29,12 @@ export type {
 export { compileFonts, font } from './font';
 export type { GoogleFontOptions } from './google-font';
 export { googleFont } from './google-font';
-export type { GlobalCSSInput, GlobalCSSOutput } from './global-css';
+export type {
+  GlobalCSSInput,
+  GlobalCSSOutput,
+  GlobalStyleBlock,
+  NestedSelectorBlock,
+} from './global-css';
 export { globalCss } from './global-css';
 export type { CompiledTheme, CompileThemeOptions, Theme, ThemeInput } from './theme';
 export { compileTheme, defineTheme } from './theme';


### PR DESCRIPTION
## Summary

Fixes #2776 — `globalCss()` types now accept nested at-rules (`@keyframes`, `@media`, `@supports`).

Previously, `globalCss()` typed each selector block as a flat map of CSS declarations, rejecting at-rule blocks with TS2353 even though the runtime already supported them conceptually.

## Public API Changes

**Additions** (no breaking changes):
- New exported types: `NestedSelectorBlock`, `GlobalStyleBlock`
- `GlobalCSSInput` now per-key narrows: `@*` keys accept `NestedSelectorBlock`, regular selector keys accept `CamelCSSDeclarations` (unknown properties → `never`, preserving typo detection)

## What Changed

- `packages/ui/src/css/global-css.ts` — `StrictGlobalBlock<K, V>` mapped type splits at-rule vs. regular selectors; `renderBlock()` rewritten to recursively emit one nested level
- `packages/ui/src/css/__tests__/global-css.test.ts` + `.test-d.ts` — runtime + type-level tests for `@keyframes` (from/to + percentage frames), `@media`, `@supports`
- `packages/mint-docs/api-reference/ui/css.mdx` — documents the nested at-rule form and updated type signatures

## Test plan

- [x] `vtz test` — 2186 passed locally
- [x] `vtz run typecheck` — clean (167 type-check files)
- [x] `vtz run lint` — clean
- [x] Pre-push CI gates passed locally (build-typecheck, lint, test, trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)