### PR TITLE
fix(landing): make build and deploy scripts work with current toolchain [#2876]

### DIFF
--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -6,9 +6,9 @@
     "dev": "vtz dev",
     "dev:presence": "vtz run src/presence-dev-server.ts",
     "dev:all": "vtz run scripts/dev-all.ts",
-    "build": "vtz run scripts/generate-og.ts && vertz build",
-    "build:og": "vtz run scripts/og-images.ts",
-    "deploy": "vtz run build && vtzx wrangler deploy --define DEPLOY_VERSION:\"'$(date +%s)'\" --define PRESENCE_WS_URL:\"'wss://vertz.dev/__presence'\" && vtz run scripts/pre-warm.ts",
+    "build": "node --experimental-strip-types scripts/generate-og.ts && bun ../../node_modules/@vertz/cli/dist/vertz.js build",
+    "build:og": "node --experimental-strip-types scripts/generate-og.ts",
+    "deploy": "bun run build && vtzx wrangler deploy --define DEPLOY_VERSION:\"'$(date +%s)'\" --define PRESENCE_WS_URL:\"'wss://vertz.dev/__presence'\" && node --experimental-strip-types scripts/pre-warm.ts",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/landing/scripts/generate-og.ts
+++ b/packages/landing/scripts/generate-og.ts
@@ -5,8 +5,10 @@
  * Similar to Next.js `ImageResponse` — define the image as a component,
  * render to SVG via Satori, convert to PNG via resvg.
  *
- * Usage: bun run scripts/generate-og.ts
+ * Usage: node --experimental-strip-types scripts/generate-og.ts
  */
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import satori from 'satori';
 import { Resvg } from '@resvg/resvg-js';
 
@@ -240,8 +242,8 @@ async function main() {
   });
   const png = resvg.render().asPng();
 
-  const outPath = `${import.meta.dir}/../public/og.png`;
-  await Bun.write(outPath, png);
+  const outPath = fileURLToPath(new URL('../public/og.png', import.meta.url));
+  writeFileSync(outPath, png);
   console.log(`✓ Generated OG image: public/og.png (${(png.byteLength / 1024).toFixed(1)} KB)`);
 }
 


### PR DESCRIPTION
## Summary

Fixes #2876. The landing `build`/`deploy` scripts were broken three different ways:

1. `vtz run scripts/generate-og.ts` — current `vtz run` only resolves package.json scripts, not file paths; this errors with `script not found`.
2. `vertz build` runs under `#!/usr/bin/env node` but calls `Bun.build()` — throws `Bun is not defined`.
3. `build:og` pointed at a non-existent `og-images.ts`.

This PR:
- Makes `scripts/generate-og.ts` Node-compatible (`writeFileSync` + `fileURLToPath(new URL(...))` instead of `Bun.write` + `import.meta.dir`).
- Invokes TS scripts with `node --experimental-strip-types`.
- Invokes `vertz build` under `bun` so `Bun.build` has a runtime.
- Repoints `build:og` at the real script.

Dev scripts (`dev:presence`, `dev:all`) still use `vtz run <file>` and still break — those are dev-only and out of scope here.

## Public API Changes

None.

## Stacked on

- #2879 (#2875) — required for `vertz build` itself to run without the ESM-require bug.

## Test plan

- [x] `bun run build` in `packages/landing/` completes and writes `dist/client/`
- [x] `node --experimental-strip-types scripts/generate-og.ts` produces `public/og.png`
- [ ] Verify `bun run deploy` once merged (requires CF creds, not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)