### PR TITLE
fix(db): emit indexes, FKs, and enum CHECK constraints in autoApply DDL [#2848]

### DIFF
--- a/.changeset/db-autoapply-constraints.md
+++ b/.changeset/db-autoapply-constraints.md
@@ -1,0 +1,21 @@
+---
+'@vertz/db': patch
+---
+
+fix(db): emit indexes, foreign keys, and enum CHECK constraints when autoApply generates DDL
+
+`createDb({ migrations: { autoApply: true } })` previously built `CREATE TABLE`
+statements by hand and skipped non-inline UNIQUE indexes from `d.index()`,
+FOREIGN KEY constraints derived from `d.ref.one()`, and CHECK constraints for
+`d.enum()` columns. Applications used autoApply for local dev and hand-written
+migrations for prod (typical Cloudflare D1 flow) got silent schema drift: tests
+passed against the permissive autoApply schema but production rejected the same
+operations.
+
+The autoApply path now uses the same snapshot + SQL generator pipeline as the
+migrations CLI, so the DDL it emits matches what `vertz db generate` would
+produce. `generateBootstrapSql()` is a new export on `@vertz/db/migration` that
+emits idempotent `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`
+for any `SchemaSnapshot`.
+
+Closes #2848.

--- a/.changeset/db-autoapply-constraints.md
+++ b/.changeset/db-autoapply-constraints.md
@@ -7,15 +7,29 @@ fix(db): emit indexes, foreign keys, and enum CHECK constraints when autoApply g
 `createDb({ migrations: { autoApply: true } })` previously built `CREATE TABLE`
 statements by hand and skipped non-inline UNIQUE indexes from `d.index()`,
 FOREIGN KEY constraints derived from `d.ref.one()`, and CHECK constraints for
-`d.enum()` columns. Applications used autoApply for local dev and hand-written
-migrations for prod (typical Cloudflare D1 flow) got silent schema drift: tests
-passed against the permissive autoApply schema but production rejected the same
-operations.
+`d.enum()` columns. Applications using autoApply for local dev and hand-written
+migrations for prod (the typical Cloudflare D1 flow) got silent schema drift:
+tests passed against the permissive autoApply schema but production rejected
+the same operations.
 
 The autoApply path now uses the same snapshot + SQL generator pipeline as the
 migrations CLI, so the DDL it emits matches what `vertz db generate` would
 produce. `generateBootstrapSql()` is a new export on `@vertz/db/migration` that
 emits idempotent `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`
-for any `SchemaSnapshot`.
+for any `SchemaSnapshot`. `createLocalSqliteDriver` now also issues
+`PRAGMA foreign_keys = ON` so the new FOREIGN KEY declarations are enforced
+across SQLite backends (upstream SQLite compiles with FK enforcement OFF by
+default).
+
+**Snapshot wire-format changes** (may produce one noisy `column_altered` entry
+on the next `vertz db generate` after upgrading; the generated ALTER is safe
+to apply):
+
+- Enum columns now store `type: <enumName>` (e.g. `"ticket_status"`) instead
+  of the literal `"enum"`, matching what `introspectPostgres` returns.
+- Column defaults are stored as SQL expressions (`"'pending'"`, `"now()"`,
+  `"true"`), matching what `introspectPostgres` / `introspectSqlite` return.
+- `.autoUpdate()` columns now carry `default: "now()"` so downstream DDL
+  consumers can emit the `DEFAULT` clause the INSERT path needs.
 
 Closes #2848.

--- a/packages/db/src/client/__tests__/createDb-local-sqlite.test.ts
+++ b/packages/db/src/client/__tests__/createDb-local-sqlite.test.ts
@@ -500,16 +500,17 @@ describe('createDb with local SQLite (path option)', () => {
     });
   });
 
-  describe('Given a table with a d.enum() column', () => {
+  describe('Given a table with two d.enum() columns', () => {
     const ticketsTable = d.table('tickets', {
       id: d.uuid().primary({ generate: 'cuid' }),
       title: d.text(),
+      priority: d.enum('ticket_priority', ['low', 'high']).default('low'),
       status: d.enum('ticket_status', ['open', 'closed']).default('open'),
     });
     const ticketsModel = d.model(ticketsTable);
 
-    describe('When inserting a row with a value outside the declared enum values', () => {
-      it('Then the CHECK constraint rejects the invalid value', async () => {
+    describe('When inserting rows that violate each enum independently', () => {
+      it('Then both CHECK constraints are enforced', async () => {
         const db = createDb({
           models: { tickets: ticketsModel },
           dialect: 'sqlite',
@@ -518,15 +519,21 @@ describe('createDb with local SQLite (path option)', () => {
         });
 
         const valid = await db.tickets.create({
-          data: { title: 'Broken login', status: 'open' },
+          data: { title: 'Broken login', priority: 'high', status: 'open' },
         });
         expect(valid.ok).toBe(true);
 
-        const invalid = await db.tickets.create({
+        const badStatus = await db.tickets.create({
           // @ts-expect-error — 'slonk' is not in the enum literal union
-          data: { title: 'Ghost status', status: 'slonk' },
+          data: { title: 'Ghost status', priority: 'high', status: 'slonk' },
         });
-        expect(invalid.ok).toBe(false);
+        expect(badStatus.ok).toBe(false);
+
+        const badPriority = await db.tickets.create({
+          // @ts-expect-error — 'mega' is not in the enum literal union
+          data: { title: 'Ghost priority', priority: 'mega', status: 'open' },
+        });
+        expect(badPriority.ok).toBe(false);
       });
     });
   });

--- a/packages/db/src/client/__tests__/createDb-local-sqlite.test.ts
+++ b/packages/db/src/client/__tests__/createDb-local-sqlite.test.ts
@@ -412,4 +412,122 @@ describe('createDb with local SQLite (path option)', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // autoApply DDL: UNIQUE indexes, FOREIGN KEYs, enum CHECK constraints (#2848)
+  // ---------------------------------------------------------------------------
+
+  describe('Given a table with a non-inline UNIQUE index', () => {
+    const tenantsTable = d.table('tenants', {
+      id: d.uuid().primary({ generate: 'cuid' }),
+      name: d.text(),
+    });
+    const installsTable = d.table(
+      'installs',
+      {
+        id: d.uuid().primary({ generate: 'cuid' }),
+        tenantId: d.uuid(),
+        provider: d.text(),
+      },
+      { indexes: [d.index(['tenantId', 'provider'], { unique: true })] },
+    );
+    const tenantsModel = d.model(tenantsTable);
+    const installsModel = d.model(installsTable);
+
+    describe('When inserting a duplicate (tenantId, provider) pair via autoApply', () => {
+      it('Then the UNIQUE INDEX rejects the duplicate', async () => {
+        const db = createDb({
+          models: { tenants: tenantsModel, installs: installsModel },
+          dialect: 'sqlite',
+          path: ':memory:',
+          migrations: { autoApply: true },
+        });
+
+        const tenant = await db.tenants.create({ data: { name: 'Acme' } });
+        expect(tenant.ok).toBe(true);
+        if (!tenant.ok) throw new Error('create tenant failed');
+
+        const first = await db.installs.create({
+          data: { tenantId: tenant.data.id, provider: 'github' },
+        });
+        expect(first.ok).toBe(true);
+
+        const duplicate = await db.installs.create({
+          data: { tenantId: tenant.data.id, provider: 'github' },
+        });
+        expect(duplicate.ok).toBe(false);
+
+        const different = await db.installs.create({
+          data: { tenantId: tenant.data.id, provider: 'slack' },
+        });
+        expect(different.ok).toBe(true);
+      });
+    });
+  });
+
+  describe('Given a table whose model declares d.ref.one() to another table', () => {
+    const orgsTable = d.table('orgs', {
+      id: d.uuid().primary({ generate: 'cuid' }),
+      name: d.text(),
+    });
+    const membersTable = d.table('members', {
+      id: d.uuid().primary({ generate: 'cuid' }),
+      orgId: d.uuid(),
+      email: d.text(),
+    });
+    const orgsModel = d.model(orgsTable);
+    const membersModel = d.model(membersTable, {
+      org: d.ref.one(() => orgsTable, 'orgId'),
+    });
+
+    describe('When inserting a row whose FK column points to a non-existent parent row', () => {
+      it('Then the FOREIGN KEY constraint rejects the orphan insert', async () => {
+        const db = createDb({
+          models: { orgs: orgsModel, members: membersModel },
+          dialect: 'sqlite',
+          path: ':memory:',
+          migrations: { autoApply: true },
+        });
+
+        const org = await db.orgs.create({ data: { name: 'Acme' } });
+        expect(org.ok).toBe(true);
+
+        const orphan = await db.members.create({
+          data: { orgId: 'does-not-exist', email: 'nobody@example.com' },
+        });
+        expect(orphan.ok).toBe(false);
+      });
+    });
+  });
+
+  describe('Given a table with a d.enum() column', () => {
+    const ticketsTable = d.table('tickets', {
+      id: d.uuid().primary({ generate: 'cuid' }),
+      title: d.text(),
+      status: d.enum('ticket_status', ['open', 'closed']).default('open'),
+    });
+    const ticketsModel = d.model(ticketsTable);
+
+    describe('When inserting a row with a value outside the declared enum values', () => {
+      it('Then the CHECK constraint rejects the invalid value', async () => {
+        const db = createDb({
+          models: { tickets: ticketsModel },
+          dialect: 'sqlite',
+          path: ':memory:',
+          migrations: { autoApply: true },
+        });
+
+        const valid = await db.tickets.create({
+          data: { title: 'Broken login', status: 'open' },
+        });
+        expect(valid.ok).toBe(true);
+
+        const invalid = await db.tickets.create({
+          // @ts-expect-error — 'slonk' is not in the enum literal union
+          data: { title: 'Ghost status', status: 'slonk' },
+        });
+        expect(invalid.ok).toBe(false);
+      });
+    });
+  });
 });

--- a/packages/db/src/client/database.ts
+++ b/packages/db/src/client/database.ts
@@ -5,7 +5,6 @@ import * as agg from '../query/aggregate';
 import * as crud from '../query/crud';
 import { executeQuery, type QueryFn } from '../query/executor';
 import { type IncludeSpec, loadRelations, type TableRegistryEntry } from '../query/relation-loader';
-import type { ColumnMetadata } from '../schema/column';
 import type {
   FilterType,
   FindResult,
@@ -1016,49 +1015,14 @@ export function createDb<TModels extends Record<string, ModelEntry>>(
         if (migrationDone) return;
         if (migrationPromise) return migrationPromise;
         migrationPromise = (async () => {
-          const { camelToSnake } = await import('../sql/casing');
-          for (const entry of Object.values(models)) {
-            const table = entry.table;
-            const cols: string[] = [];
-            const primaryKeys: string[] = [];
-            for (const [colName, colBuilder] of Object.entries(table._columns)) {
-              const meta = (colBuilder as { _meta: ColumnMetadata })._meta;
-              const snakeName = camelToSnake(colName);
-              const sqlType = dialectObj.mapColumnType(meta.sqlType, {
-                ...(meta.dimensions != null && { dimensions: meta.dimensions }),
-                ...(meta.length != null && { length: meta.length }),
-                ...(meta.precision != null && { precision: meta.precision }),
-                ...(meta.scale != null && { scale: meta.scale }),
-              });
-              let def = `"${snakeName}" ${sqlType}`;
-              if (meta.primary) primaryKeys.push(`"${snakeName}"`);
-              if (meta.unique && !meta.primary) def += ' UNIQUE';
-              if (!meta.nullable) def += ' NOT NULL';
-              if (meta.hasDefault && meta.defaultValue !== undefined) {
-                if (meta.defaultValue === 'now') def += ` DEFAULT (${dialectObj.now()})`;
-                else if (typeof meta.defaultValue === 'string')
-                  def += ` DEFAULT '${meta.defaultValue.replace(/'/g, "''")}'`;
-                else if (typeof meta.defaultValue === 'number')
-                  def += ` DEFAULT ${meta.defaultValue}`;
-                else if (typeof meta.defaultValue === 'boolean')
-                  def += ` DEFAULT ${meta.defaultValue ? 1 : 0}`;
-              } else if (meta.isAutoUpdate) {
-                // autoUpdate timestamps need a DEFAULT for the initial INSERT
-                def += ` DEFAULT (${dialectObj.now()})`;
-              }
-              cols.push(def);
-            }
-            if (primaryKeys.length === 1) {
-              // Single PK: add inline to the column definition
-              const pkCol = primaryKeys[0]!;
-              const idx = cols.findIndex((c) => c.startsWith(pkCol));
-              if (idx !== -1) cols[idx] += ' PRIMARY KEY';
-            } else if (primaryKeys.length > 1) {
-              // Composite PK: add table-level constraint
-              cols.push(`PRIMARY KEY (${primaryKeys.join(', ')})`);
-            }
-            const ddl = `CREATE TABLE IF NOT EXISTS "${table._name}" (\n  ${cols.join(',\n  ')}\n)`;
-            await sqliteDriver!.execute(ddl);
+          const [{ createSnapshot }, { generateBootstrapSql }] = await Promise.all([
+            import('../migration/snapshot'),
+            import('../migration/sql-generator'),
+          ]);
+          const snapshot = createSnapshot(Object.values(models));
+          const statements = generateBootstrapSql(snapshot, dialectObj);
+          for (const sql of statements) {
+            await sqliteDriver!.execute(sql);
           }
           migrationDone = true;
         })();

--- a/packages/db/src/client/sqlite-driver.ts
+++ b/packages/db/src/client/sqlite-driver.ts
@@ -286,6 +286,12 @@ export async function createLocalSqliteDriver(
 
   const db = await resolveLocalSqliteDatabase(dbPath);
 
+  // Enforce FK constraints declared in CREATE TABLE. SQLite's upstream default
+  // is OFF; bun:sqlite / better-sqlite3 happen to compile with it ON, but
+  // relying on that would silently regress autoApply FK enforcement on any
+  // backend that ships with the library's default.
+  db.exec('PRAGMA foreign_keys = ON');
+
   // Enable WAL mode for file-based paths (not :memory:)
   if (dbPath !== ':memory:') {
     db.exec('PRAGMA journal_mode = WAL');

--- a/packages/db/src/migration/index.ts
+++ b/packages/db/src/migration/index.ts
@@ -39,5 +39,5 @@ export type {
 export { createSnapshot } from './snapshot';
 export { NodeSnapshotStorage } from './snapshot-storage';
 export type { SqlGeneratorContext } from './sql-generator';
-export { generateMigrationSql, generateRollbackSql } from './sql-generator';
+export { generateBootstrapSql, generateMigrationSql, generateRollbackSql } from './sql-generator';
 export type { SnapshotStorage } from './storage';

--- a/packages/db/src/migration/snapshot.ts
+++ b/packages/db/src/migration/snapshot.ts
@@ -1,3 +1,4 @@
+import type { ModelEntry } from '../schema/inference';
 import type { ModelDef } from '../schema/model';
 import type { RelationDef } from '../schema/relation';
 import type { ColumnRecord, IndexType, TableDef } from '../schema/table';
@@ -54,7 +55,26 @@ export interface SchemaSnapshot {
   rls?: import('./rls-snapshot').RlsSnapshot;
 }
 
-function isModelDef(v: unknown): v is ModelDef {
+/**
+ * Convert a raw column default value into a SQL expression string, matching the
+ * format produced by `introspectPostgres` / `introspectSqlite`.
+ *
+ * - Strings are wrapped in single quotes with internal quotes doubled (`'foo''bar'`).
+ * - The special sentinel `'now'` becomes `now()` (dialect-specific translation
+ *   happens at emit time in the sql-generator).
+ * - Numbers and booleans are stringified via `String()`.
+ */
+function formatDefaultExpr(value: unknown): string {
+  if (value === 'now') return 'now()';
+  if (typeof value === 'string') {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  return String(value);
+}
+
+type SnapshotEntry = TableDef<ColumnRecord> | ModelDef | ModelEntry;
+
+function isModelLike(v: unknown): v is ModelDef | ModelEntry {
   return (
     v !== null &&
     typeof v === 'object' &&
@@ -64,12 +84,12 @@ function isModelDef(v: unknown): v is ModelDef {
   );
 }
 
-function resolveTable(entry: TableDef<ColumnRecord> | ModelDef): TableDef<ColumnRecord> {
-  return isModelDef(entry) ? entry.table : entry;
+function resolveTable(entry: SnapshotEntry): TableDef<ColumnRecord> {
+  return isModelLike(entry) ? entry.table : entry;
 }
 
-function resolveRelations(entry: TableDef<ColumnRecord> | ModelDef): Record<string, RelationDef> {
-  return isModelDef(entry) ? entry.relations : {};
+function resolveRelations(entry: SnapshotEntry): Record<string, RelationDef> {
+  return isModelLike(entry) ? entry.relations : {};
 }
 
 function findPkColumns(table: TableDef<ColumnRecord>): string[] {
@@ -117,7 +137,7 @@ function deriveForeignKeys(
   return foreignKeys;
 }
 
-export function createSnapshot(entries: (TableDef<ColumnRecord> | ModelDef)[]): SchemaSnapshot {
+export function createSnapshot(entries: SnapshotEntry[]): SchemaSnapshot {
   const snapshot: SchemaSnapshot = {
     version: 1,
     tables: {},
@@ -132,16 +152,22 @@ export function createSnapshot(entries: (TableDef<ColumnRecord> | ModelDef)[]): 
 
     for (const [colName, col] of Object.entries(table._columns)) {
       const meta = col._meta;
+      // Enum columns: carry the enum name as the type so downstream consumers
+      // (sql-generator, codegen) can resolve it against snapshot.enums.
+      const columnType = meta.enumName ?? meta.sqlType;
       const colSnap: ColumnSnapshot = {
-        type: meta.sqlType,
+        type: columnType,
         nullable: meta.nullable,
         primary: meta.primary,
         unique: meta.unique,
       };
 
       if (meta.hasDefault && meta.defaultValue !== undefined) {
-        const rawDefault = String(meta.defaultValue);
-        colSnap.default = rawDefault === 'now' ? 'now()' : rawDefault;
+        colSnap.default = formatDefaultExpr(meta.defaultValue);
+      } else if (meta.isAutoUpdate) {
+        // autoUpdate() implies a DEFAULT of current-time for the initial INSERT.
+        // Subsequent UPDATEs are handled by query-layer injection (see query/helpers.ts).
+        colSnap.default = 'now()';
       }
 
       const annotationNames = meta._annotations ? Object.keys(meta._annotations) : [];

--- a/packages/db/src/migration/sql-generator.ts
+++ b/packages/db/src/migration/sql-generator.ts
@@ -3,7 +3,7 @@ import type { ColumnTypeMeta } from '../dialect/types';
 import { defaultPostgresDialect } from '../dialect';
 import { camelToSnake } from '../sql/casing';
 import type { DiffChange } from './differ';
-import type { ColumnSnapshot, TableSnapshot } from './snapshot';
+import type { ColumnSnapshot, IndexSnapshot, SchemaSnapshot, TableSnapshot } from './snapshot';
 import { validateColumns, validateIndexes } from './validate-indexes';
 
 /**
@@ -125,10 +125,26 @@ function columnDef(
   }
 
   if (col.default !== undefined) {
-    parts.push(`DEFAULT ${col.default}`);
+    parts.push(`DEFAULT ${renderDefaultExpr(col.default, dialect)}`);
   }
 
   return parts.join(' ');
+}
+
+/**
+ * Translate a dialect-agnostic default expression (as stored in the snapshot)
+ * into dialect-specific SQL. SQLite has no `now()` function — we use
+ * `datetime('now')` — and stores booleans as integers.
+ */
+function renderDefaultExpr(expr: string, dialect: Dialect): string {
+  if (dialect.name === 'sqlite') {
+    if (expr === 'now()' || expr.toUpperCase() === 'CURRENT_TIMESTAMP') {
+      return `(${dialect.now()})`;
+    }
+    if (expr === 'true') return '1';
+    if (expr === 'false') return '0';
+  }
+  return expr;
 }
 
 /**
@@ -153,6 +169,114 @@ function normalizeColumnType(type: string): string {
     VARCHAR: 'varchar',
   };
   return typeMap[typeUpper] || type.toLowerCase();
+}
+
+/**
+ * Build a CREATE TABLE statement (optionally `IF NOT EXISTS`) including
+ * column defs, table-level PRIMARY KEY, and inline FOREIGN KEY constraints.
+ */
+function buildCreateTableSql(
+  tableName: string,
+  table: TableSnapshot,
+  dialect: Dialect,
+  enums: Record<string, string[]> | undefined,
+  ifNotExists: boolean,
+): string {
+  const snakeTable = camelToSnake(tableName);
+  const cols: string[] = [];
+  const primaryKeys: string[] = [];
+
+  for (const [colName, col] of Object.entries(table.columns)) {
+    cols.push(`  ${columnDef(colName, col, dialect, enums)}`);
+    if (col.primary) {
+      primaryKeys.push(`"${camelToSnake(colName)}"`);
+    }
+  }
+
+  if (primaryKeys.length > 0) {
+    cols.push(`  PRIMARY KEY (${primaryKeys.join(', ')})`);
+  }
+
+  for (const fk of table.foreignKeys) {
+    const fkCol = camelToSnake(fk.column);
+    const fkTarget = camelToSnake(fk.targetTable);
+    const fkTargetCol = camelToSnake(fk.targetColumn);
+    cols.push(`  FOREIGN KEY ("${fkCol}") REFERENCES "${fkTarget}" ("${fkTargetCol}")`);
+  }
+
+  const prefix = ifNotExists ? 'CREATE TABLE IF NOT EXISTS' : 'CREATE TABLE';
+  return `${prefix} "${snakeTable}" (\n${cols.join(',\n')}\n);`;
+}
+
+/**
+ * Build a CREATE INDEX statement (optionally `IF NOT EXISTS`) for a snapshot
+ * index entry. Applies dialect-specific USING / WITH / WHERE clauses.
+ */
+function buildCreateIndexSql(
+  tableName: string,
+  idx: IndexSnapshot,
+  dialect: Dialect,
+  ifNotExists: boolean,
+): string {
+  const snakeTable = camelToSnake(tableName);
+  const idxColsStr = idx.opclass
+    ? idx.columns.map((c) => `"${camelToSnake(c)}" ${idx.opclass}`).join(', ')
+    : idx.columns.map((c) => `"${camelToSnake(c)}"`).join(', ');
+  const idxName =
+    idx.name ?? `idx_${snakeTable}_${idx.columns.map((c) => camelToSnake(c)).join('_')}`;
+  const unique = idx.unique ? 'UNIQUE ' : '';
+  const using = idx.type && dialect.name === 'postgres' ? ` USING ${idx.type}` : '';
+  const withParts: string[] = [];
+  if (idx.m != null) withParts.push(`m = ${idx.m}`);
+  if (idx.efConstruction != null) withParts.push(`ef_construction = ${idx.efConstruction}`);
+  if (idx.lists != null) withParts.push(`lists = ${idx.lists}`);
+  const withClause = withParts.length > 0 ? ` WITH (${withParts.join(', ')})` : '';
+  const where = idx.where ? ` WHERE ${idx.where}` : '';
+  const prefix = ifNotExists ? `CREATE ${unique}INDEX IF NOT EXISTS` : `CREATE ${unique}INDEX`;
+  return `${prefix} "${idxName}" ON "${snakeTable}"${using} (${idxColsStr})${withClause}${where};`;
+}
+
+/**
+ * Generate idempotent bootstrap DDL from a schema snapshot.
+ *
+ * Emits `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` statements
+ * for every table in the snapshot, including table-level PRIMARY KEY, inline
+ * FOREIGN KEY constraints, and CHECK constraints for enum columns (SQLite).
+ *
+ * Each statement is returned separately so drivers that prepare statements
+ * individually (like bun:sqlite) can execute them one at a time.
+ */
+export function generateBootstrapSql(
+  snapshot: SchemaSnapshot,
+  dialect: Dialect = defaultPostgresDialect,
+): string[] {
+  const statements: string[] = [];
+  const enums = snapshot.enums;
+  const emittedEnumTypes = new Set<string>();
+
+  for (const [tableName, table] of Object.entries(snapshot.tables)) {
+    // Postgres: emit CREATE TYPE ... AS ENUM before the table that references it.
+    if (dialect.name === 'postgres') {
+      for (const col of Object.values(table.columns)) {
+        if (!isEnumType(col, enums)) continue;
+        const enumSnakeName = camelToSnake(col.type);
+        if (emittedEnumTypes.has(enumSnakeName)) continue;
+        const values = getEnumValues(col, enums);
+        if (values.length === 0) continue;
+        const valuesStr = values.map((v) => `'${escapeSqlString(v)}'`).join(', ');
+        statements.push(`CREATE TYPE "${enumSnakeName}" AS ENUM (${valuesStr});`);
+        emittedEnumTypes.add(enumSnakeName);
+      }
+    }
+
+    statements.push(buildCreateTableSql(tableName, table, dialect, enums, true));
+
+    for (const idx of table.indexes) {
+      statements.push(buildCreateIndexSql(tableName, idx, dialect, true));
+    }
+  }
+
+  return statements;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `createDb({ migrations: { autoApply: true } })` now emits non-inline UNIQUE indexes, FOREIGN KEY constraints, and enum CHECK constraints — previously it silently dropped all three, so autoApply dev schemas diverged from hand-written prod migrations.
- autoApply shares its DDL pipeline with the migrations CLI (`createSnapshot` → new `generateBootstrapSql`), so what ships to the dev SQLite matches what `vertz db generate` would produce.
- `createLocalSqliteDriver` explicitly sets `PRAGMA foreign_keys = ON` so FK declarations are actually enforced across all SQLite backends, not just ones that happen to compile with the flag on.

## Public API Changes

**Additions** (non-breaking):
- `generateBootstrapSql(snapshot, dialect)` — new export on `@vertz/db/migration`. Emits idempotent `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` from a `SchemaSnapshot`, including PK, inline FK, and SQLite enum CHECK constraints.

**Snapshot wire-format changes** (may produce a one-time noisy `column_altered` on the next `vertz db generate` after upgrading; the generated ALTER is safe to apply):
- Enum columns now store `type: <enumName>` (e.g. `"ticket_status"`) instead of the literal `"enum"`, matching what `introspectPostgres` returns.
- Column defaults are stored as SQL expressions (`"'pending'"`, `"now()"`, `"true"`), matching what `introspectPostgres` / `introspectSqlite` return.
- `.autoUpdate()` columns now carry `default: "now()"` so downstream DDL consumers can emit the `DEFAULT` clause the INSERT path needs.

## Test plan

- [x] `vtz test packages/db` — 1635 passed, 1 skipped (three new Given/When/Then tests: UNIQUE duplicate rejected, orphan FK rejected, invalid enum value rejected — latter covers two enum columns on the same table).
- [x] `vtz test packages/db packages/sqlite packages/server` — 3795 passed.
- [x] `vtz run typecheck` — clean in `packages/db`.
- [x] `vtzx oxlint` on changed files — 0 errors.
- [x] Adversarial review written to [`reviews/fix-2848/phase-01-autoapply-ddl-constraints.md`](https://github.com/vertz-dev/vertz/blob/fix/autoapply-constraints-2848/reviews/fix-2848/phase-01-autoapply-ddl-constraints.md) — 0 blockers; both should-fix findings (PRAGMA, changeset snapshot-format note) addressed in follow-up commit `7580f7153`.

Closes #2848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)