### PR TITLE
fix(vtz): refuse silent downgrade in self-update [#2860]

### DIFF
--- a/.changeset/self-update-no-downgrade.md
+++ b/.changeset/self-update-no-downgrade.md
@@ -1,0 +1,19 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): refuse to silently downgrade in `vtz self-update`
+
+`vtz self-update` previously compared the installed and target versions with
+string equality, so any time the GitHub `/releases/latest` endpoint pointed at
+an older tag than what was installed (e.g., during a parallel-release race
+where an older workflow run wins the `latest` pointer, or when a developer is
+on a locally-built newer build) the updater happily replaced the binary with
+an older version.
+
+The updater now performs a semver comparison and refuses to proceed when the
+target version is older than the installed one, unless the user explicitly
+opts in via `vtz self-update --version <v>`.
+
+Addresses bug 3 in #2860. Bugs 1 and 2 (release workflow asset-upload race
+and `latest`-pointer race) remain open.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6388,7 +6388,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.71"
+version = "0.2.74"
 dependencies = [
  "napi",
  "napi-build",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.71"
+version = "0.2.74"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6420,7 +6420,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.71"
+version = "0.2.74"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/self_update.rs
+++ b/native/vtz/src/self_update.rs
@@ -80,23 +80,70 @@ async fn fetch_latest_version(
     Ok(version.to_string())
 }
 
+/// Outcome of comparing the installed version against a target version.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateDecision {
+    /// Versions are equal — nothing to do.
+    UpToDate,
+    /// Target is newer, or the user explicitly opted into a downgrade.
+    Proceed,
+    /// Target is older than what's installed and the user did not pass `--version`.
+    /// The updater must refuse to silently downgrade.
+    RefuseDowngrade,
+}
+
+/// Pure decision: should `self-update` replace the binary?
+///
+/// `explicit_target` is `true` when the user passed `--version <v>`. An explicit older
+/// version proceeds (intentional downgrade); an implicit older version (i.e. the GitHub
+/// "latest" endpoint returned something lower than what's installed) is refused.
+pub fn decide_update(
+    current: &str,
+    target: &str,
+    explicit_target: bool,
+) -> Result<UpdateDecision, Box<dyn std::error::Error>> {
+    let current_ver = node_semver::Version::parse(current)
+        .map_err(|e| format!("invalid installed version {:?}: {}", current, e))?;
+    let target_ver = node_semver::Version::parse(target)
+        .map_err(|e| format!("invalid target version {:?}: {}", target, e))?;
+
+    if target_ver == current_ver {
+        return Ok(UpdateDecision::UpToDate);
+    }
+    if target_ver < current_ver && !explicit_target {
+        return Ok(UpdateDecision::RefuseDowngrade);
+    }
+    Ok(UpdateDecision::Proceed)
+}
+
 /// Download and replace the current binary from GitHub Releases.
 ///
 /// If `target_version` is `None`, the latest release is fetched from the GitHub API.
-/// If the resolved version matches the current version, prints a message and returns.
+/// Refuses to downgrade unless the user passed `--version` explicitly.
 pub async fn self_update(target_version: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
     let old_version = current_version();
     let client = reqwest::Client::new();
 
-    // Resolve target version
+    let explicit_target = target_version.is_some();
     let new_version = match target_version {
         Some(v) => v.strip_prefix('v').unwrap_or(v).to_string(),
         None => fetch_latest_version(&client).await?,
     };
 
-    if new_version == old_version {
-        println!("Already up to date.");
-        return Ok(());
+    match decide_update(old_version, &new_version, explicit_target)? {
+        UpdateDecision::UpToDate => {
+            println!("Already up to date.");
+            return Ok(());
+        }
+        UpdateDecision::RefuseDowngrade => {
+            eprintln!(
+                "Latest release ({}) is older than the installed version ({}). \
+                 Refusing to downgrade. Pass `--version {}` to force.",
+                new_version, old_version, new_version,
+            );
+            return Ok(());
+        }
+        UpdateDecision::Proceed => {}
     }
 
     let bin = binary_name().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
@@ -315,5 +362,48 @@ mod tests {
     #[test]
     fn test_github_api_url_constant() {
         assert_eq!(GITHUB_API_URL, "https://api.github.com");
+    }
+
+    #[test]
+    fn decide_update_same_version_is_up_to_date() {
+        let decision = decide_update("0.2.74", "0.2.74", false).unwrap();
+        assert!(matches!(decision, UpdateDecision::UpToDate));
+    }
+
+    #[test]
+    fn decide_update_newer_target_proceeds() {
+        let decision = decide_update("0.2.73", "0.2.74", false).unwrap();
+        assert!(matches!(decision, UpdateDecision::Proceed));
+    }
+
+    #[test]
+    fn decide_update_implicit_older_target_refuses_downgrade() {
+        // Latest from GitHub is older than what's installed → must refuse.
+        let decision = decide_update("0.2.74", "0.2.73", false).unwrap();
+        assert!(
+            matches!(decision, UpdateDecision::RefuseDowngrade),
+            "implicit downgrade must be refused, got {:?}",
+            decision
+        );
+    }
+
+    #[test]
+    fn decide_update_explicit_older_target_proceeds() {
+        // User passed --version explicitly → allow downgrade.
+        let decision = decide_update("0.2.74", "0.2.73", true).unwrap();
+        assert!(matches!(decision, UpdateDecision::Proceed));
+    }
+
+    #[test]
+    fn decide_update_rejects_invalid_target_tag() {
+        // Per-package tags like `vertz@0.2.73` should not parse as semver.
+        let result = decide_update("0.2.74", "vertz@0.2.73", false);
+        assert!(result.is_err(), "non-semver target must be rejected");
+    }
+
+    #[test]
+    fn decide_update_rejects_invalid_current_version() {
+        let result = decide_update("not-a-version", "0.2.74", false);
+        assert!(result.is_err(), "non-semver current must be rejected");
     }
 }


### PR DESCRIPTION
## Summary

Fixes bug 3 in #2860: `vtz self-update` could silently *downgrade* the installed binary when the GitHub `/releases/latest` endpoint pointed at a tag older than what was installed.

The previous logic compared versions with string equality:

```rust
if new_version == old_version {
    println!("Already up to date.");
    return Ok(());
}
```

So `latest=0.2.72` + `installed=0.2.73` → fall through → download `v0.2.72` → silent downgrade. This was reproducible during the parallel-release races described in #2860, and also happens for any developer running a locally-built newer build.

The fix introduces a pure `decide_update(current, target, explicit_target)` helper that compares versions with semver and returns one of `UpToDate` / `Proceed` / `RefuseDowngrade`. `self_update()` uses it before downloading; an implicit older target is refused with a message:

```
Latest release (0.2.72) is older than the installed version (0.2.73).
Refusing to downgrade. Pass `--version 0.2.72` to force.
```

`vtz self-update --version <v>` (the explicit path) still allows downgrades, since users may have a legitimate reason to roll back.

## Public API Changes

- **Behavior change** — `vtz self-update` now refuses to downgrade unless the user passes `--version` explicitly. No CLI flag changes.
- **Internal API** — adds public `decide_update()` and `UpdateDecision` to `self_update.rs` for testability. Not surfaced through the CLI.

## Out of scope

Bugs 1 and 2 in #2860 remain open:
- Bug 1: Release workflow marks `latest` before all platform binaries finish uploading.
- Bug 2: Parallel Release workflow runs race on the `latest` pointer.

Both are infrastructure-side fixes and worth tackling separately.

## Test plan

- [x] Unit tests in `native/vtz/src/self_update.rs` cover: same version → up-to-date; newer target → proceed; implicit older → refused; explicit older → proceeds; non-semver target → error; non-semver current → error.
- [x] `cargo test -p vtz --lib` — 3482 passed
- [x] `cargo clippy -p vtz --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Pre-push hooks all green (build-typecheck, lint, rust-clippy, rust-fmt, rust-test, test, trojan-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)