### PR TITLE
feat(agents): durable tool execution + transactional resume [#2835]

### DIFF
--- a/.changeset/agents-durable-resume.md
+++ b/.changeset/agents-durable-resume.md
@@ -1,0 +1,36 @@
+---
+'@vertz/agents': patch
+---
+
+Durable tool execution + transactional resume. When `run()` is called
+with `store + sessionId` against a durable store (`sqliteStore` /
+`d1Store`), each tool-call step now commits atomically — pre-dispatch
+assistant-with-toolCalls in one atomic write, post-dispatch
+tool_results in another. If the process dies between the two, a later
+`run()` with the same `sessionId` detects the orphan and either
+re-invokes handlers declared `safeToRetry: true` or surfaces a
+`ToolDurabilityError` tool_result for the LLM to reason about in-band.
+
+**New exports** from `@vertz/agents`:
+
+- `AgentStore.appendMessagesAtomic(sessionId, messages, session)` — the
+  durability primitive. Implemented on all three stores.
+- `MemoryStoreNotDurableError` — thrown at `run()` entry when
+  `memoryStore()` is paired with `sessionId`. Memory store cannot
+  guarantee durable writes.
+- `ToolDurabilityError` — surfaced as a tool_result when an orphaned
+  non-`safeToRetry` tool call is detected on resume.
+- `tool({ safeToRetry: true, ... })` — optional per-tool flag. When
+  true, the framework may re-invoke the handler on resume. Default
+  (omitted) assumes side effects.
+
+**New subpath**: `@vertz/agents/testing` with
+`crashAfterToolResults(store, failOnCallNumber = 2)` for writing
+resume tests.
+
+**Removed** (pre-v1, no shim): `AgentLoopConfig.checkpointInterval` +
+`ReactLoopOptions.onCheckpoint`. They were a notification callback,
+not a durability primitive, and they created ambiguity with the new
+`store + sessionId` path.
+
+Closes #2835.

--- a/packages/agents/build.config.ts
+++ b/packages/agents/build.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@vertz/build';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cloudflare.ts'],
+  entry: ['src/index.ts', 'src/cloudflare.ts', 'src/testing/index.ts'],
   dts: true,
   external: ['bun:sqlite'],
   clean: true,

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -23,6 +23,10 @@
     "./cloudflare": {
       "import": "./dist/cloudflare.js",
       "types": "./dist/cloudflare.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing/index.js",
+      "types": "./dist/testing/index.d.ts"
     }
   },
   "publishConfig": {

--- a/packages/agents/src/__tests__/durable-resume.perf.test.ts
+++ b/packages/agents/src/__tests__/durable-resume.perf.test.ts
@@ -1,0 +1,78 @@
+// Perf regression gate for the durable-resume write pattern (#2835).
+//
+// Measures wall time for a 10-step scripted loop against
+// `sqliteStore({ path: ':memory:' })`. In-memory SQLite is not D1, but it's
+// the closest same-process transactional store and gives a useful lower bound
+// for the overhead added by per-step atomic writes. Real D1 same-region
+// measurement lives in Phase 5's manual checklist.
+//
+// Gate: < 200ms for 10 steps on in-memory SQLite. If CI makes this flaky,
+// rename back to `.local.ts` and drop from default test collection.
+
+import { describe, expect, it } from '@vertz/test';
+import { s } from '@vertz/schema';
+import { agent } from '../agent';
+import type { LLMAdapter } from '../loop/react-loop';
+import { run } from '../run';
+import { sqliteStore } from '../stores/sqlite-store';
+import { tool } from '../tool';
+
+function scriptedLLM(steps: number): LLMAdapter {
+  let i = 0;
+  return {
+    async chat() {
+      i++;
+      if (i >= steps) {
+        return { text: 'done', toolCalls: [] };
+      }
+      return {
+        text: `step ${i}`,
+        toolCalls: [{ id: `call_${i}`, name: 'ping', arguments: { n: i } }],
+      };
+    },
+  };
+}
+
+describe('perf: durable-resume write pattern', () => {
+  it('10-step loop against sqliteStore(:memory:) completes under 200ms', async () => {
+    const ping = tool({
+      description: 'no-op',
+      input: s.object({ n: s.number() }),
+      output: s.object({ ok: s.boolean() }),
+      handler: () => ({ ok: true }),
+    });
+    const perfAgent = agent('perf', {
+      state: s.object({}),
+      initialState: {},
+      tools: { ping },
+      model: { provider: 'cloudflare', model: 'test' },
+      loop: { maxIterations: 12 },
+    });
+
+    const store = sqliteStore({ path: ':memory:' });
+    await store.saveSession({
+      id: 'sess_perf',
+      agentName: 'perf',
+      userId: null,
+      tenantId: null,
+      state: '{}',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const t0 = performance.now();
+    const result = await run(perfAgent, {
+      message: 'go',
+      sessionId: 'sess_perf',
+      store,
+      llm: scriptedLLM(10),
+    });
+    const elapsed = performance.now() - t0;
+
+    // eslint-disable-next-line no-console -- perf one-shot is meant to be observed
+    console.log(`[perf] 10-step durable loop: ${elapsed.toFixed(1)}ms`);
+
+    expect(result.status).toBe('complete');
+    expect(elapsed).toBeLessThan(200);
+  });
+});

--- a/packages/agents/src/__tests__/durable-resume.test.ts
+++ b/packages/agents/src/__tests__/durable-resume.test.ts
@@ -144,6 +144,86 @@ describe('Feature: durable tool execution', () => {
     });
   });
 
+  describe('Given a safeToRetry tool + crash before tool_result persisted', () => {
+    it('Then resume re-invokes the handler automatically (no ToolDurabilityError)', async () => {
+      let getIssueCallCount = 0;
+
+      const getIssue = tool({
+        description: 'Fetch an issue',
+        input: s.object({ id: s.string() }),
+        output: s.object({ title: s.string() }),
+        safeToRetry: true,
+      });
+
+      const safeAgent = agent('safe-agent', {
+        state: s.object({}),
+        initialState: {},
+        tools: { getIssue },
+        model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        loop: { maxIterations: 5 },
+      });
+
+      const store = sqliteStore({ path: ':memory:' });
+      await store.saveSession({
+        id: 'sess_safe_test',
+        agentName: 'safe-agent',
+        userId: null,
+        tenantId: null,
+        state: '{}',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      const llm = mockLLM([
+        {
+          text: 'Fetching.',
+          toolCalls: [{ id: 'call_a', name: 'getIssue', arguments: { id: 'ISSUE-1' } }],
+        },
+        { text: 'Got it.' },
+      ]);
+
+      const crashingStore = crashAfterToolResults(store);
+      const toolProvider = {
+        async getIssue({ id }: { id: string }) {
+          getIssueCallCount++;
+          return { title: `Issue ${id}` };
+        },
+      };
+
+      await expect(
+        run(safeAgent, {
+          message: 'Fetch ISSUE-1.',
+          sessionId: 'sess_safe_test',
+          store: crashingStore,
+          llm,
+          tools: toolProvider,
+        }),
+      ).rejects.toThrow(/simulated crash/);
+
+      expect(getIssueCallCount).toBe(1);
+
+      const llm2 = mockLLM([{ text: 'Got it.' }]);
+      const result = await run(safeAgent, {
+        message: 'Fetch ISSUE-1.',
+        sessionId: 'sess_safe_test',
+        store, // healthy now
+        llm: llm2,
+        tools: toolProvider,
+      });
+
+      expect(result.status).toBe('complete');
+      expect(getIssueCallCount).toBe(2); // ← the point: RE-INVOKED on resume
+
+      // No ToolDurabilityError surfaced — the resumed result is the real one.
+      const messages = await store.loadMessages('sess_safe_test');
+      const toolMsg = messages.find((m) => m.role === 'tool' && m.toolCallId === 'call_a');
+      expect(toolMsg).toBeDefined();
+      const parsed = JSON.parse(toolMsg!.content) as { title?: string; kind?: string };
+      expect(parsed.kind).toBeUndefined(); // not a durability error
+      expect(parsed.title).toBe('Issue ISSUE-1');
+    });
+  });
+
   describe('Given store + sessionId is the memory store', () => {
     describe('When run() is called', () => {
       it('Then entry throws MemoryStoreNotDurableError before any LLM call', async () => {
@@ -178,13 +258,22 @@ describe('Feature: durable tool execution', () => {
   });
 
   describe('Type-level', () => {
-    it('rejects tool config fields that do not exist yet', () => {
+    it('accepts safeToRetry as an optional boolean', () => {
       tool({
         description: 'x',
         input: s.object({}),
         output: s.object({}),
-        // @ts-expect-error — `safeToRetry` does not exist on ToolConfig yet (Phase 4 adds it)
         safeToRetry: true,
+      });
+    });
+
+    it('rejects safeToRetry with a non-boolean value', () => {
+      tool({
+        description: 'x',
+        input: s.object({}),
+        output: s.object({}),
+        // @ts-expect-error — safeToRetry must be boolean, not string
+        safeToRetry: 'yes',
       });
     });
   });

--- a/packages/agents/src/__tests__/durable-resume.test.ts
+++ b/packages/agents/src/__tests__/durable-resume.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from '@vertz/test';
+import { s } from '@vertz/schema';
+import { agent } from '../agent';
+import type { LLMAdapter } from '../loop/react-loop';
+import { run } from '../run';
+import { memoryStore } from '../stores/memory-store';
+import { sqliteStore } from '../stores/sqlite-store';
+import { MemoryStoreNotDurableError } from '../stores/errors';
+import { crashAfterToolResults } from '../testing/crash-harness';
+import { tool } from '../tool';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ScriptedCall {
+  readonly text?: string;
+  readonly toolCalls?: Array<{
+    readonly id?: string;
+    readonly name: string;
+    readonly arguments: Record<string, unknown>;
+  }>;
+}
+
+function mockLLM(responses: ScriptedCall[]): LLMAdapter {
+  let i = 0;
+  return {
+    async chat() {
+      const r = responses[i++] ?? { text: 'No more scripted responses', toolCalls: [] };
+      return {
+        text: r.text ?? '',
+        toolCalls: (r.toolCalls ?? []).map((tc) => ({
+          id: tc.id ?? `call_${i}_${tc.name}`,
+          name: tc.name,
+          arguments: tc.arguments,
+        })),
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Feature tests — the MVP contract for durable tool execution
+// ---------------------------------------------------------------------------
+
+describe('Feature: durable tool execution', () => {
+  describe('Given a side-effecting tool + store + sessionId', () => {
+    describe('When the process crashes after handler ran but before tool_result persisted', () => {
+      // NOTE: this test is RED through Phase 1 (framework doesn't call
+      // appendMessagesAtomic yet so the crash harness never triggers), still
+      // RED after Phase 2 (atomic writes land but no resume logic), and
+      // GREEN at the end of Phase 3 (resume detection surfaces a
+      // ToolDurabilityError tool_result instead of re-invoking the handler).
+      it('Then a subsequent run() does NOT re-invoke the handler', async () => {
+        let postSlackCallCount = 0;
+
+        const postSlack = tool({
+          description: 'Post to Slack',
+          input: s.object({ text: s.string() }),
+          output: s.object({ ts: s.string() }),
+          // no safeToRetry — default side-effecting semantics
+        });
+
+        const sentinelAgent = agent('sentinel', {
+          state: s.object({}),
+          initialState: {},
+          tools: { postSlack },
+          model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          loop: { maxIterations: 5 },
+        });
+
+        const store = sqliteStore({ path: ':memory:' });
+
+        // Pre-seed the session row (matches the DO walkthrough pattern where a
+        // caller passes a fixed sessionId on every invocation — the session
+        // needs to exist in the store before the first run() with that id).
+        await store.saveSession({
+          id: 'sess_durable_test',
+          agentName: 'sentinel',
+          userId: null,
+          tenantId: null,
+          state: '{}',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+
+        const llm = mockLLM([
+          {
+            text: 'Posting to Slack.',
+            toolCalls: [{ id: 'call_1', name: 'postSlack', arguments: { text: 'hello' } }],
+          },
+          { text: 'Done.' },
+        ]);
+
+        // Wrap the store so the SECOND appendMessagesAtomic call throws,
+        // simulating a crash AFTER the handler dispatched its side effect.
+        const crashingStore = crashAfterToolResults(store);
+        const toolProvider = {
+          async postSlack({ text: _text }: { text: string }) {
+            postSlackCallCount++;
+            return { ts: `ts_${postSlackCallCount}` };
+          },
+        };
+
+        await expect(
+          run(sentinelAgent, {
+            message: 'An issue came in.',
+            sessionId: 'sess_durable_test',
+            store: crashingStore,
+            llm,
+            tools: toolProvider,
+          }),
+        ).rejects.toThrow(/simulated crash/);
+
+        expect(postSlackCallCount).toBe(1); // handler ran exactly once pre-crash
+
+        // Resume with a healthy store + fresh scripted LLM. The LLM should
+        // see a ToolDurabilityError tool_result in history and respond "Done."
+        const llm2 = mockLLM([{ text: 'Done.' }]);
+        const result = await run(sentinelAgent, {
+          message: 'An issue came in.',
+          sessionId: 'sess_durable_test', // same sessionId
+          store, // healthy now
+          llm: llm2,
+          tools: toolProvider,
+        });
+
+        expect(result.status).toBe('complete');
+        expect(postSlackCallCount).toBe(1); // ← THE POINT: NOT 2
+
+        // The resume path wrote a ToolDurabilityError tool_result for call_1.
+        const messages = await store.loadMessages('sess_durable_test');
+        const durabilityMsg = messages.find((m) => m.role === 'tool' && m.toolCallId === 'call_1');
+        expect(durabilityMsg).toBeDefined();
+        const parsed = JSON.parse(durabilityMsg!.content) as {
+          kind: string;
+          toolName: string;
+          toolCallId: string;
+        };
+        expect(parsed.kind).toBe('tool-durability-error');
+        expect(parsed.toolName).toBe('postSlack');
+        expect(parsed.toolCallId).toBe('call_1');
+      });
+    });
+  });
+
+  describe('Given store + sessionId is the memory store', () => {
+    describe('When run() is called', () => {
+      it('Then entry throws MemoryStoreNotDurableError before any LLM call', async () => {
+        let llmWasCalled = false;
+        const llm: LLMAdapter = {
+          async chat() {
+            llmWasCalled = true;
+            return { text: 'unreachable', toolCalls: [] };
+          },
+        };
+
+        const bareAgent = agent('bare', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          loop: { maxIterations: 1 },
+        });
+
+        await expect(
+          run(bareAgent, {
+            message: 'Hi',
+            sessionId: 'sess_whatever',
+            store: memoryStore(),
+            llm,
+          }),
+        ).rejects.toThrow(MemoryStoreNotDurableError);
+
+        expect(llmWasCalled).toBe(false);
+      });
+    });
+  });
+
+  describe('Type-level', () => {
+    it('rejects tool config fields that do not exist yet', () => {
+      tool({
+        description: 'x',
+        input: s.object({}),
+        output: s.object({}),
+        // @ts-expect-error — `safeToRetry` does not exist on ToolConfig yet (Phase 4 adds it)
+        safeToRetry: true,
+      });
+    });
+  });
+});

--- a/packages/agents/src/agent.test.ts
+++ b/packages/agents/src/agent.test.ts
@@ -48,7 +48,6 @@ describe('agent()', () => {
             maxIterations: 50,
             onStuck: 'escalate',
             stuckThreshold: 5,
-            checkpointInterval: 10,
           },
         });
 
@@ -56,7 +55,6 @@ describe('agent()', () => {
           maxIterations: 50,
           onStuck: 'escalate',
           stuckThreshold: 5,
-          checkpointInterval: 10,
         });
       });
     });
@@ -76,7 +74,6 @@ describe('agent()', () => {
           maxIterations: 20,
           onStuck: 'stop',
           stuckThreshold: 3,
-          checkpointInterval: 5,
         });
       });
     });

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -15,7 +15,6 @@ const DEFAULT_LOOP: AgentLoopConfig = {
   maxIterations: 20,
   onStuck: 'stop',
   stuckThreshold: 3,
-  checkpointInterval: 5,
 };
 
 const DEFAULT_PROMPT: AgentPromptConfig = {};

--- a/packages/agents/src/create-agent-runner.test.ts
+++ b/packages/agents/src/create-agent-runner.test.ts
@@ -3,7 +3,7 @@ import { s } from '@vertz/schema';
 import { agent } from './agent';
 import { createAgentRunner } from './create-agent-runner';
 import type { LLMAdapter } from './loop/react-loop';
-import { memoryStore } from './stores/memory-store';
+import { sqliteStore } from './stores/sqlite-store';
 import { tool } from './tool';
 
 // ---------------------------------------------------------------------------
@@ -119,7 +119,7 @@ describe('createAgentRunner()', () => {
   describe('Given a runner with a store', () => {
     describe('When called without sessionId', () => {
       it('Then creates a new session and returns sessionId', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM('Hello!');
         const runner = createAgentRunner([testAgent], { llm, store });
 
@@ -134,7 +134,7 @@ describe('createAgentRunner()', () => {
   describe('Given a runner with a store and existing session', () => {
     describe('When called with sessionId', () => {
       it('Then resumes the session', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM('Hello!');
         const runner = createAgentRunner([testAgent], { llm, store });
 
@@ -167,7 +167,7 @@ describe('createAgentRunner()', () => {
   describe('Given a runner with a store and session ownership', () => {
     describe('When user B tries to resume user A session', () => {
       it('Then throws access denied error', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM('Hello!');
         const runner = createAgentRunner([testAgent], { llm, store });
 

--- a/packages/agents/src/errors.test.ts
+++ b/packages/agents/src/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from '@vertz/test';
+import { ToolDurabilityError, serializeToolDurabilityError } from './errors';
+
+describe('ToolDurabilityError', () => {
+  describe('Given a toolCallId + toolName', () => {
+    describe('When instantiated', () => {
+      it('Then carries the identifiers + canonical code/kind fields', () => {
+        const err = new ToolDurabilityError('call_42', 'postSlack');
+        expect(err.code).toBe('TOOL_DURABILITY_ERROR');
+        expect(err.kind).toBe('tool-durability-error');
+        expect(err.toolCallId).toBe('call_42');
+        expect(err.toolName).toBe('postSlack');
+        expect(err.name).toBe('ToolDurabilityError');
+        expect(err).toBeInstanceOf(Error);
+      });
+
+      it('Then the message names the tool and offers remediation', () => {
+        const err = new ToolDurabilityError('call_42', 'postSlack');
+        expect(err.message).toContain("Tool 'postSlack'");
+        expect(err.message).toContain('call_42');
+        expect(err.message).toContain('safeToRetry');
+      });
+    });
+  });
+});
+
+describe('serializeToolDurabilityError()', () => {
+  it('Then produces a JSON string with error / kind / toolName / toolCallId', () => {
+    const err = new ToolDurabilityError('call_1', 'postSlack');
+    const serialized = serializeToolDurabilityError(err);
+    const parsed = JSON.parse(serialized) as {
+      error: string;
+      kind: string;
+      toolName: string;
+      toolCallId: string;
+    };
+    expect(parsed.kind).toBe('tool-durability-error');
+    expect(parsed.toolName).toBe('postSlack');
+    expect(parsed.toolCallId).toBe('call_1');
+    expect(parsed.error).toContain("Tool 'postSlack'");
+  });
+});

--- a/packages/agents/src/errors.ts
+++ b/packages/agents/src/errors.ts
@@ -1,0 +1,46 @@
+// Package-level errors for @vertz/agents. Store-specific errors live in
+// `stores/errors.ts`. This file is for cross-cutting runtime errors surfaced
+// to callers via the agent loop (resume path, tool execution, etc.).
+
+/**
+ * Raised when a session resumes and an assistant-with-toolCalls message
+ * is missing one or more corresponding tool_result rows. For non-safeToRetry
+ * tools, the framework cannot know whether the handler's side effect
+ * committed before the previous run crashed, so it surfaces this error as
+ * a synthetic tool_result in the message history. The LLM reads the error
+ * in-band and decides recovery.
+ *
+ * The class is exported so callers inspecting resumed history can pattern-
+ * match on it; the instance is serialized as JSON into the `tool` message's
+ * content (same encoding handler errors use).
+ */
+export class ToolDurabilityError extends Error {
+  readonly code = 'TOOL_DURABILITY_ERROR' as const;
+  readonly kind = 'tool-durability-error' as const;
+  readonly toolCallId: string;
+  readonly toolName: string;
+
+  constructor(toolCallId: string, toolName: string) {
+    super(
+      `Tool '${toolName}' (call ${toolCallId}) was requested but its execution ` +
+        `did not complete durably before the process ended. The tool is not ` +
+        `declared 'safeToRetry: true', so the framework will not automatically ` +
+        `re-invoke it. Decide recovery based on observable external state — e.g., ` +
+        `check whether the side effect already occurred. If this tool is a pure ` +
+        `read with no side effects, add \`safeToRetry: true\` to its declaration.`,
+    );
+    this.name = 'ToolDurabilityError';
+    this.toolCallId = toolCallId;
+    this.toolName = toolName;
+  }
+}
+
+/** Serialize a `ToolDurabilityError` as the JSON content of a `tool` message. */
+export function serializeToolDurabilityError(err: ToolDurabilityError): string {
+  return JSON.stringify({
+    error: err.message,
+    kind: err.kind,
+    toolName: err.toolName,
+    toolCallId: err.toolCallId,
+  });
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -65,6 +65,7 @@ export {
   SessionAccessDeniedError,
   SessionNotFoundError,
 } from './stores/errors';
+export { ToolDurabilityError } from './errors';
 
 // Workflow
 export type {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -60,7 +60,11 @@ export { sqliteStore } from './stores/sqlite-store';
 export type { SqliteStoreOptions } from './stores/sqlite-store';
 export { d1Store } from './stores/d1-store';
 export type { D1Binding, D1PreparedStatement, D1Result, D1StoreOptions } from './stores/d1-store';
-export { SessionNotFoundError, SessionAccessDeniedError } from './stores/errors';
+export {
+  MemoryStoreNotDurableError,
+  SessionAccessDeniedError,
+  SessionNotFoundError,
+} from './stores/errors';
 
 // Workflow
 export type {

--- a/packages/agents/src/loop/react-loop.test.ts
+++ b/packages/agents/src/loop/react-loop.test.ts
@@ -237,15 +237,14 @@ describe('reactLoop()', () => {
     });
   });
 
-  describe('Given a checkpoint callback', () => {
-    describe('When checkpointInterval iterations pass', () => {
-      it('Then calls the checkpoint callback at the right intervals', async () => {
+  describe('Given persistStep callback', () => {
+    describe('When the loop runs multiple tool-call steps', () => {
+      it('Then fires twice per step: once for assistant-with-tool-calls, once for tool-results', async () => {
         const noop = makeTool('noop', () => ({}));
-        const checkpoints: number[] = [];
+        const phases: Array<'assistant-with-tool-calls' | 'tool-results'> = [];
+        const writtenCounts: number[] = [];
 
         const llm = mockLLM([
-          { toolCalls: [{ name: 'noop', arguments: {} }] },
-          { toolCalls: [{ name: 'noop', arguments: {} }] },
           { toolCalls: [{ name: 'noop', arguments: {} }] },
           { toolCalls: [{ name: 'noop', arguments: {} }] },
           { text: 'Done.' },
@@ -258,13 +257,62 @@ describe('reactLoop()', () => {
           userMessage: 'Do stuff',
           maxIterations: 10,
           toolContext: TEST_TOOL_CONTEXT,
-          checkpointInterval: 2,
-          onCheckpoint(iteration, _messages) {
-            checkpoints.push(iteration);
+          async persistStep({ phase, newMessages }) {
+            phases.push(phase);
+            writtenCounts.push(newMessages.length);
           },
         });
 
-        expect(checkpoints).toEqual([2, 4]);
+        expect(phases).toEqual([
+          'assistant-with-tool-calls',
+          'tool-results',
+          'assistant-with-tool-calls',
+          'tool-results',
+        ]);
+        expect(writtenCounts).toEqual([1, 1, 1, 1]);
+      });
+    });
+
+    describe('When the loop ends with a text-only response (no tool calls)', () => {
+      it('Then persistStep is NOT fired for that step', async () => {
+        const phases: string[] = [];
+        const llm = mockLLM([{ text: 'Just text.' }]);
+
+        await reactLoop({
+          llm,
+          tools: {},
+          systemPrompt: 'x',
+          userMessage: 'y',
+          maxIterations: 10,
+          toolContext: TEST_TOOL_CONTEXT,
+          async persistStep({ phase }) {
+            phases.push(phase);
+          },
+        });
+
+        expect(phases).toEqual([]);
+      });
+    });
+
+    describe('When persistStep rejects', () => {
+      it('Then the error propagates out of the loop', async () => {
+        const noop = makeTool('noop', () => ({}));
+        const llm = mockLLM([{ toolCalls: [{ name: 'noop', arguments: {} }] }, { text: 'Done.' }]);
+
+        await expect(
+          reactLoop({
+            llm,
+            tools: { noop },
+            systemPrompt: 'x',
+            userMessage: 'y',
+            maxIterations: 10,
+            toolContext: TEST_TOOL_CONTEXT,
+            async persistStep() {
+              // eslint-disable-next-line vertz-rules/no-throw-plain-error -- test sentinel
+              throw new Error('simulated persist failure');
+            },
+          }),
+        ).rejects.toThrow('simulated persist failure');
       });
     });
   });

--- a/packages/agents/src/loop/react-loop.ts
+++ b/packages/agents/src/loop/react-loop.ts
@@ -467,13 +467,13 @@ function partitionToolCalls(
   return batches;
 }
 
-interface ToolCallResult {
+export interface ToolCallResult {
   message: Message;
   success: boolean;
 }
 
 /** Execute a single tool call and return the result message + success flag. */
-async function executeToolCall(
+export async function executeToolCall(
   toolCall: ToolCall,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tools have varying types
   tools: Record<string, ToolDefinition<any, any>>,

--- a/packages/agents/src/loop/react-loop.ts
+++ b/packages/agents/src/loop/react-loop.ts
@@ -117,10 +117,22 @@ export interface ReactLoopOptions {
   readonly maxIterations: number;
   readonly stuckThreshold?: number;
   readonly toolContext: ToolContext;
-  readonly checkpointInterval?: number;
-  readonly onCheckpoint?: (iteration: number, messages: readonly Message[]) => void;
   /** Pre-existing conversation messages (from a resumed session). Injected between system prompt and new user message. */
   readonly previousMessages?: readonly Message[];
+  /**
+   * Called at step boundaries when the caller wants durable-per-step writes.
+   * Fires twice per tool-call step: once right after the assistant message
+   * with toolCalls is pushed, once after all tool_result messages for the
+   * step are pushed. `newMessages` is the new messages added for that write
+   * (not the entire conversation).
+   *
+   * If the callback rejects, the error propagates out of the loop — callers
+   * simulate crashes that way.
+   */
+  readonly persistStep?: (args: {
+    readonly phase: 'assistant-with-tool-calls' | 'tool-results';
+    readonly newMessages: readonly Message[];
+  }) => Promise<void>;
   /** Token budget configuration. */
   readonly tokenBudget?: TokenBudgetConfig;
   /** Diminishing returns detection. */
@@ -151,12 +163,11 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
     maxIterations,
     stuckThreshold,
     toolContext,
-    checkpointInterval,
-    onCheckpoint,
     previousMessages,
     tokenBudget,
     diminishingReturns,
     contextCompression,
+    persistStep,
   } = options;
 
   const messages: Message[] = [
@@ -311,7 +322,7 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
     }
 
     // LLM requested tool calls — store them on the assistant message for protocol fidelity
-    messages.push({
+    const assistantWithToolCalls: Message = {
       role: 'assistant',
       content: response.text || `[Calling ${response.toolCalls.map((tc) => tc.name).join(', ')}]`,
       toolCalls: response.toolCalls.map((tc) => ({
@@ -319,10 +330,22 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
         name: tc.name,
         arguments: tc.arguments,
       })),
-    });
+    };
+    messages.push(assistantWithToolCalls);
+
+    // Durable-write phase A: assistant-with-toolCalls is now in memory — persist
+    // it before dispatching any handlers. If persistStep throws, the loop aborts
+    // with nothing in the store yet (crash before write #1 in the design taxonomy).
+    if (persistStep) {
+      await persistStep({
+        phase: 'assistant-with-tool-calls',
+        newMessages: [assistantWithToolCalls],
+      });
+    }
 
     let hadSuccessfulToolCall = false;
     const maxConcurrency = options.maxToolConcurrency ?? 5;
+    const toolResultsThisStep: Message[] = [];
 
     // Track tool call counts for summary
     for (const tc of response.toolCalls) {
@@ -344,6 +367,7 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
         );
         for (const r of results) {
           messages.push(r.message);
+          toolResultsThisStep.push(r.message);
           if (r.success) hadSuccessfulToolCall = true;
         }
       } else {
@@ -351,9 +375,20 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
         for (const toolCall of batch.calls) {
           const r = await executeToolCall(toolCall, tools, iteration, toolContext);
           messages.push(r.message);
+          toolResultsThisStep.push(r.message);
           if (r.success) hadSuccessfulToolCall = true;
         }
       }
+    }
+
+    // Durable-write phase B: all tool_result messages for this step are now
+    // in memory — commit them atomically so a crash after this point leaves
+    // the store consistent (no orphan on resume).
+    if (persistStep && toolResultsThisStep.length > 0) {
+      await persistStep({
+        phase: 'tool-results',
+        newMessages: toolResultsThisStep,
+      });
     }
 
     // Track progress for stuck detection
@@ -366,11 +401,6 @@ export async function reactLoop(options: ReactLoopOptions): Promise<LoopResult> 
     // Check stuck threshold
     if (stuckThreshold && consecutiveNoProgress >= stuckThreshold) {
       return buildResult('stuck', '');
-    }
-
-    // Checkpoint callback
-    if (checkpointInterval && onCheckpoint && iteration % checkpointInterval === 0) {
-      onCheckpoint(iteration, messages);
     }
   }
 

--- a/packages/agents/src/run.test.ts
+++ b/packages/agents/src/run.test.ts
@@ -6,6 +6,8 @@ import type { LLMAdapter } from './loop/react-loop';
 import { run } from './run';
 import { SessionAccessDeniedError, SessionNotFoundError } from './stores/errors';
 import { memoryStore } from './stores/memory-store';
+import { sqliteStore } from './stores/sqlite-store';
+import { MemoryStoreNotDurableError } from './stores/errors';
 import { tool } from './tool';
 
 /** Builds a mock LLM adapter from a sequence of responses. */
@@ -203,7 +205,7 @@ describe('run()', () => {
   describe('Given a store is provided', () => {
     describe('When run() is called without a sessionId', () => {
       it('Then creates a new session and returns a SessionLoopResult with sessionId', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([{ text: 'Hello!' }]);
 
         const result = await run(greeterAgent, { message: 'Hi', llm, store });
@@ -218,7 +220,7 @@ describe('run()', () => {
   describe('Given a store with an existing session', () => {
     describe('When run() is called with the sessionId', () => {
       it('Then resumes the session and the LLM sees conversation history', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const messageSpy: Message[][] = [];
         let callIndex = 0;
         const responses = [
@@ -283,7 +285,7 @@ describe('run()', () => {
   describe('Given a non-existent sessionId', () => {
     describe('When run() is called', () => {
       it('Then throws SessionNotFoundError', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([{ text: 'unused' }]);
 
         await expect(
@@ -296,7 +298,7 @@ describe('run()', () => {
   describe('Given a session created by user A', () => {
     describe('When user B tries to resume it', () => {
       it('Then throws SessionAccessDeniedError', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([{ text: 'Response 1' }, { text: 'Response 2' }]);
 
         // Create session as user A
@@ -326,7 +328,7 @@ describe('run()', () => {
   describe('Given a session created with a tenantId', () => {
     describe('When a user from a different tenant tries to resume it', () => {
       it('Then throws SessionAccessDeniedError', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([{ text: 'Response 1' }, { text: 'Response 2' }]);
 
         const r1 = await run(greeterAgent, {
@@ -354,7 +356,7 @@ describe('run()', () => {
   describe('Given run() results in an error status', () => {
     describe('When a store is provided', () => {
       it('Then does NOT persist messages from the failed turn', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm: LLMAdapter = {
           async chat() {
             throw new Error('LLM provider failed');
@@ -377,7 +379,7 @@ describe('run()', () => {
   describe('Given agent state is modified during execution', () => {
     describe('When the session is persisted', () => {
       it('Then the state is saved and available on the session', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const stateAgent = agent('stateful', {
           state: s.object({ topic: s.string() }),
           initialState: { topic: 'none' },
@@ -401,7 +403,7 @@ describe('run()', () => {
   describe('Given state was persisted and session is resumed', () => {
     describe('When the agent definition has a state schema', () => {
       it('Then restores and validates the persisted state', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         let capturedState: { topic: string } | undefined;
         const stateAgent = agent('stateful', {
           state: s.object({ topic: s.string() }),
@@ -436,7 +438,7 @@ describe('run()', () => {
   describe('Given maxStoredMessages is set to 4', () => {
     describe('When message count exceeds the cap after multiple turns', () => {
       it('Then prunes the oldest messages to stay within the limit', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([
           { text: 'Response 1' },
           { text: 'Response 2' },
@@ -483,7 +485,7 @@ describe('run()', () => {
   describe('Given an existing session with messages and the LLM fails on resume', () => {
     describe('When run() returns an error status', () => {
       it('Then pre-existing messages are preserved and no new messages added', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         let callCount = 0;
         const llm: LLMAdapter = {
           async chat() {
@@ -523,7 +525,7 @@ describe('run()', () => {
   describe('Given an existing session and the LLM fails on resume', () => {
     describe('When run() returns an error status', () => {
       it('Then the session state and updatedAt are NOT modified', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         let callCount = 0;
         const llm: LLMAdapter = {
           async chat() {
@@ -572,7 +574,7 @@ describe('run()', () => {
   describe('Given system prompts', () => {
     describe('When messages are persisted', () => {
       it('Then system prompt messages are NOT stored', async () => {
-        const store = memoryStore();
+        const store = sqliteStore({ path: ':memory:' });
         const llm = mockLLM([{ text: 'Hello!' }]);
 
         const result = await run(greeterAgent, { message: 'Hi', llm, store });
@@ -1110,6 +1112,66 @@ describe('run()', () => {
 
       // max-iterations, not error — output validation is skipped
       expect(result.status).toBe('max-iterations');
+    });
+  });
+
+  describe('Given memoryStore + sessionId', () => {
+    describe('When run() is called', () => {
+      it('Then throws MemoryStoreNotDurableError at entry, before any LLM call', async () => {
+        const store = memoryStore();
+        let llmWasCalled = false;
+        const llm: LLMAdapter = {
+          async chat() {
+            llmWasCalled = true;
+            return { text: 'should-not-reach', toolCalls: [] };
+          },
+        };
+
+        await expect(
+          run(greeterAgent, {
+            message: 'Hi',
+            llm,
+            store,
+            sessionId: 'sess_existing',
+          }),
+        ).rejects.toThrow(MemoryStoreNotDurableError);
+
+        expect(llmWasCalled).toBe(false);
+      });
+
+      it('Then also throws for a chat-only agent with no tool calls (no silent data loss)', async () => {
+        const store = memoryStore();
+        const chatOnly = agent('chat-only', {
+          state: s.object({}),
+          initialState: {},
+          tools: {},
+          model: { provider: 'cloudflare', model: 'test' },
+          loop: { maxIterations: 3 },
+        });
+        const llm = mockLLM([{ text: 'unreachable' }]);
+
+        await expect(
+          run(chatOnly, {
+            message: 'Hi',
+            llm,
+            store,
+            sessionId: 'sess_x',
+          }),
+        ).rejects.toThrow(MemoryStoreNotDurableError);
+      });
+    });
+  });
+
+  describe('Given memoryStore without sessionId', () => {
+    describe('When run() is called', () => {
+      it('Then the call succeeds (no durability required)', async () => {
+        const store = memoryStore();
+        const llm = mockLLM([{ text: 'Hi back' }]);
+
+        const result = await run(greeterAgent, { message: 'Hi', llm, store });
+
+        expect(result.status).toBe('complete');
+      });
     });
   });
 });

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -262,6 +262,34 @@ export async function run(
     },
   };
 
+  // Durable execution is active when the caller pairs a durable store with
+  // a sessionId. In that mode, we persist per-step via appendMessagesAtomic
+  // instead of a single end-of-run flush.
+  const durable = hasStore(options) && sessionId !== undefined && !isMemoryStore(options.store);
+  const durableStore = durable ? options.store : null;
+
+  let writtenByLoop = 0;
+
+  function buildSession(): AgentSession {
+    const now = new Date().toISOString();
+    return {
+      id: sessionId!,
+      agentName: agentDef.name,
+      userId,
+      tenantId,
+      state: JSON.stringify(ctx.state),
+      createdAt: existingCreatedAt ?? now,
+      updatedAt: now,
+    };
+  }
+
+  // Under durable execution, the new turn's user message is persisted
+  // alongside the FIRST persistStep write (bundled atomically). That way,
+  // if the LLM call fails before any step runs, nothing lands in the store
+  // and readers observe the session at its pre-turn state.
+  let userPersisted = false;
+  const newUserMessage: Message = { role: 'user', content: message };
+
   // Run the ReAct loop
   const result = await reactLoop({
     llm,
@@ -271,12 +299,20 @@ export async function run(
     maxIterations: agentDef.loop.maxIterations,
     stuckThreshold: agentDef.loop.stuckThreshold,
     toolContext: { agentId, agentName: agentDef.name, agents },
-    checkpointInterval: agentDef.loop.checkpointInterval,
     previousMessages,
     tokenBudget: agentDef.loop.tokenBudget,
     diminishingReturns: agentDef.loop.diminishingReturns,
     maxToolConcurrency: agentDef.loop.maxToolConcurrency,
     contextCompression: agentDef.loop.contextCompression,
+    persistStep:
+      durable && durableStore
+        ? async ({ newMessages }) => {
+            const batch = userPersisted ? [...newMessages] : [newUserMessage, ...newMessages];
+            userPersisted = true;
+            await durableStore.appendMessagesAtomic(sessionId!, batch, buildSession());
+            writtenByLoop += batch.length;
+          }
+        : undefined,
   });
 
   // Lifecycle: onComplete or onStuck
@@ -332,36 +368,53 @@ export async function run(
     const { store } = options;
 
     if (result.status !== 'error') {
-      const now = new Date().toISOString();
-      const createdAt = existingCreatedAt ?? now;
+      if (durable && durableStore) {
+        // Compute what reactLoop produced NEW in this turn (skipping system
+        // prompt and any pre-existing resumed messages).
+        const newSinceResume = result.messages
+          .filter((m) => m.role !== 'system')
+          .slice(previousMessages?.length ?? 0);
 
-      const session: AgentSession = {
-        id: sessionId,
-        agentName: agentDef.name,
-        userId,
-        tenantId,
-        state: JSON.stringify(ctx.state),
-        createdAt,
-        updatedAt: now,
-      };
+        // Already persisted by persistStep: writtenByLoop messages plus the
+        // user message if it was bundled into the first persist.
+        const alreadyPersisted = (userPersisted ? 0 : 0) + writtenByLoop + (userPersisted ? 1 : 0);
+        // Unpersisted tail: user message (if loop never called persistStep)
+        // plus any trailing text-only assistant response.
+        const tail = userPersisted ? newSinceResume.slice(alreadyPersisted) : newSinceResume; // includes the user message
+        if (tail.length > 0) {
+          await durableStore.appendMessagesAtomic(sessionId, [...tail], buildSession());
+        } else {
+          // No tail to flush, but session.state may have changed via
+          // onComplete — bump the session row so readers see final state.
+          await durableStore.saveSession(buildSession());
+        }
 
-      await store.saveSession(session);
+        // Prune messages if maxStoredMessages is set
+        const maxStored = options.maxStoredMessages;
+        if (maxStored !== undefined) {
+          await durableStore.pruneMessages(sessionId, maxStored);
+        }
+      } else {
+        // Non-durable legacy path: saveSession + appendMessages at end.
+        const session = buildSession();
+        await store.saveSession(session);
 
-      // Persist new messages (exclude system prompts)
-      const newMessages = result.messages.filter((m) => m.role !== 'system');
-      // If resuming, only persist messages from this turn (not the loaded ones)
-      const messagesToPersist = previousMessages
-        ? newMessages.slice(previousMessages.length)
-        : newMessages;
+        // Persist new messages (exclude system prompts)
+        const newMessages = result.messages.filter((m) => m.role !== 'system');
+        // If resuming, only persist messages from this turn (not the loaded ones)
+        const messagesToPersist = previousMessages
+          ? newMessages.slice(previousMessages.length)
+          : newMessages;
 
-      if (messagesToPersist.length > 0) {
-        await store.appendMessages(sessionId, [...messagesToPersist]);
-      }
+        if (messagesToPersist.length > 0) {
+          await store.appendMessages(sessionId, [...messagesToPersist]);
+        }
 
-      // Prune messages if maxStoredMessages is set
-      const maxStored = options.maxStoredMessages;
-      if (maxStored !== undefined) {
-        await store.pruneMessages(sessionId, maxStored);
+        // Prune messages if maxStoredMessages is set
+        const maxStored = options.maxStoredMessages;
+        if (maxStored !== undefined) {
+          await store.pruneMessages(sessionId, maxStored);
+        }
       }
     }
 

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -1,8 +1,10 @@
+import { ToolDurabilityError, serializeToolDurabilityError } from './errors';
 import type {
   LLMAdapter,
   LoopResult,
   Message,
   TokenUsageSummary,
+  ToolCall,
   ToolCallSummaryEntry,
 } from './loop/react-loop';
 import { reactLoop } from './loop/react-loop';
@@ -93,6 +95,42 @@ function generateSessionId(): string {
 
 function hasStore(opts: RunOptions): opts is RunOptionsWithStore {
   return opts.store !== undefined;
+}
+
+/**
+ * Scan the loaded message history for an "orphaned" assistant-with-toolCalls —
+ * an assistant message whose tool_call ids are not all matched by tool_result
+ * messages that come after it. Returns the missing tool_calls, or null if the
+ * history is consistent.
+ */
+function findOrphanAssistantWithToolCalls(
+  messages: readonly Message[],
+): { missingToolCalls: ToolCall[] } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    if (m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0) {
+      const laterToolResultIds = new Set(
+        messages
+          .slice(i + 1)
+          .filter(
+            (x): x is Message & { toolCallId: string } =>
+              x.role === 'tool' && typeof x.toolCallId === 'string',
+          )
+          .map((x) => x.toolCallId),
+      );
+      const missing = m.toolCalls.filter(
+        (tc): tc is ToolCall & { id: string } =>
+          typeof tc.id === 'string' && tc.id.length > 0 && !laterToolResultIds.has(tc.id),
+      );
+      return missing.length > 0 ? { missingToolCalls: [...missing] } : null;
+    }
+    if (m.role !== 'tool') {
+      // Reached a non-tool, non-assistant row (typically `user`) without
+      // finding an assistant-with-toolCalls closer to the tail → no orphan.
+      break;
+    }
+  }
+  return null;
 }
 
 /**
@@ -199,6 +237,32 @@ export async function run(
 
       // Load previous messages (excluding system prompts)
       previousMessages = await store.loadMessages(sessionId);
+
+      // Resume detection: if the last assistant message has toolCalls and
+      // any tool_result is missing, the previous run crashed between the
+      // pre-dispatch write and the post-dispatch write. Persist synthetic
+      // ToolDurabilityError tool_results for the missing ids so the loop
+      // resumes with a consistent conversation. (Phase 3 of #2835.)
+      const orphan = findOrphanAssistantWithToolCalls(previousMessages);
+      if (orphan && !isMemoryStore(store)) {
+        const now = new Date().toISOString();
+        const syntheticResults: Message[] = orphan.missingToolCalls.map((tc) => ({
+          role: 'tool',
+          content: serializeToolDurabilityError(new ToolDurabilityError(tc.id ?? '', tc.name)),
+          toolCallId: tc.id ?? '',
+          toolName: tc.name,
+        }));
+        await store.appendMessagesAtomic(sessionId, syntheticResults, {
+          id: sessionId,
+          agentName: agentDef.name,
+          userId,
+          tenantId,
+          state: JSON.stringify(initialState),
+          createdAt: existingCreatedAt ?? now,
+          updatedAt: now,
+        });
+        previousMessages = [...previousMessages, ...syntheticResults];
+      }
     } else {
       // Create new session
       sessionId = generateSessionId();

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -7,7 +7,7 @@ import type {
   ToolCall,
   ToolCallSummaryEntry,
 } from './loop/react-loop';
-import { reactLoop } from './loop/react-loop';
+import { executeToolCall, reactLoop } from './loop/react-loop';
 import {
   MemoryStoreNotDurableError,
   SessionAccessDeniedError,
@@ -15,7 +15,13 @@ import {
 } from './stores/errors';
 import { isMemoryStore } from './stores/memory-store';
 import type { AgentSession, AgentStore } from './stores/types';
-import type { AgentContext, AgentDefinition, ToolDefinition, ToolProvider } from './types';
+import type {
+  AgentContext,
+  AgentDefinition,
+  ToolContext,
+  ToolDefinition,
+  ToolProvider,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // Run options — discriminated union
@@ -235,34 +241,10 @@ export async function run(
         initialState = structuredClone(agentDef.initialState);
       }
 
-      // Load previous messages (excluding system prompts)
+      // Load previous messages (excluding system prompts). Resume detection
+      // happens later, after ctx + resolvedTools are built (so safeToRetry
+      // tools can be re-invoked with full toolContext).
       previousMessages = await store.loadMessages(sessionId);
-
-      // Resume detection: if the last assistant message has toolCalls and
-      // any tool_result is missing, the previous run crashed between the
-      // pre-dispatch write and the post-dispatch write. Persist synthetic
-      // ToolDurabilityError tool_results for the missing ids so the loop
-      // resumes with a consistent conversation. (Phase 3 of #2835.)
-      const orphan = findOrphanAssistantWithToolCalls(previousMessages);
-      if (orphan && !isMemoryStore(store)) {
-        const now = new Date().toISOString();
-        const syntheticResults: Message[] = orphan.missingToolCalls.map((tc) => ({
-          role: 'tool',
-          content: serializeToolDurabilityError(new ToolDurabilityError(tc.id ?? '', tc.name)),
-          toolCallId: tc.id ?? '',
-          toolName: tc.name,
-        }));
-        await store.appendMessagesAtomic(sessionId, syntheticResults, {
-          id: sessionId,
-          agentName: agentDef.name,
-          userId,
-          tenantId,
-          state: JSON.stringify(initialState),
-          createdAt: existingCreatedAt ?? now,
-          updatedAt: now,
-        });
-        previousMessages = [...previousMessages, ...syntheticResults];
-      }
     } else {
       // Create new session
       sessionId = generateSessionId();
@@ -345,6 +327,45 @@ export async function run(
       createdAt: existingCreatedAt ?? now,
       updatedAt: now,
     };
+  }
+
+  // Resume detection (Phases 3 + 4 of #2835): if the loaded history ends in
+  // an assistant-with-toolCalls with unmatched tool_result ids, the previous
+  // run crashed between write #1 and write #2. For each missing call, either:
+  //   - the tool declares `safeToRetry: true` → re-invoke its handler and
+  //     persist the real result (the side effect, if any, was safe to retry);
+  //   - otherwise → surface a synthetic ToolDurabilityError tool_result so
+  //     the LLM decides recovery in-band.
+  if (durable && durableStore && previousMessages) {
+    const orphan = findOrphanAssistantWithToolCalls(previousMessages);
+    if (orphan) {
+      const toolContextForResume: ToolContext = {
+        agentId,
+        agentName: agentDef.name,
+        agents,
+      };
+      const resumeResults: Message[] = [];
+      for (const missing of orphan.missingToolCalls) {
+        const toolDef = resolvedTools[missing.name];
+        if (toolDef?.safeToRetry) {
+          const result = await executeToolCall(missing, resolvedTools, 0, toolContextForResume);
+          resumeResults.push(result.message);
+        } else {
+          resumeResults.push({
+            role: 'tool',
+            content: serializeToolDurabilityError(
+              new ToolDurabilityError(missing.id ?? '', missing.name),
+            ),
+            toolCallId: missing.id ?? '',
+            toolName: missing.name,
+          });
+        }
+      }
+      if (resumeResults.length > 0) {
+        await durableStore.appendMessagesAtomic(sessionId!, resumeResults, buildSession());
+        previousMessages = [...previousMessages, ...resumeResults];
+      }
+    }
   }
 
   // Under durable execution, the new turn's user message is persisted

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -6,7 +6,12 @@ import type {
   ToolCallSummaryEntry,
 } from './loop/react-loop';
 import { reactLoop } from './loop/react-loop';
-import { SessionAccessDeniedError, SessionNotFoundError } from './stores/errors';
+import {
+  MemoryStoreNotDurableError,
+  SessionAccessDeniedError,
+  SessionNotFoundError,
+} from './stores/errors';
+import { isMemoryStore } from './stores/memory-store';
 import type { AgentSession, AgentStore } from './stores/types';
 import type { AgentContext, AgentDefinition, ToolDefinition, ToolProvider } from './types';
 
@@ -155,6 +160,13 @@ export async function run(
 
   if (hasStore(options)) {
     const { store } = options;
+
+    // Fail fast if a sessionId is paired with the non-durable memory store —
+    // otherwise a chat-only agent (no tool calls) would silently appear to
+    // work and lose data on restart. See #2835.
+    if (options.sessionId && isMemoryStore(store)) {
+      throw new MemoryStoreNotDurableError();
+    }
 
     if (options.sessionId) {
       // Resume existing session

--- a/packages/agents/src/stores/d1-store.test.ts
+++ b/packages/agents/src/stores/d1-store.test.ts
@@ -326,4 +326,104 @@ describe('d1Store()', () => {
       });
     });
   });
+
+  describe('appendMessagesAtomic', () => {
+    describe('Given a session + 2 messages', () => {
+      it('Then the session is upserted and both messages are visible after the call', async () => {
+        const store = d1Store({ binding: mockD1Binding() });
+        const session = makeSession();
+        const messages: Message[] = [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi' },
+        ];
+
+        await store.appendMessagesAtomic(session.id, messages, session);
+
+        const loadedSession = await store.loadSession(session.id);
+        expect(loadedSession).toEqual(session);
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded).toEqual(messages);
+      });
+    });
+
+    describe('Given successive atomic appends to the same session', () => {
+      it('Then each message gets a monotonic sequence number (batch subquery picks up prior inserts)', async () => {
+        const store = d1Store({ binding: mockD1Binding() });
+        const session = makeSession();
+
+        await store.appendMessagesAtomic(
+          session.id,
+          [
+            { role: 'user', content: 'a' },
+            { role: 'assistant', content: 'b' },
+          ],
+          session,
+        );
+        await store.appendMessagesAtomic(
+          session.id,
+          [
+            { role: 'user', content: 'c' },
+            { role: 'assistant', content: 'd' },
+          ],
+          session,
+        );
+
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded.map((m) => m.content)).toEqual(['a', 'b', 'c', 'd']);
+      });
+    });
+
+    describe('Given db.batch() rejects', () => {
+      it('Then no partial state is visible (atomic rollback)', async () => {
+        // Wrap the mock binding to make batch() throw.
+        const underlying = mockD1Binding();
+        const failingBinding: D1Binding = {
+          exec: underlying.exec.bind(underlying),
+          prepare: underlying.prepare.bind(underlying),
+          async batch() {
+            // eslint-disable-next-line vertz-rules/no-throw-plain-error -- test mock simulating a driver-level failure; not user-facing
+            throw new Error('simulated D1 failure');
+          },
+        };
+        const store = d1Store({ binding: failingBinding });
+        const session = makeSession();
+
+        await expect(
+          store.appendMessagesAtomic(
+            session.id,
+            [{ role: 'user', content: 'never-landed' }],
+            session,
+          ),
+        ).rejects.toThrow('simulated D1 failure');
+
+        // Recreate the store over the underlying (healthy) binding, confirm
+        // no session row was written.
+        const healthyStore = d1Store({ binding: underlying });
+        const loadedSession = await healthyStore.loadSession(session.id);
+        expect(loadedSession).toBeNull();
+        const loaded = await healthyStore.loadMessages(session.id);
+        expect(loaded).toEqual([]);
+      });
+    });
+
+    describe('Given messages with toolCall metadata', () => {
+      it('Then toolCallId, toolName, and toolCalls are preserved through the batch', async () => {
+        const store = d1Store({ binding: mockD1Binding() });
+        const session = makeSession();
+        const messages: Message[] = [
+          {
+            role: 'assistant',
+            content: 'calling tools',
+            toolCalls: [{ id: 'call_1', name: 'postSlack', arguments: { text: 'hi' } }],
+          },
+          { role: 'tool', content: '{"ts":"123"}', toolCallId: 'call_1', toolName: 'postSlack' },
+        ];
+
+        await store.appendMessagesAtomic(session.id, messages, session);
+
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded).toEqual(messages);
+      });
+    });
+  });
 });

--- a/packages/agents/src/stores/d1-store.ts
+++ b/packages/agents/src/stores/d1-store.ts
@@ -276,9 +276,63 @@ export function d1Store(options: D1StoreOptions): AgentStore {
       return result.results.map(rowToSession);
     },
 
-    async appendMessagesAtomic(_sessionId, _messages, _session) {
-      // Implemented in Phase 1 Task 3.
-      throw new Error('appendMessagesAtomic: not yet implemented for d1Store');
+    async appendMessagesAtomic(sessionId, messages, session) {
+      await ensureTables();
+
+      // One D1 batch: session upsert + N message inserts. D1 executes all
+      // statements in a single implicit transaction, so statements see
+      // prior inserts in the same batch — we use `COALESCE(MAX(seq), 0) + 1`
+      // in every INSERT's subquery to derive a monotonic seq without a
+      // pre-batch SELECT. The whole batch commits atomically or not at all.
+      // Per https://developers.cloudflare.com/d1/worker-api/prepared-statements/#batch-statements
+      const now = new Date().toISOString();
+      const statements: D1PreparedStatement[] = [
+        db
+          .prepare(
+            `INSERT INTO agent_sessions (id, agent_name, user_id, tenant_id, state, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               user_id = excluded.user_id,
+               tenant_id = excluded.tenant_id,
+               state = excluded.state,
+               updated_at = excluded.updated_at`,
+          )
+          .bind(
+            session.id,
+            session.agentName,
+            session.userId,
+            session.tenantId,
+            session.state,
+            session.createdAt,
+            session.updatedAt,
+          ),
+      ];
+
+      for (const msg of messages) {
+        statements.push(
+          db
+            .prepare(
+              `INSERT INTO agent_messages (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, created_at)
+               VALUES (
+                 ?,
+                 COALESCE((SELECT MAX(seq) FROM agent_messages WHERE session_id = ?), 0) + 1,
+                 ?, ?, ?, ?, ?, ?
+               )`,
+            )
+            .bind(
+              sessionId,
+              sessionId,
+              msg.role,
+              msg.content,
+              msg.toolCallId ?? null,
+              msg.toolName ?? null,
+              msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+              now,
+            ),
+        );
+      }
+
+      await db.batch(statements);
     },
   };
 }

--- a/packages/agents/src/stores/d1-store.ts
+++ b/packages/agents/src/stores/d1-store.ts
@@ -275,5 +275,10 @@ export function d1Store(options: D1StoreOptions): AgentStore {
       const result = await stmt.all<SessionRow>();
       return result.results.map(rowToSession);
     },
+
+    async appendMessagesAtomic(_sessionId, _messages, _session) {
+      // Implemented in Phase 1 Task 3.
+      throw new Error('appendMessagesAtomic: not yet implemented for d1Store');
+    },
   };
 }

--- a/packages/agents/src/stores/errors.test.ts
+++ b/packages/agents/src/stores/errors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@vertz/test';
-import { SessionAccessDeniedError, SessionNotFoundError } from './errors';
+import {
+  MemoryStoreNotDurableError,
+  SessionAccessDeniedError,
+  SessionNotFoundError,
+} from './errors';
 
 describe('SessionNotFoundError', () => {
   describe('Given a session ID', () => {
@@ -24,6 +28,23 @@ describe('SessionAccessDeniedError', () => {
         expect(error.code).toBe('SESSION_ACCESS_DENIED');
         expect(error.name).toBe('SessionAccessDeniedError');
         expect(error).toBeInstanceOf(Error);
+      });
+    });
+  });
+});
+
+describe('MemoryStoreNotDurableError', () => {
+  describe('Given memory store is used with a sessionId', () => {
+    describe('When the error is instantiated', () => {
+      it('Then has a descriptive message directing the caller to a durable store', () => {
+        const error = new MemoryStoreNotDurableError();
+        expect(error.code).toBe('MEMORY_STORE_NOT_DURABLE');
+        expect(error.name).toBe('MemoryStoreNotDurableError');
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toContain('memoryStore()');
+        expect(error.message).toContain('sqliteStore');
+        expect(error.message).toContain('d1Store');
+        expect(error.message).toContain('omit sessionId');
       });
     });
   });

--- a/packages/agents/src/stores/errors.ts
+++ b/packages/agents/src/stores/errors.ts
@@ -17,3 +17,24 @@ export class SessionAccessDeniedError extends Error {
     this.name = 'SessionAccessDeniedError';
   }
 }
+
+/**
+ * Thrown when `memoryStore()` is combined with a `sessionId` on `run()`.
+ *
+ * The memory store keeps state in-process and cannot provide the durable
+ * step-by-step writes that sessionId-based resume requires. Callers who
+ * want persistence must use `sqliteStore(...)` or `d1Store(...)`; callers
+ * who don't need persistence should omit `sessionId` and run statelessly.
+ */
+export class MemoryStoreNotDurableError extends Error {
+  readonly code = 'MEMORY_STORE_NOT_DURABLE' as const;
+
+  constructor() {
+    super(
+      'memoryStore() cannot provide durable resume. ' +
+        'Pass sessionId with a durable store (sqliteStore, d1Store) ' +
+        'or omit sessionId to run statelessly.',
+    );
+    this.name = 'MemoryStoreNotDurableError';
+  }
+}

--- a/packages/agents/src/stores/memory-store.ts
+++ b/packages/agents/src/stores/memory-store.ts
@@ -1,15 +1,29 @@
 import type { Message } from '../loop/react-loop';
+import { MemoryStoreNotDurableError } from './errors';
 import type { AgentSession, AgentStore, ListSessionsFilter } from './types';
+
+/** Brand used by `run()` to detect memoryStore() without `instanceof` across HMR/bundle boundaries. */
+export const MEMORY_STORE_KIND: unique symbol = Symbol.for('@vertz/agents::memoryStore');
+
+/** Returns true if the given store was produced by `memoryStore()`. */
+export function isMemoryStore(store: AgentStore): boolean {
+  return (store as { [MEMORY_STORE_KIND]?: boolean })[MEMORY_STORE_KIND] === true;
+}
 
 /**
  * In-memory store for agent sessions and messages.
  * Sessions are lost on process restart. Useful for testing.
+ *
+ * Non-durable by construction: `appendMessagesAtomic` always throws
+ * `MemoryStoreNotDurableError`. `run()` also detects memoryStore + sessionId
+ * at entry and throws before any work starts (see `isMemoryStore`).
  */
 export function memoryStore(): AgentStore {
   const sessions = new Map<string, AgentSession>();
   const messages = new Map<string, Message[]>();
 
-  return {
+  const store: AgentStore & { [MEMORY_STORE_KIND]: true } = {
+    [MEMORY_STORE_KIND]: true,
     async loadSession(sessionId) {
       return sessions.get(sessionId) ?? null;
     },
@@ -58,5 +72,11 @@ export function memoryStore(): AgentStore {
 
       return result;
     },
+
+    async appendMessagesAtomic(_sessionId, _newMessages, _session) {
+      throw new MemoryStoreNotDurableError();
+    },
   };
+
+  return store;
 }

--- a/packages/agents/src/stores/sqlite-store.test.ts
+++ b/packages/agents/src/stores/sqlite-store.test.ts
@@ -348,4 +348,103 @@ describe('sqliteStore()', () => {
       });
     });
   });
+
+  describe('appendMessagesAtomic', () => {
+    describe('Given a session + 2 messages', () => {
+      it('Then the session is upserted and both messages are visible after the call', async () => {
+        const store = sqliteStore({ path: ':memory:' });
+        const session = makeSession();
+        const messages: Message[] = [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi' },
+        ];
+
+        await store.appendMessagesAtomic(session.id, messages, session);
+
+        const loadedSession = await store.loadSession(session.id);
+        expect(loadedSession).toEqual(session);
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded).toEqual(messages);
+      });
+    });
+
+    describe('Given an insert fails mid-batch (duplicate seq)', () => {
+      it('Then no partial state is visible (atomic rollback)', async () => {
+        const store = sqliteStore({ path: ':memory:' });
+        const session = makeSession();
+
+        // Prime the session with one existing message at seq=1.
+        await store.appendMessagesAtomic(
+          session.id,
+          [{ role: 'user', content: 'existing' }],
+          session,
+        );
+
+        // Force a duplicate by directly inserting a row at seq=2, then call
+        // appendMessagesAtomic which will try to insert at seq=2 again —
+        // the UNIQUE constraint will throw, and the whole transaction must roll
+        // back (no partial rows, session.updatedAt unchanged).
+        const updatedSession: AgentSession = {
+          ...session,
+          updatedAt: '2099-01-01T00:00:00.000Z',
+        };
+
+        // Inject a conflicting row using the internal sqlite driver via a
+        // second store over the SAME memory DB is not possible; instead we
+        // rely on the UNIQUE(session_id, seq) constraint: appendMessages
+        // computes starting seq from MAX+1, so to force a conflict we first
+        // mutate seq via raw SQL. Simplest: open a second writer via the
+        // public API path to force a conflict is not feasible for `:memory:`.
+        // Alternative: assert that throwing from within the transaction
+        // callback rolls back. We test this by breaking one of the prepared
+        // statements via a message with content SQL injection... or easier:
+        // pass an object that fails JSON.stringify (circular toolCalls).
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        const badMessages: Message[] = [
+          { role: 'user', content: 'this-will-commit' },
+          // toolCalls with a circular reference → JSON.stringify throws.
+          { role: 'assistant', content: 'fails', toolCalls: circular as never },
+        ];
+
+        await expect(
+          store.appendMessagesAtomic(session.id, badMessages, updatedSession),
+        ).rejects.toThrow();
+
+        // Messages from the failed call must NOT be persisted.
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded).toEqual([{ role: 'user', content: 'existing' }]);
+
+        // Session.updatedAt from the failed call must NOT be persisted.
+        const loadedSession = await store.loadSession(session.id);
+        expect(loadedSession?.updatedAt).toBe('2026-03-30T00:00:00.000Z');
+      });
+    });
+
+    describe('Given multiple atomic appends to the same session', () => {
+      it('Then each message gets a monotonic sequence number', async () => {
+        const store = sqliteStore({ path: ':memory:' });
+        const session = makeSession();
+        await store.appendMessagesAtomic(
+          session.id,
+          [
+            { role: 'user', content: 'a' },
+            { role: 'assistant', content: 'b' },
+          ],
+          session,
+        );
+        await store.appendMessagesAtomic(
+          session.id,
+          [
+            { role: 'user', content: 'c' },
+            { role: 'assistant', content: 'd' },
+          ],
+          session,
+        );
+
+        const loaded = await store.loadMessages(session.id);
+        expect(loaded.map((m) => m.content)).toEqual(['a', 'b', 'c', 'd']);
+      });
+    });
+  });
 });

--- a/packages/agents/src/stores/sqlite-store.ts
+++ b/packages/agents/src/stores/sqlite-store.ts
@@ -230,5 +230,10 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
       const rows = db.prepare<SessionRow, (string | number)[]>(query).all(...params);
       return rows.map(rowToSession);
     },
+
+    async appendMessagesAtomic(_sessionId, _messages, _session) {
+      // Implemented in Phase 1 Task 2.
+      throw new Error('appendMessagesAtomic: not yet implemented for sqliteStore');
+    },
   };
 }

--- a/packages/agents/src/stores/sqlite-store.ts
+++ b/packages/agents/src/stores/sqlite-store.ts
@@ -231,9 +231,38 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
       return rows.map(rowToSession);
     },
 
-    async appendMessagesAtomic(_sessionId, _messages, _session) {
-      // Implemented in Phase 1 Task 2.
-      throw new Error('appendMessagesAtomic: not yet implemented for sqliteStore');
+    async appendMessagesAtomic(sessionId, messages, session) {
+      // One synchronous transaction: upsert session + insert each message at
+      // the next seq. Runs over already-resolved data — no `await` allowed
+      // inside the transaction callback (the sqlite driver is sync).
+      const tx = db.transaction(() => {
+        upsertSessionStmt.run(
+          session.id,
+          session.agentName,
+          session.userId,
+          session.tenantId,
+          session.state,
+          session.createdAt,
+          session.updatedAt,
+        );
+        const maxSeqRow = maxSeqStmt.get(sessionId);
+        let seq = (maxSeqRow?.max_seq ?? 0) + 1;
+        const now = new Date().toISOString();
+        for (const msg of messages) {
+          insertMessageStmt.run(
+            sessionId,
+            seq,
+            msg.role,
+            msg.content,
+            msg.toolCallId ?? null,
+            msg.toolName ?? null,
+            msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+            now,
+          );
+          seq++;
+        }
+      });
+      tx();
     },
   };
 }

--- a/packages/agents/src/stores/types.ts
+++ b/packages/agents/src/stores/types.ts
@@ -48,4 +48,24 @@ export interface AgentStore {
 
   /** List sessions, optionally filtered. Ordered by updatedAt descending. */
   listSessions(filter?: ListSessionsFilter): Promise<AgentSession[]>;
+
+  /**
+   * Atomically append messages AND upsert the session row in a single
+   * transaction (D1 `batch`, SQLite `transaction`, etc.). Readers must
+   * observe either all of the writes or none — no partial visibility.
+   *
+   * Implementations must not `await` between internal statements; the whole
+   * atomic unit runs as one driver-level transaction over already-resolved
+   * data. The memory store cannot provide durability and throws
+   * `MemoryStoreNotDurableError` on any call.
+   *
+   * Used on every step boundary under durable execution (`run()` called
+   * with `store + sessionId`). Replaces the end-of-run
+   * `saveSession` + `appendMessages` pair for that path.
+   */
+  appendMessagesAtomic(
+    sessionId: string,
+    messages: Message[],
+    session: AgentSession,
+  ): Promise<void>;
 }

--- a/packages/agents/src/testing/crash-harness.test.ts
+++ b/packages/agents/src/testing/crash-harness.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from '@vertz/test';
+import { sqliteStore } from '../stores/sqlite-store';
+import type { AgentSession } from '../stores/types';
+import { crashAfterToolResults } from './crash-harness';
+
+function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    id: 'sess_test-1',
+    agentName: 'test',
+    userId: null,
+    tenantId: null,
+    state: '{}',
+    createdAt: '2026-04-19T00:00:00.000Z',
+    updatedAt: '2026-04-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('crashAfterToolResults()', () => {
+  describe('Given default behavior (fail on 2nd call)', () => {
+    it('Then the first appendMessagesAtomic call passes through', async () => {
+      const underlying = sqliteStore({ path: ':memory:' });
+      const harness = crashAfterToolResults(underlying);
+      const session = makeSession();
+
+      await harness.appendMessagesAtomic(session.id, [{ role: 'user', content: 'first' }], session);
+
+      const loaded = await underlying.loadMessages(session.id);
+      expect(loaded).toEqual([{ role: 'user', content: 'first' }]);
+    });
+
+    it('Then the second appendMessagesAtomic call throws and nothing lands', async () => {
+      const underlying = sqliteStore({ path: ':memory:' });
+      const harness = crashAfterToolResults(underlying);
+      const session = makeSession();
+
+      await harness.appendMessagesAtomic(session.id, [{ role: 'user', content: 'first' }], session);
+
+      await expect(
+        harness.appendMessagesAtomic(
+          session.id,
+          [{ role: 'assistant', content: 'second' }],
+          session,
+        ),
+      ).rejects.toThrow('simulated crash after tool results');
+
+      const loaded = await underlying.loadMessages(session.id);
+      expect(loaded).toEqual([{ role: 'user', content: 'first' }]);
+    });
+  });
+
+  describe('Given failOnCallNumber is 1', () => {
+    it('Then the first call throws', async () => {
+      const harness = crashAfterToolResults(sqliteStore({ path: ':memory:' }), 1);
+      const session = makeSession();
+
+      await expect(harness.appendMessagesAtomic(session.id, [], session)).rejects.toThrow(
+        'simulated crash after tool results',
+      );
+    });
+  });
+
+  describe('Given pass-through methods', () => {
+    it('Then loadSession, saveSession, appendMessages, pruneMessages, deleteSession, listSessions all delegate', async () => {
+      const underlying = sqliteStore({ path: ':memory:' });
+      const harness = crashAfterToolResults(underlying);
+      const session = makeSession({ id: 'sess_passthrough' });
+
+      await harness.saveSession(session);
+      const loaded = await harness.loadSession(session.id);
+      expect(loaded).toEqual(session);
+
+      await harness.appendMessages(session.id, [{ role: 'user', content: 'pt' }]);
+      const msgs = await harness.loadMessages(session.id);
+      expect(msgs).toEqual([{ role: 'user', content: 'pt' }]);
+
+      const list = await harness.listSessions();
+      expect(list).toHaveLength(1);
+
+      await harness.deleteSession(session.id);
+      expect(await harness.loadSession(session.id)).toBeNull();
+    });
+  });
+});

--- a/packages/agents/src/testing/crash-harness.ts
+++ b/packages/agents/src/testing/crash-harness.ts
@@ -1,0 +1,35 @@
+import type { Message } from '../loop/react-loop';
+import type { AgentSession, AgentStore } from '../stores/types';
+
+/**
+ * Wraps an `AgentStore` so that the Nth call to `appendMessagesAtomic` throws.
+ * Default: the 2nd call throws, which simulates a crash between the
+ * "assistant-with-toolCalls" write and the "tool-results" write that land in
+ * Phase 2 of #2835. All other store methods pass through unchanged.
+ *
+ * Used in `durable-resume.test.ts` to exercise resume semantics against a
+ * deterministic crash point.
+ *
+ * @param store underlying store (typically `sqliteStore({ path: ':memory:' })`)
+ * @param failOnCallNumber 1-indexed; which `appendMessagesAtomic` call to fail (default 2)
+ */
+export function crashAfterToolResults(store: AgentStore, failOnCallNumber: number = 2): AgentStore {
+  let atomicCallCount = 0;
+  return {
+    loadSession: (id) => store.loadSession(id),
+    saveSession: (s) => store.saveSession(s),
+    loadMessages: (id) => store.loadMessages(id),
+    appendMessages: (id, msgs) => store.appendMessages(id, msgs),
+    pruneMessages: (id, keep) => store.pruneMessages(id, keep),
+    deleteSession: (id) => store.deleteSession(id),
+    listSessions: (f) => store.listSessions(f),
+    async appendMessagesAtomic(sessionId: string, messages: Message[], session: AgentSession) {
+      atomicCallCount++;
+      if (atomicCallCount === failOnCallNumber) {
+        // eslint-disable-next-line vertz-rules/no-throw-plain-error -- test-harness sentinel; not user-facing
+        throw new Error('simulated crash after tool results');
+      }
+      await store.appendMessagesAtomic(sessionId, messages, session);
+    },
+  };
+}

--- a/packages/agents/src/testing/index.ts
+++ b/packages/agents/src/testing/index.ts
@@ -1,0 +1,7 @@
+// @vertz/agents/testing — test-only helpers for durable resume scenarios.
+//
+// These are NOT shipped in the main `@vertz/agents` entrypoint because they
+// exist solely to simulate failure modes in tests. Import from
+// '@vertz/agents/testing'.
+
+export { crashAfterToolResults } from './crash-harness';

--- a/packages/agents/src/tool.test.ts
+++ b/packages/agents/src/tool.test.ts
@@ -70,4 +70,25 @@ describe('tool()', () => {
       });
     });
   });
+
+  describe('safeToRetry flag', () => {
+    it('forwards safeToRetry: true from config to definition', () => {
+      const def = tool({
+        description: 'Pure read',
+        input: s.object({}),
+        output: s.object({}),
+        safeToRetry: true,
+      });
+      expect(def.safeToRetry).toBe(true);
+    });
+
+    it('leaves safeToRetry undefined when omitted (side-effecting default)', () => {
+      const def = tool({
+        description: 'Post to Slack',
+        input: s.object({}),
+        output: s.object({}),
+      });
+      expect(def.safeToRetry).toBeUndefined();
+    });
+  });
 });

--- a/packages/agents/src/tool.ts
+++ b/packages/agents/src/tool.ts
@@ -25,6 +25,7 @@ export function tool<TInput, TOutput>(
     output: config.output as SchemaAny,
     handler: config.handler,
     parallel: config.parallel,
+    safeToRetry: config.safeToRetry,
   };
 
   return deepFreeze(def);

--- a/packages/agents/src/types.test-d.ts
+++ b/packages/agents/src/types.test-d.ts
@@ -182,15 +182,17 @@ agent('with-prompt', {
 });
 
 // ---------------------------------------------------------------------------
-// checkpointInterval (renamed from checkpointEvery)
+// AgentLoopConfig — deleted fields (pre-v1, no shim)
 // ---------------------------------------------------------------------------
 
-// Agent accepts checkpointInterval in loop config
-agent('with-interval', {
+// checkpointInterval was removed in #2835 in favor of store + sessionId for
+// durable resume. Regression guard: type system must reject it now.
+agent('no-checkpoint', {
   state: s.object({}),
   initialState: {},
   tools: {},
   model: { provider: 'cloudflare', model: 'test' },
+  // @ts-expect-error — checkpointInterval removed from AgentLoopConfig
   loop: { maxIterations: 10, checkpointInterval: 5 },
 });
 

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -168,7 +168,6 @@ export interface AgentLoopConfig {
   readonly maxIterations: number;
   readonly onStuck?: OnStuckBehavior;
   readonly stuckThreshold?: number;
-  readonly checkpointInterval?: number;
   readonly tokenBudget?: import('./loop/react-loop').TokenBudgetConfig;
   readonly diminishingReturns?: import('./loop/react-loop').DiminishingReturnsConfig;
   readonly maxToolConcurrency?: number;

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -34,6 +34,17 @@ export interface ToolConfig<
   readonly handler?: (input: TInput, ctx: ToolContext) => TOutput | Promise<TOutput>;
   /** When true, this tool can execute concurrently with other parallel tools. Default: false. */
   readonly parallel?: boolean;
+  /**
+   * When true, the framework may re-invoke this tool's handler during session
+   * resume if the previous attempt's `tool_result` was not persisted.
+   *
+   * Set ONLY on pure-read tools or handlers that are safe to execute twice.
+   * The default (`undefined`/`false`) assumes side effects and surfaces a
+   * `ToolDurabilityError` tool_result on orphan detection instead of
+   * retrying — the LLM decides recovery. This is distinct from HTTP/network
+   * retry: `safeToRetry` only controls resume replay.
+   */
+  readonly safeToRetry?: boolean;
 }
 
 /**
@@ -92,6 +103,8 @@ export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   readonly handler?: (input: TInput, ctx: ToolContext) => TOutput | Promise<TOutput>;
   /** When true, this tool can execute concurrently with other parallel tools. */
   readonly parallel?: boolean;
+  /** When true, the framework may re-invoke this handler on session resume. */
+  readonly safeToRetry?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mint-docs/docs.json
+++ b/packages/mint-docs/docs.json
@@ -106,7 +106,11 @@
           },
           {
             "group": "@vertz/agents",
-            "pages": ["guides/agents/overview", "guides/agents/workflows"]
+            "pages": [
+              "guides/agents/overview",
+              "guides/agents/workflows",
+              "guides/agents/durable-resume"
+            ]
           },
           {
             "group": "@vertz/db",

--- a/packages/mint-docs/guides/agents/durable-resume.mdx
+++ b/packages/mint-docs/guides/agents/durable-resume.mdx
@@ -1,0 +1,180 @@
+---
+title: Durable resume
+description: 'At-most-once tool execution for side-effecting agents — automatic crash recovery with no extra API.'
+---
+
+Agents that post to Slack, send email, charge customers, or call paid
+external APIs need **at-most-once** tool execution. If the process dies
+between "handler ran" and "tool result persisted," a naive resume re-runs
+the handler on the next invocation — your bot posts twice, your customer
+gets billed twice, your external API fires twice.
+
+`@vertz/agents` handles this automatically. Pair a durable store with a
+`sessionId` on `run()` and you get:
+
+- Each tool-call step commits atomically (one write pre-dispatch, one
+  post-dispatch).
+- On resume, the framework detects orphaned tool calls and either
+  re-invokes safe handlers or surfaces a typed `ToolDurabilityError`
+  tool_result for the LLM to reason about.
+- No separate `resume()` API, no durable-mode flag — durability is a
+  consequence of using a durable store with session identity.
+
+## Activation
+
+Durable resume turns on when **all three** are true:
+
+1. You pass a `store` to `run()`.
+2. You pass a `sessionId`.
+3. The store is durable — `sqliteStore` or `d1Store`. The in-memory
+   `memoryStore` cannot guarantee durable writes and throws
+   `MemoryStoreNotDurableError` at entry if combined with `sessionId`.
+
+```ts
+import { createAnthropicAdapter, run } from '@vertz/agents';
+import { d1Store } from '@vertz/agents/cloudflare';
+import { triageAgent } from './agents/triage';
+import { createSlackProvider } from './providers/slack';
+
+await run(triageAgent, {
+  message: 'An issue came in: ...',
+  sessionId: this.state.id.toString(), // e.g. a Durable Object ID
+  store: d1Store(this.env.DB),
+  llm: createAnthropicAdapter({ apiKey: this.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+  tools: { postSlack: createSlackProvider(this.env) },
+});
+```
+
+## The `safeToRetry` flag
+
+A tool declaration controls how the framework behaves if its handler
+was requested but its result was lost:
+
+```ts
+import { tool } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+// Pure read. Safe to re-invoke on resume — the framework will call
+// getIssue() again if its tool_result was lost before the previous run
+// persisted it.
+export const getIssue = tool({
+  description: 'Fetch a Sentry issue by ID',
+  input: s.object({ id: s.string() }),
+  output: s.object({ title: s.string(), status: s.string() }),
+  safeToRetry: true,
+});
+
+// Side-effecting. Default. The framework will NOT re-invoke on
+// resume — instead, a ToolDurabilityError tool_result is persisted and
+// the LLM decides recovery in-band.
+export const postSlack = tool({
+  description: 'Post a message to a Slack channel',
+  input: s.object({ channel: s.string(), text: s.string() }),
+  output: s.object({ ts: s.string() }),
+});
+```
+
+### `safeToRetry` is NOT network retry
+
+This is a common confusion worth calling out:
+
+- `safeToRetry` **only** controls resume replay — whether the framework
+  re-invokes a handler when a previous run crashed.
+- It does **nothing** for transient network errors during normal
+  execution. If your handler calls `fetch()` and the fetch fails, the
+  error is persisted as the `tool_result` either way.
+
+`safeToRetry: true` is a declaration about the operation, not about
+retry policy. Think "this call is safe to run twice" not "retry this
+call on failure."
+
+## What resume looks like
+
+Consider a triage bot whose handler posts to Slack. The normal flow:
+
+1. LLM: "I'll post to Slack" → requests `postSlack`.
+2. Framework writes the assistant message with the tool_call id.
+3. `postSlack` handler runs. **Slack gets the message.**
+4. Framework writes the tool_result.
+
+If the process dies between step 3 and step 4, a later `run()` with the
+same `sessionId` loads the session and sees: assistant asked for
+`postSlack`, no tool_result exists. For a non-`safeToRetry` tool like
+`postSlack`:
+
+5. Framework writes a synthetic tool_result with content:
+   ```json
+   {
+     "error": "Tool 'postSlack' (call toolu_01) was requested but its execution did not complete durably...",
+     "kind": "tool-durability-error",
+     "toolName": "postSlack",
+     "toolCallId": "toolu_01"
+   }
+   ```
+6. The LLM's next turn sees the error in the message history and decides
+   what to do: check Slack for a duplicate post, ask the user, abort
+   the thread, etc.
+
+For a `safeToRetry: true` tool like `getIssue`, step 5 instead
+re-invokes the handler and persists the real result. Step 6 never
+happens — the LLM never sees the crash.
+
+## Crash windows in detail
+
+The framework performs **two** atomic writes per tool-call step, plus
+one at end-of-turn for trailing text. Crash outcomes:
+
+| Crash window | Store state | Resume behavior |
+|---|---|---|
+| Before the first persisted write | no new messages for this turn | No orphan. Next LLM call starts fresh from prior state. |
+| Between write #1 (assistant + user + toolCalls) and handler dispatch | assistant-with-toolCalls persisted, no tool_results | Orphan. For each call: if `safeToRetry`, re-invoke; else surface `ToolDurabilityError`. |
+| During handler dispatch | same as above | Same behavior. The framework cannot distinguish "handler never started" from "handler ran + result lost" without `safeToRetry`. |
+| Between handlers and write #2 | same as above | Same behavior. |
+| Mid-write #2 | atomic — either all tool_results present or none | Either case is well-defined. |
+| After write #2 | full step committed | No orphan. Loop resumes normally. |
+
+Non-`safeToRetry` tools that crash in the middle windows are
+**intentionally** pessimistic: the framework cannot know if your side
+effect landed. The LLM decides, with the error visible in history.
+
+## Performance
+
+Under durable execution, each tool-call step commits two atomic writes
+to the store instead of one end-of-run batch. For a 10-step loop with
+2 tools per step, that's roughly 20 writes instead of 1. On Cloudflare
+D1 same-region, expect ~100–200ms overhead per 10-step session. For
+high-volume read-heavy agents that don't need crash recovery, omit
+`sessionId` to run statelessly — no durable writes happen.
+
+## The `ToolDurabilityError` class
+
+Exported from `@vertz/agents` so callers inspecting resumed session
+history can pattern-match:
+
+```ts
+import { ToolDurabilityError } from '@vertz/agents';
+
+const messages = await store.loadMessages(sessionId);
+const durabilityEvents = messages.filter((m) => {
+  if (m.role !== 'tool' || !m.content) return false;
+  try {
+    return JSON.parse(m.content).kind === 'tool-durability-error';
+  } catch {
+    return false;
+  }
+});
+```
+
+## Testing
+
+The package exposes a crash harness at `@vertz/agents/testing` for
+writing resume tests:
+
+```ts
+import { crashAfterToolResults } from '@vertz/agents/testing';
+import { sqliteStore } from '@vertz/agents';
+
+const store = sqliteStore({ path: ':memory:' });
+const harness = crashAfterToolResults(store); // throws on the 2nd appendMessagesAtomic call
+// Run your agent against `harness`, then run again with `store` to exercise resume.
+```

--- a/packages/mint-docs/guides/agents/durable-resume.mdx
+++ b/packages/mint-docs/guides/agents/durable-resume.mdx
@@ -124,14 +124,14 @@ happens — the LLM never sees the crash.
 The framework performs **two** atomic writes per tool-call step, plus
 one at end-of-turn for trailing text. Crash outcomes:
 
-| Crash window | Store state | Resume behavior |
-|---|---|---|
-| Before the first persisted write | no new messages for this turn | No orphan. Next LLM call starts fresh from prior state. |
-| Between write #1 (assistant + user + toolCalls) and handler dispatch | assistant-with-toolCalls persisted, no tool_results | Orphan. For each call: if `safeToRetry`, re-invoke; else surface `ToolDurabilityError`. |
-| During handler dispatch | same as above | Same behavior. The framework cannot distinguish "handler never started" from "handler ran + result lost" without `safeToRetry`. |
-| Between handlers and write #2 | same as above | Same behavior. |
-| Mid-write #2 | atomic — either all tool_results present or none | Either case is well-defined. |
-| After write #2 | full step committed | No orphan. Loop resumes normally. |
+| Crash window                                                         | Store state                                         | Resume behavior                                                                                                                 |
+| -------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Before the first persisted write                                     | no new messages for this turn                       | No orphan. Next LLM call starts fresh from prior state.                                                                         |
+| Between write #1 (assistant + user + toolCalls) and handler dispatch | assistant-with-toolCalls persisted, no tool_results | Orphan. For each call: if `safeToRetry`, re-invoke; else surface `ToolDurabilityError`.                                         |
+| During handler dispatch                                              | same as above                                       | Same behavior. The framework cannot distinguish "handler never started" from "handler ran + result lost" without `safeToRetry`. |
+| Between handlers and write #2                                        | same as above                                       | Same behavior.                                                                                                                  |
+| Mid-write #2                                                         | atomic — either all tool_results present or none    | Either case is well-defined.                                                                                                    |
+| After write #2                                                       | full step committed                                 | No orphan. Loop resumes normally.                                                                                               |
 
 Non-`safeToRetry` tools that crash in the middle windows are
 **intentionally** pessimistic: the framework cannot know if your side

--- a/packages/mint-docs/index.mdx
+++ b/packages/mint-docs/index.mdx
@@ -131,8 +131,8 @@ Vertz is a full-stack TypeScript framework. It includes a database ORM with type
 
 ## The stack
 
-| Layer          | What                                                                | Package               |
-| -------------- | ------------------------------------------------------------------- | --------------------- |
+| Layer          | What                                                                | Package                |
+| -------------- | ------------------------------------------------------------------- | ---------------------- |
 | **Schema**     | 40+ column types, runtime validation, JSON Schema output            | `@vertz/schema`        |
 | **Database**   | Typed queries, migrations, PostgreSQL + SQLite + D1                 | `@vertz/db`            |
 | **Server**     | Entity CRUD, services, access control, CORS, `createEnv()`          | `@vertz/server`        |

--- a/packages/mint-docs/installation.mdx
+++ b/packages/mint-docs/installation.mdx
@@ -60,10 +60,9 @@ vtz add @vertz/ui @vertz/theme-shadcn
 `@vertz/ui` is the UI runtime (JSX, signals, router, forms). Add `@vertz/server`, `@vertz/db`, `@vertz/schema`, `@vertz/fetch`, etc. as you need them. `@vertz/theme-shadcn` provides design tokens for the `css()` utility (optional but recommended).
 
 <Note>
-  A convenience meta package named `vertz` re-exports everything under subpaths
-  (`vertz/ui`, `vertz/server`, ...). It works, but we recommend the granular
-  `@vertz/*` packages — smaller installs, clearer dependencies, and LLM coding
-  assistants pick the right imports more reliably.
+  A convenience meta package named `vertz` re-exports everything under subpaths (`vertz/ui`,
+  `vertz/server`, ...). It works, but we recommend the granular `@vertz/*` packages — smaller
+  installs, clearer dependencies, and LLM coding assistants pick the right imports more reliably.
 </Note>
 
 ### 2. Configure TypeScript

--- a/plans/agents-durable-resume.md
+++ b/plans/agents-durable-resume.md
@@ -1,0 +1,628 @@
+# Design Doc — Durable Tool Execution & Transactional Resume for `@vertz/agents`
+
+**Issue:** [#2835](https://github.com/vertz-dev/vertz/issues/2835)
+**Related:** [#2834](https://github.com/vertz-dev/vertz/issues/2834) (Anthropic adapter — **merged**; triagebot production path now unblocked on the adapter side; this feature is the remaining gate).
+**Status:** Rev 2 — approved (3 agent reviews + human sign-off 2026-04-19); implementation in progress.
+**Author:** Vinicius Dacal (with Claude Opus 4.7)
+**Date:** 2026-04-19
+
+---
+
+## Problem
+
+`@vertz/agents` today has no durable resume primitive. In `packages/agents/src/run.ts:318-354`, session state + messages are flushed to the store **only after `reactLoop()` returns**. The ReAct loop in `packages/agents/src/loop/react-loop.ts:216-375` accumulates messages in memory:
+
+1. LLM response arrives with `toolCalls`.
+2. Assistant-with-toolCalls message is pushed to the in-memory `messages` array (line 314).
+3. Each tool handler runs (line 352 / `runConcurrentBatch`).
+4. Tool-result messages are pushed to the in-memory array (line 346/353).
+5. The loop continues — or returns, at which point `run.ts` persists everything at once.
+
+If the process is killed between (3) and (5) — a Cloudflare Durable Object alarm preemption, a Worker OOM, a deploy mid-request — the tool handler ran (side effects committed) but the `tool_result` message was never persisted. The next invocation re-enters the loop from the last durable state (the user message) and the LLM, seeing no record of the tool call, **asks for it again**. `slack.postMessage` fires twice.
+
+For side-effecting tools (Slack, email, billing, external paid APIs), this is a P0 correctness hole. It limits Vertz agents to read-only / naturally-idempotent use cases and blocks the first external consumer ([`triagebot`](https://github.com/viniciusdacal/triagebot)).
+
+The existing `checkpointInterval` config (`react-loop.ts:372-374`) is a notification callback, not a durable resume primitive. **This design deletes it** — it's ambiguous with real durability and pre-v1 policy is "consolidate aggressively, no back-compat shims" (`.claude/rules/policies.md`).
+
+---
+
+## Goals
+
+1. **At-most-once execution** of side-effecting tool handlers across process restarts, within a single `run()` session.
+2. **Automatic resume, zero config** — passing `store + sessionId` to `run()` is the opt-in. No separate `resume()` API, no new flag, no mode to discover.
+3. **Transactional store writes** for the critical step boundary: messages written in the store are always consistent with handler execution reality.
+4. **Explicit-retry opt-in via `safeToRetry: true`** — pure-read tools can declare themselves safe to re-invoke on resume and skip the "surface to LLM" fallback. Default behavior (side-effecting) is safe.
+5. **Degrades gracefully** — memory store is non-durable by construction and must fail loudly if used with `sessionId` — at `run()` entry, before any work starts, so a chat-only agent (no tool calls) doesn't silently appear to work and lose data on restart.
+
+## Why now
+
+Agents has one named external consumer (`triagebot`), and that consumer is blocked on this correctness hole. The competing priorities from project memory are vtz test runner (internal tooling, no external block), cloud platform (active design, not yet shipping), and multi-level tenancy (design-approved, not on the critical path for triagebot). Durable resume is the smallest atomic gate between Vertz agents and any production side-effecting use case — Slack, email, billing, paid APIs all want it on day one. Shipping this unblocks agents from "read-only demo" to "production-ready for the interesting market segment" with ~1 week of focused work on code paths we already own. Deferring it stays on the "read-only demo" ceiling indefinitely. The trade-off is accepting that the vtz test runner work is pushed by that week.
+
+## Non-Goals
+
+- **Cross-session coordination.** Two runners running the same `sessionId` concurrently is undefined behavior; the caller owns sessionId ownership (CF Durable Object input gate already provides serialization per DO for the intended use case).
+- **Generic distributed transactions across arbitrary side effects.** We don't compensate. A tool whose result is persisted returns its stored result on replay; we do not undo side effects.
+- **Streaming resume.** All providers today return non-streaming `LLMResponse` (`packages/agents/src/providers/`). Streaming durability is a separate design.
+- **Tool-handler-internal crash recovery.** If a handler crashes halfway through a 3-step side effect, this design does not make those steps atomic. Handler authors own internal idempotency / compensation. We only guarantee the *framework* doesn't re-fire the whole handler.
+- **Automatic retry of failed tool calls.** A handler error is persisted as an error `tool_result`. On resume, the LLM sees the error and decides. We don't silently retry.
+- **Multi-level tenancy semantics.** Sessions continue to follow whatever `userId` / `tenantId` contract `run()` already surfaces. If the multi-level tenancy work (#1787) changes that contract, this design inherits the change — no new primitives.
+- **Observability hooks** (replacement for `checkpointInterval`). Out of scope for this design; can be added later if a real need emerges. Crash signals surface as typed `ToolDurabilityError` tool_results in the message history.
+
+---
+
+## API Surface
+
+### Canonical `run()` call — one shape, used everywhere
+
+```ts
+import { createAnthropicAdapter, run } from '@vertz/agents';
+import { d1Store } from '@vertz/agents/cloudflare';
+import { triageAgent } from './agents/triage';
+import { createSlackProvider } from './tools/slack';
+import { createIssueProvider } from './tools/issue';
+
+const result = await run(triageAgent, {
+  message: 'An issue came in: ...',
+  sessionId: 'sess_abc123',
+  store: d1Store(env.DB),
+  llm: createAnthropicAdapter({ apiKey: env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+  tools: {
+    getIssue: createIssueProvider(env),
+    postSlack: createSlackProvider(env),
+  },
+  userId: 'u_42',     // optional
+  tenantId: 't_1',    // optional
+});
+```
+
+This is the **only** shape. Walkthrough, E2E tests, and docs all use it verbatim.
+
+If this invocation crashes after `postSlack`'s handler fires but before the `tool_result` row is persisted, a subsequent `run()` call with the same `sessionId` loads the session, detects the orphaned assistant-with-toolCalls (has tool_calls, missing matching tool_result rows), and:
+
+- For each missing tool_result, if the tool is declared `safeToRetry: true` → re-invoke the handler.
+- Otherwise → persist a synthetic `ToolDurabilityError` tool_result and let the LLM decide recovery (check external state, ask the user, abort the thread, etc.).
+
+### Tool declaration — new optional `safeToRetry` flag
+
+```ts
+import { tool } from '@vertz/agents';
+import { s } from '@vertz/schema';
+
+// Pure read. Safe to re-invoke on resume.
+export const getIssue = tool({
+  description: 'Fetch a Sentry issue by ID',
+  input: s.object({ id: s.string() }),
+  output: s.object({ title: s.string(), status: s.string() }),
+  safeToRetry: true, // ← new
+});
+
+// Side-effecting — default. Framework surfaces ToolDurabilityError on orphaned calls.
+export const postSlackMessage = tool({
+  description: 'Post a message to a Slack channel',
+  input: s.object({ channel: s.string(), text: s.string() }),
+  output: s.object({ ts: s.string() }),
+  // No `safeToRetry` → default: NOT safe; surface error on resume.
+});
+```
+
+**Naming rationale:** `safeToRetry` names exactly what the framework does with the flag — the framework may re-invoke the handler. `idempotent` was considered and rejected because an idempotent operation (e.g., `stripe.charge({ idempotencyKey })`) can still have side effects and still needs the durable-bookkeeping path. An LLM writing `stripe.charge` would correctly call it "idempotent" and incorrectly opt out of safety. `safeToRetry` maps 1:1 to framework behavior, so the failure mode is obvious to both humans and LLMs.
+
+### Store interface — new `appendMessagesAtomic()`
+
+```ts
+// packages/agents/src/stores/types.ts
+export interface AgentStore {
+  // ... existing methods unchanged ...
+
+  /**
+   * Atomically append messages AND upsert the session row in a single
+   * transaction (or the store's strongest equivalent — D1 batch, SQLite
+   * transaction). Readers must either see all of the writes or none.
+   *
+   * Used on every step boundary under durable execution. Replaces the
+   * end-of-run `saveSession` + `appendMessages` pair for that path.
+   */
+  appendMessagesAtomic(
+    sessionId: string,
+    messages: Message[],
+    session: AgentSession,
+  ): Promise<void>;
+}
+```
+
+Three implementations land:
+- **D1** — `db.batch([...inserts, sessionUpsert])` — a single batch call is implicitly transactional on D1 per https://developers.cloudflare.com/d1/worker-api/prepared-statements/#batch-statements. Crucially, the batch must NOT straddle an `await` — the whole batch is one atomic unit with no async gap.
+- **SQLite** (via `@vertz/sqlite`) — `db.transaction(() => { ... })` over already-resolved inserts. `@vertz/sqlite`'s `transaction()` is synchronous (better-sqlite3 style); we must not `await` inside it. This is an invariant the implementation enforces.
+- **Memory** — non-atomic. If called with `sessionId` under durable execution, **throws a runtime error**: `MemoryStoreNotDurableError`. Memory store is for tests and stateless runs; it cannot provide durability.
+
+### Durability sentinel — message history alone, no new fields
+
+Resume detection does **not** introduce a new column or a new message field. The sentinel is the existing message shape:
+
+> An `assistant` message with non-empty `toolCalls` is "orphaned" if there is no `tool` message in the same session whose `toolCallId` matches one of the assistant message's tool_call ids.
+
+This detection runs on `run()` startup before the first LLM call. It needs zero schema changes. Rationale: adding a `toolCallStatus` column introduces a migration problem (existing `agent_messages` tables have no such column) AND a race (a `pending` status written in transaction T1 has to be flipped to `committed` in transaction T2 — there's no atomic way to "span the handler dispatch" across the two transactions, so the column's value only encodes what the row array already tells us).
+
+### Step-boundary write sequence
+
+Under durable execution (`store + sessionId` present and store is durable):
+
+```
+LLM returns response with toolCalls
+  ↓
+[atomic write #1 — appendMessagesAtomic]
+  append assistant-with-toolCalls message
+  upsert session (updatedAt)
+  ↓
+run tool handlers (parallel or sequential, normal today)
+  ↓
+[atomic write #2 — appendMessagesAtomic]
+  append tool_result messages (successes and errors)
+  upsert session (updatedAt)
+  ↓
+loop continues to next LLM call
+```
+
+**Crash taxonomy** (what resume sees + does):
+
+| Crash window | Store state | Resume behavior |
+|-------------|-------------|-----------------|
+| Before write #1 | no assistant msg for this step | No orphan. Next LLM call starts fresh from prior state. |
+| Between write #1 and handler dispatch | assistant w/ toolCalls, no tool_results | Orphan. For each call: if tool is `safeToRetry`, re-invoke handler (safe — handler never ran). Else surface `ToolDurabilityError`. |
+| Mid-handler | assistant w/ toolCalls, no tool_results | **Same as above.** We cannot distinguish "handler never started" from "handler ran, side-effect committed, result lost" without an additional pre-dispatch marker — and that marker is infeasible given SQLite sync-transaction semantics (see `stores/sqlite-store.ts:174-189`). The honest story: crash in this window = ambiguous = surface to LLM unless `safeToRetry`. |
+| After handler dispatch, before write #2 | assistant w/ toolCalls, no tool_results | Same again. Same behavior. |
+| Mid-write #2 | atomic — either all tool_results present or none | Either case is well-defined. |
+| After write #2 | assistant + all tool_results | No orphan. Loop resumes normally at next LLM call. |
+
+The pessimism for non-`safeToRetry` tools in the middle windows is **intentional**: the framework cannot know if the side effect landed. Surfacing to the LLM is the only correct answer. Developers who can tolerate a re-invocation declare `safeToRetry: true`.
+
+### `ToolDurabilityError` — surfaced as a tool_result
+
+```ts
+// packages/agents/src/errors.ts
+export class ToolDurabilityError extends Error {
+  readonly kind = 'tool-durability-error';
+  readonly toolCallId: string;
+  readonly toolName: string;
+  constructor(toolCallId: string, toolName: string) {
+    super(
+      `Tool '${toolName}' (call ${toolCallId}) was requested but its execution ` +
+      `did not complete durably before the process ended. The tool is not ` +
+      `declared 'safeToRetry: true', so the framework will not automatically ` +
+      `re-invoke it. Decide recovery based on observable external state — e.g., ` +
+      `check whether the side effect already occurred. If this tool is a pure ` +
+      `read with no side effects, add \`safeToRetry: true\` to its declaration.`,
+    );
+    this.toolCallId = toolCallId;
+    this.toolName = toolName;
+  }
+}
+```
+
+The error instance is **serialized into the `tool_result` message's content** as JSON (`{ error: '...', kind: 'tool-durability-error', toolName, toolCallId }`) — matching how handler errors are already encoded today (`react-loop.ts:459-467`, `528-538`). The LLM sees the error in-band; no new schema.
+
+The class is exported for callers who want to pattern-match on resumed message history (e.g., to log / page when a session resumed with a durability error).
+
+### Removed API — `checkpointInterval` + `onCheckpoint`
+
+Deleted (pre-v1, no shim). Rationale: ambiguous with durable execution; "one way to do things" (Principle 2). If callers need step-boundary observability in the future, we add a typed hook — the door is open, but this design doesn't force a particular shape.
+
+### Memory store — hard runtime error under durable execution
+
+```ts
+// packages/agents/src/stores/memory-store.ts
+export class MemoryStoreNotDurableError extends Error {
+  constructor() {
+    super(
+      `memoryStore() cannot provide durable resume. Pass sessionId with a durable ` +
+      `store (d1Store, sqliteStore) or omit sessionId to run statelessly.`,
+    );
+  }
+}
+```
+
+The memory store's `appendMessagesAtomic` throws this immediately. Tests that want to exercise durable-resume paths use `sqliteStore({ path: ':memory:' })` — SQLite in-memory DBs ARE transactional.
+
+---
+
+## Manifesto Alignment
+
+### 1. If it builds, it works (Principle 1)
+
+Durability is a property of the store + sessionId combination. The `AgentStore` interface requires `appendMessagesAtomic`; memory store implements it as a runtime throw. No silent degradation. A caller mixing memory store with sessionId gets a loud error on first use, not a quiet data loss at 3am.
+
+### 2. One way to do things (Principle 2)
+
+- One entry point: `run()`. No `resume()`.
+- One activation: `store + sessionId`. No `durableResume` flag.
+- One mental model: "durability is automatic when you persist."
+- One opt-out: `safeToRetry: true` on safe tools. (Rejection note: `tool({ idempotent })` and `agent({ loop: { durableResume } })` from Rev 1 were both cut because each created a second way to describe what the call shape already says.)
+- `checkpointInterval` is **deleted** — no ambiguity with durable execution.
+
+### 3. AI agents are first-class users (Principle 3)
+
+The LLM sees `ToolDurabilityError` in-band as an error tool_result and reasons about recovery the same way it reasons about any handler error. No special protocol. An LLM reading the error message above can immediately decide: "check if the Slack post already landed, then either acknowledge and continue or resend with a deduplication header."
+
+### 4. Test what matters, nothing more (Principle 4)
+
+The E2E Acceptance Test (below) is the only behavioral test required. TDD RED lands in Phase 1. No speculative retry policies, no exponential backoff configs.
+
+### 5. If you can't test it, don't build it (Principle 5)
+
+Crash injection is trivial: a test-harness store that throws after the first atomic write but before the second. That harness IS the durable-resume test. The E2E test below exercises this shape end-to-end.
+
+### 6. Performance is not optional (Principle 7)
+
+Two atomic writes per step (was one at end-of-run). For a 10-iteration loop with 2 tool calls/step, we go from 1 write to ~20 writes. On D1 same-region, ~5–10ms per batch → ~100–200ms added per session. Budget in Phase 1: measure actual D1 same-region and same-DO-colo latency; target < 200ms added per 10-step session. If we blow the budget, fallback is batching multiple steps per write during compaction — deferred to a follow-up unless measurement forces it.
+
+### What was rejected vs. Rev 1
+
+- **`durableResume: true/false` flag** — cut. Default-off contradicted "zero config happy path"; default-on was just noise. Activation is `store + sessionId` already.
+- **`toolCallStatus: 'pending' | 'committed'` field** — cut. The two-transaction design can't atomically span handler dispatch on any backend (D1 batch can't straddle awaits; SQLite `transaction()` is sync). The status column would just encode what the message history already tells us, while requiring a schema migration.
+- **`idempotent: true`** (Rev 1 name) — renamed to `safeToRetry: true`. Matches actual framework behavior; avoids collision with industry "idempotency key" semantics.
+- **Separate `resume(sessionId)` API** (from issue sketch) — cut. Violates Principle 2.
+- **Content-addressed idempotency keys** (from issue sketch) — cut. The LLM's `tool_call_id` on the assistant message is stable *because we persist it pre-dispatch*, and resume matches on it. Hashing inputs adds complexity without adding guarantees.
+
+---
+
+## Unknowns
+
+1. **Actual D1 same-colo write latency for two batches/step.** Target < 200ms/10-step session. Resolved in Phase 1 by instrumenting the E2E test and an integration run against a real D1 instance.
+
+2. **Anthropic `tool_call_id` stability across replays.** Not an issue for this design — we persist the assistant-with-toolCalls message in atomic write #1 BEFORE any LLM retry could change ids. Resume matches ids from the stored message, not from a fresh LLM call. Callout in `ToolDurabilityError` docs: if the LLM is re-prompted mid-session (new ids), the assistant history is the source of truth.
+
+3. **Tool-set drift across deploys.** If a tool is removed between crash and resume, resume encounters a persisted tool_call for a tool that no longer exists. `react-loop.ts:456-467` already handles "Tool not found" as an error tool_result; we reuse that path. No new handling.
+
+4. **CF Durable Object eviction after D1 batch issued but before response.** D1 may have committed; DO never saw the response. Next `run()` sees the durable state → replays correctly. Invariant: step-commit is defined by D1's view, not the DO's. Documented.
+
+5. **Concurrent-batch tool failures.** `runConcurrentBatch` (current behavior at `react-loop.ts:338-357`): on partial failure, all successes + the error are written in atomic write #2 as a mixed set of tool_result messages. Already how errors are encoded. No new schema.
+
+---
+
+## POC Results
+
+**None required.** Each ingredient is a known quantity:
+- D1 `batch()` as single atomic unit — documented.
+- SQLite `transaction()` over sync operations — standard.
+- Two-phase write with no cross-phase atomicity — the honest story we owe users.
+- No new generics, no new schema column.
+
+The only measured unknown is D1 perf at 2 writes/step, addressed in Phase 1.
+
+---
+
+## Type Flow Map
+
+Every new generic and its consumer:
+
+**There are no new generics.** Every change is runtime behavior + one optional flag:
+
+```
+tool<TInput, TOutput>({ safeToRetry?: boolean, ... })
+  ↓
+ToolDefinition<TInput, TOutput> { safeToRetry?: boolean }
+  ↓
+reactLoop() reads def.safeToRetry at resume-dispatch time
+  (no generic impact — runtime check only)
+```
+
+```
+AgentStore.appendMessagesAtomic(
+  sessionId: string,
+  messages: Message[],        // public type, unchanged
+  session: AgentSession,      // public type, unchanged
+): Promise<void>
+  ↓
+Store implementations — concrete classes, no generic surface.
+```
+
+**Dead-generic check:** `tool()`'s `TInput`/`TOutput` still flow to `ToolDefinition.input` / `.output` / `.handler`. `AgentConfig<TState, TTools, TOutputSchema>` unchanged. No added dead generics. No removed used generics.
+
+**Existing generic flow preserved:** Resume doesn't change how tool inputs/outputs are typed — it just controls whether the handler is re-invoked or a synthetic error tool_result is persisted. Both paths produce the same output shape the LLM expects.
+
+---
+
+## E2E Acceptance Test
+
+```ts
+// packages/agents/src/__tests__/durable-resume.test.ts
+import { afterEach, describe, expect, it } from '@vertz/test';
+import { s } from '@vertz/schema';
+import { agent, run, sqliteStore, tool } from '@vertz/agents';
+import { crashAfterToolResults } from '@vertz/agents/testing';
+import { mockLLM } from './helpers'; // local helper, same shape as run.test.ts:12-32
+
+describe('Feature: durable tool execution', () => {
+  describe('Given a side-effecting tool + store + sessionId', () => {
+    describe('When the process crashes after handler ran but before tool_result persisted', () => {
+      it('Then a subsequent run() does NOT re-invoke the handler', async () => {
+        let postSlackCallCount = 0;
+
+        const postSlack = tool({
+          description: 'Post to Slack',
+          input: s.object({ text: s.string() }),
+          output: s.object({ ts: s.string() }),
+          // no safeToRetry — default side-effecting semantics
+        });
+
+        const sentinel = agent('sentinel', {
+          state: s.object({}),
+          initialState: {},
+          tools: { postSlack },
+          model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          loop: { maxIterations: 5 },
+        });
+
+        const store = sqliteStore({ path: ':memory:' });
+
+        const llm = mockLLM([
+          {
+            text: 'Posting to Slack.',
+            toolCalls: [{ id: 'call_1', name: 'postSlack', arguments: { text: 'hello' } }],
+          },
+          { text: 'Done.' },
+        ]);
+
+        // Crash harness: wraps the store so that the SECOND atomic write
+        // (tool_results) throws, simulating a crash after handler dispatch.
+        const crashingStore = crashAfterToolResults(store);
+
+        await expect(
+          run(sentinel, {
+            message: 'An issue came in.',
+            sessionId: 'sess_test',
+            store: crashingStore,
+            llm,
+            tools: {
+              postSlack: async ({ text }) => {
+                postSlackCallCount++;
+                return { ts: `ts_${postSlackCallCount}` };
+              },
+            },
+          }),
+        ).rejects.toThrow(/simulated crash/);
+
+        expect(postSlackCallCount).toBe(1); // handler ran once pre-crash
+
+        // Resume with a healthy store + fresh scripted LLM (only the final response).
+        const llm2 = mockLLM([{ text: 'Done.' }]);
+        const result = await run(sentinel, {
+          message: 'An issue came in.',
+          sessionId: 'sess_test', // same sessionId
+          store,                   // healthy now
+          llm: llm2,
+          tools: {
+            postSlack: async ({ text }) => {
+              postSlackCallCount++;
+              return { ts: `ts_${postSlackCallCount}` };
+            },
+          },
+        });
+
+        expect(result.ok).toBe(true);
+        expect(postSlackCallCount).toBe(1); // ← the point: NOT 2
+
+        // The LLM's second response sees a ToolDurabilityError tool_result
+        // in the message history and responded "Done." accordingly.
+        const messages = await store.loadMessages('sess_test');
+        const durabilityError = messages.find(
+          (m) =>
+            m.role === 'tool' &&
+            m.toolCallId === 'call_1' &&
+            m.content.includes('tool-durability-error'),
+        );
+        expect(durabilityError).toBeDefined();
+      });
+    });
+  });
+
+  describe('Given a safeToRetry tool + crash mid-step', () => {
+    it('Then the handler IS re-invoked automatically on resume', async () => {
+      let getIssueCallCount = 0;
+
+      const getIssue = tool({
+        description: 'Fetch an issue',
+        input: s.object({ id: s.string() }),
+        output: s.object({ title: s.string() }),
+        safeToRetry: true,
+      });
+
+      // ... same crash-injection setup as above ...
+      // expected: after resume, getIssueCallCount === 2 (that's the point —
+      //           safeToRetry opts into automatic re-invocation) and
+      //           result.ok === true.
+    });
+  });
+
+  describe('Given store + sessionId is memory store', () => {
+    it('Then the first durable write throws MemoryStoreNotDurableError', async () => {
+      // ... exercises the memory-store safeguard ...
+    });
+  });
+
+  describe('Type-level', () => {
+    it('rejects misspelled tool config at compile time', () => {
+      tool({
+        description: 'x',
+        input: s.object({}),
+        output: s.object({}),
+        // @ts-expect-error — 'safeToRetry' must be boolean
+        safeToRetry: 'yes',
+      });
+
+      tool({
+        description: 'x',
+        input: s.object({}),
+        output: s.object({}),
+        // @ts-expect-error — unknown flag
+        idempotent: true,
+      });
+    });
+  });
+});
+```
+
+**What this test proves:**
+1. Side-effecting tool handler fires exactly once across a crash + resume.
+2. `safeToRetry: true` re-invokes automatically.
+3. Memory store + sessionId fails loudly instead of silently losing durability.
+4. Type-level: misconfigured tools rejected at compile time; the old `idempotent` name is rejected (protects against anyone carrying the Rev 1 habit forward).
+
+---
+
+## Phases
+
+Five phases. **Phases 1–3 are the shippable MVP** — they close the P0 correctness hole (no double-fire side effects) and unblock triagebot's production use case. **Phases 4–5 are follow-ups**: Phase 4 is the `safeToRetry` usability sweetener (`postSlack` — the motivating tool — is side-effecting and does NOT opt in); Phase 5 is docs + CF DO verification + changeset. If scope pressure emerges, Phase 4 can ship as a follow-up PR without blocking the MVP. Each phase is independently mergeable because the behavior change is activated by `store + sessionId` presence, not by a flag.
+
+### Phase 1 — Store transactions + failing E2E test (TDD RED) — MVP
+
+- Add `appendMessagesAtomic` to `AgentStore` interface.
+- Implement in D1 (single `db.batch()`; the whole batch must NOT straddle an `await`), SQLite (`db.transaction()` over already-resolved inserts — no `await` inside), memory store (stored for completeness; see below).
+- Add `MemoryStoreNotDurableError` export. Emit it at **`run()` entry** — not lazily on first write — whenever `store` is memory AND `sessionId` is present. Chat-only agents with no tool calls must still fail loudly.
+- Commit to `packages/agents/src/testing/crash-harness.ts` with an exported `crashAfterToolResults(store: AgentStore): AgentStore` factory, re-exported from `@vertz/agents/testing`. This is the only new module.
+- Land the E2E test at `packages/agents/src/__tests__/durable-resume.test.ts` — **RED** against current code.
+- Add a perf one-shot at `packages/agents/src/__tests__/durable-resume.perf.local.ts` (`.local.ts` per `.claude/rules/integration-test-safety.md`) — measures 10-step D1 same-region latency once against a real D1 instance. Record the measured number in the retrospective (not a CI regression gate; the `< 200ms` budget is a release-gate decision, not per-commit). If the measurement exceeds budget, design decision escalates back to this doc.
+
+**Acceptance:**
+- `AgentStore.appendMessagesAtomic` exists with three implementations.
+- `MemoryStoreNotDurableError` thrown at `run()` entry (not first write).
+- `durable-resume.test.ts` compiles, runs, and fails only on the "does not re-invoke handler" assertion.
+- `crash-harness.ts` + `@vertz/agents/testing` re-export land.
+
+### Phase 2 — Per-step atomic write in the ReAct loop — MVP
+
+- On each step in `reactLoop`, when store + sessionId are present:
+  - After LLM returns toolCalls: call `appendMessagesAtomic` with the assistant-with-toolCalls message + session upsert.
+  - After handlers resolve: call `appendMessagesAtomic` with all tool_result messages + session upsert.
+- Remove the end-of-run batch persistence in `run.ts` when durable execution is active; keep it for the non-durable path (no sessionId, or stateless).
+- **Delete `checkpointInterval` + `onCheckpoint`** from `AgentLoopConfig`, `reactLoop` wiring, and all tests that reference them (`packages/agents/src/loop/react-loop.test.ts`, `packages/agents/src/agent.test.ts`, `packages/agents/src/types.test-d.ts`). Any currently-passing test referencing the old callback is deleted or rewritten to exercise the new durability story.
+- **Provider adapter invariant (callout):** LLM provider adapters must return the final, non-retried response to the loop. If an adapter retries internally and returns different `tool_call_id`s on the second attempt, the framework persists those final ids in atomic write #1 — resume reads from storage and is self-consistent. Adapters must never deliver a mid-retry response to the loop.
+
+**Acceptance:**
+- Phase 1's E2E test: the "handler count after resume" assertion still fails (no resume logic yet), but store state shows the orphaned assistant message after crash.
+- All remaining tests pass. No test still references `checkpointInterval` or `onCheckpoint`.
+
+### Phase 3 — Resume detection + ToolDurabilityError — MVP
+
+- On `run()` entry with store + sessionId:
+  - Load messages.
+  - Detect orphaned assistant-with-toolCalls (no matching tool_result).
+  - For each orphan tool_call: surface `ToolDurabilityError` as a synthetic error `tool_result` (content shape matches existing handler-error encoding at `react-loop.ts:459-467`).
+  - Write the synthetic tool_results via `appendMessagesAtomic`.
+  - Proceed into the loop as if step had completed.
+
+**Acceptance:**
+- Phase 1's E2E test GREEN on the "does not re-invoke handler" + "error surfaces in history" assertions.
+- **This is the end of the MVP slice.** Merging here closes #2835's P0 correctness hole. Phases 4–5 can ship as follow-up PRs if scope pressure demands.
+
+### Phase 4 — `tool({ safeToRetry })` opt-in — follow-up sweetener
+
+- Add `safeToRetry?: boolean` to `ToolConfig` + `ToolDefinition`.
+- On resume detection: if `safeToRetry: true`, re-invoke the tool handler instead of surfacing `ToolDurabilityError`; persist the real result.
+- Add the `safeToRetry` E2E test scenario.
+
+**Acceptance:**
+- E2E test's "safeToRetry re-invokes" assertion GREEN.
+
+### Phase 5 — Docs + CF DO verification + changeset — follow-up
+
+- `packages/mint-docs/` update: durable-resume guide, `safeToRetry` flag, cost guidance ("expect ~2 D1 writes per step; for high-volume read-heavy agents consider stateless mode"), FAQ entry clarifying that `safeToRetry` is about **resume replay**, not HTTP/network retries.
+- Manual verification checklist against triagebot in a CF DO environment (requires #2834 merged for production run; the framework E2E tests pass independently).
+- Changeset (patch bump).
+- Retrospective in `plans/post-implementation-reviews/agents-durable-resume.md`, including the Phase 1 perf measurement number.
+
+**Acceptance:**
+- Docs live.
+- Manual CF DO verification recorded in the retrospective.
+
+---
+
+## Developer Walkthrough
+
+Someone building `triagebot`:
+
+1. Declare tools — the read is `safeToRetry: true`; the write is left as the side-effecting default.
+   ```ts
+   // tools.ts
+   import { tool } from '@vertz/agents';
+   import { s } from '@vertz/schema';
+
+   export const getIssue = tool({
+     description: 'Fetch a Sentry issue by ID',
+     input: s.object({ id: s.string() }),
+     output: s.object({ title: s.string(), status: s.string() }),
+     safeToRetry: true,
+   });
+
+   export const postSlack = tool({
+     description: 'Post to Slack',
+     input: s.object({ channel: s.string(), text: s.string() }),
+     output: s.object({ ts: s.string() }),
+   });
+   ```
+
+2. Define the agent:
+   ```ts
+   // agent.ts
+   import { agent } from '@vertz/agents';
+   import { s } from '@vertz/schema';
+   import { getIssue, postSlack } from './tools';
+
+   export const triageAgent = agent('triage', {
+     state: s.object({}),
+     initialState: {},
+     tools: { getIssue, postSlack },
+     model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+     loop: { maxIterations: 10 },
+   });
+   ```
+
+3. In the Durable Object:
+   ```ts
+   // triagebot-do.ts
+   import { createAnthropicAdapter, run } from '@vertz/agents';
+   import { d1Store } from '@vertz/agents/cloudflare';
+   import { triageAgent } from './agent';
+   import { createIssueProvider } from './providers/issue';
+   import { createSlackProvider } from './providers/slack';
+
+   export class TriagebotDO {
+     async fetch(request: Request) {
+       const { issueId, message } = await request.json();
+       await run(triageAgent, {
+         message,
+         sessionId: this.state.id.toString(),
+         store: d1Store(this.env.DB),
+         llm: createAnthropicAdapter({ apiKey: this.env.ANTHROPIC_API_KEY, model: 'claude-sonnet-4-6' }),
+         tools: {
+           getIssue: createIssueProvider(this.env),
+           postSlack: createSlackProvider(this.env),
+         },
+       });
+       return new Response('ok');
+     }
+   }
+   ```
+
+4. DO crashes mid-`postSlack` — CF reroutes the next request to the same DO (input-gate serialization). `run()` re-enters with the same `sessionId`. Resume logic sees the orphaned assistant-with-toolCalls for `postSlack`, persists `ToolDurabilityError` as the tool_result, and the LLM — seeing the error in-band — either asks the user, checks Slack for the message, or aborts the thread. `postSlack`'s handler is **not** re-invoked. No double-post.
+
+5. For `getIssue` specifically, had the crash happened inside its handler, resume would re-invoke automatically (it's `safeToRetry`). The LLM sees a valid tool_result and continues.
+
+That's the whole story. Two flags, one store. No `durableResume`, no `resume()`, no `idempotent`.
+
+**Don't want durability for this agent?** Omit `sessionId` to run statelessly (fresh conversation every call), or use `memoryStore()` *without* `sessionId` for in-process scratch state. Durability activates only when both `store + sessionId` are present AND the store is a durable backend.
+
+---
+
+## Changes Against Rev 1 (for reviewers tracking diffs)
+
+- **Removed:** `durableResume` flag (now implicit from `store + sessionId`).
+- **Removed:** `toolCallStatus: 'pending' | 'committed'` field (incompatible with SQLite sync-transaction + D1 batch semantics; message history alone suffices).
+- **Removed:** separate `resume()` API (never had one, but Rev 1 considered it).
+- **Renamed:** `idempotent: true` → `safeToRetry: true`.
+- **Deleted:** `checkpointInterval` + `onCheckpoint` (pre-v1, no shim).
+- **Tightened:** memory store under durable execution throws `MemoryStoreNotDurableError`.
+- **Added:** canonical `run()` call shape used consistently across the entire doc (no drift between API Surface, Walkthrough, and E2E).
+- **Added:** explicit crash taxonomy table — what resume sees, what it does, for each crash window.
+- **Added:** #2834 sequencing note (framework lands independently; production triagebot activation requires both).
+- **Reduced phases:** 6 → 5 (Phase 1 now includes the E2E test as RED per TDD, matching Principle 5).

--- a/plans/agents-durable-resume/phase-01-store-transactions-and-red-e2e.md
+++ b/plans/agents-durable-resume/phase-01-store-transactions-and-red-e2e.md
@@ -1,0 +1,400 @@
+# Phase 1: Store Transactions + Failing E2E Test (TDD RED) — MVP
+
+## Context
+
+P0 correctness hole in `@vertz/agents` (issue #2835): the ReAct loop writes
+messages to the store only at end-of-run, so a crash mid-loop loses tool_result
+rows while tool handlers' side effects already committed. The full design is
+`plans/agents-durable-resume.md` (approved Rev 2).
+
+This phase lays the durability primitive (`appendMessagesAtomic`) across all
+three stores, adds the memory-store safety rail (throw at `run()` entry when
+combined with `sessionId`), ships a crash-injection test harness, and lands
+the E2E test as **TDD RED** — failing at exactly the "does not re-invoke
+handler" assertion. Phases 2 and 3 make it green.
+
+**Design invariants the code must honor:**
+- `appendMessagesAtomic` never `await`s between the first and last underlying
+  write — it is atomic by being a single driver call (D1 `db.batch(...)`,
+  SQLite `db.transaction(() => { ... })()`).
+- Memory store throws `MemoryStoreNotDurableError` at `run()` entry — not on
+  first write — whenever `store` is the memory store and `sessionId` is
+  provided. This catches chat-only agents that never call a tool.
+- The crash harness wraps any `AgentStore` and throws on the **second**
+  `appendMessagesAtomic` call, simulating a crash after handler dispatch.
+  (Phases 2+ will call this method twice per step; Phase 1 only tests the
+  harness mechanics.)
+
+**Key files to study before starting:**
+- `packages/agents/src/stores/types.ts` — `AgentStore` interface (add one method).
+- `packages/agents/src/stores/memory-store.ts`, `sqlite-store.ts`, `d1-store.ts` —
+  three impls (add one method each).
+- `packages/agents/src/stores/errors.ts` — existing store errors (add one class).
+- `packages/agents/src/run.ts` — public `run()`; entry check for memory + sessionId.
+- `packages/agents/src/run.test.ts:12-32` — `mockLLM` pattern (inline in new tests).
+- `packages/sqlite/src/index.ts` — `Database.transaction<T>(fn: () => T): () => T`
+  returns a callable; sync, no-await.
+- `packages/agents/src/stores/sqlite-store.ts:174` — example of using
+  `db.transaction(() => { ... })()` over `.run()` statements.
+
+---
+
+## Tasks
+
+### Task 1: Add `appendMessagesAtomic` to the store interface + memory-store throw + `MemoryStoreNotDurableError`
+
+**Files:** (4)
+- `packages/agents/src/stores/types.ts` (modified — add method signature)
+- `packages/agents/src/stores/errors.ts` (modified — add `MemoryStoreNotDurableError`)
+- `packages/agents/src/stores/memory-store.ts` (modified — implement method that always throws `MemoryStoreNotDurableError`)
+- `packages/agents/src/stores/errors.test.ts` (modified — add RED test asserting `MemoryStoreNotDurableError` is exported + has correct message)
+
+**What to implement:**
+
+Extend `AgentStore` with:
+
+```ts
+appendMessagesAtomic(
+  sessionId: string,
+  messages: Message[],
+  session: AgentSession,
+): Promise<void>;
+```
+
+Add `MemoryStoreNotDurableError` to `errors.ts`:
+
+```ts
+export class MemoryStoreNotDurableError extends Error {
+  readonly code = 'MEMORY_STORE_NOT_DURABLE' as const;
+  constructor() {
+    super(
+      'memoryStore() cannot provide durable resume. Pass sessionId with a ' +
+      'durable store (sqliteStore, d1Store) or omit sessionId to run statelessly.',
+    );
+    this.name = 'MemoryStoreNotDurableError';
+  }
+}
+```
+
+Memory store implementation:
+
+```ts
+async appendMessagesAtomic(
+  _sessionId: string,
+  _messages: Message[],
+  _session: AgentSession,
+): Promise<void> {
+  throw new MemoryStoreNotDurableError();
+}
+```
+
+**Acceptance criteria:**
+- [ ] `AgentStore.appendMessagesAtomic` is a required method on the interface.
+- [ ] `MemoryStoreNotDurableError` is exported from `@vertz/agents` (add to `src/index.ts`).
+- [ ] Calling `memoryStore().appendMessagesAtomic('s', [], session)` throws
+      `MemoryStoreNotDurableError` with the documented message.
+- [ ] `vtz test packages/agents` passes.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+### Task 2: Implement `appendMessagesAtomic` for the SQLite store
+
+**Files:** (2)
+- `packages/agents/src/stores/sqlite-store.ts` (modified — add method, wrap inserts + upsert in a sync `db.transaction(...)`)
+- `packages/agents/src/stores/sqlite-store.test.ts` (modified — add tests: atomic success, atomic rollback on a throw mid-transaction, no-await invariant)
+
+**What to implement:**
+
+In `sqlite-store.ts`, implement the method using `db.transaction(() => { ... })()`:
+
+```ts
+async appendMessagesAtomic(sessionId, messages, session) {
+  const now = new Date().toISOString();
+  const tx = db.transaction(() => {
+    // 1. UPSERT session (created_at preserved on conflict, updated_at bumped)
+    upsertSessionStmt.run(
+      session.id, session.agentName, session.userId, session.tenantId,
+      session.state, session.createdAt, now,
+    );
+    // 2. Get current max seq for this session
+    const maxSeq = (selectMaxSeqStmt.get(sessionId)?.max_seq ?? 0) as number;
+    // 3. Insert each message with incrementing seq
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i]!;
+      insertMessageStmt.run(
+        sessionId, maxSeq + i + 1, m.role, m.content,
+        m.toolCallId ?? null, m.toolName ?? null,
+        m.toolCalls ? JSON.stringify(m.toolCalls) : null,
+        now,
+      );
+    }
+  });
+  tx(); // execute the sync transaction — no await inside
+}
+```
+
+**Acceptance criteria:**
+- [ ] `sqliteStore({ path: ':memory:' })` implements `appendMessagesAtomic`.
+- [ ] Test: atomic success — after call, `loadMessages` returns the new messages + `loadSession` reflects updated fields.
+- [ ] Test: atomic rollback — if insertion throws partway (e.g., forced duplicate seq), no messages appear and session row is unchanged.
+- [ ] Test: invariant — the method must not `await` inside the transaction (static lint — grep the implementation for `await` inside the `db.transaction` callback in a simple test, OR inspect by code review; mark as a type-level note if automated detection is not feasible).
+- [ ] All existing sqlite-store tests still pass.
+- [ ] `vtz test packages/agents` passes.
+
+---
+
+### Task 3: Implement `appendMessagesAtomic` for the D1 store
+
+**Files:** (2)
+- `packages/agents/src/stores/d1-store.ts` (modified — add method using `db.batch([stmt1, stmt2, ...])`)
+- `packages/agents/src/stores/d1-store.test.ts` (modified — add tests using the test D1 fake)
+
+**What to implement:**
+
+D1's `db.batch([...statements])` submits as one unit and is implicitly
+transactional per https://developers.cloudflare.com/d1/worker-api/prepared-statements/#batch-statements.
+The whole batch must be constructed synchronously (no `await` between
+`db.prepare()` calls and `db.batch()` invocation).
+
+```ts
+async appendMessagesAtomic(sessionId, messages, session) {
+  const now = new Date().toISOString();
+  const statements = [
+    // 1. UPSERT session
+    db.prepare(
+      `INSERT INTO agent_sessions ... ON CONFLICT(id) DO UPDATE SET ...`
+    ).bind(...),
+    // 2. ...for each message, a prepared INSERT bound with seq = (current max + i + 1)
+  ];
+  // D1 has no "SELECT then INSERT in same batch" — compute seq from a subquery
+  // in the INSERT itself: `INSERT INTO agent_messages (session_id, seq, ...)
+  // VALUES (?, COALESCE((SELECT MAX(seq) FROM agent_messages WHERE session_id = ?), 0) + ?, ...)`
+  // where the last `?` is the per-message offset (1, 2, 3...).
+  await db.batch(statements);
+}
+```
+
+**Note:** the SQL subquery pattern is required because D1 can't pause a batch
+to read an intermediate result. Each statement's `seq` is computed as
+`COALESCE((SELECT MAX(seq) FROM agent_messages WHERE session_id = ?), 0) + N`
+where N is the per-message offset. This is safe: the batch runs as one
+transactional unit, so no external inserts can interleave.
+
+**Acceptance criteria:**
+- [ ] `d1Store(db)` implements `appendMessagesAtomic`.
+- [ ] Test: atomic success — messages and session write together.
+- [ ] Test: if `db.batch()` rejects (the D1 fake throws), no partial writes are visible.
+- [ ] All existing d1-store tests pass.
+- [ ] `vtz test packages/agents` passes.
+
+---
+
+### Task 4: Add `run()` entry check for memory store + sessionId + export errors
+
+**Files:** (3)
+- `packages/agents/src/run.ts` (modified — entry check before any work)
+- `packages/agents/src/index.ts` (modified — export `MemoryStoreNotDurableError`)
+- `packages/agents/src/run.test.ts` (modified — test: memory + sessionId throws at entry, not on first write; both no-tool and with-tool agents fail loudly)
+
+**What to implement:**
+
+At the top of `run()` (before session load), detect the combination:
+
+```ts
+if (opts.sessionId && opts.store && isMemoryStore(opts.store)) {
+  throw new MemoryStoreNotDurableError();
+}
+```
+
+Use a branded/nominal check: add a symbol or a `.__kind` property to
+`memoryStore()` so `isMemoryStore(store)` is reliable without `instanceof`.
+
+```ts
+// In memory-store.ts
+const MEMORY_STORE_KIND = Symbol.for('@vertz/agents::memoryStore');
+export function memoryStore(): AgentStore {
+  return {
+    [MEMORY_STORE_KIND]: true,
+    // ...existing methods...
+  } as AgentStore & { [MEMORY_STORE_KIND]: true };
+}
+export function isMemoryStore(store: AgentStore): boolean {
+  return (store as { [MEMORY_STORE_KIND]?: boolean })[MEMORY_STORE_KIND] === true;
+}
+```
+
+**Acceptance criteria:**
+- [ ] `run()` with `memoryStore() + sessionId` throws `MemoryStoreNotDurableError` **before** the agent loop starts (assert error happens before LLM is ever called).
+- [ ] `run()` with `memoryStore()` and no `sessionId` continues to work unchanged.
+- [ ] `run()` with any non-memory store (sqlite) and `sessionId` does NOT throw.
+- [ ] `MemoryStoreNotDurableError` is exported from `@vertz/agents`.
+- [ ] All existing `run.test.ts` tests pass.
+- [ ] `vtz test packages/agents` passes.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+### Task 5: Crash harness + `@vertz/agents/testing` subpath + export
+
+**Files:** (3)
+- `packages/agents/src/testing/crash-harness.ts` (new — `crashAfterToolResults(store)` factory)
+- `packages/agents/src/testing/index.ts` (new — barrel for the testing subpath)
+- `packages/agents/package.json` + `packages/agents/tsconfig.typecheck.json` (modified — add `./testing` subpath export + include glob)
+
+**What to implement:**
+
+`crashAfterToolResults(store)` returns a wrapper `AgentStore` that:
+- Delegates every method to the underlying store.
+- Counts calls to `appendMessagesAtomic`.
+- Throws `Error('simulated crash after tool results')` on the **second** call (the tool-results-commit write that Phase 2 will add).
+
+```ts
+// packages/agents/src/testing/crash-harness.ts
+import type { AgentSession, AgentStore } from '../stores/types';
+import type { Message } from '../loop/react-loop';
+
+export function crashAfterToolResults(store: AgentStore): AgentStore {
+  let atomicCallCount = 0;
+  return {
+    ...store, // delegate all other methods
+    loadSession: (id) => store.loadSession(id),
+    saveSession: (s) => store.saveSession(s),
+    loadMessages: (id) => store.loadMessages(id),
+    appendMessages: (id, msgs) => store.appendMessages(id, msgs),
+    pruneMessages: (id, keep) => store.pruneMessages(id, keep),
+    deleteSession: (id) => store.deleteSession(id),
+    listSessions: (f) => store.listSessions(f),
+    async appendMessagesAtomic(
+      sessionId: string, messages: Message[], session: AgentSession,
+    ) {
+      atomicCallCount++;
+      if (atomicCallCount >= 2) {
+        throw new Error('simulated crash after tool results');
+      }
+      await store.appendMessagesAtomic(sessionId, messages, session);
+    },
+  };
+}
+```
+
+Add subpath export:
+
+```json
+// packages/agents/package.json exports
+"./testing": {
+  "import": "./dist/testing/index.js",
+  "types": "./dist/testing/index.d.ts"
+}
+```
+
+**Acceptance criteria:**
+- [ ] `import { crashAfterToolResults } from '@vertz/agents/testing'` resolves.
+- [ ] Calling the wrapper's `appendMessagesAtomic` once delegates; calling it a second time throws `'simulated crash after tool results'`.
+- [ ] All other wrapper methods pass through unchanged (verify via spy on the underlying store).
+- [ ] `vtz test packages/agents` passes.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+- [ ] `vtz run build --filter=@vertz/agents` produces `dist/testing/index.js` and `dist/testing/index.d.ts`.
+
+---
+
+### Task 6: Land the RED E2E test + one-shot perf probe
+
+**Files:** (2)
+- `packages/agents/src/__tests__/durable-resume.test.ts` (new — the RED E2E from the design doc)
+- `packages/agents/src/__tests__/durable-resume.perf.local.ts` (new — Phase-1 one-shot perf probe, `.local.ts` per `.claude/rules/integration-test-safety.md`)
+
+**What to implement:**
+
+Paste the E2E test from the design doc's "E2E Acceptance Test" section,
+adjusting imports to match what actually exists:
+
+```ts
+import { afterEach, describe, expect, it } from '@vertz/test';
+import { s } from '@vertz/schema';
+import { agent, run, sqliteStore, tool, memoryStore, MemoryStoreNotDurableError } from '@vertz/agents';
+import { crashAfterToolResults } from '@vertz/agents/testing';
+import type { LLMAdapter } from '@vertz/agents';
+
+function mockLLM(
+  responses: Array<{ text?: string; toolCalls?: Array<{ id?: string; name: string; arguments: Record<string, unknown> }> }>,
+): LLMAdapter {
+  let i = 0;
+  return {
+    async chat() {
+      const r = responses[i++] ?? { text: 'No more responses' };
+      return { text: r.text ?? '', toolCalls: r.toolCalls ?? [] };
+    },
+  };
+}
+
+describe('Feature: durable tool execution', () => {
+  describe('Given a side-effecting tool + store + sessionId', () => {
+    describe('When the process crashes after handler ran but before tool_result persisted', () => {
+      it('Then a subsequent run() does NOT re-invoke the handler', async () => {
+        // ... as in the design doc ...
+      });
+    });
+  });
+
+  describe('Given store + sessionId is memory store', () => {
+    it('Then run() entry throws MemoryStoreNotDurableError before the loop starts', async () => {
+      // ... from design doc; assert no LLM calls happened ...
+    });
+  });
+
+  describe('Type-level', () => {
+    it('rejects misspelled tool config at compile time', () => {
+      tool({
+        description: 'x',
+        input: s.object({}),
+        output: s.object({}),
+        // @ts-expect-error — 'safeToRetry' does not exist yet (Phase 4)
+        safeToRetry: true,
+      });
+    });
+  });
+});
+```
+
+**Expected state at end of Phase 1 (RED):**
+- The "does not re-invoke handler" test **fails** with a runtime error (the
+  crash harness triggers before the framework has resume logic, so the loop
+  aborts and the test expectation that `postSlackCallCount === 1` after the
+  resumed run fails with "no second run happened" or similar).
+- The memory-store entry-check test **passes** (Task 4 implemented it).
+- The type-level `@ts-expect-error` **passes** (`safeToRetry` doesn't exist yet
+  — the directive fires because the field is unknown).
+
+The perf one-shot `durable-resume.perf.local.ts` measures wall time of a
+10-step scripted loop against `sqliteStore({ path: ':memory:' })` (in-memory
+SQLite is the closest thing we can exercise in a unit test; a real-D1 measurement
+lives in Phase 5's manual checklist). Print the measured time; record in the
+retrospective. Not a CI gate.
+
+**Acceptance criteria:**
+- [ ] `durable-resume.test.ts` exists and fails **only** at the "does not re-invoke" assertion — all other assertions pass.
+- [ ] `durable-resume.perf.local.ts` exists, runs under `vtz test src/__tests__/durable-resume.perf.local.ts`, and prints a measured time.
+- [ ] `vtz test packages/agents` has exactly one failing test (the Phase-1 RED assertion) and everything else green.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+## Out of scope for Phase 1
+
+- Per-step atomic writes in the ReAct loop (Phase 2).
+- Resume detection & `ToolDurabilityError` (Phase 3).
+- `safeToRetry` flag on tools (Phase 4).
+- Documentation updates (Phase 5).
+
+## Notes for the implementing agent
+
+1. **TDD strictly per phase.** Inside this phase, the RED test lands last
+   (Task 6). Tasks 1–5 each get their own red→green→refactor micro-cycles
+   (unit tests for each new method).
+2. **No `@ts-ignore`, no `as any`.** Every cast should use `as unknown as T`
+   or a narrower type (see `.claude/rules/policies.md`).
+3. **Commit per task** — six commits for Phase 1, each referencing `#2835`.
+4. **Keep the design doc as the source of truth.** If you find a design
+   conflict while implementing, stop and escalate instead of deviating
+   silently.

--- a/plans/agents-durable-resume/phase-02-per-step-atomic-write.md
+++ b/plans/agents-durable-resume/phase-02-per-step-atomic-write.md
@@ -1,0 +1,219 @@
+# Phase 2: Per-Step Atomic Write in the ReAct Loop + Delete `checkpointInterval` — MVP
+
+## Context
+
+Phase 1 added `appendMessagesAtomic` to all stores + the crash harness + the
+RED E2E. This phase rewires the ReAct loop to use the primitive: each tool
+step does two atomic writes (pre-dispatch assistant-with-toolCalls, then
+post-dispatch tool_results). End-of-run batch persistence is kept **only** for
+non-durable runs (no `sessionId` or no store).
+
+This phase also deletes the now-obsolete `checkpointInterval` + `onCheckpoint`
+config (pre-v1 policy: consolidate aggressively, no shims).
+
+**After Phase 2 the E2E test still fails** on the "does not re-invoke handler"
+assertion (no resume logic yet), but the store state inspection should show
+the orphaned assistant-with-toolCalls after crash. Phase 3 makes it green.
+
+**Design invariants this phase must honor:**
+- Pre-dispatch write #1 and post-dispatch write #2 are **two separate**
+  `appendMessagesAtomic` calls. We do not attempt to span dispatch with a
+  single transaction (see design doc §Crash taxonomy — impossible on
+  SQLite sync-transaction + D1 no-await-in-batch).
+- Provider adapter invariant: adapters must return the final (post-retry)
+  LLM response. The framework persists whichever `tool_call_id`s arrive from
+  the adapter; resume matches from storage.
+- When durable execution is active, **do not** duplicate writes at
+  end-of-run. Only the non-durable path keeps the current
+  `saveSession`+`appendMessages` pair.
+
+**Key files:**
+- `packages/agents/src/loop/react-loop.ts:145-380` — the loop.
+- `packages/agents/src/run.ts:130-370` — where messages are flushed today.
+- `packages/agents/src/types.ts:163-178` — `AgentLoopConfig` (delete
+  `checkpointInterval`).
+- `packages/agents/src/agent.ts:18` — `agent()` factory, reads
+  `checkpointInterval`.
+- Tests that touch `checkpointInterval`/`onCheckpoint`:
+  - `packages/agents/src/loop/react-loop.test.ts:241-262`
+  - `packages/agents/src/agent.test.ts:51-79`
+  - `packages/agents/src/types.test-d.ts:185-194`
+
+---
+
+## Tasks
+
+### Task 1: Thread a durable-write callback into `reactLoop`
+
+**Files:** (3)
+- `packages/agents/src/loop/react-loop.ts` (modified — add optional
+  `persistStep({ messages, phase })` callback in `ReactLoopOptions`; call it
+  twice per step when set)
+- `packages/agents/src/run.ts` (modified — provide `persistStep` only when
+  durable execution is active; otherwise keep end-of-run flush)
+- `packages/agents/src/run.test.ts` (modified — add a test that with
+  `sqliteStore + sessionId`, `appendMessagesAtomic` is called twice per step
+  for each tool-call step)
+
+**What to implement:**
+
+Add to `ReactLoopOptions`:
+
+```ts
+export interface ReactLoopOptions {
+  // ...existing...
+  /**
+   * Called at step boundaries when the caller wants durable-per-step writes.
+   * Phase A: right after an assistant-with-toolCalls message is pushed.
+   * Phase B: right after all tool_result messages for that step are pushed.
+   * The callback receives a snapshot of the messages array for that write
+   * (the new messages, not the entire conversation).
+   */
+  persistStep?: (args: {
+    phase: 'assistant-with-tool-calls' | 'tool-results';
+    newMessages: Message[];
+  }) => Promise<void>;
+}
+```
+
+In the loop body, after pushing the assistant-with-toolCalls message:
+
+```ts
+messages.push({ role: 'assistant', content, toolCalls });
+if (options.persistStep) {
+  await options.persistStep({
+    phase: 'assistant-with-tool-calls',
+    newMessages: [messages[messages.length - 1]!],
+  });
+}
+```
+
+And after all tool-result messages for this step are pushed:
+
+```ts
+// at end of batch loop, track newMessages added this step
+if (options.persistStep && toolResultMessagesThisStep.length > 0) {
+  await options.persistStep({
+    phase: 'tool-results',
+    newMessages: toolResultMessagesThisStep,
+  });
+}
+```
+
+In `run.ts`, wire `persistStep` only when `sessionId && store` and
+`isMemoryStore(store) === false`. The `persistStep` implementation calls
+`store.appendMessagesAtomic(sessionId, newMessages, session)` with the
+current session metadata (bump `updatedAt`).
+
+**Acceptance criteria:**
+- [ ] `ReactLoopOptions.persistStep` is wired through.
+- [ ] Test: run with `sqliteStore + sessionId` + a 2-step scripted LLM + a
+      tool that always succeeds → `appendMessagesAtomic` called 2 times (once
+      per step × 1 "tool-results" phase; plus "assistant-with-tool-calls"
+      phases = 4 calls total over 2 steps).
+- [ ] Test: run with NO sessionId → `persistStep` never invoked; existing
+      end-of-run flush path still runs.
+- [ ] All Phase 1 tests still pass (Phase 1 RED still RED).
+- [ ] `vtz test packages/agents` passes (Phase 1 RED still the only failing
+      assertion, and only on the durable scenario).
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+### Task 2: Skip end-of-run flush when durable writes are active
+
+**Files:** (2)
+- `packages/agents/src/run.ts` (modified — conditionally skip the current
+  end-of-run `saveSession + appendMessages` pair)
+- `packages/agents/src/run.test.ts` (modified — test: under durable execution,
+  no double-write at end-of-run)
+
+**What to implement:**
+
+In `run.ts`, locate the post-`reactLoop` block (currently around lines
+318–354). Before calling `saveSession`/`appendMessages`, check whether
+durable execution was used. If yes, skip — the per-step writes already
+persisted everything. If no (non-durable path), keep the current behavior
+intact.
+
+Track durability in a local flag at the top of `run()` rather than re-deriving it.
+
+**Acceptance criteria:**
+- [ ] Test: 2-step durable run → `appendMessagesAtomic` called N times (per
+      step); `appendMessages` (non-atomic) is **not** called after `reactLoop`.
+- [ ] Test: stateless run (no sessionId) → unchanged behavior — `appendMessages`
+      not called (no store). No regressions.
+- [ ] Test: non-durable-but-stored run (no sessionId, just `store`) → still
+      works as today.
+- [ ] All existing tests pass.
+- [ ] `vtz test packages/agents` passes.
+
+---
+
+### Task 3: Delete `checkpointInterval` + `onCheckpoint` + every reference
+
+**Files:** (5 — at the 5-file task cap; if more are needed, split into a
+task 3b)
+- `packages/agents/src/types.ts` (modified — remove `checkpointInterval`
+  from `AgentLoopConfig`)
+- `packages/agents/src/loop/react-loop.ts` (modified — remove
+  `checkpointInterval`, `onCheckpoint`, and the `if (checkpointInterval...)`
+  block at ~line 372)
+- `packages/agents/src/agent.ts` (modified — drop `checkpointInterval`
+  pass-through)
+- `packages/agents/src/run.ts` (modified — drop `checkpointInterval` wiring
+  into `reactLoop`)
+- `packages/agents/src/types.test-d.ts` + `packages/agents/src/agent.test.ts`
+  + `packages/agents/src/loop/react-loop.test.ts` (modified — remove or
+  rewrite every test that references the deleted symbols; NOTE: this spans
+  three test files and counts as one logical unit because the task is "make
+  every reference go away"; if the resulting change set exceeds 5 files
+  total across Task 3, split as 3a/3b)
+
+**What to implement:**
+
+Grep for `checkpointInterval` and `onCheckpoint` across `packages/agents/`:
+
+```bash
+grep -rn 'checkpointInterval\|onCheckpoint' packages/agents/
+```
+
+Delete every reference. Tests that asserted the callback fires should be
+deleted (not rewritten — the feature is gone pre-v1). Tests that asserted
+`AgentLoopConfig` shape should drop the field from expectations.
+
+**Acceptance criteria:**
+- [ ] `grep -rn 'checkpointInterval\|onCheckpoint' packages/agents/` returns
+      zero results.
+- [ ] All agents tests pass.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+- [ ] `vtz run lint --filter=@vertz/agents` passes.
+
+---
+
+## Out of scope for Phase 2
+
+- Resume detection on `run()` entry (Phase 3).
+- `ToolDurabilityError` class + surface (Phase 3).
+- `safeToRetry` flag (Phase 4).
+- Docs updates (Phase 5).
+
+## Expected state at end of Phase 2
+
+- Phase 1 E2E test still fails at "does not re-invoke handler" — but now the
+  failure reason is different: the first `run()` call crashes
+  mid-step (crash harness throws on write #2), the second `run()` call
+  re-enters the loop from the persisted state. Since no resume logic exists
+  yet, the LLM sees the orphaned assistant-with-toolCalls in history, and
+  depending on model behavior, may or may not ask for the tool again.
+  Either way the handler count assertion will fail until Phase 3 lands the
+  resume path. Document this expected behavior in the test's comment.
+- `checkpointInterval` is fully gone.
+
+## Notes
+
+1. The two `persistStep` phases are NOT atomic with each other. This is by
+   design — see design doc crash taxonomy. Phase 3 handles the fallout.
+2. When the crash happens between write #1 and write #2, `appendMessagesAtomic`
+   has already persisted the assistant-with-toolCalls in write #1. On resume,
+   the store contains that orphan. Good — that is exactly what Phase 3 uses.

--- a/plans/agents-durable-resume/phase-03-resume-and-tool-durability-error.md
+++ b/plans/agents-durable-resume/phase-03-resume-and-tool-durability-error.md
@@ -1,0 +1,234 @@
+# Phase 3: Resume Detection + `ToolDurabilityError` — MVP (GREEN milestone)
+
+## Context
+
+Phase 2 made the ReAct loop write per step atomically. After a crash between
+write #1 (assistant-with-toolCalls) and write #2 (tool_results), the store
+contains an orphan: an `assistant` row with non-empty `toolCalls` and zero
+matching `tool_result` rows for this session.
+
+This phase adds the resume primitive: at `run()` entry with `store + sessionId`,
+scan for the orphan; for each missing tool_call_id, persist a synthetic
+`ToolDurabilityError` as a `tool` message (committed in a single atomic write
+with a bumped session.updatedAt). The loop then proceeds from the next LLM
+call — the LLM sees the error in the message history and decides recovery.
+
+**This is the GREEN milestone for the MVP**: Phase 1's RED E2E test at
+`packages/agents/src/__tests__/durable-resume.test.ts` must pass on the
+"does not re-invoke handler" assertion after this phase.
+
+**Design invariants:**
+- Resume runs **before** the first LLM call — `loadMessages(sessionId)`
+  happens in `run.ts` already; extend that path.
+- The synthetic `tool_result` content matches the shape existing handler
+  errors use (`react-loop.ts:459-467` / `528-538` encode errors as JSON like
+  `{ error: string }`); the synthetic result adds a `kind: 'tool-durability-error'`
+  discriminator so callers + LLMs can pattern-match.
+- Resume writes the synthetic tool_results via `appendMessagesAtomic` as
+  **one atomic write**, preserving the per-step invariant.
+- If the orphan has N tool_calls, we emit N `tool_result` messages in a
+  single atomic write, not N separate writes.
+
+**Key files:**
+- `packages/agents/src/stores/errors.ts` — add `ToolDurabilityError`.
+- `packages/agents/src/run.ts` — entry-time orphan scan + synthetic write.
+- `packages/agents/src/__tests__/durable-resume.test.ts` — the Phase 1 E2E,
+  now expected to go GREEN on the "does not re-invoke handler" + "error
+  surfaces in history" assertions.
+
+---
+
+## Tasks
+
+### Task 1: Add `ToolDurabilityError` + helper to serialize as a tool_result
+
+**Files:** (3)
+- `packages/agents/src/errors.ts` (new — top-level `errors.ts`; the existing
+  `stores/errors.ts` stays; cross-cutting errors like this belong one level
+  up; if the repo convention is single `errors.ts` per package, use that
+  instead)
+- `packages/agents/src/index.ts` (modified — export `ToolDurabilityError`
+  from the main barrel)
+- `packages/agents/src/errors.test.ts` (new — class shape + error content
+  encoding tests)
+
+**What to implement:**
+
+```ts
+// packages/agents/src/errors.ts
+export class ToolDurabilityError extends Error {
+  readonly code = 'TOOL_DURABILITY_ERROR' as const;
+  readonly kind = 'tool-durability-error' as const;
+  readonly toolCallId: string;
+  readonly toolName: string;
+
+  constructor(toolCallId: string, toolName: string) {
+    super(
+      `Tool '${toolName}' (call ${toolCallId}) was requested but its execution ` +
+      `did not complete durably before the process ended. The tool is not ` +
+      `declared 'safeToRetry: true', so the framework will not automatically ` +
+      `re-invoke it. Decide recovery based on observable external state — e.g., ` +
+      `check whether the side effect already occurred. If this tool is a pure ` +
+      `read with no side effects, add \`safeToRetry: true\` to its declaration.`,
+    );
+    this.name = 'ToolDurabilityError';
+    this.toolCallId = toolCallId;
+    this.toolName = toolName;
+  }
+}
+
+/** Serialize a ToolDurabilityError as the JSON content of a `tool` role message. */
+export function serializeToolDurabilityError(err: ToolDurabilityError): string {
+  return JSON.stringify({
+    error: err.message,
+    kind: err.kind,
+    toolName: err.toolName,
+    toolCallId: err.toolCallId,
+  });
+}
+```
+
+**Acceptance criteria:**
+- [ ] `ToolDurabilityError` class exists with `code`, `kind`, `toolCallId`,
+      `toolName` fields.
+- [ ] `ToolDurabilityError` exported from `@vertz/agents`.
+- [ ] `serializeToolDurabilityError` returns a JSON string with all four fields.
+- [ ] Unit test asserts the serialized shape.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+### Task 2: Orphan detection on `run()` entry
+
+**Files:** (2)
+- `packages/agents/src/run.ts` (modified — after `loadMessages`, detect
+  orphaned assistant-with-toolCalls; if detected, synthesize tool_result
+  messages for each missing tool_call_id and call `appendMessagesAtomic`
+  once with all of them)
+- `packages/agents/src/run.test.ts` (modified — tests: orphan detection
+  triggers when last assistant has toolCalls and tool_results are missing;
+  does NOT trigger when all tool_results are present; does NOT trigger when
+  last message is a `user` or complete `assistant`)
+
+**What to implement:**
+
+In `run.ts`, after loading previous messages (around line 176) and before
+constructing the loop inputs:
+
+```ts
+if (sessionId && store && !isMemoryStore(store)) {
+  const orphan = findOrphanAssistantWithToolCalls(previousMessages);
+  if (orphan) {
+    const session = /* current loaded session */;
+    const syntheticResults: Message[] = orphan.missingToolCalls.map((tc) => ({
+      role: 'tool',
+      content: serializeToolDurabilityError(
+        new ToolDurabilityError(tc.id, tc.name),
+      ),
+      toolCallId: tc.id,
+      toolName: tc.name,
+    }));
+    await store.appendMessagesAtomic(sessionId, syntheticResults, {
+      ...session,
+      updatedAt: new Date().toISOString(),
+    });
+    previousMessages.push(...syntheticResults);
+  }
+}
+```
+
+Where:
+
+```ts
+function findOrphanAssistantWithToolCalls(
+  messages: Message[],
+): { missingToolCalls: ToolCall[] } | null {
+  // Find the last assistant message that has toolCalls.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    if (m.role === 'assistant' && m.toolCalls?.length) {
+      // Collect tool_result messages AFTER this assistant message.
+      const laterToolResults = messages
+        .slice(i + 1)
+        .filter((x) => x.role === 'tool' && x.toolCallId)
+        .map((x) => x.toolCallId!);
+      const missing = m.toolCalls.filter(
+        (tc) => tc.id && !laterToolResults.includes(tc.id),
+      );
+      return missing.length > 0 ? { missingToolCalls: missing } : null;
+    }
+    if (m.role !== 'tool') break; // tool rows are fine to skip over
+  }
+  return null;
+}
+```
+
+**Acceptance criteria:**
+- [ ] Test: stored state = `[user, assistant(toolCalls: [A, B])]` →
+      orphan detected, 2 synthetic tool_results written, loop proceeds.
+- [ ] Test: stored state = `[user, assistant(toolCalls: [A, B]), tool(A), tool(B)]`
+      → no orphan, no synthetic write.
+- [ ] Test: stored state = `[user, assistant(toolCalls: [A, B]), tool(A)]` →
+      orphan for B only; 1 synthetic write.
+- [ ] Test: stored state = `[user, assistant(no toolCalls)]` → no orphan.
+- [ ] The synthetic write goes through `appendMessagesAtomic` (not
+      `appendMessages`) with all synthetic messages in one call.
+
+---
+
+### Task 3: Verify the Phase 1 RED E2E test is now GREEN
+
+**Files:** (1)
+- `packages/agents/src/__tests__/durable-resume.test.ts` (modified — drop
+  the "expected RED" comments now that the test passes; strengthen
+  assertions)
+
+**What to implement:**
+
+Confirm the `it('Then a subsequent run() does NOT re-invoke the handler', ...)`
+assertion passes. Add assertions that verify the synthetic tool_result
+content shape:
+
+```ts
+const messages = await store.loadMessages('sess_test');
+const durabilityMsg = messages.find(
+  (m) => m.role === 'tool' && m.toolCallId === 'call_1',
+);
+expect(durabilityMsg).toBeDefined();
+const parsed = JSON.parse(durabilityMsg!.content);
+expect(parsed.kind).toBe('tool-durability-error');
+expect(parsed.toolName).toBe('postSlack');
+expect(parsed.toolCallId).toBe('call_1');
+```
+
+**Acceptance criteria:**
+- [ ] `durable-resume.test.ts` — the "does not re-invoke handler" assertion
+      passes.
+- [ ] The `@ts-expect-error` on `safeToRetry: true` STILL fires (the field
+      does not exist yet — Phase 4 adds it; if this directive becomes unused,
+      the tool config type was widened prematurely).
+- [ ] `vtz test packages/agents` passes with no failures.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+- [ ] `vtz run lint --filter=@vertz/agents` passes.
+
+---
+
+## Out of scope for Phase 3
+
+- `safeToRetry: true` opt-in (Phase 4).
+- Docs (Phase 5).
+
+## Expected state at end of Phase 3 — MVP COMPLETE
+
+Phases 1–3 closed the P0 correctness hole. If scope pressure required it,
+the feature could ship here as a minor release with:
+
+- Durable stores (D1, SQLite).
+- `appendMessagesAtomic` as the primitive.
+- Per-step atomic writes when `store + sessionId` are present.
+- Resume detection that surfaces `ToolDurabilityError` for non-safeToRetry tools.
+- Memory store safely rejects durable use.
+
+Phase 4 (safeToRetry) and Phase 5 (docs + retro + PR) follow immediately in
+the same feature branch but can be merged separately if scope pressure
+emerges.

--- a/plans/agents-durable-resume/phase-04-safe-to-retry.md
+++ b/plans/agents-durable-resume/phase-04-safe-to-retry.md
@@ -1,0 +1,141 @@
+# Phase 4: `tool({ safeToRetry: true })` Opt-in — follow-up sweetener
+
+## Context
+
+Phases 1–3 deliver the MVP: side-effecting tools never double-fire; if a
+crash loses the tool_result, resume surfaces `ToolDurabilityError` to the LLM
+and it decides what to do.
+
+This phase adds the opt-out: pure-read tools declare `safeToRetry: true`, and
+on orphan detection, the framework **re-invokes the handler** instead of
+surfacing the error. Saves the LLM a detour for reads that are safe to rerun.
+
+**This is a follow-up sweetener** — it can ship in the same PR or a separate
+one. Triagebot's motivating tool (`postSlack`) is side-effecting and does NOT
+opt in.
+
+---
+
+## Tasks
+
+### Task 1: Add `safeToRetry?: boolean` to `ToolConfig` + `ToolDefinition`
+
+**Files:** (3)
+- `packages/agents/src/types.ts` (modified — add optional field to both
+  `ToolConfig` and `ToolDefinition` interfaces; update `ToolContext` docs
+  if anything references it)
+- `packages/agents/src/tool.ts` (modified — forward the flag from config to
+  definition in the freeze step)
+- `packages/agents/src/tool.test.ts` (modified — test: `tool({ ..., safeToRetry: true })`
+  produces a definition with `safeToRetry === true`; test: omitting the flag
+  yields `safeToRetry === undefined`)
+
+**What to implement:**
+
+```ts
+// types.ts
+export interface ToolConfig<...> {
+  // ...existing...
+  /**
+   * When true, this tool's handler may be automatically re-invoked by the
+   * framework on session resume if the previous attempt's tool_result was
+   * not persisted. Set only on pure reads or handlers that are safe to
+   * execute twice. Default: undefined/false (framework surfaces
+   * ToolDurabilityError on orphan instead of retrying).
+   */
+  readonly safeToRetry?: boolean;
+}
+
+export interface ToolDefinition<...> {
+  // ...existing...
+  readonly safeToRetry?: boolean;
+}
+```
+
+```ts
+// tool.ts
+const def: ToolDefinition<TInput, TOutput> = {
+  kind: 'tool',
+  description: config.description,
+  input: config.input as SchemaAny,
+  output: config.output as SchemaAny,
+  handler: config.handler,
+  parallel: config.parallel,
+  safeToRetry: config.safeToRetry, // new
+};
+```
+
+**Acceptance criteria:**
+- [ ] `tool({ ..., safeToRetry: true })` compiles and `.safeToRetry === true`.
+- [ ] `tool({ ... })` without the flag compiles and `.safeToRetry === undefined`.
+- [ ] Type test in `types.test-d.ts`: `@ts-expect-error` on `safeToRetry: 'yes'`
+      (string where boolean expected).
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+### Task 2: Re-invoke handler on resume when `safeToRetry` is set
+
+**Files:** (3)
+- `packages/agents/src/run.ts` (modified — in the orphan-detection branch
+  from Phase 3, inspect the tool's `safeToRetry` flag; if true, re-invoke
+  the handler via the same path `executeToolCall` uses, capture the result
+  or error, and write it as the real tool_result; if false, continue to
+  surface `ToolDurabilityError` as before)
+- `packages/agents/src/run.test.ts` (modified — test: resume with
+  `safeToRetry: true` tool → handler called again, real result persisted,
+  no `ToolDurabilityError`; test: mixed tools in one orphan — some retry,
+  some surface error)
+- `packages/agents/src/__tests__/durable-resume.test.ts` (modified — GREEN
+  the second scenario: `safeToRetry: true` tool re-invokes on resume)
+
+**What to implement:**
+
+In the orphan-handling block of `run.ts` (added in Phase 3), for each
+missing tool_call:
+
+```ts
+const toolDef = agent.tools[toolCall.name];
+if (toolDef?.safeToRetry) {
+  // Re-invoke the handler via the same path reactLoop uses.
+  const result = await invokeToolHandler(toolDef, toolCall, toolProvider, toolContext);
+  // result is either a success { content: JSON } or error tool_result
+  resumeWrites.push({
+    role: 'tool',
+    content: result.content,
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+  });
+} else {
+  // Existing Phase 3 path: synthesize ToolDurabilityError
+  resumeWrites.push(syntheticDurabilityError(toolCall));
+}
+```
+
+**Acceptance criteria:**
+- [ ] Test: `tool({ safeToRetry: true })` + orphan state → handler invoked
+      exactly once during resume; real tool_result persisted; no
+      `ToolDurabilityError` in history.
+- [ ] Test: mixed orphan — tool A is `safeToRetry`, tool B is not → A's
+      handler invoked, B's `ToolDurabilityError` surfaced.
+- [ ] Test: handler throws during resume re-invocation → error persisted as
+      normal error tool_result (same encoding as handler errors today).
+- [ ] The second scenario in `durable-resume.test.ts` (`safeToRetry` re-invokes)
+      passes.
+- [ ] `vtz test packages/agents` passes with no failures.
+- [ ] `vtz run typecheck --filter=@vertz/agents` passes.
+
+---
+
+## Out of scope for Phase 4
+
+- Docs (Phase 5).
+- Any network-retry / transient-error behavior. `safeToRetry` is
+  exclusively about resume replay, NOT HTTP retries. The docs FAQ in
+  Phase 5 clarifies this.
+
+## Expected state at end of Phase 4
+
+Both E2E scenarios in `durable-resume.test.ts` pass:
+- Side-effecting tool (no flag) → orphan surfaces `ToolDurabilityError`.
+- Read tool (`safeToRetry: true`) → orphan re-invokes handler automatically.

--- a/plans/agents-durable-resume/phase-05-docs-verification-pr.md
+++ b/plans/agents-durable-resume/phase-05-docs-verification-pr.md
@@ -1,0 +1,140 @@
+# Phase 5: Docs + CF DO Verification + Changeset + PR — follow-up
+
+## Context
+
+Phases 1–4 delivered: durable primitives, per-step atomic writes, resume
+detection, and `safeToRetry` opt-in. All E2E tests green. This phase is
+the "release" work — docs, changeset, retro, rebase, PR to main, CI
+monitoring.
+
+---
+
+## Tasks
+
+### Task 1: Update `packages/mint-docs/`
+
+**Files:** (≤5)
+- `packages/mint-docs/docs/agents/durable-resume.mdx` (new — the guide)
+- `packages/mint-docs/docs/agents/tools.mdx` or equivalent (modified — add
+  `safeToRetry` reference + FAQ line clarifying it's about **resume
+  replay**, NOT network retry)
+- `packages/mint-docs/docs/agents/stores.mdx` or equivalent (modified —
+  `appendMessagesAtomic` mention + `MemoryStoreNotDurableError` note)
+- `packages/mint-docs/mint.json` (modified — add the new guide to nav)
+- Inline code example files if needed — keep the count ≤ 5
+
+**What to write:**
+
+The guide covers:
+- Why durable resume exists (triagebot / side-effecting agents / DO
+  preemption).
+- How to activate it — pass `store + sessionId` to `run()`. No flag.
+- The memory-store guardrail — what throws, why, when.
+- The crash taxonomy table from the design doc (simplified for users).
+- `safeToRetry` flag — when to use, when NOT to use.
+- Cost impact — "expect ~2 D1 writes per step; for high-volume read-heavy
+  agents consider running stateless (omit sessionId)."
+- FAQ:
+  - **Q: Does `safeToRetry` affect HTTP/network retries?**
+    **A:** No. It only controls whether the framework re-invokes a tool's
+    handler during session resume (after a crash between write phases). It
+    does nothing for transient network errors during normal execution.
+  - **Q: What happens if my DO is evicted mid-write?**
+    **A:** D1 commits are the source of truth. Next request to the same DO
+    calls `run()`; resume reads the durable state and proceeds.
+
+**Acceptance criteria:**
+- [ ] Guide exists, linked from nav, renders without errors.
+- [ ] `safeToRetry` FAQ present with the resume-vs-network-retry clarification.
+- [ ] Cost guidance present.
+- [ ] Crash taxonomy covered in user-readable form.
+
+---
+
+### Task 2: CF DO manual verification checklist
+
+**Files:** (1)
+- `plans/post-implementation-reviews/agents-durable-resume.md` (new — the
+  retrospective document; includes a "manual verification checklist"
+  section with the CF DO steps run against triagebot)
+
+**What to do:**
+
+Trigger `triagebot` in a Cloudflare DO staging environment:
+1. Configure DO with `d1Store` + `run()` using the new framework.
+2. Prime a run with a toolCall to `postSlack`.
+3. Force a crash by throwing in the middle of the handler (via a feature
+   flag in the handler or by killing the DO process during the
+   `appendMessagesAtomic` second write). Verify Slack shows exactly one
+   post.
+4. Trigger the same DO a second time with the same sessionId; verify the
+   framework detects the orphan and surfaces `ToolDurabilityError` in
+   history (LLM's response should acknowledge it). Verify no second
+   Slack post.
+5. Re-do with a `safeToRetry: true` read tool — verify it IS re-invoked
+   on resume.
+
+Record steps + results in the retrospective.
+
+**Acceptance criteria:**
+- [ ] Retrospective exists with all steps + observed results.
+- [ ] No double-post observed.
+- [ ] `safeToRetry` retry observed.
+- [ ] Phase 1 perf measurement (`durable-resume.perf.local.ts`) recorded
+      in the retro.
+
+---
+
+### Task 3: Changeset + rebase + PR
+
+**Files:** (≤4)
+- `.changeset/agents-durable-resume.md` (new — patch bump per
+  `.claude/rules/policies.md`)
+- Rebase the feature branch on latest `main` and resolve any conflicts
+- Push
+- Open PR with title `feat(agents): durable tool execution + transactional
+  resume [#2835]`
+
+**What to include in the PR description:**
+- Summary of all 5 phases.
+- Public API Changes:
+  - Added: `AgentStore.appendMessagesAtomic(...)`, `MemoryStoreNotDurableError`,
+    `ToolDurabilityError`, `tool({ safeToRetry })`, `@vertz/agents/testing`
+    subpath with `crashAfterToolResults`.
+  - Removed: `AgentLoopConfig.checkpointInterval`,
+    `ReactLoopOptions.onCheckpoint` (pre-v1, no shim).
+- Consolidated review findings + resolutions from all 5 phases.
+- E2E test status (both scenarios GREEN).
+- Reference: closes #2835.
+
+**Acceptance criteria:**
+- [ ] Changeset added (patch bump).
+- [ ] Branch rebased on latest main; quality gates re-run post-rebase.
+- [ ] PR opened; CI started.
+- [ ] Monitor CI (`gh pr checks <pr-number> --watch`) until green.
+- [ ] Notify user only after CI is fully green.
+
+---
+
+## Quality gates before push (must all pass)
+
+```bash
+vtz test --filter=@vertz/agents
+vtz run typecheck --filter=@vertz/agents
+vtz run lint --filter=@vertz/agents
+# And cross-package:
+vtz test
+vtz run typecheck
+vtz run lint
+```
+
+## Definition of done
+
+- [ ] All 5 phases merged to the feature branch.
+- [ ] E2E acceptance test passing (both scenarios).
+- [ ] Docs live.
+- [ ] Changeset present.
+- [ ] Retrospective written.
+- [ ] CF DO manual verification recorded.
+- [ ] PR CI green.
+- [ ] User notified; awaiting human merge.

--- a/plans/post-implementation-reviews/agents-durable-resume.md
+++ b/plans/post-implementation-reviews/agents-durable-resume.md
@@ -1,0 +1,174 @@
+# Post-Implementation Review — `@vertz/agents` Durable Tool Execution
+
+**Issue:** [#2835](https://github.com/vertz-dev/vertz/issues/2835)
+**Design:** `plans/agents-durable-resume.md` (Rev 2, approved 2026-04-19)
+**Phases:** `plans/agents-durable-resume/phase-01..05.md`
+**Branch:** `feat/agents-durable-resume`
+**Date:** 2026-04-19
+**Author:** Vinicius Dacal (with Claude Opus 4.7)
+
+---
+
+## Delivered
+
+The MVP (Phases 1–3) plus the optional `safeToRetry` opt-in (Phase 4) shipped
+as one feature branch. Public surface:
+
+- `AgentStore.appendMessagesAtomic(sessionId, messages, session)` — required
+  method on the interface; implemented in memory (throw), SQLite (sync
+  `db.transaction`), D1 (single `db.batch`).
+- `MemoryStoreNotDurableError` — thrown at `run()` entry when
+  `memoryStore()` is paired with `sessionId`. Covers chat-only agents that
+  would otherwise silently lose data.
+- `ToolDurabilityError` — surfaced as a tool_result when an orphaned,
+  non-`safeToRetry` call is detected on resume. Exported from the barrel so
+  callers can pattern-match.
+- `tool({ safeToRetry: true, ... })` — optional, boolean. `true` means "the
+  framework may re-invoke this handler on resume." Default (omitted) = safer
+  fallback (surface the error, LLM decides).
+- `@vertz/agents/testing` subpath — `crashAfterToolResults(store, N)`
+  harness for simulating a crash between writes.
+
+Removed (pre-v1, no shim): `AgentLoopConfig.checkpointInterval` +
+`ReactLoopOptions.onCheckpoint`. The `types.test-d.ts` regression guard
+now asserts the field is rejected.
+
+## Numbers
+
+- **7 commits** on the feature branch (1 docs + 5 Phase 1 tasks + 1 each
+  for Phases 2, 3, 4, and this retro).
+- **240 tests** in `packages/agents/` pass end-to-end. No RED left.
+- **Perf**: 10-step durable loop on in-memory SQLite completes in ~4ms.
+  Target was < 200ms. Real D1 same-region is expected higher; captured
+  in the manual-verification section below.
+- **Type flow**: no new generics introduced; `safeToRetry` is a pure
+  runtime flag. Dead-generic check passes.
+
+## What went well
+
+1. **Design discipline paid off.** Three reviewer sign-offs (DX, Product,
+   Technical) caught multiple real issues at the design stage:
+   - DX blocked on `idempotent` → `safeToRetry` (industry collision with
+     Stripe-idempotency-key semantics). The rename saved every external
+     consumer.
+   - Technical flagged that `toolCallStatus` as a schema column was
+     incompatible with D1/SQLite transaction semantics. Dropping it
+     removed both a schema migration AND a subtle correctness gap.
+   - Product killed `durableResume: true/false` as a flag. Making
+     activation implicit from `store + sessionId` reduced API surface
+     and matched Principle 2 ("one way to do things").
+
+2. **TDD-RED-at-Phase-1 worked exactly as planned.** The E2E test landed
+   red, stayed red through Phase 2 (atomic writes), and flipped green
+   at Phase 3 (resume detection). Each phase had a clear, concrete
+   goalpost.
+
+3. **Zero new generics.** The whole feature is runtime behavior toggled
+   by two pre-existing facts (durable store + sessionId) plus one optional
+   boolean flag. No type-flow gymnastics; nothing for future-me to
+   debug.
+
+4. **No schema migration.** The "orphaned assistant + missing
+   tool_result" sentinel is derivable from the existing message
+   history. Stores deployed against the old schema continue to work
+   unchanged.
+
+## What went wrong
+
+1. **Test-migration scope creep in Phase 1 Task 4.** 12 existing
+   `run.test.ts` tests used `memoryStore() + sessionId` for non-durable
+   session continuity. When I added the entry guard, they all broke.
+   Migrating them to `sqliteStore({ path: ':memory:' })` was mechanical
+   but was not called out in the phase file. Should have been a
+   sub-task with explicit acceptance criteria.
+
+2. **First durable E2E failed on "session not found."** The design's
+   walkthrough passes a fixed `sessionId` (e.g., a Durable Object ID)
+   to `run()` on every call, but the existing `run.ts` requires the
+   session row to exist in the store before that call succeeds. The
+   test papered over this by pre-seeding the session row. Not
+   necessarily wrong — the DO platform creates the row on the first
+   request — but worth flagging as a UX gap: a first-time caller with a
+   known sessionId gets `SessionNotFoundError` today.
+
+3. **The `.local.ts` perf-test convention didn't run under `vtz test`.**
+   The design plan said to use `.local.ts` per
+   `.claude/rules/integration-test-safety.md`, but the runner's default
+   collector pattern is `**/*.test.ts`. Renamed to
+   `durable-resume.perf.test.ts` and gated with `expect(elapsed).toBeLessThan(200)`.
+   Acceptable but not what the rule prescribed. Follow-up: update the
+   rule to reflect runner reality or add a distinct test pattern for
+   `.local.ts`.
+
+## How to avoid it next time
+
+- **Pre-phase sweep for contract-breaking changes.** When a phase changes
+  an invariant (like "memoryStore + sessionId is an error"), run a
+  global grep for existing callers FIRST and bake the migration into
+  the same task/commit. This avoids cascade-break surprises.
+
+- **Add a "first-call create-if-not-exists" story to `run()`.** If the
+  DO walkthrough is the canonical pattern, the framework should handle
+  the first-time call without requiring a side-door `saveSession`. Not
+  in scope for #2835, but worth an issue.
+
+- **Document the `.local.ts` vs `.test.ts` decision explicitly** in
+  `.claude/rules/integration-test-safety.md`, with the CI-gate
+  trade-off called out.
+
+## Phase 1 perf measurement
+
+Recorded at commit `aa96522b7` (Phase 1 Task 6 landing):
+
+- 10-step loop, `sqliteStore({ path: ':memory:' })`, scripted LLM, no
+  tool-handler work: **~4ms wall time**.
+- 200ms budget leaves ~50x headroom for real-world handler work +
+  serialization + driver overhead.
+- Real D1 same-region measurement (triagebot in CF): pending
+  manual-verification checklist below.
+
+## Manual verification — Cloudflare Durable Object
+
+**Checklist for triagebot staging deployment:**
+
+- [ ] Deploy triagebot with `@vertz/agents` at this branch + `d1Store`
+      wired to staging D1.
+- [ ] Prime a DO with a `postSlack` tool call that will succeed.
+      Verify one Slack post lands and `tool_result` is persisted.
+- [ ] Force a crash in the `postSlack` handler (throw after the Slack
+      API responds but before returning). Verify the DO alarms / next
+      request triggers `run()` again with the same `sessionId`.
+- [ ] Confirm: exactly one Slack post in the channel (no duplicate);
+      the session's stored history contains a `tool-durability-error`
+      tool_result for the orphaned call; the LLM's subsequent response
+      acknowledges the partial state.
+- [ ] Repeat with a `safeToRetry: true` read tool — verify it IS
+      re-invoked on resume and the real result lands.
+- [ ] Record D1 same-region atomic-write p50 and p95 latency under
+      10-step load. Write to this retro.
+
+**Results:** _pending — will be filled in after the PR merges and the
+staging deploy completes. The framework tests pass independently of
+the manual verification; this is release gating, not merge gating._
+
+## Open follow-ups
+
+1. **First-call `run()` with a pre-chosen `sessionId` should auto-create
+   the session row.** Current behavior throws `SessionNotFoundError`. The
+   DO walkthrough works around this by having the DO create the row on
+   first request, but that's a hidden contract. File a follow-up issue.
+
+2. **`findOrphanAssistantWithToolCalls` assumes LLM-provided
+   `tool_call.id`.** For providers that don't supply stable ids, the
+   sentinel fails gracefully (no orphan detected, normal loop). Worth
+   documenting which providers are supported.
+
+3. **Perf under large parallel tool batches.** The implementation
+   commits all N tool_results in one atomic write at step end. For N=20
+   concurrent tools, that's a single D1 batch — should be fine but
+   unmeasured.
+
+## Status
+
+Ready for PR → main. Awaiting CF staging verification before closing
+the issue.


### PR DESCRIPTION
## Summary

Closes #2835. Ships **durable tool execution** for `@vertz/agents` — at-most-once handler execution across crashes, with automatic resume when `run()` is called with `store + sessionId` against a durable store. Production triagebot path is now unblocked (`#2834` Anthropic adapter + this feature).

### Public API Changes

**Added** (patch bump):

- `AgentStore.appendMessagesAtomic(sessionId, messages, session)` — the durability primitive. Implemented on memory (throw), SQLite (`db.transaction`), and D1 (`db.batch`).
- `MemoryStoreNotDurableError` — thrown at `run()` entry when `memoryStore()` is paired with `sessionId`. Catches chat-only agents that would silently lose data.
- `ToolDurabilityError` — surfaced as a tool_result when an orphaned non-`safeToRetry` call is detected on resume. Exported from the main barrel so callers can pattern-match.
- `tool({ safeToRetry: true, ... })` — optional per-tool flag. When `true`, the framework may re-invoke the handler on resume. Default assumes side effects.
- `@vertz/agents/testing` subpath — `crashAfterToolResults(store, N)` harness for writing resume tests.

**Removed** (pre-v1, no shim):

- `AgentLoopConfig.checkpointInterval` — was a notification callback, not durability.
- `ReactLoopOptions.onCheckpoint` — same.

### Design

Three agent sign-offs (DX, Product, Technical) + human sign-off on the Rev 2 design doc before implementation. See:

- Design: [`plans/agents-durable-resume.md`](https://github.com/vertz-dev/vertz/blob/feat/agents-durable-resume/plans/agents-durable-resume.md)
- Phases: [`plans/agents-durable-resume/phase-01..05.md`](https://github.com/vertz-dev/vertz/tree/feat/agents-durable-resume/plans/agents-durable-resume)
- Retrospective: [`plans/post-implementation-reviews/agents-durable-resume.md`](https://github.com/vertz-dev/vertz/blob/feat/agents-durable-resume/plans/post-implementation-reviews/agents-durable-resume.md)

### Phases summary

- **Phase 1** — `appendMessagesAtomic` interface + 3 impls, `MemoryStoreNotDurableError` at `run()` entry, `@vertz/agents/testing` subpath with crash harness, E2E test as TDD RED + perf gate (~4ms for 10-step in-memory SQLite loop, well under 200ms budget).
- **Phase 2** — ReAct loop writes per-step atomically via a `persistStep` callback. End-of-run flush kept only for the non-durable path. `checkpointInterval` deleted across the package.
- **Phase 3** — Resume detection: orphaned assistant-with-toolCalls + missing tool_result → synthetic `ToolDurabilityError` tool_result. **E2E flips GREEN.** MVP complete.
- **Phase 4** — `tool({ safeToRetry })` opt-in. Resume re-invokes handlers declared safe; falls back to the error for the rest.
- **Phase 5** — [durable-resume guide](https://github.com/vertz-dev/vertz/blob/feat/agents-durable-resume/packages/mint-docs/guides/agents/durable-resume.mdx) in `packages/mint-docs/`, changeset, retrospective with CF DO manual-verification checklist.

### E2E acceptance test status

Both scenarios green at `packages/agents/src/__tests__/durable-resume.test.ts`:

1. Side-effecting tool + crash → handler runs once, `ToolDurabilityError` in resumed history.
2. `safeToRetry: true` tool + crash → handler re-invokes on resume, real result persisted.

Plus memory-store guard fires at `run()` entry (before any LLM call) for both tool-calling and chat-only agents.

### Test plan

- [x] `vtz test` in `packages/agents` — 243 pass, 13 skipped (unrelated to this PR).
- [x] `vtz run typecheck` in `packages/agents` — clean.
- [x] Perf gate (`durable-resume.perf.test.ts`) — ~4ms, < 200ms budget.
- [x] Rebased onto latest main (resolved conflict with #2838 index.ts).
- [ ] CF DO manual verification against triagebot staging — **post-merge, per retro**. Framework tests are merge-gating; DO verification is release-gating.

### Breaking changes

Pre-v1, so technically none external. For existing callers:

- `checkpointInterval` / `onCheckpoint` removed. Any caller using them must migrate — resume is the replacement if that's what they wanted.
- `memoryStore() + sessionId` now throws at entry. Callers wanting in-process session continuity should use `sqliteStore({ path: ':memory:' })`; those wanting stateless should drop `sessionId`. All affected tests in this repo were migrated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)