### PR TITLE
fix(compiler): recognize regex literals in strip_comments [#2878]

### DIFF
--- a/.changeset/strip-comments-regex.md
+++ b/.changeset/strip-comments-regex.md
@@ -1,0 +1,14 @@
+---
+'@vertz/native-compiler': patch
+'@vertz/ui-primitives': patch
+---
+
+fix(compiler): recognize regex literals in `strip_comments` so a backtick inside a regex body doesn't eat the rest of the file
+
+Closes [#2878](https://github.com/vertz-dev/vertz/issues/2878).
+
+The native compiler's `import_injection` pass scans source for helper usage via `strip_comments`, which replaces string-literal contents with spaces so `signal()` inside a template literal doesn't trigger a spurious `signal` import. A `` ` `` inside a regex literal like ``/`([^`]+)`/`` was being treated as a template-literal opener — the scanner then consumed everything to EOF looking for a closing backtick and erased every subsequent helper call (`__element`, `__flushMountFrame`, `__discardMountFrame`, …). Those helpers then never made it into the generated import block and the bundled component crashed at runtime with `ReferenceError: __flushMountFrame is not defined` as soon as it tried to render under SSR.
+
+`strip_comments` now detects regex literals (using the preceding-token heuristic — `/` after `)`, `]`, `}`, or an expression-valued identifier is division; anything else that isn't a `//` or `/*` comment starts a regex) and copies the regex body verbatim. Fixes pre-render for routes that transitively rendered `packages/landing/src/components/features.tsx` (vertz.dev `/` and `/openapi`), which reached the landing page as the inner repro from #2878.
+
+Also adds a List SSR regression test in `@vertz/ui-primitives` covering `<List><List.Item/></List>` end-to-end through `ssrRenderSinglePass` so the Provider/context flow the original ticket worried about is exercised on the server path.

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -190,6 +190,18 @@ fn strip_comments(code: &str) -> String {
                 }
                 continue;
             }
+            // `/` that's not a comment may start a regex literal. If so, skip
+            // it verbatim — otherwise a backtick INSIDE the regex body (e.g.
+            // `/`([^`]+)`/`) would be misread as a template-literal opener and
+            // swallow every helper call that follows. See #2878.
+            if is_regex_start(&chars, i) {
+                let end = skip_regex_literal(&chars, i);
+                for &c in &chars[i..end] {
+                    result.push(c);
+                }
+                i = end;
+                continue;
+            }
         }
 
         // Replace string literal contents with spaces to avoid false matches.
@@ -221,6 +233,123 @@ fn strip_comments(code: &str) -> String {
     }
 
     result
+}
+
+/// Decide whether `/` at `pos` starts a regex literal (versus a division
+/// operator). Uses the classic heuristic: if the previous non-whitespace
+/// character produces an expression value (identifier, number, `)`, `]`, `}`),
+/// `/` is division; otherwise it starts a regex.
+fn is_regex_start(chars: &[char], pos: usize) -> bool {
+    if pos + 1 >= chars.len() {
+        return false;
+    }
+    let next = chars[pos + 1];
+    // Comment starts are handled earlier; a regex body can't begin with `*`.
+    if next == '/' || next == '*' {
+        return false;
+    }
+    // An empty regex `//` is rejected above. A single `/` at EOF falls through.
+
+    // Walk backwards to the previous non-whitespace char.
+    let mut j = pos;
+    loop {
+        if j == 0 {
+            // No preceding token — we're at the top of the file, which is a
+            // valid regex context (e.g. an expression statement).
+            return true;
+        }
+        j -= 1;
+        if !chars[j].is_whitespace() {
+            break;
+        }
+    }
+    let prev = chars[j];
+    // Characters that end an expression value — a `/` after these is division.
+    if prev.is_ascii_alphanumeric() || prev == '_' || prev == '$' {
+        // Could still be a keyword (return, typeof, etc.) — check the token.
+        let token_end = j + 1;
+        let mut token_start = token_end;
+        while token_start > 0 {
+            let c = chars[token_start - 1];
+            if c.is_ascii_alphanumeric() || c == '_' || c == '$' {
+                token_start -= 1;
+            } else {
+                break;
+            }
+        }
+        let token: String = chars[token_start..token_end].iter().collect();
+        // Keywords that take an expression afterwards → the `/` starts a regex.
+        matches!(
+            token.as_str(),
+            "return"
+                | "typeof"
+                | "instanceof"
+                | "in"
+                | "of"
+                | "delete"
+                | "void"
+                | "new"
+                | "throw"
+                | "yield"
+                | "await"
+                | "case"
+                | "do"
+                | "else"
+        )
+    } else {
+        // Division follows `)`, `]`, `}` — otherwise it's a regex.
+        !matches!(prev, ')' | ']' | '}')
+    }
+}
+
+/// Scan a regex literal starting at `start` (which points at the opening `/`).
+/// Returns the index just past the closing `/` and any flags. If the regex is
+/// unterminated, returns the end of the line (regex literals can't span
+/// newlines outside a character class).
+///
+/// The caller copies the spanned range VERBATIM into the stripped output —
+/// that's intentional and load-bearing. `is_regex_start` is a heuristic and
+/// returns `true` for a few false positives (e.g. `i++ / 2`). Keeping the
+/// "regex" body verbatim means helper calls inside a false-positive body
+/// still get detected by `contains_standalone_call`, so the outcome stays
+/// correct even when the classification is wrong. Don't switch to erasing
+/// the body with spaces without first tightening the heuristic.
+fn skip_regex_literal(chars: &[char], start: usize) -> usize {
+    let len = chars.len();
+    debug_assert_eq!(chars[start], '/');
+    let mut i = start + 1;
+    let mut in_char_class = false;
+    while i < len {
+        match chars[i] {
+            '\\' if i + 1 < len => {
+                // Escape sequence — skip next char verbatim
+                i += 2;
+            }
+            '[' => {
+                in_char_class = true;
+                i += 1;
+            }
+            ']' if in_char_class => {
+                in_char_class = false;
+                i += 1;
+            }
+            '/' if !in_char_class => {
+                i += 1;
+                // Consume flag characters
+                while i < len && chars[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                return i;
+            }
+            '\n' => {
+                // Unterminated regex — stop at the newline so we don't eat
+                // more of the file than necessary.
+                return i;
+            }
+            _ => i += 1,
+        }
+    }
+    i
 }
 
 /// Check if `name(` appears as a standalone call (not a method call like `obj.name(`
@@ -613,6 +742,61 @@ mod tests {
         let code = r#"const x = "computed(() => v)";"#;
         let result = inject(code);
         assert_eq!(result, code);
+    }
+
+    #[test]
+    fn backtick_in_regex_does_not_eat_rest_of_file() {
+        // Regex literals may contain literal backticks (e.g. `/`([^`]+)`/`).
+        // Before the fix, the scanner entered template-literal mode at the
+        // first backtick and kept scanning for a closing backtick to EOF,
+        // erasing every helper call that followed. See #2878.
+        let code = "
+function RichText(text) {
+  const parts = text.split(/`([^`]+)`/);
+  return parts.map((p) => p);
+}
+export function Features() {
+  __element('section');
+  __flushMountFrame();
+}
+";
+        let result = inject(code);
+        assert!(
+            result.contains("__element") && result.contains("__flushMountFrame"),
+            "expected both helpers to be injected; got: {result}"
+        );
+    }
+
+    #[test]
+    fn division_after_identifier_is_not_regex() {
+        // Regression guard: `a / b` must not be treated as a regex literal,
+        // otherwise normal division expressions would trigger regex-skipping.
+        let code = "function f() { const a = 10; const b = 2; const c = a / b; __element('div'); }";
+        let result = inject(code);
+        assert!(result.contains("__element"), "got: {result}");
+    }
+
+    #[test]
+    fn slash_inside_regex_char_class_does_not_terminate_scan() {
+        // `/[/]/` — the `/` inside the character class must NOT close the
+        // regex early; if it did, the rest of the literal would be parsed
+        // as source and the trailing `/` would (wrongly) start another regex.
+        let code = "function f() { const r = /[/]/; __element('div'); }";
+        let result = inject(code);
+        assert!(result.contains("__element"), "got: {result}");
+    }
+
+    #[test]
+    fn unterminated_regex_at_newline_stops_scan_at_newline() {
+        // Syntactically invalid source: a `/` that looks like a regex start
+        // but never terminates on the same line. The scanner must stop at
+        // `\n` so that helpers on later lines still get detected.
+        let code = "function broken() { const r = /oops\n__element('div');\n}";
+        let result = inject(code);
+        assert!(
+            result.contains("__element"),
+            "expected later-line helpers to still be detected; got: {result}"
+        );
     }
 
     // ── All DOM helpers detected ───────────────────────────────────

--- a/packages/ui-primitives/src/list/__tests__/list-ssr.test.tsx
+++ b/packages/ui-primitives/src/list/__tests__/list-ssr.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * SSR rendering for the List primitive.
+ *
+ * Exercises the SSR pipeline that `vertz build` uses for pre-rendering, so
+ * Provider-based context propagation between `<List>` and `<List.Item>` is
+ * covered end-to-end on the server side (#2878).
+ */
+
+import { describe, expect, it } from '@vertz/test';
+import { installDomShim } from '@vertz/ui-server/dom-shim';
+import { ssrRenderSinglePass } from '@vertz/ui-server';
+import { ComposedList as List } from '../list-composed';
+
+installDomShim();
+
+describe('Feature: List primitive SSR rendering', () => {
+  describe('Given <List><List.Item /></List> in a page component', () => {
+    describe('When pre-rendering via the SSR pipeline', () => {
+      it('then the route pre-renders and emits both the <ul> and <li> children', async () => {
+        const module = {
+          default: () => (
+            <List>
+              <List.Item>first</List.Item>
+              <List.Item>second</List.Item>
+            </List>
+          ),
+        };
+
+        const result = await ssrRenderSinglePass(module, '/');
+
+        expect(result.html).toContain('<ul');
+        expect(result.html).toContain('<li');
+        expect(result.html).toContain('first');
+        expect(result.html).toContain('second');
+      });
+
+      it('then items produced by .map() render through the List context', async () => {
+        const items = [
+          { id: 1, text: 'one' },
+          { id: 2, text: 'two' },
+        ];
+        const module = {
+          default: () => (
+            <List animate={{ duration: 200, easing: 'ease-out' }}>
+              {items.map((item) => (
+                <List.Item key={item.id}>{item.text}</List.Item>
+              ))}
+            </List>
+          ),
+        };
+
+        const result = await ssrRenderSinglePass(module, '/');
+
+        expect(result.html).toContain('<ul');
+        expect(result.html).toContain('one');
+        expect(result.html).toContain('two');
+      });
+    });
+  });
+
+  describe('Given <List.Item /> rendered WITHOUT a parent <List>', () => {
+    describe('When pre-rendering', () => {
+      it('then it still throws the descriptive error (no regression)', async () => {
+        const module = {
+          default: () => <List.Item>orphan</List.Item>,
+        };
+
+        await expect(ssrRenderSinglePass(module, '/')).rejects.toThrow(
+          /List\.Item must be used inside a <List>/,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes pre-render failure of vertz.dev `/` and `/openapi` reported as "`List.Item must be used inside a <List> component`" in #2878.
- Root cause is a scanner bug in the native compiler's `import_injection::strip_comments`: a backtick inside a regex body like ``text.split(/`([^`]+)`/)`` in `packages/landing/src/components/features.tsx` was treated as a template-literal opener, swallowing the rest of the file as "string content". Every DOM-helper call (`__element`, `__flushMountFrame`, `__discardMountFrame`, …) that appeared after the regex was hidden from the injector, so Features compiled without those imports and threw `ReferenceError: __flushMountFrame is not defined` at pre-render time — which unwound the tree and the user saw the less-informative List error as the bubbled-up symptom.
- `strip_comments` now detects JS regex literals using the classic "previous non-whitespace token" heuristic and copies the regex body verbatim (deliberate — see [comment on `skip_regex_literal`](https://github.com/vertz-dev/vertz/blob/fix/2878-list-context-ssr/native/vertz-compiler-core/src/import_injection.rs#L239-L253); copy-verbatim is load-bearing so false-positive regex classifications still detect helpers inside the "regex" body).
- Adds an SSR regression test for `<List><List.Item/></List>` through `ssrRenderSinglePass` — covers the ticket's requested "Unit / hydration test covers the SSR path for List context" criterion and locks in that the Provider/context flow the issue worried about actually works on the server path.

## Public API Changes

None. Pure compile-pipeline bug fix plus a test file in `@vertz/ui-primitives`.

## Review

Adversarial review written locally at `reviews/2878-list-context-ssr/phase-01-strip-comments-regex.md` (not pushed — working artifact). **Approved, no blockers, no should-fix findings.** Reviewer probed 15+ adversarial patterns (increment/decrement adjacent to `/`, TypeScript casts, template-expression division, JSX expression containers, char-class `/[/]/`, unterminated regex at EOF, `const re = /batch(foo)/`) and confirmed outcomes are correct. Nits 3/5/6 were addressed in the committed code (added comment on the "copy-verbatim is load-bearing" invariant, plus direct tests for `skip_regex_literal`'s char-class branch and unterminated-at-newline case).

## Verification

- `cargo test --package vertz-compiler-core` — 75 passed (75 in `import_injection::tests`, up from 71 baseline).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `vtz test packages/ui-primitives/src/list/__tests__/` — 66 passed including 3 new SSR tests.
- `vtz test packages/ui-server/src/__tests__/` — 972 passed / 59 skipped / 15 todo (baseline). No new failures.
- Landing build: `/`, `/manifesto`, `/openapi` all pre-render successfully. `dist/client/index.html` contains 1 `<ul>` + 15 `<li>` elements, zero `"must be used inside"` errors.
- The pre-existing 36 Calendar/DatePicker test failures exist on plain `origin/main` without this change (verified via `git stash`) — happy-dom `replaceChildren is not a function`. Unrelated.

## Test plan

- [x] Rust unit tests for the new scanner branch
- [x] SSR regression test for `<List><List.Item/></List>` via `ssrRenderSinglePass`
- [x] End-to-end landing build pre-renders `/` successfully
- [ ] Reviewer confirms the fix holds up against their own adversarial patterns

Closes #2878

🤖 Generated with [Claude Code](https://claude.com/claude-code)