### PR TITLE
fix(changesets): use valid package names in two changesets

### DIFF
--- a/.changeset/jsx-default-value.md
+++ b/.changeset/jsx-default-value.md
@@ -1,7 +1,7 @@
 ---
 '@vertz/native-compiler': patch
 '@vertz/ui': patch
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(jsx): honor `defaultValue` / `defaultChecked` on `<input>` and `<textarea>`

--- a/.changeset/rename-vertz-env-to-client.md
+++ b/.changeset/rename-vertz-env-to-client.md
@@ -1,6 +1,6 @@
 ---
 'vertz': patch
-'create-vertz-app': patch
+'@vertz/create-vertz-app': patch
 ---
 
 Rename `vertz/env` → `vertz/client` so tsconfig `types` discoverability matches


### PR DESCRIPTION
## Summary

The Release workflow has been failing on every push to `main` since PR #2833 merged. The changeset assembly step fails with:

```
Error: Found changeset jsx-default-value for package vtz which is not in the workspace
```

Two changesets referenced package names that do not exist in the workspace:

- `.changeset/jsx-default-value.md` used `'vtz'` — no such package. The `vtz` binary is shipped by `@vertz/runtime`, which is the correct target.
- `.changeset/rename-vertz-env-to-client.md` used `'create-vertz-app'` (unscoped) — the workspace name is `@vertz/create-vertz-app`.

Verified locally with `npx changeset status` — plan now assembles cleanly for all 14 pending changesets.

## Test plan

- [ ] Release workflow advances past the `changeset version` step on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)