### PR TITLE
feat(agents): add Anthropic provider adapter [#2834]

### DIFF
--- a/.changeset/agents-anthropic-adapter.md
+++ b/.changeset/agents-anthropic-adapter.md
@@ -1,0 +1,22 @@
+---
+'@vertz/agents': patch
+---
+
+feat(agents): add Anthropic provider adapter
+
+`@vertz/agents` now supports Anthropic's Claude models via the native Messages
+API. Use `{ provider: 'anthropic', model: 'claude-sonnet-4-6' }` in your agent
+config and set `ANTHROPIC_API_KEY` in the environment.
+
+```ts
+const triage = agent({
+  model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+  // ...
+});
+```
+
+The adapter speaks the native Messages API (not the OpenAI-compatible shim),
+so tool calls flow through `tool_use` / `tool_result` content blocks and
+token usage is reported via `TokenUsageSummary`.
+
+Closes #2834.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -82,6 +82,7 @@ export { toolsToDescriptions } from './providers/tool-description';
 
 // LLM adapters
 export { createAdapter } from './providers/create-adapter';
+export { createAnthropicAdapter } from './providers/anthropic';
 export { createCloudflareAdapter } from './providers/cloudflare';
 export { createMinimaxAdapter } from './providers/minimax';
 

--- a/packages/agents/src/providers/anthropic.test.ts
+++ b/packages/agents/src/providers/anthropic.test.ts
@@ -1,0 +1,583 @@
+import { afterEach, describe, expect, it, mock } from '@vertz/test';
+import { s } from '@vertz/schema';
+import { tool } from '../tool';
+import { createAnthropicAdapter } from './anthropic';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+function mockFetch(response: unknown, status = 200) {
+  globalThis.fetch = mock(async () => new Response(JSON.stringify(response), { status }));
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env.ANTHROPIC_API_KEY = originalEnv.ANTHROPIC_API_KEY;
+});
+
+const testTool = tool({
+  description: 'Test tool',
+  input: s.object({ x: s.string() }),
+  output: s.object({ y: s.string() }),
+  handler(input) {
+    return { y: input.x };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAnthropicAdapter()', () => {
+  describe('Given a valid ANTHROPIC_API_KEY and a text-only response', () => {
+    describe('When chat() is called', () => {
+      it('Then sends a request to the Anthropic messages endpoint', async () => {
+        process.env.ANTHROPIC_API_KEY = 'test-key';
+
+        mockFetch({
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello!' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 12, output_tokens: 3 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        const result = await adapter.chat([
+          { role: 'system', content: 'Be helpful.' },
+          { role: 'user', content: 'Hi' },
+        ]);
+
+        expect(result.text).toBe('Hello!');
+        expect(result.toolCalls).toEqual([]);
+        expect(result.usage).toEqual({ inputTokens: 12, outputTokens: 3 });
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const [url, options] = fetchMock.mock.calls[0];
+        expect(url).toBe('https://api.anthropic.com/v1/messages');
+        expect(options.method).toBe('POST');
+        expect(options.headers['x-api-key']).toBe('test-key');
+        expect(options.headers['anthropic-version']).toBe('2023-06-01');
+        expect(options.headers['content-type']).toBe('application/json');
+
+        const body = JSON.parse(options.body);
+        expect(body.model).toBe('claude-sonnet-4-6');
+        expect(body.system).toBe('Be helpful.');
+        expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
+        expect(body.max_tokens).toBeGreaterThan(0);
+        expect(body.tools).toHaveLength(1);
+        expect(body.tools[0].name).toBe('test');
+        expect(body.tools[0].description).toBe('Test tool');
+        expect(body.tools[0].input_schema).toEqual({
+          type: 'object',
+          properties: { x: { type: 'string' } },
+          required: ['x'],
+        });
+      });
+    });
+  });
+
+  describe('Given a response with tool_use content blocks', () => {
+    describe('When chat() is called', () => {
+      it('Then parses tool calls from the response', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'msg_2',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me use a tool.' },
+            {
+              type: 'tool_use',
+              id: 'toolu_abc',
+              name: 'test',
+              input: { x: 'hello' },
+            },
+          ],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 5, output_tokens: 8 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        const result = await adapter.chat([{ role: 'user', content: 'Use test tool' }]);
+
+        expect(result.text).toBe('Let me use a tool.');
+        expect(result.toolCalls).toEqual([
+          { id: 'toolu_abc', name: 'test', arguments: { x: 'hello' } },
+        ]);
+      });
+    });
+  });
+
+  describe('Given multiple system messages in the conversation', () => {
+    describe('When chat() is called', () => {
+      it('Then concatenates them into the top-level system field', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        await adapter.chat([
+          { role: 'system', content: 'Rule one.' },
+          { role: 'user', content: 'Hi' },
+          { role: 'system', content: 'Rule two.' },
+        ]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.system).toBe('Rule one.\n\nRule two.');
+        expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
+      });
+    });
+  });
+
+  describe('Given an assistant message with tool calls followed by tool result messages', () => {
+    describe('When chat() is called', () => {
+      it('Then converts tool calls to tool_use blocks and tool results to a user message with tool_result blocks', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Done' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        await adapter.chat([
+          { role: 'user', content: 'Run two tools' },
+          {
+            role: 'assistant',
+            content: '[Calling test, test]',
+            toolCalls: [
+              { id: 'toolu_1', name: 'test', arguments: { x: 'a' } },
+              { id: 'toolu_2', name: 'test', arguments: { x: 'b' } },
+            ],
+          },
+          { role: 'tool', toolCallId: 'toolu_1', toolName: 'test', content: '{"y":"a"}' },
+          { role: 'tool', toolCallId: 'toolu_2', toolName: 'test', content: '{"y":"b"}' },
+          { role: 'user', content: 'thanks' },
+        ]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+        expect(body.messages).toEqual([
+          { role: 'user', content: 'Run two tools' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'toolu_1', name: 'test', input: { x: 'a' } },
+              { type: 'tool_use', id: 'toolu_2', name: 'test', input: { x: 'b' } },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'toolu_1', content: '{"y":"a"}' },
+              { type: 'tool_result', tool_use_id: 'toolu_2', content: '{"y":"b"}' },
+            ],
+          },
+          { role: 'user', content: 'thanks' },
+        ]);
+      });
+    });
+  });
+
+  describe('Given an assistant message with both text and tool calls', () => {
+    describe('When chat() is called', () => {
+      it('Then emits text and tool_use blocks together in the assistant content array', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'done' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        await adapter.chat([
+          { role: 'user', content: 'q' },
+          {
+            role: 'assistant',
+            content: 'Thinking out loud.',
+            toolCalls: [{ id: 'toolu_1', name: 'test', arguments: { x: 'a' } }],
+          },
+          { role: 'tool', toolCallId: 'toolu_1', toolName: 'test', content: '{"y":"a"}' },
+        ]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.messages[1]).toEqual({
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Thinking out loud.' },
+            { type: 'tool_use', id: 'toolu_1', name: 'test', input: { x: 'a' } },
+          ],
+        });
+      });
+    });
+  });
+
+  describe('Given missing ANTHROPIC_API_KEY', () => {
+    describe('When createAnthropicAdapter is called', () => {
+      it('Then throws a configuration error', () => {
+        delete process.env.ANTHROPIC_API_KEY;
+
+        expect(() =>
+          createAnthropicAdapter({
+            config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+            tools: {},
+          }),
+        ).toThrow('ANTHROPIC_API_KEY');
+      });
+    });
+  });
+
+  describe('Given the API returns a non-OK status', () => {
+    describe('When chat() is called', () => {
+      it('Then throws an error with the status and body', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({ error: { type: 'authentication_error', message: 'invalid key' } }, 401);
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        await expect(adapter.chat([{ role: 'user', content: 'Hi' }])).rejects.toThrow(
+          'Anthropic API request failed (401)',
+        );
+      });
+    });
+  });
+
+  describe('Given no tools are provided', () => {
+    describe('When chat() is called', () => {
+      it('Then omits the tools field from the request body', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.tools).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Given a response with missing usage fields', () => {
+    describe('When chat() is called', () => {
+      it('Then returns a response with no usage data', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+        expect(result.usage).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Given a tool result message with no toolCallId', () => {
+    describe('When chat() is called', () => {
+      it('Then throws at conversion time rather than sending an empty tool_use_id', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        await expect(
+          adapter.chat([
+            { role: 'user', content: 'hi' },
+            { role: 'tool', content: '{"y":"a"}' },
+          ]),
+        ).rejects.toThrow('Anthropic tool_result requires a toolCallId');
+      });
+    });
+  });
+
+  describe('Given an assistant message with repeated tool names and no ids', () => {
+    describe('When chat() is called', () => {
+      it('Then synthesises unique tool_use ids by index to avoid collisions', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        await adapter.chat([
+          { role: 'user', content: 'q' },
+          {
+            role: 'assistant',
+            content: '[Calling test, test]',
+            toolCalls: [
+              { name: 'test', arguments: { x: 'a' } },
+              { name: 'test', arguments: { x: 'b' } },
+            ],
+          },
+        ]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const ids = body.messages[1].content.map((b: { id: string }) => b.id);
+        expect(new Set(ids).size).toBe(2);
+      });
+    });
+  });
+
+  describe('Given a user message interleaved between tool calls and tool results', () => {
+    describe('When chat() is called', () => {
+      it('Then the tool_result goes in a fresh user message, not fused into the interleaved text user message', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        await adapter.chat([
+          { role: 'user', content: 'start' },
+          {
+            role: 'assistant',
+            content: '[Calling test]',
+            toolCalls: [{ id: 'toolu_1', name: 'test', arguments: { x: 'a' } }],
+          },
+          { role: 'user', content: 'wait' },
+          { role: 'tool', toolCallId: 'toolu_1', toolName: 'test', content: '{"y":"a"}' },
+        ]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.messages).toEqual([
+          { role: 'user', content: 'start' },
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'toolu_1', name: 'test', input: { x: 'a' } }],
+          },
+          { role: 'user', content: 'wait' },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: '{"y":"a"}' }],
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('Given a response with multiple text blocks', () => {
+    describe('When chat() is called', () => {
+      it('Then concatenates the text blocks without a separator', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Hello ' },
+            { type: 'text', text: 'world.' },
+          ],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+        expect(result.text).toBe('Hello world.');
+      });
+    });
+  });
+
+  describe('Given a tool_use block with a non-object input', () => {
+    describe('When chat() is called', () => {
+      it('Then coerces the arguments to an empty object', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'toolu_a', name: 'test', input: null },
+            { type: 'tool_use', id: 'toolu_b', name: 'test', input: 'not-an-object' },
+            { type: 'tool_use', id: 'toolu_c', name: 'test', input: [1, 2, 3] },
+          ],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: { test: testTool },
+        });
+
+        const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+        expect(result.toolCalls).toEqual([
+          { id: 'toolu_a', name: 'test', arguments: {} },
+          { id: 'toolu_b', name: 'test', arguments: {} },
+          { id: 'toolu_c', name: 'test', arguments: {} },
+        ]);
+      });
+    });
+  });
+
+  describe('Given the adapter sends a request', () => {
+    describe('When inspecting the headers', () => {
+      it('Then uses x-api-key and does not send an Authorization header', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        await adapter.chat([{ role: 'user', content: 'Hi' }]);
+
+        const fetchMock = globalThis.fetch as ReturnType<typeof mock>;
+        const headers = fetchMock.mock.calls[0][1].headers;
+        expect(headers['x-api-key']).toBe('k');
+        expect(headers['Authorization']).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Given a response with an empty content array', () => {
+    describe('When chat() is called', () => {
+      it('Then returns empty text and empty tool calls', async () => {
+        process.env.ANTHROPIC_API_KEY = 'k';
+
+        mockFetch({
+          id: 'm',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 0 },
+        });
+
+        const adapter = createAnthropicAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          tools: {},
+        });
+
+        const result = await adapter.chat([{ role: 'user', content: 'Hi' }]);
+        expect(result.text).toBe('');
+        expect(result.toolCalls).toEqual([]);
+      });
+    });
+  });
+});

--- a/packages/agents/src/providers/anthropic.ts
+++ b/packages/agents/src/providers/anthropic.ts
@@ -1,0 +1,231 @@
+import { toJSONSchema } from '@vertz/schema';
+import type { LLMAdapter, LLMResponse, Message, ToolCall } from '../loop/react-loop';
+import type { ToolDefinition } from '../types';
+import type { CreateAdapterOptions } from './types';
+
+const ANTHROPIC_API_BASE = 'https://api.anthropic.com/v1';
+const ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MAX_TOKENS = 4096;
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages API types (only what we use)
+// ---------------------------------------------------------------------------
+
+interface AnthropicTextBlock {
+  readonly type: 'text';
+  readonly text: string;
+}
+
+interface AnthropicToolUseBlock {
+  readonly type: 'tool_use';
+  readonly id: string;
+  readonly name: string;
+  readonly input: Record<string, unknown>;
+}
+
+interface AnthropicToolResultBlock {
+  readonly type: 'tool_result';
+  readonly tool_use_id: string;
+  readonly content: string;
+}
+
+type AnthropicAssistantBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+type AnthropicUserBlock = AnthropicToolResultBlock;
+
+interface AnthropicMessage {
+  readonly role: 'user' | 'assistant';
+  readonly content: string | readonly AnthropicAssistantBlock[] | readonly AnthropicUserBlock[];
+}
+
+interface AnthropicTool {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: Record<string, unknown>;
+}
+
+/**
+ * Create an LLM adapter for Anthropic's Claude models via the native Messages API.
+ *
+ * Uses `POST https://api.anthropic.com/v1/messages` with native tool_use /
+ * tool_result content blocks — not the OpenAI-compatible shim.
+ *
+ * Required environment variables:
+ * - `ANTHROPIC_API_KEY` — Anthropic API key (sent via `x-api-key` header)
+ */
+export function createAnthropicAdapter(options: CreateAdapterOptions): LLMAdapter {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required for Anthropic adapter');
+  }
+
+  const url = `${ANTHROPIC_API_BASE}/messages`;
+  const anthropicTools = toAnthropicTools(options.tools);
+  const model = options.config.model;
+
+  return {
+    async chat(messages: readonly Message[]): Promise<LLMResponse> {
+      const { system, messages: apiMessages } = toAnthropicMessages(messages);
+
+      const body: Record<string, unknown> = {
+        model,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        messages: apiMessages,
+      };
+
+      if (system) {
+        body.system = system;
+      }
+
+      if (anthropicTools.length > 0) {
+        body.tools = anthropicTools;
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 120_000);
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-api-key': apiKey,
+            'anthropic-version': ANTHROPIC_VERSION,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Anthropic API request failed (${response.status}): ${text}`);
+      }
+
+      const json = await response.json();
+      return fromAnthropicResponse(json);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Conversion — Vertz messages → Anthropic Messages API
+// ---------------------------------------------------------------------------
+
+interface AnthropicRequest {
+  system: string;
+  messages: AnthropicMessage[];
+}
+
+function toAnthropicMessages(messages: readonly Message[]): AnthropicRequest {
+  const systemParts: string[] = [];
+  const apiMessages: AnthropicMessage[] = [];
+
+  for (const msg of messages) {
+    if (msg.role === 'system') {
+      systemParts.push(msg.content);
+      continue;
+    }
+
+    if (msg.role === 'tool') {
+      if (!msg.toolCallId) {
+        throw new Error(
+          'Anthropic tool_result requires a toolCallId. Tool messages without toolCallId cannot be converted to the Messages API.',
+        );
+      }
+      const resultBlock: AnthropicToolResultBlock = {
+        type: 'tool_result',
+        tool_use_id: msg.toolCallId,
+        content: msg.content,
+      };
+
+      const last = apiMessages[apiMessages.length - 1];
+      if (last && last.role === 'user' && Array.isArray(last.content)) {
+        // Merge consecutive tool results into a single user message.
+        (last.content as AnthropicUserBlock[]).push(resultBlock);
+      } else {
+        apiMessages.push({ role: 'user', content: [resultBlock] });
+      }
+      continue;
+    }
+
+    if (msg.role === 'assistant' && msg.toolCalls && msg.toolCalls.length > 0) {
+      const blocks: AnthropicAssistantBlock[] = [];
+      // The react-loop synthesises "[Calling ...]" placeholders when the model
+      // returns no text alongside tool calls. Drop those — Anthropic expects a
+      // real text block or none at all.
+      if (msg.content && !msg.content.startsWith('[Calling ')) {
+        blocks.push({ type: 'text', text: msg.content });
+      }
+      msg.toolCalls.forEach((tc, i) => {
+        blocks.push({
+          type: 'tool_use',
+          // Suffix with index so repeated tool names don't collide when the
+          // model emitted no id (Anthropic requires unique tool_use ids per turn).
+          id: tc.id ?? `call_${i}_${tc.name}`,
+          name: tc.name,
+          input: tc.arguments,
+        });
+      });
+      apiMessages.push({ role: 'assistant', content: blocks });
+      continue;
+    }
+
+    apiMessages.push({ role: msg.role, content: msg.content });
+  }
+
+  return { system: systemParts.join('\n\n'), messages: apiMessages };
+}
+
+function toAnthropicTools(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tools have varying types
+  tools: Record<string, ToolDefinition<any, any>>,
+): AnthropicTool[] {
+  return Object.entries(tools).map(([name, def]) => ({
+    name,
+    description: def.description,
+    input_schema: toJSONSchema(def.input),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Conversion — Anthropic response → Vertz LLMResponse
+// ---------------------------------------------------------------------------
+
+function fromAnthropicResponse(response: unknown): LLMResponse {
+  const resp = response as Record<string, unknown>;
+  const rawContent = Array.isArray(resp?.content) ? resp.content : [];
+
+  let text = '';
+  const toolCalls: ToolCall[] = [];
+
+  for (const block of rawContent) {
+    const b = block as Record<string, unknown>;
+    if (b?.type === 'text' && typeof b.text === 'string') {
+      text += b.text;
+    } else if (b?.type === 'tool_use') {
+      const input = b.input;
+      toolCalls.push({
+        id: typeof b.id === 'string' ? b.id : undefined,
+        name: typeof b.name === 'string' ? b.name : 'unknown',
+        arguments:
+          typeof input === 'object' && input !== null && !Array.isArray(input)
+            ? (input as Record<string, unknown>)
+            : {},
+      });
+    }
+  }
+
+  const rawUsage = resp?.usage as Record<string, unknown> | undefined;
+  const usage =
+    rawUsage &&
+    typeof rawUsage.input_tokens === 'number' &&
+    typeof rawUsage.output_tokens === 'number'
+      ? { inputTokens: rawUsage.input_tokens, outputTokens: rawUsage.output_tokens }
+      : undefined;
+
+  return usage ? { text, toolCalls, usage } : { text, toolCalls };
+}

--- a/packages/agents/src/providers/create-adapter.test.ts
+++ b/packages/agents/src/providers/create-adapter.test.ts
@@ -13,6 +13,7 @@ afterEach(() => {
   process.env.CLOUDFLARE_ACCOUNT_ID = originalEnv.CLOUDFLARE_ACCOUNT_ID;
   process.env.CLOUDFLARE_API_TOKEN = originalEnv.CLOUDFLARE_API_TOKEN;
   process.env.MINIMAX_API_KEY = originalEnv.MINIMAX_API_KEY;
+  process.env.ANTHROPIC_API_KEY = originalEnv.ANTHROPIC_API_KEY;
 });
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,22 @@ describe('createAdapter()', () => {
 
         const adapter = createAdapter({
           config: { provider: 'minimax', model: 'test' },
+          tools: {},
+        });
+
+        expect(adapter).toBeDefined();
+        expect(typeof adapter.chat).toBe('function');
+      });
+    });
+  });
+
+  describe('Given provider is "anthropic"', () => {
+    describe('When createAdapter is called', () => {
+      it('Then returns an Anthropic adapter', () => {
+        process.env.ANTHROPIC_API_KEY = 'key';
+
+        const adapter = createAdapter({
+          config: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
           tools: {},
         });
 

--- a/packages/agents/src/providers/create-adapter.ts
+++ b/packages/agents/src/providers/create-adapter.ts
@@ -1,4 +1,5 @@
 import type { LLMAdapter } from '../loop/react-loop';
+import { createAnthropicAdapter } from './anthropic';
 import { createCloudflareAdapter } from './cloudflare';
 import { createMinimaxAdapter } from './minimax';
 import type { CreateAdapterOptions } from './types';
@@ -9,7 +10,8 @@ import type { CreateAdapterOptions } from './types';
  * Dispatches to the appropriate provider adapter:
  * - `'cloudflare'` → Cloudflare Workers AI (OpenAI-compatible REST API)
  * - `'minimax'` → MiniMax (OpenAI-compatible REST API)
- * - `'anthropic'` / `'openai'` — not yet implemented
+ * - `'anthropic'` → Anthropic Messages API (native tool-use blocks)
+ * - `'openai'` — not yet implemented
  */
 export function createAdapter(options: CreateAdapterOptions): LLMAdapter {
   switch (options.config.provider) {
@@ -17,9 +19,11 @@ export function createAdapter(options: CreateAdapterOptions): LLMAdapter {
       return createCloudflareAdapter(options);
     case 'minimax':
       return createMinimaxAdapter(options);
+    case 'anthropic':
+      return createAnthropicAdapter(options);
     default:
       throw new Error(
-        `Unsupported LLM provider: "${options.config.provider}". Supported: cloudflare, minimax`,
+        `Unsupported LLM provider: "${options.config.provider}". Supported: cloudflare, minimax, anthropic`,
       );
   }
 }


### PR DESCRIPTION
## Summary

Closes #2834.

Adds `createAnthropicAdapter` to `@vertz/agents`, backed by the **native Anthropic Messages API** (not the OpenAI-compatible shim). Wires it into `createAdapter()` dispatch so agent configs can declare `{ provider: 'anthropic', model: 'claude-sonnet-4-6' }`.

### Public API changes (additive)

- New exports from `@vertz/agents`: `createAnthropicAdapter`.
- `createAdapter({ config: { provider: 'anthropic', model } })` now returns an adapter instead of throwing.
- New env var: `ANTHROPIC_API_KEY` (sent as `x-api-key`, with `anthropic-version: 2023-06-01`).

### Message conversion

- System messages extracted into the top-level `system` field (concat with `\n\n`).
- Assistant messages with `toolCalls` emit an `assistant` turn with `tool_use` blocks (plus a `text` block when the loop's `[Calling …]` placeholder is absent).
- Tool result messages merge into the **last `user` turn** when that turn is already block-shaped, preserving Anthropic's user/assistant alternation requirement. If a `user` text message is interleaved, the tool_result starts a fresh user turn.
- `toolCallId` is required on tool messages — the adapter throws at conversion time with a clear message rather than emitting an empty `tool_use_id` that Anthropic would reject as a 400.
- When the model returns `toolCalls` without `id`, synthesized ids are indexed (`call_0_name`, `call_1_name`, …) so repeated tool names don't collide within a single assistant turn.

### Response parsing

- All `text` blocks concatenated (no separator).
- All `tool_use` blocks mapped into `LLMResponse.toolCalls` with defensive `input` coercion — non-object inputs (`null`, strings, arrays) fall back to `{}`.
- `usage.input_tokens` / `usage.output_tokens` → `LLMResponse.usage`.

### Safety / consistency

- 120s `AbortController` timeout, matching `minimax.ts`.
- Unit test coverage: 16 scenarios covering happy path, tool-calling round-trip, multi-system concat, interleaved user message, repeated-tool-name id synthesis, non-OK status, missing env var, missing usage fields, empty content, header assertions (no `Authorization` header).

## Test plan

- [x] `vtz test` (agents package) — 212 passed, 13 skipped
- [x] `tsgo --noEmit -p tsconfig.typecheck.json` — clean
- [x] `oxlint` — 0 errors (4 warnings match existing `throw new Error` pattern in `cloudflare.ts` / `minimax.ts`)
- [x] `oxfmt --check` — clean
- [x] Adversarial self-review run; blockers around `tool_use_id` fallback, duplicate-id collisions, and non-object `input` handling all fixed with accompanying tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)