### PR TITLE
fix(landing): land #2876 + #2877 on main — missed during stacked merge

### DIFF
--- a/packages/cli/src/production-build/ui-build-pipeline.ts
+++ b/packages/cli/src/production-build/ui-build-pipeline.ts
@@ -666,11 +666,23 @@ ${modulepreloadLinks}
       }
 
       if (prerenderableRoutes.length > 0) {
-        // Pre-render each route
+        // Pre-render each route. Per-route failures are logged as warnings
+        // and skipped so one broken component doesn't sink the whole build
+        // — the healthy routes still get pre-rendered HTML.
+        const routeErrors: Array<{ path: string; error: Error }> = [];
         const results = await prerenderRoutes(ssrModule, html, {
           routes: prerenderableRoutes,
           fallbackMetrics,
+          onRouteError: (path, error) => {
+            routeErrors.push({ path, error });
+            console.log(`  ⚠ Pre-render failed for ${path}: ${error.message.split('\n')[0]}`);
+          },
         });
+        if (routeErrors.length > 0) {
+          console.log(
+            `  ⚠ ${routeErrors.length} of ${prerenderableRoutes.length} route(s) skipped due to render errors`,
+          );
+        }
 
         // Only strip JS from static pages when the app uses islands mode.
         // Detect islands mode: at least one pre-rendered page has a data-v-island marker.

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -6,9 +6,9 @@
     "dev": "vtz dev",
     "dev:presence": "vtz run src/presence-dev-server.ts",
     "dev:all": "vtz run scripts/dev-all.ts",
-    "build": "vtz run scripts/generate-og.ts && vertz build",
-    "build:og": "vtz run scripts/og-images.ts",
-    "deploy": "vtz run build && vtzx wrangler deploy --define DEPLOY_VERSION:\"'$(date +%s)'\" --define PRESENCE_WS_URL:\"'wss://vertz.dev/__presence'\" && vtz run scripts/pre-warm.ts",
+    "build": "node --experimental-strip-types scripts/generate-og.ts && bun ../../node_modules/@vertz/cli/dist/vertz.js build",
+    "build:og": "node --experimental-strip-types scripts/generate-og.ts",
+    "deploy": "bun run build && vtzx wrangler deploy --define DEPLOY_VERSION:\"'$(date +%s)'\" --define PRESENCE_WS_URL:\"'wss://vertz.dev/__presence'\" && node --experimental-strip-types scripts/pre-warm.ts",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/landing/scripts/generate-og.ts
+++ b/packages/landing/scripts/generate-og.ts
@@ -5,8 +5,10 @@
  * Similar to Next.js `ImageResponse` — define the image as a component,
  * render to SVG via Satori, convert to PNG via resvg.
  *
- * Usage: bun run scripts/generate-og.ts
+ * Usage: node --experimental-strip-types scripts/generate-og.ts
  */
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import satori from 'satori';
 import { Resvg } from '@resvg/resvg-js';
 
@@ -240,8 +242,8 @@ async function main() {
   });
   const png = resvg.render().asPng();
 
-  const outPath = `${import.meta.dir}/../public/og.png`;
-  await Bun.write(outPath, png);
+  const outPath = fileURLToPath(new URL('../public/og.png', import.meta.url));
+  writeFileSync(outPath, png);
   console.log(`✓ Generated OG image: public/og.png (${(png.byteLength / 1024).toFixed(1)} KB)`);
 }
 

--- a/packages/landing/src/app.tsx
+++ b/packages/landing/src/app.tsx
@@ -12,7 +12,10 @@ export const theme = landingTheme;
 export const styles = [themeGlobals.css, appGlobals.css];
 
 // ── Routes ─────────────────────────────────────────────────
-const routes = defineRoutes({
+// Exported so `vertz build`'s pre-render pipeline can enumerate them
+// via `collectPrerenderPaths(ssrModule.routes)` as a deterministic
+// fallback when runtime route discovery (render '/') fails.
+export const routes = defineRoutes({
   '/': { component: () => <HomePage /> },
   '/manifesto': { component: () => <ManifestoPage /> },
   '/openapi': { component: () => <OpenAPIPage /> },

--- a/packages/ui-server/src/__tests__/prerender.test.ts
+++ b/packages/ui-server/src/__tests__/prerender.test.ts
@@ -71,6 +71,59 @@ describe('discoverRoutes', () => {
 
     expect(patterns).toEqual([]);
   });
+
+  it('falls back to exported routes when rendering / throws', async () => {
+    // Simulates the landing-page regression: a broken component at the root
+    // threw during SSR render, so runtime discovery returned nothing and the
+    // whole pre-render pass was skipped even though `/manifesto` was healthy.
+    const module = {
+      default: () => {
+        throw new Error('home page component crashed');
+      },
+      routes: [
+        { pattern: '/', prerender: false },
+        { pattern: '/manifesto' },
+        { pattern: '/openapi' },
+      ],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/');
+    expect(patterns).toContain('/manifesto');
+    expect(patterns).toContain('/openapi');
+  });
+
+  it('falls back to exported routes when runtime discovery returns empty', async () => {
+    const module = {
+      default: () => document.createElement('div'),
+      routes: [{ pattern: '/foo' }, { pattern: '/bar' }],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/foo');
+    expect(patterns).toContain('/bar');
+  });
+
+  it('prefers runtime discovery over exported routes when both are available', async () => {
+    const module = {
+      default: () => {
+        const routes = defineRoutes({
+          '/runtime-only': { component: () => document.createElement('div') },
+        });
+        const router = createRouter(routes);
+        router.current.value;
+        return document.createElement('div');
+      },
+      routes: [{ pattern: '/static-only' }],
+    };
+
+    const patterns = await discoverRoutes(module);
+
+    expect(patterns).toContain('/runtime-only');
+    expect(patterns).not.toContain('/static-only');
+  });
 });
 
 describe('filterPrerenderableRoutes', () => {
@@ -368,5 +421,35 @@ describe('prerenderRoutes', () => {
     await expect(prerenderRoutes(module, template, { routes: ['/pricing'] })).rejects.toThrow(
       /Pre-render failed for \/pricing/,
     );
+  });
+
+  it('reports per-route errors via onRouteError and continues on remaining routes', async () => {
+    // Module throws on the first call, succeeds afterwards. Mimics the
+    // landing-page regression where a broken component at one route was
+    // blocking pre-render of every other static route.
+    let callCount = 0;
+    const module = {
+      default: () => {
+        callCount += 1;
+        if (callCount === 1) throw new Error('component crashed');
+        const el = document.createElement('div');
+        el.textContent = `rendered call #${callCount}`;
+        return el;
+      },
+    };
+
+    const errors: Array<{ path: string; message: string }> = [];
+    const results = await prerenderRoutes(module, template, {
+      routes: ['/', '/manifesto'],
+      onRouteError: (path, error) => {
+        errors.push({ path, message: error.message });
+      },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.path).toBe('/');
+    expect(errors[0]?.message).toMatch(/Pre-render failed for \//);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe('/manifesto');
   });
 });

--- a/packages/ui-server/src/prerender.ts
+++ b/packages/ui-server/src/prerender.ts
@@ -24,6 +24,13 @@ export interface PrerenderOptions {
   nonce?: string;
   /** Pre-computed font fallback metrics for zero-CLS font loading. */
   fallbackMetrics?: Record<string, FontFallbackMetrics>;
+  /**
+   * Per-route error callback. When provided, pre-rendering a broken route
+   * is reported via this callback and the loop continues with the remaining
+   * routes instead of aborting the whole build. The caller decides whether
+   * to warn or fail based on accumulated errors.
+   */
+  onRouteError?: (path: string, error: Error) => void;
 }
 
 /**
@@ -31,10 +38,44 @@ export interface PrerenderOptions {
  *
  * Renders `/` to trigger `createRouter()`, which registers route patterns
  * with the SSR context. Returns the discovered patterns (including dynamic).
+ *
+ * Falls back to walking the exported `routes` array if rendering `/` fails
+ * (e.g. because a component at `/` throws under SSR). The runtime-discovery
+ * path has one failure mode — if the shared layout for `/` breaks, we lose
+ * the whole route map — while the static walk doesn't exercise components,
+ * so the remaining routes can still be pre-rendered.
  */
 export async function discoverRoutes(module: SSRModule): Promise<string[]> {
-  const result = await ssrRenderSinglePass(module, '/');
-  return result.discoveredRoutes ?? [];
+  try {
+    const result = await ssrRenderSinglePass(module, '/');
+    if (result.discoveredRoutes && result.discoveredRoutes.length > 0) {
+      return result.discoveredRoutes;
+    }
+  } catch {
+    // Fall through to static walk
+  }
+  if (module.routes) {
+    return collectRoutePatterns(module.routes);
+  }
+  return [];
+}
+
+/**
+ * Walk a CompiledRoute[] tree and return every pattern (static + dynamic),
+ * qualified with parent prefixes. Unlike `collectPrerenderPaths`, this does
+ * NOT filter by `prerender` / `generateParams` — it returns the raw patterns
+ * so the caller can reuse `filterPrerenderableRoutes`.
+ */
+function collectRoutePatterns(routes: CompiledRoute[], prefix = ''): string[] {
+  const patterns: string[] = [];
+  for (const route of routes) {
+    const fullPattern = joinPatterns(prefix, route.pattern);
+    patterns.push(fullPattern);
+    if (route.children) {
+      patterns.push(...collectRoutePatterns(route.children, fullPattern));
+    }
+  }
+  return patterns;
 }
 
 /**
@@ -87,12 +128,17 @@ export async function prerenderRoutes(
         fallbackMetrics: options.fallbackMetrics,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
+      const err = error instanceof Error ? error : new Error(String(error));
+      const wrapped = new Error(
         `Pre-render failed for ${routePath}\n` +
-          `  ${message}\n` +
+          `  ${err.message}\n` +
           '  Hint: If this route requires runtime data, add `prerender: false` to its route config.',
       );
+      if (options.onRouteError) {
+        options.onRouteError(routePath, wrapped);
+        continue;
+      }
+      throw wrapped;
     }
 
     const html = injectIntoTemplate({


### PR DESCRIPTION
## Summary

Re-delivers the two landing-page fixes that got orphaned when the original stacked PRs (#2880, #2881) merged into their intermediate base branches instead of \`main\`. Only #2879 (#2875) landed on \`main\`; this PR brings #2876 and #2877 onto \`main\` so the landing can actually be deployed.

Two commits, rebased on latest \`main\`:

- **[#2876]** \`fix(landing): make build and deploy scripts work with current toolchain\` — \`vtz run scripts/...\` no longer resolves file paths and \`vertz build\` needs the Bun runtime; switches TS scripts to \`node --experimental-strip-types\`, invokes the CLI under \`bun\`, drops Bun-only APIs from \`generate-og.ts\`, repoints \`build:og\` at the real script.
- **[#2877]** \`fix(landing,ui-server,cli): recover pre-render from single-route failures\` — exports \`routes\` from \`packages/landing/src/app.tsx\`, adds a static-walk fallback to \`discoverRoutes()\`, and threads an \`onRouteError\` callback through \`prerenderRoutes()\` + \`buildUI\` so one broken component doesn't sink every other static route.

## Public API Changes

Carried forward from #2881:
- \`PrerenderOptions\` gains optional \`onRouteError?: (path: string, error: Error) => void\`.
- \`discoverRoutes()\` falls back to \`module.routes\` when rendering \`/\` throws or returns empty.

Both are additive — strict callers see no behavior difference.

## Test plan

- [x] \`oxfmt --check packages/\` clean
- [x] \`vtz test\` on \`prerender.test.ts\` + \`native-compiler-loader.test.ts\` — 38 passed
- [x] Fresh \`bun run build\` in \`packages/landing/\` writes \`dist/client/manifesto/index.html\` with the manifesto H1 and title
- [x] \`/\` and \`/openapi\` still fail pre-render (tracked as #2878) but now log as skipped and don't abort the build
- [ ] Deploy landing after merge — verify \`curl https://vertz.dev/manifesto\` returns the manifesto HTML

## Related

- Closes the delivery gap from #2880 and #2881
- #2878 — follow-up: List primitive SSR context lost, root cause of \`/\` and \`/openapi\` pre-render failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)