### PR TITLE
fix(ci): stop premature "latest" flips on release workflow [#2860]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,9 +382,18 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           LEFTHOOK: '0'
 
+      # Only touch GitHub releases when this run actually published packages
+      # to npm. On non-publishing runs (e.g. an unrelated commit lands on main
+      # while a "Version Packages" PR is still open), `scripts/version.sh`
+      # still bumps `version.txt` locally via changesets/action, which used to
+      # trip this step into creating a premature `v${VERSION}` release with
+      # only the fallback `vtz-linux-x64` binary — and marking it "latest".
+      # That is #2860 bug 1.
       - name: Upload binaries to GitHub Release
+        if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           VERSION=$(cat version.txt)
           TAG="v${VERSION}"
@@ -403,18 +412,40 @@ jobs:
             exit 0
           fi
 
+          # Decide whether we should claim the "latest" pointer. If a newer
+          # v-prefixed semver release already holds it (e.g. a parallel
+          # release run for a later version finished first), refuse to
+          # regress the pointer. That is #2860 bug 2.
+          CURRENT_LATEST=$(gh api "repos/$REPO/releases/latest" --jq .tag_name 2>/dev/null || echo "")
+          MAKE_LATEST="true"
+          if [[ "$CURRENT_LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$CURRENT_LATEST" != "$TAG" ]; then
+            TAG_VER="${TAG#v}"
+            LATEST_VER="${CURRENT_LATEST#v}"
+            HIGHEST=$(printf '%s\n%s\n' "$LATEST_VER" "$TAG_VER" | sort -V | tail -1)
+            if [ "$HIGHEST" != "$TAG_VER" ]; then
+              echo "::notice::A newer release ($CURRENT_LATEST) already holds 'latest' — not regressing to $TAG."
+              MAKE_LATEST="false"
+            fi
+          fi
+
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG exists, replacing binary assets..."
             for asset in "${ASSETS[@]}"; do
               gh release delete-asset "$TAG" "$asset" --yes 2>/dev/null || true
             done
             gh release upload "$TAG" "${ASSETS[@]}"
-            # Mark as latest so install.sh can find binaries via releases/latest
-            gh release edit "$TAG" --latest
           else
             gh release create "$TAG" \
               --title "$TAG" \
               --generate-notes \
-              --latest \
               "${ASSETS[@]}"
+          fi
+
+          # `gh release create` defaults `make_latest` to true, so we must
+          # explicitly PATCH it either way to honor the semver guard above.
+          RELEASE_ID=$(gh api "repos/$REPO/releases/tags/$TAG" --jq .id)
+          gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" \
+            -f "make_latest=$MAKE_LATEST" > /dev/null
+          if [ "$MAKE_LATEST" = "true" ]; then
+            echo "Marked $TAG as latest."
           fi


### PR DESCRIPTION
## Summary

Finishes #2860 by addressing bugs 1 and 2, which were left open when #2861 shipped the downgrade guard in `vtz self-update` (bug 3).

- **Bug 1 (premature partial release)** — the release workflow used to create `v${VERSION}` releases on every push to main. `scripts/version.sh` (invoked by `changesets/action` when opening a "Version Packages" PR) bumps `version.txt` in the running checkout, so any unrelated commit that landed while a Version Packages PR was still open would read the bumped version, fall back to downloading only the `vtz-linux-x64` binary from the prior release, and call `gh release create "v${VERSION}" --latest vtz-linux-x64`. The release appeared as "Latest" on GitHub with only 1 of 4 platform binaries until the actual Version Packages merge ran later (~22 min in the original repro for `v0.2.74`). Other platforms 404'd on the asset URL in that window.
- **Bug 2 (older version overwrites latest)** — both `gh release create --latest` and `gh release edit --latest` unconditionally claim the "latest" pointer. If an older version's workflow runs after a newer one (parallel release race), it silently regresses the pointer.

## Changes

- Gate "Upload binaries to GitHub Release" on `steps.changesets.outputs.published == 'true'` — non-publishing runs never touch GitHub releases. Fixes bug 1.
- Drop the explicit `--latest` flags. Before create/upload, compare `v${VERSION}` against the current `releases/latest` tag (when it's a v-prefixed semver). If a newer release already holds the pointer, set `MAKE_LATEST=false` and skip the promotion.
- After create/upload, explicitly `PATCH make_latest=$MAKE_LATEST` on the release — `gh release create` defaults `make_latest` to true via the API, so the PATCH is required to honor the semver guard. Fixes bug 2.

## Test plan

Manual verification (CI cannot exercise the release workflow without merging):
- [ ] Merge a non-version-bump PR to main while a Version Packages PR is open → confirm no `v${VERSION}` release is created for the not-yet-published version.
- [ ] Merge the Version Packages PR → confirm `v${VERSION}` release is created with all four `vtz-*` binaries and marked `latest`.
- [ ] If two Version Packages PRs land back-to-back, confirm the older one's workflow logs `A newer release ($CURRENT_LATEST) already holds 'latest'` and skips the PATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)