### PR TITLE
fix(compiler): keep ternaries inside callback bodies scoped [#2816]

### DIFF
--- a/.changeset/fix-jsx-nested-callback-scope.md
+++ b/.changeset/fix-jsx-nested-callback-scope.md
@@ -1,0 +1,20 @@
+---
+'@vertz/native-compiler': patch
+---
+
+fix(compiler): don't reactify ternaries inside callback bodies in JSX branches
+
+When a conditional's non-JSX branch contained a nested callback with its
+own ternary (e.g., `onPick={(v) => selected = v ? env.id : null}`), the
+JSX compiler would lift that inner ternary out of its closure, rewriting
+it as `__conditional(() => v, () => env.id, () => null)` at the call site.
+This produced a runtime `ReferenceError: v is not defined` because the
+callback parameter `v` no longer existed in the outer scope.
+
+The branch-level `ConditionalSpanFinder` now stops descending into
+function/arrow-function bodies that are strictly nested inside the target
+branch span, so imperative ternaries inside callbacks stay in place while
+genuine JSX-level nested ternaries (`a ? <X/> : b ? <Y/> : <Z/>`) keep
+their reactive `__conditional` wrapping.
+
+Closes #2816.

--- a/native/vertz-compiler-core/src/jsx_transformer.rs
+++ b/native/vertz-compiler-core/src/jsx_transformer.rs
@@ -2010,6 +2010,7 @@ fn find_conditional_in_span(
         target_start: start,
         target_end: end,
         result: None,
+        function_depth: 0,
     };
     for stmt in &program.body {
         finder.visit_statement(stmt);
@@ -2024,11 +2025,22 @@ struct ConditionalSpanFinder {
     target_start: u32,
     target_end: u32,
     result: Option<ConditionalSpanInfo>,
+    /// Depth of nested function/arrow bodies we're currently inside.
+    /// A ternary found while `function_depth > 0` belongs to imperative code
+    /// inside a callback (e.g., `onPick={(v) => selected = v ? x : null}`) —
+    /// it must NOT be reactified as a JSX-level conditional, or the callback
+    /// parameter would be hoisted out of scope (issue #2816).
+    function_depth: u32,
 }
 
 impl<'c> Visit<'c> for ConditionalSpanFinder {
     fn visit_conditional_expression(&mut self, cond: &ConditionalExpression<'c>) {
         if self.result.is_some() {
+            return;
+        }
+        // Skip ternaries inside nested callback bodies — see `function_depth` doc.
+        if self.function_depth > 0 {
+            oxc_ast_visit::walk::walk_conditional_expression(self, cond);
             return;
         }
         let span = cond.span;
@@ -2046,6 +2058,40 @@ impl<'c> Visit<'c> for ConditionalSpanFinder {
             return;
         }
         oxc_ast_visit::walk::walk_conditional_expression(self, cond);
+    }
+
+    fn visit_function(&mut self, func: &Function<'c>, flags: oxc_syntax::scope::ScopeFlags) {
+        let nested = self.is_strictly_inside_target(func.span.start, func.span.end);
+        if nested {
+            self.function_depth += 1;
+        }
+        oxc_ast_visit::walk::walk_function(self, func, flags);
+        if nested {
+            self.function_depth -= 1;
+        }
+    }
+
+    fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'c>) {
+        let nested = self.is_strictly_inside_target(arrow.span.start, arrow.span.end);
+        if nested {
+            self.function_depth += 1;
+        }
+        oxc_ast_visit::walk::walk_arrow_function_expression(self, arrow);
+        if nested {
+            self.function_depth -= 1;
+        }
+    }
+}
+
+impl ConditionalSpanFinder {
+    /// A function is a "nested scope" only when it sits strictly inside the
+    /// target branch span. A function that contains (or equals) the target is
+    /// the surrounding component — we're walking through it to reach the
+    /// branch, not crossing into a new callback.
+    fn is_strictly_inside_target(&self, start: u32, end: u32) -> bool {
+        start >= self.target_start
+            && end <= self.target_end
+            && (start > self.target_start || end < self.target_end)
     }
 }
 
@@ -4887,6 +4933,42 @@ export function App() {
         let html_offset = result.find("__html(__el0, () => x)").unwrap();
         assert!(class_offset < html_offset, "class before html: {result}");
         assert!(click_offset < html_offset, "click before html: {result}");
+    }
+
+    /// Issue #2816: inline callback params must not leak out of their closure.
+    /// A ternary inside an arrow function body (e.g., `(v) => selected = v ? x : null`)
+    /// must NOT be reactified into `__conditional(() => v, ...)` at the call site —
+    /// that hoists `v` out of scope and produces `ReferenceError: v is not defined`.
+    #[test]
+    fn ternary_inside_callback_body_is_not_reactified() {
+        let result = transform(
+            r#"export function App(props) {
+    let selected = null;
+    return (
+      <div>
+        {props.collapsed ? null : props.items.map((env) => (
+          <Row key={env.id} onPick={(v) => { selected = v ? env.id : null; }} />
+        ))}
+      </div>
+    );
+}"#,
+        );
+        // Must NOT lift the callback-body ternary into a __conditional wrapper.
+        assert!(
+            !result.contains("__conditional(() => v,"),
+            "inline callback param `v` was hoisted out of its closure: {result}"
+        );
+        // The callback body must stay intact (the ternary stays inside the arrow).
+        assert!(
+            result.contains("v ? env.id : null"),
+            "callback body lost its ternary: {result}"
+        );
+        // The outer map call must still be rendered (the whole false branch must
+        // not get replaced by the inner ternary).
+        assert!(
+            result.contains("__listValue(") || result.contains("props.items.map"),
+            "outer items.map was lost: {result}"
+        );
     }
 
     /// `<pre innerHTML />` (no value) is not reachable from TypeScript — the


### PR DESCRIPTION
## Summary

Closes #2816 — JSX with an inline callback prop whose body contained a ternary
(`onPick={(v) => selected = v ? env.id : null}`) crashed at runtime with
`ReferenceError: v is not defined` because the compiler lifted that ternary out
of its closure into a top-level `__conditional(() => v, ...)`, silently dropping
the surrounding `.map(...)` too.

### Root cause

`transform_branch()` in `native/vertz-compiler-core/src/jsx_transformer.rs` calls
`find_conditional_in_span()` on a non-JSX branch to discover nested ternaries
that should be reactified (e.g. `a ? <X/> : (b ? <Y/> : <Z/>)`). The finder
walked the whole AST subtree without stopping at function/arrow boundaries, so
an imperative ternary inside a callback body was picked up and transformed,
replacing the whole branch.

### Fix

`ConditionalSpanFinder` now carries a `function_depth` counter. `visit_function`
and `visit_arrow_function_expression` increment it **only when the function
span is strictly inside the target branch span** — so the surrounding component
function (which contains the target) isn't counted, but a callback nested
inside the branch is. `visit_conditional_expression` refuses to record a match
while `function_depth > 0`.

Genuine JSX-level nested ternaries (`a ? <X/> : b ? <Y/> : <Z/>`) still compile
to nested `__conditional()` calls; the existing `nested_ternary_deep` test
continues to pass.

### Before

```js
__append(__el0, __conditional(
  () => props.collapsed,
  () => null,
  () => __conditional(() => v, () => env.id, () => null)   // ← v not in scope
));
```

### After

```js
__append(__el0, __conditional(
  () => props.collapsed,
  () => null,
  () => __listValue(() => props.items, ..., (env) => /* <Row onPick={(v) => ...} /> */)
));
```

## Public API Changes

None. Internal compiler bug fix.

## Test plan

- [x] New regression test `ternary_inside_callback_body_is_not_reactified` in `jsx_transformer.rs`
- [x] All 1128 `vertz-compiler-core` tests pass
- [x] Full Rust quality gates green: `cargo test --all`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] Adversarial review — no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)