### PR TITLE
fix(ui-server): use createRequire for ESM-safe module loading [#2875]

### DIFF
--- a/packages/ui-server/src/__tests__/native-compiler-loader.test.ts
+++ b/packages/ui-server/src/__tests__/native-compiler-loader.test.ts
@@ -1,5 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@vertz/test';
 import { loadNativeCompiler } from '../compiler/native-compiler';
+
+// Files that load modules via CJS require at module-init time. Bundled as ESM,
+// they must use `createRequire(import.meta.url)` — the global `require` is not
+// defined at runtime.
+const ESM_REQUIRE_SOURCES = [
+  new URL('../compiler/native-compiler.ts', import.meta.url),
+  new URL('../compiler/reactivity-manifest.ts', import.meta.url),
+  new URL('../build-plugin/plugin.ts', import.meta.url),
+];
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
 
 // Check if the native binary is available on this platform
 function isNativeBinaryAvailable(): boolean {
@@ -64,6 +79,36 @@ describe('Feature: Native compiler loader', () => {
         expect(result.code).not.toContain('__register');
       });
     });
+  });
+
+  describe('Given the module is consumed as pure ESM', () => {
+    // Regression guard for #2875: the compiled ESM bundle cannot use the
+    // CJS `require` global (esbuild's `__require` shim throws at runtime).
+    // Every file that loads a module at init-time must use
+    // `createRequire(import.meta.url)` instead of the bare `require` global.
+    for (const url of ESM_REQUIRE_SOURCES) {
+      const filename = url.pathname.split('/').pop();
+      const source = readFileSync(fileURLToPath(url), 'utf8');
+      const stripped = stripComments(source);
+
+      describe(`When inspecting ${filename}`, () => {
+        it('Then the source imports createRequire from node:module', () => {
+          expect(source).toContain("import { createRequire } from 'node:module'");
+        });
+
+        it('Then the source instantiates createRequire(import.meta.url)', () => {
+          expect(source).toContain('createRequire(import.meta.url)');
+        });
+
+        it('Then the source contains no bare require(...) call', () => {
+          expect(stripped).not.toMatch(/(?<![a-zA-Z_.])require\(/);
+        });
+
+        it('Then the source contains no bare require.resolve(...) call', () => {
+          expect(stripped).not.toMatch(/(?<![a-zA-Z_.])require\.resolve\(/);
+        });
+      });
+    }
   });
 
   describe('Given the native compiler is required (no fallback)', () => {

--- a/packages/ui-server/src/build-plugin/plugin.ts
+++ b/packages/ui-server/src/build-plugin/plugin.ts
@@ -15,6 +15,7 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, relative, resolve } from 'node:path';
 import type { EncodedSourceMap } from '@ampproject/remapping';
 import remapping from '@ampproject/remapping';
@@ -155,9 +156,12 @@ export function createVertzBuildPlugin(options?: VertzBuildPluginOptions): Vertz
   // time. This enables the compiler to understand the reactivity shape of
   // imports from user files (custom hooks, barrel re-exports, etc.).
   const srcDir = options?.srcDir ?? resolve(projectRoot, 'src');
-  // Load the raw JSON manifest to avoid Set→Array round-trip
-  const frameworkManifestJson = require(
-    require.resolve('@vertz/ui/reactivity.json'),
+  // Load the raw JSON manifest to avoid Set→Array round-trip. `createRequire`
+  // gives us a real CJS require in ESM-bundled output where the global
+  // `require` is not defined.
+  const esmRequire = createRequire(import.meta.url);
+  const frameworkManifestJson = esmRequire(
+    esmRequire.resolve('@vertz/ui/reactivity.json'),
   ) as ReactivityManifest;
   const manifestResult = generateAllManifests({
     srcDir,

--- a/packages/ui-server/src/compiler/native-compiler.ts
+++ b/packages/ui-server/src/compiler/native-compiler.ts
@@ -127,8 +127,15 @@ interface RawNativeCompiler {
 // ─── Loader ─────────────────────────────────────────────────────────
 
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// When this module is bundled as pure ESM, the global `require` is not
+// defined at runtime. `createRequire` gives us a real CJS require scoped
+// to this module's URL — needed to load the `.node` binary and to resolve
+// subpath exports of `@vertz/native-compiler`.
+const esmRequire = createRequire(import.meta.url);
 
 let cachedCompiler: RawNativeCompiler | null = null;
 let nativeUnavailable = false;
@@ -152,7 +159,7 @@ function resolveBinaryName(): string {
 function resolveBinaryPath(binaryName: string): string | null {
   // Try 1: standard npm module resolution
   try {
-    return require.resolve(`@vertz/native-compiler/${binaryName}`);
+    return esmRequire.resolve(`@vertz/native-compiler/${binaryName}`);
   } catch {
     // Fall through to workspace resolution
   }
@@ -160,11 +167,9 @@ function resolveBinaryPath(binaryName: string): string | null {
   // Try 2: workspace-relative resolution (monorepo / CI)
   // Walk up from this file's directory to find `native/vertz-compiler/`
   const startDir =
-    (typeof import.meta !== 'undefined' && import.meta.dir) ||
     (typeof import.meta !== 'undefined' && import.meta.url
       ? dirname(fileURLToPath(import.meta.url))
-      : null) ||
-    (typeof __dirname !== 'undefined' ? __dirname : null);
+      : null) || (typeof __dirname !== 'undefined' ? __dirname : null);
   if (!startDir) return null;
 
   let dir = dirname(startDir);
@@ -199,7 +204,7 @@ export function loadNativeCompiler(): NativeCompiler {
     );
   }
 
-  cachedCompiler = require(binaryPath) as RawNativeCompiler;
+  cachedCompiler = esmRequire(binaryPath) as RawNativeCompiler;
   return wrapCompiler(cachedCompiler);
 }
 

--- a/packages/ui-server/src/compiler/reactivity-manifest.ts
+++ b/packages/ui-server/src/compiler/reactivity-manifest.ts
@@ -4,6 +4,7 @@
  * Converts JSON manifest files (with string[] arrays) into runtime
  * representations (with Set<string>) for O(1) lookups.
  */
+import { createRequire } from 'node:module';
 import type {
   LoadedExportReactivityInfo,
   LoadedReactivityManifest,
@@ -83,8 +84,11 @@ let cachedFrameworkManifest: LoadedReactivityManifest | null = null;
 export function loadFrameworkManifest(): LoadedReactivityManifest {
   if (cachedFrameworkManifest) return cachedFrameworkManifest;
 
-  const manifestPath = require.resolve('@vertz/ui/reactivity.json');
-  const json = require(manifestPath) as ReactivityManifest;
+  // `createRequire` gives us a real CJS require in ESM-bundled output where
+  // the global `require` is not defined.
+  const esmRequire = createRequire(import.meta.url);
+  const manifestPath = esmRequire.resolve('@vertz/ui/reactivity.json');
+  const json = esmRequire(manifestPath) as ReactivityManifest;
   cachedFrameworkManifest = loadManifestFromJson(json);
   return cachedFrameworkManifest;
 }


### PR DESCRIPTION
## Summary

Fixes #2875 — `vertz build` was unusable because `@vertz/ui-server`'s loaders relied on the CJS `require` global, which esbuild's `__require` shim throws on in pure-ESM consumers.

- `native-compiler.ts` (binary loader)
- `reactivity-manifest.ts` (loads `@vertz/ui/reactivity.json`)
- `build-plugin/plugin.ts` (loads `@vertz/ui/reactivity.json`)

All three switched to `createRequire(import.meta.url)`.

## Public API Changes

None.

## Test plan

- [x] New regression tests assert every loader file imports `createRequire` and contains no bare `require(...)` / `require.resolve(...)`
- [x] `vtz test src/` in `@vertz/ui-server` — 1255 passed, 2 pre-existing load errors unrelated to this change
- [x] Manually verified: `node -e "import(...)"` on the built ESM `ui-server/dist/index.js` loads `loadNativeCompiler()` and returns `{ compile, compileForSsrAot }`

## Unblocks

- #2876, #2877 (landing-page deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)