### PR TITLE
feat(agents): export d1Store from main @vertz/agents entry [#2838]

### DIFF
--- a/.changeset/agents-d1-store-public.md
+++ b/.changeset/agents-d1-store-public.md
@@ -1,0 +1,21 @@
+---
+'@vertz/agents': patch
+---
+
+feat(agents): export `d1Store` from the main `@vertz/agents` entry
+
+`d1Store` was previously only reachable via the internal `@vertz/agents/cloudflare`
+subpath (or via a deep relative import into `stores/d1-store`). It now sits
+alongside `memoryStore` and `sqliteStore` on the main entry:
+
+```ts
+import { d1Store, run } from '@vertz/agents';
+
+const store = d1Store({ binding: env.DB });
+```
+
+Also exports the `D1Binding` and `D1StoreOptions` types for consumers who
+want to abstract over the binding. The `@vertz/agents/cloudflare` subpath
+is unchanged — existing imports still work.
+
+Closes #2838.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -122,6 +122,32 @@ const result = await run(researcher, {
 
 **Available stores:** `memoryStore()`, `sqliteStore()`, `d1Store()` (Cloudflare D1)
 
+### Cloudflare D1 (Workers / Durable Objects)
+
+Use `d1Store` from the Worker `env` binding for durable session storage:
+
+```typescript
+import { d1Store, run } from '@vertz/agents';
+
+export default {
+  async fetch(request: Request, env: { DB: D1Database }) {
+    const store = d1Store({ binding: env.DB });
+
+    const result = await run(researcher, {
+      message: 'Find recent papers on transformer architectures',
+      llm: adapter,
+      store,
+      userId: 'user-123',
+      sessionId: request.headers.get('x-session-id') ?? undefined,
+    });
+
+    return Response.json(result);
+  },
+};
+```
+
+The D1 store lazily creates its `agent_sessions` / `agent_messages` tables on first use — no migration step required.
+
 ## Workflows
 
 Chain multiple agents into typed, multi-step workflows with approval gates.
@@ -176,7 +202,7 @@ import { createAgentRunner } from '@vertz/agents';
 const runner = createAgentRunner({
   agents: { researcher, greeter },
   llm: adapter,
-  store: d1Store(env.DB),
+  store: d1Store({ binding: env.DB }),
 });
 ```
 

--- a/packages/agents/src/cloudflare.ts
+++ b/packages/agents/src/cloudflare.ts
@@ -1,4 +1,4 @@
 // @vertz/agents/cloudflare — Cloudflare-specific entrypoint
 
 export { d1Store } from './stores/d1-store';
-export type { D1Binding, D1StoreOptions } from './stores/d1-store';
+export type { D1Binding, D1PreparedStatement, D1Result, D1StoreOptions } from './stores/d1-store';

--- a/packages/agents/src/index.test.ts
+++ b/packages/agents/src/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@vertz/test';
+import * as publicApi from './index';
+import * as cloudflareSubpath from './cloudflare';
+import type { D1Binding } from './index';
+
+// ---------------------------------------------------------------------------
+// Public entry re-export contract
+// ---------------------------------------------------------------------------
+//
+// These tests pin which symbols are part of the public `@vertz/agents` entry
+// so accidental removals (or `export *` drift) are caught in review.
+
+function makeNoopBinding(): D1Binding {
+  const stmt = {
+    bind() {
+      return stmt;
+    },
+    async all<T>() {
+      return { results: [] as T[], success: true };
+    },
+    async run() {
+      return { results: [], success: true };
+    },
+    async first<T>(): Promise<T | null> {
+      return null;
+    },
+  };
+  return {
+    async exec() {
+      return {};
+    },
+    prepare() {
+      return stmt;
+    },
+    async batch() {
+      return [];
+    },
+  };
+}
+
+describe('@vertz/agents public entry', () => {
+  describe('Given the main index exports', () => {
+    describe('When listing store factories', () => {
+      it('Then exposes memoryStore, sqliteStore, and d1Store', () => {
+        expect(typeof publicApi.memoryStore).toBe('function');
+        expect(typeof publicApi.sqliteStore).toBe('function');
+        expect(typeof publicApi.d1Store).toBe('function');
+      });
+    });
+  });
+
+  describe('Given d1Store is reachable from both the main entry and the cloudflare subpath', () => {
+    describe('When comparing the two references', () => {
+      it('Then they point at the exact same function (no duplicate implementation)', () => {
+        expect(publicApi.d1Store).toBe(cloudflareSubpath.d1Store);
+      });
+    });
+  });
+
+  describe('Given the d1Store factory is invoked with a D1 binding', () => {
+    describe('When building a store', () => {
+      it('Then returns an AgentStore-shaped object', () => {
+        const store = publicApi.d1Store({ binding: makeNoopBinding() });
+        expect(typeof store.loadSession).toBe('function');
+        expect(typeof store.saveSession).toBe('function');
+        expect(typeof store.appendMessages).toBe('function');
+        expect(typeof store.listSessions).toBe('function');
+      });
+    });
+  });
+});

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -58,6 +58,8 @@ export type { AgentSession, AgentStore, ListSessionsFilter } from './stores/type
 export { memoryStore } from './stores/memory-store';
 export { sqliteStore } from './stores/sqlite-store';
 export type { SqliteStoreOptions } from './stores/sqlite-store';
+export { d1Store } from './stores/d1-store';
+export type { D1Binding, D1PreparedStatement, D1Result, D1StoreOptions } from './stores/d1-store';
 export { SessionNotFoundError, SessionAccessDeniedError } from './stores/errors';
 
 // Workflow

--- a/packages/agents/src/stores/d1-store.ts
+++ b/packages/agents/src/stores/d1-store.ts
@@ -12,14 +12,16 @@ export interface D1Binding {
   batch(statements: D1PreparedStatement[]): Promise<D1Result<unknown>[]>;
 }
 
-interface D1PreparedStatement {
+/** Minimal D1 prepared-statement shape — matches Cloudflare's `D1PreparedStatement`. */
+export interface D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
   all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
   run(): Promise<D1Result<unknown>>;
   first<T = Record<string, unknown>>(): Promise<T | null>;
 }
 
-interface D1Result<T> {
+/** Minimal D1 result shape — matches Cloudflare's `D1Result`. */
+export interface D1Result<T> {
   results: T[];
   success: boolean;
 }
@@ -127,8 +129,10 @@ function rowToMessage(row: MessageRow): Message {
  * Cloudflare D1-backed store for agent sessions and messages.
  * Uses the raw D1 binding (not @vertz/db wrapper).
  *
+ * Available from both the main entry and the Cloudflare subpath:
+ *
  * ```ts
- * import { d1Store } from '@vertz/agents/cloudflare';
+ * import { d1Store } from '@vertz/agents';
  * const store = d1Store({ binding: env.DB });
  * ```
  */

--- a/packages/agents/src/types.test-d.ts
+++ b/packages/agents/src/types.test-d.ts
@@ -416,3 +416,36 @@ run(testAgent, { message: 'hi', llm: testLlm, userId: null, tenantId: null });
 
 // @ts-expect-error — userId must be string | null, not number
 run(testAgent, { message: 'hi', llm: testLlm, userId: 42 });
+
+// ---------------------------------------------------------------------------
+// Public entry: `d1Store` and its supporting types are reachable from
+// `@vertz/agents`. These live in `./index.ts` so accidental removal shows up
+// as a compile error here (proving the public type surface stays stable).
+// ---------------------------------------------------------------------------
+// eslint-disable-next-line no-duplicate-imports -- namespace import keeps this block self-contained
+import type { AgentStore, D1Binding, D1PreparedStatement, D1Result, D1StoreOptions } from './index';
+// eslint-disable-next-line no-duplicate-imports
+import { d1Store } from './index';
+
+// D1StoreOptions must accept a D1Binding.
+const _d1Options: D1StoreOptions = {
+  binding: {} as D1Binding,
+};
+void _d1Options;
+
+// D1Binding.prepare returns a namable D1PreparedStatement.
+const _stmt: D1PreparedStatement = {} as D1Binding extends { prepare(q: string): infer S }
+  ? S
+  : never;
+void _stmt;
+
+// batch returns an array of D1Result<unknown>.
+const _results: D1Result<unknown>[] = [];
+void _results;
+
+// d1Store returns an AgentStore — the public interface agents code operates on.
+const _d1StoreInstance: AgentStore = d1Store({ binding: {} as D1Binding });
+void _d1StoreInstance;
+
+// @ts-expect-error — options.binding is required
+d1Store({});

--- a/packages/mint-docs/guides/agents/workflows.mdx
+++ b/packages/mint-docs/guides/agents/workflows.mdx
@@ -308,10 +308,11 @@ const second = await run(greeter, {
 
 ### Available stores
 
-| Store         | Import          | Description                       |
-| ------------- | --------------- | --------------------------------- |
-| `memoryStore` | `@vertz/agents` | In-memory, for testing and dev.   |
-| `sqliteStore` | `@vertz/agents` | SQLite-backed via `vertz:sqlite`. |
+| Store         | Import          | Description                                                                     |
+| ------------- | --------------- | ------------------------------------------------------------------------------- |
+| `memoryStore` | `@vertz/agents` | In-memory, for testing and dev.                                                 |
+| `sqliteStore` | `@vertz/agents` | SQLite-backed via `vertz:sqlite`.                                               |
+| `d1Store`     | `@vertz/agents` | Cloudflare D1 — pass `{ binding: env.DB }`. Tables are created on first call.   |
 
 ### Session options
 

--- a/packages/mint-docs/guides/agents/workflows.mdx
+++ b/packages/mint-docs/guides/agents/workflows.mdx
@@ -308,11 +308,11 @@ const second = await run(greeter, {
 
 ### Available stores
 
-| Store         | Import          | Description                                                                     |
-| ------------- | --------------- | ------------------------------------------------------------------------------- |
-| `memoryStore` | `@vertz/agents` | In-memory, for testing and dev.                                                 |
-| `sqliteStore` | `@vertz/agents` | SQLite-backed via `vertz:sqlite`.                                               |
-| `d1Store`     | `@vertz/agents` | Cloudflare D1 — pass `{ binding: env.DB }`. Tables are created on first call.   |
+| Store         | Import          | Description                                                                   |
+| ------------- | --------------- | ----------------------------------------------------------------------------- |
+| `memoryStore` | `@vertz/agents` | In-memory, for testing and dev.                                               |
+| `sqliteStore` | `@vertz/agents` | SQLite-backed via `vertz:sqlite`.                                             |
+| `d1Store`     | `@vertz/agents` | Cloudflare D1 — pass `{ binding: env.DB }`. Tables are created on first call. |
 
 ### Session options
 


### PR DESCRIPTION
## Summary

Closes #2838.

`d1Store` sat behind the `@vertz/agents/cloudflare` subpath even though the package's own README, mint-docs, and `createAgentRunner` example all presented it as a first-class public store. It now lives on the main entry alongside `memoryStore` / `sqliteStore`:

```ts
import { d1Store, run } from '@vertz/agents';

const store = d1Store({ binding: env.DB });
```

### Public API changes (additive)

- New value exports: `d1Store`.
- New type exports: `D1Binding`, `D1PreparedStatement`, `D1Result`, `D1StoreOptions`.
- The `@vertz/agents/cloudflare` subpath is unchanged; existing imports still work.

### Doc fixes picked up along the way

- `README.md` had `d1Store(env.DB)` (wrong — the function takes `{ binding }`); corrected + added a Workers / Durable Objects usage snippet.
- `mint-docs/guides/agents/workflows.mdx` store table gained a `d1Store` row.
- `d1-store.ts` JSDoc now shows the main-entry import.

### Tests

- `src/index.test.ts` (new): runtime contract — `memoryStore` / `sqliteStore` / `d1Store` are all `typeof === 'function'` on the public entry; `d1Store({ binding })` returns an `AgentStore`-shaped object.
- **Dual-path identity test** (per adversarial review): `publicApi.d1Store` and `cloudflareSubpath.d1Store` resolve to the same reference, so accidental re-implementation in either file fails the build.
- `src/types.test-d.ts`: type-level asserts that `D1Binding`, `D1PreparedStatement`, `D1Result`, `D1StoreOptions`, and `d1Store` are all reachable from `@vertz/agents` (with a `@ts-expect-error` on the no-args call).

## Test plan

- [x] `vtz test` — 215 passed, 13 skipped
- [x] `tsgo --noEmit` — clean
- [x] `oxlint` — 0 warnings, 0 errors on touched files
- [x] `oxfmt --check` — clean
- [x] Adversarial review identified two should-fix items (dual-path identity test, type reachability test, export `D1PreparedStatement` / `D1Result` that leaked from the binding surface) — all addressed before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)