### PR TITLE
fix(landing,ui-server,cli): recover pre-render from single-route failures [#2877]

### DIFF
--- a/packages/cli/src/production-build/ui-build-pipeline.ts
+++ b/packages/cli/src/production-build/ui-build-pipeline.ts
@@ -666,11 +666,23 @@ ${modulepreloadLinks}
       }
 
       if (prerenderableRoutes.length > 0) {
-        // Pre-render each route
+        // Pre-render each route. Per-route failures are logged as warnings
+        // and skipped so one broken component doesn't sink the whole build
+        // — the healthy routes still get pre-rendered HTML.
+        const routeErrors: Array<{ path: string; error: Error }> = [];
         const results = await prerenderRoutes(ssrModule, html, {
           routes: prerenderableRoutes,
           fallbackMetrics,
+          onRouteError: (path, error) => {
+            routeErrors.push({ path, error });
+            console.log(`  ⚠ Pre-render failed for ${path}: ${error.message.split('\n')[0]}`);
+          },
         });
+        if (routeErrors.length > 0) {
+          console.log(
+            `  ⚠ ${routeErrors.length} of ${prerenderableRoutes.length} route(s) skipped due to render errors`,
+          );
+        }
 
         // Only strip JS from static pages when the app uses islands mode.
         // Detect islands mode: at least one pre-rendered page has a data-v-island marker.

--- a/packages/landing/src/app.tsx
+++ b/packages/landing/src/app.tsx
@@ -12,7 +12,10 @@ export const theme = landingTheme;
 export const styles = [themeGlobals.css, appGlobals.css];
 
 // ── Routes ─────────────────────────────────────────────────
-const routes = defineRoutes({
+// Exported so `vertz build`'s pre-render pipeline can enumerate them
+// via `collectPrerenderPaths(ssrModule.routes)` as a deterministic
+// fallback when runtime route discovery (render '/') fails.
+export const routes = defineRoutes({
   '/': { component: () => <HomePage /> },
   '/manifesto': { component: () => <ManifestoPage /> },
   '/openapi': { component: () => <OpenAPIPage /> },

--- a/packages/ui-server/src/__tests__/prerender.test.ts
+++ b/packages/ui-server/src/__tests__/prerender.test.ts
@@ -71,6 +71,59 @@ describe('discoverRoutes', () => {
 
     expect(patterns).toEqual([]);
   });
+
+  it('falls back to exported routes when rendering / throws', async () => {
+    // Simulates the landing-page regression: a broken component at the root
+    // threw during SSR render, so runtime discovery returned nothing and the
+    // whole pre-render pass was skipped even though `/manifesto` was healthy.
+    const module = {
+      default: () => {
+        throw new Error('home page component crashed');
+      },
+      routes: [
+        { pattern: '/', prerender: false },
+        { pattern: '/manifesto' },
+        { pattern: '/openapi' },
+      ],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/');
+    expect(patterns).toContain('/manifesto');
+    expect(patterns).toContain('/openapi');
+  });
+
+  it('falls back to exported routes when runtime discovery returns empty', async () => {
+    const module = {
+      default: () => document.createElement('div'),
+      routes: [{ pattern: '/foo' }, { pattern: '/bar' }],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/foo');
+    expect(patterns).toContain('/bar');
+  });
+
+  it('prefers runtime discovery over exported routes when both are available', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/runtime-only': { component: () => document.createElement('div') },
+        });
+        const router = createRouter(routes);
+        router.current.value;
+        return document.createElement('div');
+      },
+      routes: [{ pattern: '/static-only' }],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/runtime-only');
+    expect(patterns).not.toContain('/static-only');
+  });
 });
 
 describe('filterPrerenderableRoutes', () => {
@@ -368,5 +421,35 @@ describe('prerenderRoutes', () => {
     await expect(prerenderRoutes(module, template, { routes: ['/pricing'] })).rejects.toThrow(
       /Pre-render failed for \/pricing/,
     );
+  });
+
+  it('reports per-route errors via onRouteError and continues on remaining routes', async () => {
+    // Module throws on the first call, succeeds afterwards. Mimics the
+    // landing-page regression where a broken component at one route was
+    // blocking pre-render of every other static route.
+    let callCount = 0;
+    const module = {
+      default: () => {
+        callCount += 1;
+        if (callCount === 1) throw new Error('component crashed');
+        const el = document.createElement('div');
+        el.textContent = `rendered call #${callCount}`;
+        return el;
+      },
+    };
+
+    const errors: Array<{ path: string; message: string }> = [];
+    const results = await prerenderRoutes(module, template, {
+      routes: ['/', '/manifesto'],
+      onRouteError: (path, error) => {
+        errors.push({ path, message: error.message });
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.path).toBe('/');
+    expect(errors[0]?.message).toMatch(/Pre-render failed for \//);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe('/manifesto');
   });
 });

--- a/packages/ui-server/src/prerender.ts
+++ b/packages/ui-server/src/prerender.ts
@@ -24,6 +24,13 @@ export interface PrerenderOptions {
   nonce?: string;
   /** Pre-computed font fallback metrics for zero-CLS font loading. */
   fallbackMetrics?: Record<string, FontFallbackMetrics>;
+  /**
+   * Per-route error callback. When provided, pre-rendering a broken route
+   * is reported via this callback and the loop continues with the remaining
+   * routes instead of aborting the whole build. The caller decides whether
+   * to warn or fail based on accumulated errors.
+   */
+  onRouteError?: (path: string, error: Error) => void;
 }
 
 /**
@@ -31,10 +38,44 @@ export interface PrerenderOptions {
  *
  * Renders `/` to trigger `createRouter()`, which registers route patterns
  * with the SSR context. Returns the discovered patterns (including dynamic).
+ *
+ * Falls back to walking the exported `routes` array if rendering `/` fails
+ * (e.g. because a component at `/` throws under SSR). The runtime-discovery
+ * path has one failure mode — if the shared layout for `/` breaks, we lose
+ * the whole route map — while the static walk doesn't exercise components,
+ * so the remaining routes can still be pre-rendered.
  */
 export async function discoverRoutes(module: SSRModule): Promise<string[]> {
-  const result = await ssrRenderSinglePass(module, '/');
-  return result.discoveredRoutes ?? [];
+  try {
+    const result = await ssrRenderSinglePass(module, '/');
+    if (result.discoveredRoutes && result.discoveredRoutes.length > 0) {
+      return result.discoveredRoutes;
+    }
+  } catch {
+    // Fall through to static walk
+  }
+  if (module.routes) {
+    return collectRoutePatterns(module.routes);
+  }
+  return [];
+}
+
+/**
+ * Walk a CompiledRoute[] tree and return every pattern (static + dynamic),
+ * qualified with parent prefixes. Unlike `collectPrerenderPaths`, this does
+ * NOT filter by `prerender` / `generateParams` — it returns the raw patterns
+ * so the caller can reuse `filterPrerenderableRoutes`.
+ */
+function collectRoutePatterns(routes: CompiledRoute[], prefix = ''): string[] {
+  const patterns: string[] = [];
+  for (const route of routes) {
+    const fullPattern = joinPatterns(prefix, route.pattern);
+    patterns.push(fullPattern);
+    if (route.children) {
+      patterns.push(...collectRoutePatterns(route.children, fullPattern));
+    }
+  }
+  return patterns;
 }
 
 /**
@@ -87,12 +128,17 @@ export async function prerenderRoutes(
         fallbackMetrics: options.fallbackMetrics,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
+      const err = error instanceof Error ? error : new Error(String(error));
+      const wrapped = new Error(
         `Pre-render failed for ${routePath}\n` +
-          `  ${message}\n` +
+          `  ${err.message}\n` +
           '  Hint: If this route requires runtime data, add `prerender: false` to its route config.',
       );
+      if (options.onRouteError) {
+        options.onRouteError(routePath, wrapped);
+        continue;
+      }
+      throw wrapped;
     }
 
     const html = injectIntoTemplate({


### PR DESCRIPTION
## Summary

Fixes #2877 and restores the missing `/manifesto/index.html` in the landing's deploy output.

Three coordinated changes:

- `packages/landing/src/app.tsx` exports `routes` so the build pipeline has a deterministic fallback when runtime route discovery fails.
- `discoverRoutes()` in `@vertz/ui-server/prerender` catches render failures, falls back to `module.routes`, and collects the raw patterns.
- `prerenderRoutes()` accepts an `onRouteError` callback. When provided, per-route failures are reported and skipped instead of aborting the build. `@vertz/cli`'s `buildUI` wires the callback so one broken component doesn't sink every other static route. Default-throw behavior is preserved for strict callers.

Net result: `vertz build` now writes `dist/client/manifesto/index.html` even while `/` and `/openapi` still crash during SSR. Those two failures are tracked as [#2878](https://github.com/vertz-dev/vertz/issues/2878) — the SSR context for the `<List>` primitive is lost during pre-render, causing `List.Item` to throw on any page that uses `<Hero>`.

## Public API Changes

- `PrerenderOptions` gains an optional `onRouteError?: (path: string, error: Error) => void`.
- `discoverRoutes()` now falls back to `module.routes` when rendering `/` throws or returns empty.

Both changes are additive — existing strict callers see no behavior difference.

## Stacked on

- #2880 (#2876)
- #2879 (#2875)

## Test plan

- [x] 25 `prerender.test.ts` cases pass, including new coverage for `onRouteError` and the `discoverRoutes` fallback (render-throws / empty / prefer-runtime-over-static)
- [x] Full `bun run build` in `packages/landing/` produces `dist/client/manifesto/index.html` with the correct `<title>` and the "The Vertz Manifesto" h1; `/` and `/openapi` log as skipped
- [ ] Post-merge: re-deploy landing and verify `curl https://vertz.dev/manifesto` returns the manifesto HTML (blocked until this stack merges + a deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)