### PR TITLE
fix(vtz): scope CI cache restore_keys to same package

### DIFF
--- a/native/vtz/src/ci/cache.rs
+++ b/native/vtz/src/ci/cache.rs
@@ -112,16 +112,14 @@ pub fn cache_key(task_name: &str, package: Option<&str>, platform: &str, hash: &
 }
 
 /// Generate restore key prefixes for fallback matching.
+///
+/// Fallback is scoped to the same `(task, package)` pair. A broader
+/// task-only fallback would let one package's build tarball be restored
+/// into another package's working directory, silently corrupting `dist/`.
 pub fn restore_keys(task_name: &str, package: Option<&str>, platform: &str) -> Vec<String> {
     match package {
-        Some(pkg) => vec![
-            format!("pipe-v1-{platform}-{task_name}-{pkg}-"),
-            format!("pipe-v1-{platform}-{task_name}-"),
-        ],
-        None => vec![
-            format!("pipe-v1-{platform}-{task_name}-root-"),
-            format!("pipe-v1-{platform}-{task_name}-"),
-        ],
+        Some(pkg) => vec![format!("pipe-v1-{platform}-{task_name}-{pkg}-")],
+        None => vec![format!("pipe-v1-{platform}-{task_name}-root-")],
     }
 }
 
@@ -696,19 +694,84 @@ mod tests {
     // -- restore keys --
 
     #[test]
-    fn restore_keys_package() {
+    fn restore_keys_package_scoped_to_same_package() {
+        // Fallback must only match entries from the SAME package.
+        // A task-only fallback (no package) would let one package's build
+        // tarball overwrite another package's dist on restore.
         let keys = restore_keys("build", Some("@vertz/ui"), "darwin-aarch64");
-        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.len(), 1);
         assert_eq!(keys[0], "pipe-v1-darwin-aarch64-build-@vertz/ui-");
-        assert_eq!(keys[1], "pipe-v1-darwin-aarch64-build-");
     }
 
     #[test]
-    fn restore_keys_root() {
+    fn restore_keys_root_scoped_to_root() {
         let keys = restore_keys("lint", None, "linux-x86_64");
-        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.len(), 1);
         assert_eq!(keys[0], "pipe-v1-linux-x86_64-lint-root-");
-        assert_eq!(keys[1], "pipe-v1-linux-x86_64-lint-");
+    }
+
+    #[tokio::test]
+    async fn fallback_never_matches_other_package_entry() {
+        // Regression: `restore_keys` used to include a package-less fallback
+        // (`pipe-v1-{platform}-{task}-`) that matched ANY package's entry.
+        // When @vertz/ci's build key missed, the scheduler warm-restored
+        // @vertz/test's build tarball into @vertz/ci's working dir, silently
+        // corrupting packages/ci/dist/ with @vertz/test's dist files.
+        let (_dir, cache_dir) = test_cache_dir();
+        let cache = LocalCache::new(cache_dir, None);
+
+        // Another package's prior build cache exists.
+        cache
+            .put(
+                "pipe-v1-darwin-aarch64-build-@vertz/test-abc123",
+                b"other-package-data",
+            )
+            .await
+            .unwrap();
+
+        // Look up @vertz/ci's build key (miss).
+        let restore = restore_keys("build", Some("@vertz/ci"), "darwin-aarch64");
+        let result = cache
+            .get("pipe-v1-darwin-aarch64-build-@vertz/ci-def456", &restore)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "fallback must not match a different package's entry (got {:?})",
+            result.map(|(k, _)| k),
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_matches_same_package_with_different_hash() {
+        // Counterpart to `fallback_never_matches_other_package_entry`: prove the
+        // narrow per-package prefix still serves its purpose — restoring a prior
+        // build tarball for the same (task, package) when only the input hash
+        // changed.
+        let (_dir, cache_dir) = test_cache_dir();
+        let cache = LocalCache::new(cache_dir, None);
+
+        cache
+            .put(
+                "pipe-v1-darwin-aarch64-build-@vertz/ci-old-hash",
+                b"prior-ci-build",
+            )
+            .await
+            .unwrap();
+
+        let restore = restore_keys("build", Some("@vertz/ci"), "darwin-aarch64");
+        let result = cache
+            .get("pipe-v1-darwin-aarch64-build-@vertz/ci-new-hash", &restore)
+            .await
+            .unwrap();
+
+        let (matched_key, data) = result.expect("same-package fallback should hit");
+        assert_eq!(
+            matched_key,
+            "pipe-v1-darwin-aarch64-build-@vertz/ci-old-hash"
+        );
+        assert_eq!(&data[..], b"prior-ci-build");
     }
 
     // -- platform string --


### PR DESCRIPTION
## Summary

The `vtz ci` pipe scheduler's `restore_keys()` returned a task-only fallback prefix (`pipe-v1-{platform}-{task}-`) in addition to the per-package one. When a package's exact build cache key missed, this fallback prefix-matched **any other package's tarball** for the same task. The scheduler's warm-restore path then extracted the matched tarball into the current package's working directory — silently overwriting `dist/` with a different package's build output.

**Concrete failure I hit:** while pushing an unrelated UI fix, the pre-push CI hook restored `@vertz/test`'s build tarball into `packages/ci/dist/`. The polluted dist made the pre-push hook itself fail (`'@vertz/ci' does not provide an export named 'pipe'`), blocking the push.

## Fix

Remove the task-only fallback. `restore_keys` now only returns the per-package prefix, so warm-restore can only match cache entries for the same `(task, package)` pair. Same-package restores with a different input hash continue to work — that's the intended use of the prefix fallback.

## Public API Changes

None — `restore_keys` is internal to the vtz crate.

## Tests

Two new regression tests in `native/vtz/src/ci/cache.rs`:

- `fallback_never_matches_other_package_entry` — seeds another package's entry, asserts `LocalCache::get()` returns `None` when the current package's exact key misses.
- `fallback_matches_same_package_with_different_hash` — seeds the same package's prior entry, asserts the lookup returns it when only the input hash changed (proves we didn't break warm restores).

The two existing `restore_keys_*` unit tests are updated to assert `keys.len() == 1`.

## Test plan

- [x] `cargo test -p vtz cache::` — 104 passed, including the two new tests
- [x] `cargo test --all` — 3457 vtz lib tests pass, plus all other crates
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push CI gates: build-typecheck, lint, rust-clippy, rust-fmt, rust-test, test, trojan-source — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)