### PR TITLE
fix(landing): replace array-wrapped css() blocks with plain objects

### DIFF
--- a/packages/landing/src/components/benchmarks.tsx
+++ b/packages/landing/src/components/benchmarks.tsx
@@ -45,8 +45,8 @@ const s = css({
       'color 150ms cubic-bezier(0.4, 0, 0.2, 1), background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), border-color 150ms cubic-bezier(0.4, 0, 0.2, 1), outline-color 150ms cubic-bezier(0.4, 0, 0.2, 1), text-decoration-color 150ms cubic-bezier(0.4, 0, 0.2, 1), fill 150ms cubic-bezier(0.4, 0, 0.2, 1), stroke 150ms cubic-bezier(0.4, 0, 0.2, 1)',
     '&': { background: 'none', border: 'none', outline: 'none', borderRadius: '2px' },
   },
-  panelWrap: [{ '&': { display: 'grid' } }],
-  panel: [],
+  panelWrap: { display: 'grid' },
+  panel: {},
   card: { padding: token.spacing[6], borderWidth: '1px' },
   barGroup: { display: 'flex', flexDirection: 'column', gap: token.spacing[3] },
   barRow: { display: 'flex', flexDirection: 'column', gap: token.spacing[1] },
@@ -54,7 +54,7 @@ const s = css({
   barName: { fontSize: token.font.size.xs },
   barValue: { fontSize: token.font.size.xs },
   barTrack: { position: 'relative' },
-  barFill: [],
+  barFill: {},
   footnote: { fontSize: token.font.size.xs, textAlign: 'center', marginTop: token.spacing[8] },
 });
 

--- a/packages/landing/src/components/features.tsx
+++ b/packages/landing/src/components/features.tsx
@@ -63,8 +63,8 @@ const s = css({
       padding: '0.75rem 1rem',
     },
   },
-  content: [{ '&': { display: 'grid', position: 'relative', 'min-width': '0' } }],
-  page: { display: 'flex', flexDirection: 'column', gap: token.spacing[6], '&': { minWidth: '0' } },
+  content: { display: 'grid', position: 'relative', minWidth: '0' },
+  page: { display: 'flex', flexDirection: 'column', gap: token.spacing[6], minWidth: '0' },
   pageTag: { fontSize: token.font.size.xs, letterSpacing: '0.1em', textTransform: 'uppercase' },
   pageTitle: {
     fontSize: token.font.size.xl,

--- a/packages/landing/src/components/get-started.tsx
+++ b/packages/landing/src/components/get-started.tsx
@@ -19,9 +19,9 @@ const s = css({
     '&': { overflowX: 'auto', borderRadius: '2px' },
   },
   terminalLine: { marginBottom: token.spacing[2] },
-  terminalCmd: [],
+  terminalCmd: {},
   successLine: { marginTop: token.spacing[4] },
-  success: [],
+  success: {},
 });
 
 export function GetStarted() {

--- a/packages/landing/src/components/glue-code.tsx
+++ b/packages/landing/src/components/glue-code.tsx
@@ -20,7 +20,7 @@ const s = css({
     '&': { minWidth: '0' },
     '@media (min-width: 768px)': { gridTemplateColumns: '1fr 1fr' },
   },
-  gridItem: [{ '&': { 'min-width': '0' } }],
+  gridItem: { minWidth: '0' },
   columnLabel: {
     fontSize: token.font.size.xs,
     textTransform: 'uppercase',

--- a/packages/landing/src/components/openapi-features.tsx
+++ b/packages/landing/src/components/openapi-features.tsx
@@ -63,8 +63,8 @@ const s = css({
       padding: '0.75rem 1rem',
     },
   },
-  content: [{ '&': { display: 'grid', position: 'relative', 'min-width': '0' } }],
-  page: { display: 'flex', flexDirection: 'column', gap: token.spacing[6], '&': { minWidth: '0' } },
+  content: { display: 'grid', position: 'relative', minWidth: '0' },
+  page: { display: 'flex', flexDirection: 'column', gap: token.spacing[6], minWidth: '0' },
   pageTag: { fontSize: token.font.size.xs, letterSpacing: '0.1em', textTransform: 'uppercase' },
   pageTitle: {
     fontSize: token.font.size.xl,


### PR DESCRIPTION
## Summary

Five \`css()\` calls on the landing used \`[{ '&': { ... } }]\` instead of a plain object. The native CSS extractor only walks object-valued blocks — an array value makes the whole call classify as Reactive, so no CSS gets emitted at build time and every class name on that sheet resolves with no rules.

The most visible symptom: the Features section's \`.content\` needed \`display: grid\` to stack the six tab pages in one grid cell. With no styles emitted they flowed vertically and the section ballooned to ~5× its intended height. Same shape was also hiding styles in OpenAPI features (tabs), Benchmarks (\`panelWrap\` grid), Glue Code (grid item \`min-width\`), and Get Started (empty placeholder classes).

Fix: replace \`[{ '&': {...} }]\` with \`{...}\` and normalize the \`'min-width'\` kebab-case keys that rode along → \`minWidth\`.

## Test plan

- [x] Fresh \`bun run build\` — features class now emits \`display: grid; position: relative; min-width: 0;\`
- [x] Local wrangler preview: Features section shows one active tab (\`01 Auto Field Selection\`) with the rest stacked behind in the same grid cell; section height ~930px instead of ~5000px; tab switching still works via the Island.

## Public API Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)