### PR TITLE
fix(vtz): hint TS2339 on ImportMeta.hot at vertz/client tsconfig fix [#2814]

### DIFF
--- a/.changeset/fix-hmr-types-hint.md
+++ b/.changeset/fix-hmr-types-hint.md
@@ -1,0 +1,16 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): point TS2339 on `ImportMeta.hot` at the `vertz/client` tsconfig fix
+
+When TypeScript reports `Property 'hot' does not exist on type 'ImportMeta'`
+— the common symptom of a tsconfig missing the `vertz/client` type
+augmentation — the dev server now appends a Vertz-specific hint with the
+exact fix and a link to `https://vertz.dev/guides/hmr-types`.
+
+The hint only fires for the `'hot'` + `'ImportMeta'` shape, so other
+TS2339 errors keep the generic suggestion. Set `VTZ_NO_HMR_HINT=1` to
+suppress the hint if you don't want it.
+
+Closes #2814.

--- a/native/vtz/src/errors/suggestions.rs
+++ b/native/vtz/src/errors/suggestions.rs
@@ -187,7 +187,15 @@ pub fn suggest_runtime_fix(message: &str) -> Option<String> {
 /// Only provides suggestions for errors where the fix is NOT obvious from the
 /// error message itself. Self-explanatory errors (e.g., TS2322 "type X is not
 /// assignable to type Y") get no suggestion — the error message is sufficient.
-pub fn suggest_typecheck_fix(ts_code: u32) -> Option<String> {
+///
+/// `hmr_hint_enabled` gates the Vertz-specific `import.meta.hot` hint so users
+/// can suppress it via `VTZ_NO_HMR_HINT=1` without losing the generic TS2339
+/// suggestion.
+pub fn suggest_typecheck_fix(
+    ts_code: u32,
+    message: &str,
+    hmr_hint_enabled: bool,
+) -> Option<String> {
     match ts_code {
         // TS2307: Cannot find module 'X' or its corresponding type declarations.
         2307 => Some(
@@ -210,11 +218,21 @@ pub fn suggest_typecheck_fix(ts_code: u32) -> Option<String> {
         // TS7006: Parameter 'x' implicitly has an 'any' type.
         7006 => Some("Add an explicit type annotation to this parameter.".into()),
         // TS2339: Property 'X' does not exist on type 'Y'.
-        2339 => Some(
-            "The property doesn't exist on this type. Check spelling, \
-             or verify the object's type is what you expect."
-                .into(),
-        ),
+        2339 => {
+            if hmr_hint_enabled && is_import_meta_hot_miss(message) {
+                return Some(
+                    "Add `vertz/client` to your tsconfig `compilerOptions.types` to pick up HMR \
+                     type augmentations (`import.meta.hot`). \
+                     See https://vertz.dev/guides/hmr-types"
+                        .into(),
+                );
+            }
+            Some(
+                "The property doesn't exist on this type. Check spelling, \
+                 or verify the object's type is what you expect."
+                    .into(),
+            )
+        }
         // TS2551: Property 'X' does not exist on type 'Y'. Did you mean 'Z'?
         2551 => Some(
             "Check the property name — TypeScript suggests a similar name in the error.".into(),
@@ -228,6 +246,19 @@ pub fn suggest_typecheck_fix(ts_code: u32) -> Option<String> {
         // Self-explanatory errors (TS2322, etc.) — no suggestion
         _ => None,
     }
+}
+
+/// Detect the specific TS2339 shape emitted when `import.meta.hot` is used
+/// without the `vertz/client` type augmentation:
+///
+/// `Property 'hot' does not exist on type 'ImportMeta'.`
+///
+/// Anchored on the full canonical TS2339 phrasing so that unrelated
+/// diagnostics mentioning `'hot'` and `'ImportMeta'` separately (e.g. a
+/// "Did you mean 'hot'?" continuation on an `'env' does not exist on type
+/// 'ImportMeta'` error) don't trigger the Vertz-specific hint.
+fn is_import_meta_hot_miss(message: &str) -> bool {
+    message.contains("Property 'hot' does not exist on type 'ImportMeta'")
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -399,49 +430,109 @@ mod tests {
 
     #[test]
     fn test_suggest_typecheck_ts2307_cannot_find_module() {
-        let suggestion = suggest_typecheck_fix(2307);
+        let suggestion = suggest_typecheck_fix(2307, "Cannot find module 'foo'.", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("import path"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts2304_cannot_find_name() {
-        let suggestion = suggest_typecheck_fix(2304);
+        let suggestion = suggest_typecheck_fix(2304, "Cannot find name 'foo'.", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("imported or declared"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts2345_argument_type_mismatch() {
-        let suggestion = suggest_typecheck_fix(2345);
+        let suggestion = suggest_typecheck_fix(2345, "Argument of type X.", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("function signature"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts7006_implicit_any() {
-        let suggestion = suggest_typecheck_fix(7006);
+        let suggestion = suggest_typecheck_fix(7006, "Parameter 'x' implicitly has any.", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("type annotation"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts2339_property_not_exist() {
-        let suggestion = suggest_typecheck_fix(2339);
+        let suggestion =
+            suggest_typecheck_fix(2339, "Property 'foo' does not exist on type 'Bar'.", true);
         assert!(suggestion.is_some());
-        assert!(suggestion.unwrap().contains("property"));
+        let s = suggestion.unwrap();
+        assert!(s.contains("property"));
+        // Generic TS2339 message, not the HMR-specific hint
+        assert!(!s.contains("vertz/client"));
+    }
+
+    #[test]
+    fn test_suggest_typecheck_ts2339_import_meta_hot_hint() {
+        let suggestion = suggest_typecheck_fix(
+            2339,
+            "Property 'hot' does not exist on type 'ImportMeta'.",
+            true,
+        );
+        assert!(suggestion.is_some());
+        let s = suggestion.unwrap();
+        assert!(
+            s.contains("vertz/client"),
+            "expected vertz/client hint but got: {}",
+            s
+        );
+        assert!(s.contains("compilerOptions.types"));
+        assert!(s.contains("https://vertz.dev/guides/hmr-types"));
+    }
+
+    #[test]
+    fn test_suggest_typecheck_ts2339_hmr_hint_disabled_falls_back_to_generic() {
+        let suggestion = suggest_typecheck_fix(
+            2339,
+            "Property 'hot' does not exist on type 'ImportMeta'.",
+            false,
+        );
+        assert!(suggestion.is_some());
+        let s = suggestion.unwrap();
+        assert!(
+            !s.contains("vertz/client"),
+            "HMR hint should be suppressed but got: {}",
+            s
+        );
+        assert!(s.contains("property"));
+    }
+
+    #[test]
+    fn test_suggest_typecheck_ts2339_hmr_hint_requires_both_hot_and_importmeta() {
+        // 'hot' on a non-ImportMeta type — should not trigger the HMR hint.
+        let suggestion = suggest_typecheck_fix(
+            2339,
+            "Property 'hot' does not exist on type 'Thermometer'.",
+            true,
+        );
+        assert!(suggestion.is_some());
+        assert!(!suggestion.unwrap().contains("vertz/client"));
+
+        // ImportMeta but a different missing property — also should not trigger.
+        let suggestion = suggest_typecheck_fix(
+            2339,
+            "Property 'env' does not exist on type 'ImportMeta'.",
+            true,
+        );
+        assert!(suggestion.is_some());
+        assert!(!suggestion.unwrap().contains("vertz/client"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts2551_did_you_mean() {
-        let suggestion = suggest_typecheck_fix(2551);
+        let suggestion = suggest_typecheck_fix(2551, "Did you mean 'foo'?", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("similar name"));
     }
 
     #[test]
     fn test_suggest_typecheck_ts1259_esmodule_interop() {
-        let suggestion = suggest_typecheck_fix(1259);
+        let suggestion = suggest_typecheck_fix(1259, "esModuleInterop.", true);
         assert!(suggestion.is_some());
         assert!(suggestion.unwrap().contains("esModuleInterop"));
     }
@@ -449,9 +540,9 @@ mod tests {
     #[test]
     fn test_suggest_typecheck_self_explanatory_returns_none() {
         // TS2322: Type 'X' is not assignable to type 'Y' — self-explanatory
-        assert!(suggest_typecheck_fix(2322).is_none());
+        assert!(suggest_typecheck_fix(2322, "Type 'x'.", true).is_none());
         // Unknown codes
-        assert!(suggest_typecheck_fix(9999).is_none());
+        assert!(suggest_typecheck_fix(9999, "anything", true).is_none());
     }
 
     #[test]

--- a/native/vtz/src/typecheck/parser.rs
+++ b/native/vtz/src/typecheck/parser.rs
@@ -37,18 +37,32 @@ impl TscDiagnostic {
     /// Attaches an actionable suggestion if one is available for this TS error code.
     /// Optionally enriches with a code snippet if `root_dir` is provided and the
     /// source file can be read.
-    pub fn to_dev_error(&self) -> DevError {
+    ///
+    /// `hmr_hint_enabled` gates the Vertz-specific `import.meta.hot` hint; users
+    /// can disable it via `VTZ_NO_HMR_HINT=1`. `DiagnosticBuffer::flush()`
+    /// re-reads the env var on every flush so a running dev server picks up
+    /// toggles without a restart.
+    pub fn to_dev_error(&self, hmr_hint_enabled: bool) -> DevError {
         let msg = format!("TS{}: {}", self.code, self.message);
         let mut error = DevError::typecheck(msg)
             .with_file(&self.file)
             .with_location(self.line, self.col);
 
-        if let Some(suggestion) = suggestions::suggest_typecheck_fix(self.code) {
+        if let Some(suggestion) =
+            suggestions::suggest_typecheck_fix(self.code, &self.message, hmr_hint_enabled)
+        {
             error = error.with_suggestion(suggestion);
         }
 
         error
     }
+}
+
+/// Resolve the `VTZ_NO_HMR_HINT` env var once at the point where we batch
+/// diagnostics. Centralised so tests can feed the flag explicitly without
+/// racing on the process env.
+pub fn hmr_hint_enabled_from_env() -> bool {
+    std::env::var("VTZ_NO_HMR_HINT").as_deref() != Ok("1")
 }
 
 /// Parse a single line of tsc `--pretty false --watch` output.
@@ -193,11 +207,15 @@ impl DiagnosticBuffer {
     }
 
     /// Flush the buffer and return all accumulated errors as DevErrors.
+    ///
+    /// Reads `VTZ_NO_HMR_HINT` once per flush to decide whether to emit the
+    /// Vertz-specific `import.meta.hot` hint for TS2339 diagnostics.
     pub fn flush(&mut self) -> Vec<DevError> {
+        let hmr_hint_enabled = hmr_hint_enabled_from_env();
         let errors: Vec<DevError> = self
             .diagnostics
             .drain(..)
-            .map(|d| d.to_dev_error())
+            .map(|d| d.to_dev_error(hmr_hint_enabled))
             .collect();
         self.has_content = false;
         errors
@@ -372,7 +390,7 @@ mod tests {
             severity: "error".to_string(),
         };
 
-        let err = diag.to_dev_error();
+        let err = diag.to_dev_error(true);
         assert_eq!(
             err.category,
             crate::errors::categories::ErrorCategory::TypeCheck
@@ -397,9 +415,53 @@ mod tests {
             severity: "error".to_string(),
         };
 
-        let err = diag.to_dev_error();
+        let err = diag.to_dev_error(true);
         assert!(err.suggestion.is_some());
         assert!(err.suggestion.unwrap().contains("import path"));
+    }
+
+    #[test]
+    fn test_diagnostic_to_dev_error_emits_hmr_hint_for_import_meta_hot() {
+        let diag = TscDiagnostic {
+            file: "src/entry-client.ts".to_string(),
+            line: 1,
+            col: 1,
+            code: 2339,
+            message: "Property 'hot' does not exist on type 'ImportMeta'.".to_string(),
+            severity: "error".to_string(),
+        };
+
+        let err = diag.to_dev_error(true);
+        let suggestion = err.suggestion.expect("expected a suggestion");
+        assert!(
+            suggestion.contains("vertz/client"),
+            "expected HMR hint, got: {}",
+            suggestion
+        );
+        assert!(suggestion.contains("https://vertz.dev/guides/hmr-types"));
+    }
+
+    #[test]
+    fn test_diagnostic_to_dev_error_hmr_hint_suppressed_when_flag_off() {
+        let diag = TscDiagnostic {
+            file: "src/entry-client.ts".to_string(),
+            line: 1,
+            col: 1,
+            code: 2339,
+            message: "Property 'hot' does not exist on type 'ImportMeta'.".to_string(),
+            severity: "error".to_string(),
+        };
+
+        let err = diag.to_dev_error(false);
+        let suggestion = err
+            .suggestion
+            .expect("still expect the generic TS2339 suggestion");
+
+        assert!(
+            !suggestion.contains("vertz/client"),
+            "HMR hint should be suppressed, got: {}",
+            suggestion
+        );
     }
 
     #[test]
@@ -413,11 +475,60 @@ mod tests {
             severity: "error".to_string(),
         };
 
-        let err = diag.to_dev_error();
+        let err = diag.to_dev_error(true);
         assert!(err.suggestion.is_none());
     }
 
     // ── DiagnosticBuffer ──
+
+    #[test]
+    fn test_buffer_flush_threads_hmr_flag_into_diagnostics() {
+        // Integration: a TS2339 `import.meta.hot` diagnostic fed through the
+        // full buffer → flush pipeline picks up the HMR hint when the env
+        // default applies (no override set).
+        let mut buf = DiagnosticBuffer::new();
+        buf.feed(parse_tsc_line(
+            "src/entry-client.ts(1,1): error TS2339: Property 'hot' does not exist on type 'ImportMeta'.",
+        ));
+        let errors = buf
+            .feed(parse_tsc_line(
+                "[12:00:00] Found 1 error. Watching for file changes.",
+            ))
+            .expect("sentinel should flush");
+
+        assert_eq!(errors.len(), 1);
+        let suggestion = errors[0]
+            .suggestion
+            .as_ref()
+            .expect("expected a suggestion");
+        // When env is not set to "1", the HMR hint fires.
+        if hmr_hint_enabled_from_env() {
+            assert!(
+                suggestion.contains("vertz/client"),
+                "expected HMR hint when VTZ_NO_HMR_HINT is unset, got: {}",
+                suggestion
+            );
+        } else {
+            assert!(
+                !suggestion.contains("vertz/client"),
+                "HMR hint should be suppressed when VTZ_NO_HMR_HINT=1, got: {}",
+                suggestion
+            );
+        }
+    }
+
+    #[test]
+    fn test_hmr_hint_enabled_from_env_defaults_to_true_when_unset() {
+        // This test is intentionally tolerant: if the ambient test env happens
+        // to have VTZ_NO_HMR_HINT=1, we accept `false` instead. What matters
+        // is that the function reads the env var and returns a bool.
+        let result = hmr_hint_enabled_from_env();
+        let env_value = std::env::var("VTZ_NO_HMR_HINT").ok();
+        match env_value.as_deref() {
+            Some("1") => assert!(!result),
+            _ => assert!(result),
+        }
+    }
 
     #[test]
     fn test_buffer_accumulates_diagnostics() {


### PR DESCRIPTION
## Summary

Closes #2814.

When tsgo reports `Property 'hot' does not exist on type 'ImportMeta'` — the tell-tale sign of a tsconfig that's missing the `vertz/client` type augmentation — the dev server now attaches a Vertz-specific suggestion:

> Add \`vertz/client\` to your tsconfig \`compilerOptions.types\` to pick up HMR type augmentations (\`import.meta.hot\`). See https://vertz.dev/guides/hmr-types

### Scope / behaviour

- **Only fires for the exact shape.** The matcher anchors on the full canonical phrasing `Property 'hot' does not exist on type 'ImportMeta'`, so unrelated TS2339s mentioning `'hot'` and `'ImportMeta'` separately (e.g. a `Did you mean 'hot'?` continuation on a different diagnostic) don't trigger the Vertz hint.
- **Other TS2339s are untouched.** They keep the existing generic "property doesn't exist" suggestion.
- **Disableable via env var.** `VTZ_NO_HMR_HINT=1` suppresses the hint — the generic TS2339 suggestion still appears. Mirrors the existing `VTZ_NO_UPDATE_CHECK` convention (prefix, negation form, `==\"1\"` check).

### Design choice — flag threaded, not env read at the matcher

`suggest_typecheck_fix` now takes `(code, message, hmr_hint_enabled)`. `DiagnosticBuffer::flush()` reads the env once per flush and threads the bool through. This keeps the matcher pure, lets tests pin both states without mutating process env (avoids parallel `cargo test` races), and allows users to toggle the flag mid-session without restarting the dev server.

## Test plan

- [x] `cargo test --all` — 3476 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Adversarial self-review; tightened the matcher from substring to anchored phrase, fixed a doc-string drift, added a `DiagnosticBuffer::flush()` integration test and a `hmr_hint_enabled_from_env()` unit test

### New test coverage (excerpt)

- Hint fires for the canonical shape
- Hint does NOT fire for generic TS2339 (`Property 'foo' on type 'Bar'`)
- Hint does NOT fire for `'hot'` on a non-ImportMeta type or for `ImportMeta` with a different missing property
- When the flag is `false`, the generic TS2339 suggestion still appears (hint specifically removed)
- Round-trip through `TscDiagnostic::to_dev_error` both flags
- Round-trip through the full `DiagnosticBuffer::flush()` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)