### PR TITLE
chore(ui-server): re-export toVNode from main barrel [#2781]

### DIFF
--- a/.changeset/promote-tovnode-to-main-barrel.md
+++ b/.changeset/promote-tovnode-to-main-barrel.md
@@ -1,0 +1,14 @@
+---
+'@vertz/ui-server': patch
+---
+
+chore(ui-server): re-export `toVNode` from the main barrel
+
+`toVNode` was previously only reachable via the `@vertz/ui-server/dom-shim`
+subpath, which forced integration tests inside `ui-server` to reach into the
+package via a relative `../dom-shim` import. It now ships alongside the other
+SSR helpers (`renderToHTML`, `serializeToHtml`, `compile`, …) on the main
+`@vertz/ui-server` entry, so tests and consumers can depend on the public
+contract instead of the internal module layout.
+
+Closes #2781.

--- a/packages/ui-server/src/__tests__/inner-html-integration.test.ts
+++ b/packages/ui-server/src/__tests__/inner-html-integration.test.ts
@@ -12,8 +12,8 @@ afterAll(() => {
 // DOM adapter picks up the real DOM rather than failing.
 import { mount, signal } from '@vertz/ui';
 import { __element, __html } from '@vertz/ui/internals';
+import { toVNode } from '@vertz/ui-server';
 import { compile } from '../compiler/native-compiler';
-import { toVNode } from '../dom-shim';
 import { renderToHTML } from '../render-to-html';
 
 describe('Feature: innerHTML across SSR + hydration + reactive update', () => {

--- a/packages/ui-server/src/__tests__/inner-html-integration.test.ts
+++ b/packages/ui-server/src/__tests__/inner-html-integration.test.ts
@@ -9,12 +9,14 @@ afterAll(() => {
 });
 
 // Imports must follow happy-dom registration so that @vertz/ui's auto-detected
-// DOM adapter picks up the real DOM rather than failing.
+// DOM adapter picks up the real DOM rather than failing. `toVNode` and
+// `renderToHTML` come from the same `@vertz/ui-server` entry so that they share
+// the bundled `SSRElement` class identity — `toVNode`'s `instanceof SSRElement`
+// check would fall through otherwise.
 import { mount, signal } from '@vertz/ui';
 import { __element, __html } from '@vertz/ui/internals';
-import { toVNode } from '@vertz/ui-server';
+import { renderToHTML, toVNode } from '@vertz/ui-server';
 import { compile } from '../compiler/native-compiler';
-import { renderToHTML } from '../render-to-html';
 
 describe('Feature: innerHTML across SSR + hydration + reactive update', () => {
   let root: HTMLElement;

--- a/packages/ui-server/src/__tests__/ssr-aot-poc.test.ts
+++ b/packages/ui-server/src/__tests__/ssr-aot-poc.test.ts
@@ -14,7 +14,8 @@
 import { describe, expect, it } from '@vertz/test';
 import { query } from '@vertz/ui';
 import { __styleStr as styleObjectToString } from '@vertz/ui/internals';
-import { installDomShim, toVNode } from '../dom-shim';
+import { toVNode } from '@vertz/ui-server';
+import { installDomShim } from '../dom-shim';
 import { escapeAttr, escapeHtml, serializeToHtml } from '../html-serializer';
 import { ssrStorage } from '../ssr-context';
 import { createRequestContext, type SSRModule } from '../ssr-shared';

--- a/packages/ui-server/src/index.ts
+++ b/packages/ui-server/src/index.ts
@@ -26,6 +26,7 @@ export {
 export { loadAotManifest } from './aot-manifest-loader';
 export { renderAssetTags } from './asset-pipeline';
 export { inlineCriticalCss } from './critical-css';
+export { toVNode } from './dom-shim';
 export { detectFallbackFont, extractFontMetrics } from './font-metrics';
 export { HeadCollector, renderHeadToHtml } from './head';
 export { serializeToHtml } from './html-serializer';


### PR DESCRIPTION
## Summary

Re-exports `toVNode` from the main `@vertz/ui-server` entry so tests (and any downstream consumers) can import it via the public package name instead of reaching into the package's internal layout.

- `packages/ui-server/src/index.ts` — adds `export { toVNode } from './dom-shim'` alongside the other SSR helpers.
- `packages/ui-server/src/__tests__/inner-html-integration.test.ts` and `ssr-aot-poc.test.ts` — swap `../dom-shim` for `@vertz/ui-server`. `installDomShim` stays relative (out of scope for #2781; still reachable via `@vertz/ui-server/dom-shim`).
- `.changeset/promote-tovnode-to-main-barrel.md` — patch changeset.

## Why main barrel instead of `/test-utils`

`toVNode` is used in production code (`ssr-aot-pipeline.ts`, `ssr-single-pass.ts`), not just tests. Placing it next to `compile`, `compileForSsrAot`, `renderToHTML`, `serializeToHtml`, `extractRoutes` matches the existing public surface and closes the inconsistency called out in the issue.

## Public API Changes

- **Addition:** `toVNode` is now exported from `@vertz/ui-server` (was only exposed via `@vertz/ui-server/dom-shim`). No breaking changes.

## Acceptance Criteria

- [x] `toVNode` importable as `import { toVNode } from '@vertz/ui-server'`
- [x] All `import { toVNode } from '../dom-shim'` in `packages/ui-server/src/__tests__/` replaced
- [x] `vtz test` passes with no regressions (`ssr-aot-poc`: 17 pass / 6 skipped; `inner-html-integration` load error is pre-existing on `main` — unrelated `__html` export gap in `@vertz/ui/internals`)

## Test plan

- [x] `turbo run typecheck build --filter=@vertz/ui-server` green
- [x] `oxfmt --check` on changed files clean
- [x] `vtz test src/__tests__/ssr-aot-poc.test.ts` green
- [ ] GitHub CI green

Closes #2781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)