### PR TITLE
fix(vtz): clear persisted errors.json on dev-server startup [#2819]

### DIFF
--- a/native/vtz/src/errors/broadcaster.rs
+++ b/native/vtz/src/errors/broadcaster.rs
@@ -65,7 +65,13 @@ impl ErrorBroadcaster {
     }
 
     /// Create a new error broadcaster with a root directory for terminal display.
+    ///
+    /// Resets the persisted `.vertz/dev/errors.json` log so stale errors from a
+    /// previous session (including ones that reference now-deleted files) do not
+    /// survive across restarts. See issue #2819.
     pub fn with_root_dir(root_dir: PathBuf) -> Self {
+        terminal::write_error_log(&[], &root_dir);
+
         let (broadcast_tx, _) = broadcast::channel(64);
         Self {
             broadcast_tx,
@@ -359,6 +365,29 @@ mod tests {
         let broadcaster = ErrorBroadcaster::new();
         assert!(!broadcaster.has_errors().await);
         assert_eq!(broadcaster.client_count().await, 0);
+    }
+
+    #[test]
+    fn test_with_root_dir_clears_stale_error_log() {
+        // A previous dev-server session left .vertz/dev/errors.json with stale
+        // errors referring to files that may no longer exist. Starting a new
+        // broadcaster must reset the file so it matches our fresh, empty state.
+        let tmp = tempfile::tempdir().unwrap();
+        let vertz_dir = tmp.path().join(".vertz").join("dev");
+        std::fs::create_dir_all(&vertz_dir).unwrap();
+        let log_path = vertz_dir.join("errors.json");
+        std::fs::write(
+            &log_path,
+            r#"{"errors":[{"category":"build","severity":"error","message":"stale","file":"src/deleted.tsx"}],"count":1,"timestamp":"0"}"#,
+        )
+        .unwrap();
+
+        let _broadcaster = ErrorBroadcaster::with_root_dir(tmp.path().to_path_buf());
+
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed["count"], 0);
+        assert_eq!(parsed["errors"].as_array().unwrap().len(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #2819.

`ErrorBroadcaster::with_root_dir` constructed a fresh, empty in-memory error state but never touched the on-disk `.vertz/dev/errors.json`. If a prior dev-server session had written errors to that file and the new session had no errors to report at startup (e.g., clean typecheck), the stale JSON persisted — surfacing errors for source files that might have been deleted weeks earlier to any LLM/agent reading the file directly.

Reset the log to `{ errors: [], count: 0 }` on broadcaster construction so the on-disk file matches the fresh in-memory state. Any real errors are repopulated as the compiler and typechecker run.

## Public API Changes

None — internal dev-server behavior only.

## Test plan

- [x] New unit test `test_with_root_dir_clears_stale_error_log` seeds a stale `errors.json`, constructs the broadcaster, asserts the file is reset to empty.
- [x] `cargo test --all` — all 17 broadcaster tests pass, full workspace green.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)