### PR TITLE
fix(jsx): honor defaultValue/defaultChecked on input and textarea [#2820]

### DIFF
--- a/.changeset/jsx-default-value.md
+++ b/.changeset/jsx-default-value.md
@@ -1,0 +1,27 @@
+---
+'@vertz/native-compiler': patch
+'@vertz/ui': patch
+'vtz': patch
+---
+
+fix(jsx): honor `defaultValue` / `defaultChecked` on `<input>` and `<textarea>`
+
+The React-style uncontrolled-initial-value props were silently dropped:
+
+```tsx
+<textarea defaultValue="Hello world" />  // rendered empty
+<input defaultValue="initial" />          // rendered empty
+<input type="checkbox" defaultChecked /> // rendered unchecked
+```
+
+Both have no HTML content attribute, so the compiler's fallback to
+`setAttribute("defaultValue", ...)` was a no-op in the browser.
+
+The native compiler and the test-time JSX runtime now route these through
+the IDL property path (`el.defaultValue = "..."`, `el.defaultChecked = true`),
+matching how `value` / `checked` are already handled. The SSR DOM shim
+serializes them to the correct initial HTML — `value="..."` for `<input>`,
+text content for `<textarea>`, and the `checked` attribute for
+`<input type="checkbox">` — so the value is visible before hydration.
+
+Closes #2820.

--- a/native/vertz-compiler-core/src/jsx_transformer.rs
+++ b/native/vertz-compiler-core/src/jsx_transformer.rs
@@ -36,17 +36,25 @@ struct ReactivityContext {
 
 /// IDL properties that must use direct property assignment instead of setAttribute.
 /// setAttribute doesn't reflect the displayed state for these after user interaction.
+///
+/// `defaultValue` and `defaultChecked` are React-style uncontrolled-initial-value
+/// props. They have no HTML content attribute, so setAttribute is a silent no-op
+/// — they must go through the IDL property path. See #2820.
 fn is_idl_property(tag_name: &str, attr_name: &str) -> bool {
     match tag_name {
-        "input" => attr_name == "value" || attr_name == "checked",
-        "select" | "textarea" => attr_name == "value",
+        "input" => matches!(
+            attr_name,
+            "value" | "checked" | "defaultValue" | "defaultChecked"
+        ),
+        "textarea" => matches!(attr_name, "value" | "defaultValue"),
+        "select" => attr_name == "value",
         _ => false,
     }
 }
 
 /// Boolean IDL properties — boolean shorthand emits `.prop = true`.
 fn is_boolean_idl_property(attr_name: &str) -> bool {
-    attr_name == "checked"
+    matches!(attr_name, "checked" | "defaultChecked")
 }
 
 /// Check if an element supports the `debounce` prop transform.
@@ -2673,6 +2681,17 @@ mod tests {
     }
 
     #[test]
+    fn is_idl_property_default_value() {
+        assert!(is_idl_property("input", "defaultValue"));
+        assert!(is_idl_property("input", "defaultChecked"));
+        assert!(is_idl_property("textarea", "defaultValue"));
+        // defaultChecked is meaningless on textarea/select
+        assert!(!is_idl_property("textarea", "defaultChecked"));
+        assert!(!is_idl_property("select", "defaultValue"));
+        assert!(!is_idl_property("div", "defaultValue"));
+    }
+
+    #[test]
     fn is_boolean_idl_property_checked() {
         assert!(is_boolean_idl_property("checked"));
         assert!(!is_boolean_idl_property("value"));
@@ -2958,6 +2977,51 @@ export function App() {
         assert!(
             exit_pos.unwrap() < value_pos.unwrap(),
             "value assignment must come after __exitChildren: {result}"
+        );
+    }
+
+    // ========== defaultValue / defaultChecked (#2820) ==========
+
+    #[test]
+    fn textarea_default_value_static_emits_idl_assignment() {
+        let result = transform(
+            r#"export function App() {
+    return <textarea defaultValue="Hello world" />;
+}"#,
+        );
+        assert!(
+            result.contains(r#"__el0.defaultValue = "Hello world""#),
+            "expected IDL property assignment, got: {result}"
+        );
+        assert!(
+            !result.contains(r#"setAttribute("defaultValue""#),
+            "must not fall back to setAttribute, got: {result}"
+        );
+    }
+
+    #[test]
+    fn input_default_value_static_emits_idl_assignment() {
+        let result = transform(
+            r#"export function App() {
+    return <input defaultValue="initial" />;
+}"#,
+        );
+        assert!(
+            result.contains(r#"__el0.defaultValue = "initial""#),
+            "expected IDL property assignment, got: {result}"
+        );
+    }
+
+    #[test]
+    fn input_default_checked_boolean_shorthand_emits_idl_assignment() {
+        let result = transform(
+            r#"export function App() {
+    return <input type="checkbox" defaultChecked />;
+}"#,
+        );
+        assert!(
+            result.contains("__el0.defaultChecked = true"),
+            "expected boolean IDL assignment, got: {result}"
         );
     }
 

--- a/native/vtz/src/ssr/dom_shim.rs
+++ b/native/vtz/src/ssr/dom_shim.rs
@@ -259,6 +259,47 @@ pub const DOM_SHIM_JS: &str = r#"
       this._classList = String(val).split(/\s+/).filter(Boolean);
     }
 
+    // React-style uncontrolled-initial-value props. The compiler emits
+    // `el.defaultValue = "x"` / `el.defaultChecked = true` for <input>
+    // and <textarea> (see #2820). Translate to the right serialized form:
+    //   - <input>:    sets the `value` (or `checked`) attribute
+    //   - <textarea>: replaces text content with the default value
+    // No-op for any other element to preserve plain JS-property semantics.
+    get defaultValue() {
+      return this._defaultValue !== undefined ? this._defaultValue : '';
+    }
+
+    set defaultValue(val) {
+      this._defaultValue = val == null ? '' : String(val);
+      if (this.localName === 'input') {
+        if (val == null) {
+          delete this.attributes.value;
+        } else {
+          this.attributes.value = String(val);
+        }
+      } else if (this.localName === 'textarea') {
+        this.childNodes = [];
+        if (val != null && String(val) !== '') {
+          this.appendChild(new SSRTextNode(String(val)));
+        }
+      }
+    }
+
+    get defaultChecked() {
+      return !!this._defaultChecked;
+    }
+
+    set defaultChecked(val) {
+      this._defaultChecked = !!val;
+      if (this.localName === 'input') {
+        if (val) {
+          this.attributes.checked = '';
+        } else {
+          delete this.attributes.checked;
+        }
+      }
+    }
+
     get classList() {
       const self = this;
       return {
@@ -1806,6 +1847,92 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result, serde_json::json!(0));
+    }
+
+    #[test]
+    fn test_textarea_default_value_serializes() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const ta = document.createElement('textarea');
+                ta.defaultValue = 'Hello world';
+                ta.outerHTML
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!("<textarea>Hello world</textarea>")
+        );
+    }
+
+    #[test]
+    fn test_input_default_value_serializes() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const input = document.createElement('input');
+                input.defaultValue = 'hello';
+                input.outerHTML
+                "#,
+            )
+            .unwrap();
+        assert_eq!(result, serde_json::json!(r#"<input value="hello" />"#));
+    }
+
+    #[test]
+    fn test_input_default_checked_serializes() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const input = document.createElement('input');
+                input.setAttribute('type', 'checkbox');
+                input.defaultChecked = true;
+                input.outerHTML
+                "#,
+            )
+            .unwrap();
+        let html: String = serde_json::from_value(result).unwrap();
+        assert!(
+            html.contains("checked"),
+            "expected checked attribute, got: {html}"
+        );
+        assert!(html.contains(r#"type="checkbox""#));
+    }
+
+    #[test]
+    fn test_default_value_no_op_on_div() {
+        let mut rt = create_runtime();
+        load_dom_shim(&mut rt).unwrap();
+        rt.execute_script_void("<test-install>", "__vertz_install_dom_shim();")
+            .unwrap();
+        let result = rt
+            .execute_script(
+                "<test>",
+                r#"
+                const div = document.createElement('div');
+                div.defaultValue = 'ignored';
+                div.outerHTML
+                "#,
+            )
+            .unwrap();
+        // defaultValue on non-form elements is a plain JS property — no DOM impact.
+        assert_eq!(result, serde_json::json!("<div></div>"));
     }
 
     #[test]

--- a/packages/ui/src/jsx-runtime/__tests__/jsx-idl-props.test.ts
+++ b/packages/ui/src/jsx-runtime/__tests__/jsx-idl-props.test.ts
@@ -52,4 +52,34 @@ describe('JSX runtime IDL property handling', () => {
       });
     });
   });
+
+  describe('Given an <input> with defaultValue prop', () => {
+    describe('When rendered via jsx()', () => {
+      it('Then sets defaultValue via property assignment', () => {
+        const input = jsx('input', { defaultValue: 'hello' }) as HTMLInputElement;
+        expect(input.defaultValue).toBe('hello');
+        expect(input.value).toBe('hello');
+      });
+    });
+  });
+
+  describe('Given a <textarea> with defaultValue prop', () => {
+    describe('When rendered via jsx()', () => {
+      it('Then sets defaultValue via property assignment', () => {
+        const textarea = jsx('textarea', { defaultValue: 'Hello world' }) as HTMLTextAreaElement;
+        expect(textarea.defaultValue).toBe('Hello world');
+        expect(textarea.value).toBe('Hello world');
+      });
+    });
+  });
+
+  describe('Given an <input type="checkbox"> with defaultChecked prop', () => {
+    describe('When rendered via jsx()', () => {
+      it('Then sets defaultChecked via property assignment', () => {
+        const input = jsx('input', { type: 'checkbox', defaultChecked: true }) as HTMLInputElement;
+        expect(input.defaultChecked).toBe(true);
+        expect(input.checked).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/ui/src/jsx-runtime/index.ts
+++ b/packages/ui/src/jsx-runtime/index.ts
@@ -165,11 +165,14 @@ function applyChildren(parent: Node, children: unknown): void {
  * IDL properties where setAttribute doesn't control the displayed state —
  * only direct property assignment (el.prop = value) works correctly.
  * Must be set AFTER children are appended (select.value needs options in DOM).
+ *
+ * `defaultValue` / `defaultChecked` have no HTML content attribute, so they
+ * must go through this path or they are silently dropped. See #2820.
  */
 const IDL_PROPS: Record<string, ReadonlySet<string>> = {
-  input: new Set(['value', 'checked']),
+  input: new Set(['value', 'checked', 'defaultValue', 'defaultChecked']),
   select: new Set(['value']),
-  textarea: new Set(['value']),
+  textarea: new Set(['value', 'defaultValue']),
 };
 
 // Implementation


### PR DESCRIPTION
## Summary

Closes #2820.

`<textarea defaultValue="...">` and `<input defaultValue="...">` were silently dropped — the React-style uncontrolled-initial-value props have no HTML content attribute, so the compiler's fallback to `setAttribute("defaultValue", ...)` was a no-op in the browser, and the SSR DOM shim never serialized the assigned IDL property.

Routes them through the existing IDL-property path the framework already uses for `value` / `checked`:

- **`@vertz/native-compiler`**: `is_idl_property` now recognizes `defaultValue` (input, textarea) and `defaultChecked` (input). Boolean shorthand (`<input defaultChecked />`) emits `__el0.defaultChecked = true`. IDL emission stays deferred until after `__exitChildren()`.
- **`@vertz/ui` JSX runtime**: `IDL_PROPS` includes the new keys so the test-time runtime defers them after children too.
- **`vtz` SSR DOM shim**: `defaultValue` setter writes the `value` attribute on `<input>` and replaces text content on `<textarea>`; `defaultChecked` toggles the `checked` attribute on `<input>`. No-op on other elements to preserve plain JS-property semantics.

## Public API Changes

- **Additions**: `defaultValue` on `<input>` / `<textarea>` and `defaultChecked` on `<input>` now behave like the React/HTML standard. No type changes — they were already accepted via the catch-all on `HTMLAttributes`.
- **Breaking**: none.

## Test plan

- [x] `cargo test --all` (1135 + 3469 + others all green; only the previously-ignored `inspector_brk` test stays ignored)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `vtz test` on `packages/ui/src/jsx-runtime` and `packages/ui/src/dom` (415 / 415 pass)
- [x] New unit tests added:
  - `is_idl_property_default_value` (compiler-core)
  - `textarea_default_value_static_emits_idl_assignment`, `input_default_value_static_emits_idl_assignment`, `input_default_checked_boolean_shorthand_emits_idl_assignment` (compiler-core)
  - `test_textarea_default_value_serializes`, `test_input_default_value_serializes`, `test_input_default_checked_serializes`, `test_default_value_no_op_on_div` (vtz dom_shim)
  - `defaultValue` / `defaultChecked` cases in `jsx-idl-props.test.ts` (@vertz/ui)

🤖 Generated with [Claude Code](https://claude.com/claude-code)