### PR TITLE
fix(testing): drop #2815 inference workaround, strengthen proxy probes

### DIFF
--- a/packages/testing/src/__tests__/test-client.test-d.ts
+++ b/packages/testing/src/__tests__/test-client.test-d.ts
@@ -67,14 +67,6 @@ const healthService = service('health', {
 // Type flow: EntityDefinition<TModel> → EntityTestProxy<TModel>
 // ---------------------------------------------------------------------------
 
-// NOTE: tsgo currently collapses `entity()`'s TModel inference to the generic
-// ModelDef default (see #2815), so `client.entity(todosEntity)` flows as
-// `EntityTestProxy<ModelDef>` instead of the concrete model. The tests below
-// verify the type flow end-to-end by annotating the proxy with the concrete
-// model the developer already has in scope — mirroring how apps consume the
-// API. When #2815 lands, the annotation can be dropped to exercise pure
-// inference.
-
 describe('Type flow: entity proxy', () => {
   it('entity proxy get() returns typed response body', () => {
     const server = createServer({
@@ -82,8 +74,11 @@ describe('Type flow: entity proxy', () => {
       _entityDbFactory: mockEntityDb,
     });
     const client = createTestClient(server);
-    const todos: EntityTestProxy<typeof todosModel> = client.entity(todosEntity);
-    void todos;
+    const todos = client.entity(todosEntity);
+
+    // Positive: inferred proxy is assignable to the concrete typed proxy.
+    const _proxy: EntityTestProxy<typeof todosModel> = todos;
+    void _proxy;
   });
 
   it('create() input is typed to $create_input', async () => {
@@ -92,10 +87,16 @@ describe('Type flow: entity proxy', () => {
       _entityDbFactory: mockEntityDb,
     });
     const client = createTestClient(server);
-    const todos: EntityTestProxy<typeof todosModel> = client.entity(todosEntity);
+    const todos = client.entity(todosEntity);
 
     // @ts-expect-error — missing required 'title' field
     todos.create({});
+
+    // @ts-expect-error — wrong type for title
+    todos.create({ title: 123 });
+
+    // Positive: valid input is accepted
+    todos.create({ title: 'buy milk' });
   });
 
   it('entity() rejects non-EntityDefinition argument', () => {
@@ -105,13 +106,11 @@ describe('Type flow: entity proxy', () => {
     });
     const client = createTestClient(server);
 
-    // Verify the constraint at the type level: the concrete `{ name }` shape
-    // must not match the EntityDefinition interface, which has many more
-    // required fields.
-    type HasKind<T> = T extends { readonly kind: 'entity' } ? true : false;
-    const hasKind: HasKind<{ name: 'fake' }> = false;
-    void hasKind;
-    void client;
+    // @ts-expect-error — bare { name } is not an EntityDefinition
+    client.entity({ name: 'fake' });
+
+    // @ts-expect-error — plain objects without the EntityDefinition shape are rejected
+    client.entity({});
   });
 });
 


### PR DESCRIPTION
## Summary

The `TestClient.entity()` TModel inference collapse reported in #2815 no longer reproduces on current `main`. This PR removes the workaround (explicit `EntityTestProxy<typeof todosModel>` annotations + note) introduced when the issue was filed, and strengthens the test-d probes so a future regression would fail loudly.

## Verification

From `packages/testing/`:

```
tsgo --noEmit -p tsconfig.typecheck.json   # clean
vtz test                                    # 47 passed
```

Under `const todos = client.entity(todosEntity)` (no annotation), the new probes fire exactly where they should:

- `@ts-expect-error` on `todos.create({})` — missing required `title`
- `@ts-expect-error` on `todos.create({ title: 123 })` — wrong type
- positive: `todos.create({ title: 'buy milk' })` compiles
- positive: `const _proxy: EntityTestProxy<typeof todosModel> = todos` — would fail if `todos` collapsed to `EntityTestProxy<ModelDef>` (verified by forcing a widened cast; assignment errors with TS2322 on `TableDef._columns`)

I also tightened the `entity() rejects non-EntityDefinition argument` test — it previously asserted via a side-channel `HasKind<T>` conditional without actually calling `client.entity()`. It now uses `@ts-expect-error` on real calls.

## Why no source change?

The issue's reproduction (at commit `8d8976dd3`) describes inference collapsing to the `ModelDef` default, but that no longer happens. Re-running `tsgo --noEmit` against the original (pre-workaround) test file on current `main` passes clean, and the new probes prove concrete `TModel` inference flows through `TestClient.entity()` to `EntityTestProxy<TModel>`. The underlying inference path through `entity<TModel extends ModelDef>()` and the `TestClient` interface is unchanged — something in dependent types between `#2777` and `main` apparently restored inference. No `@vertz/server` / `@vertz/db` change was necessary.

## Public API Changes

None. Test-only.

Closes #2815.