### PR TITLE
fix(vertz): auto-load import.meta.hot types from client-runtime subpaths [#2893]

### DIFF
--- a/.changeset/auto-load-import-meta-hot-types.md
+++ b/.changeset/auto-load-import-meta-hot-types.md
@@ -1,0 +1,13 @@
+---
+'vertz': patch
+---
+
+fix(vertz): auto-load `import.meta.hot` types when importing from any client-runtime subpath
+
+Closes [#2893](https://github.com/vertz-dev/vertz/issues/2893).
+
+The `vertz/client` type augmentation existed but required users to manually add `"types": ["vertz/client"]` to their tsconfig — a step easy to miss, leading to the TS2339 "Property 'hot' does not exist on type 'ImportMeta'" error reported in #2777 and then again in #2893.
+
+The client-runtime subpath declarations (`dist/ui.d.ts`, `dist/ui-components.d.ts`, `dist/ui-primitives.d.ts`, `dist/ui-auth.d.ts`) now start with `/// <reference types="vertz/client" />`, injected by a post-`tsc` step (`scripts/inject-client-reference.mjs`). Any file that imports from one of those subpaths — which includes every `create-vertz-app` scaffold's `entry-client.ts` — pulls in the `ImportMeta.hot` augmentation automatically, so `import.meta.hot?.accept()` typechecks with no tsconfig changes. Declaration sourcemaps are shifted by one line to stay accurate.
+
+The `"types": ["vertz/client"]` opt-in still works for cases where a file uses `import.meta.hot` without touching any of those subpaths.

--- a/packages/mint-docs/guides/hmr-types.mdx
+++ b/packages/mint-docs/guides/hmr-types.mdx
@@ -3,11 +3,14 @@ title: HMR Types (`import.meta.hot`)
 description: 'Type `import.meta.hot` in a Vertz app using the `vertz/client` augmentation.'
 ---
 
-When you write `import.meta.hot?.accept()` in a Vertz app, TypeScript may complain that `hot` doesn't exist on `ImportMeta`. Add the framework's client-side type augmentation to your tsconfig.
+`import.meta.hot` is typed as `ImportMetaHot | undefined` as soon as any file in your app imports from one of the client-runtime subpaths (`vertz/ui`, `vertz/ui/components`, `vertz/ui-primitives`, `vertz/ui-auth`). Their declarations carry a triple-slash reference that auto-loads the `vertz/client` augmentation.
 
-## The fix
+## Explicit opt-in (optional)
+
+If a file uses `import.meta.hot` without importing from any of those subpaths (e.g. a standalone client entry that only imports from `@vertz/ui` directly), wire the types up explicitly:
 
 ```jsonc
+// tsconfig.json
 {
   "compilerOptions": {
     "types": ["vertz/client"],
@@ -15,9 +18,14 @@ When you write `import.meta.hot?.accept()` in a Vertz app, TypeScript may compla
 }
 ```
 
-Newly-scaffolded apps (via `create-vertz-app`) already include this — you only need to add it if you're setting up a Vertz app by hand, or you previously used the old `vertz/env` name.
+Or, per-file:
 
-Once `vertz/client` is in `types`, `import.meta.hot` is typed as `ImportMetaHot | undefined`.
+```ts
+/// <reference types="vertz/client" />
+import.meta.hot?.accept();
+```
+
+Newly-scaffolded apps (via `create-vertz-app`) already include the tsconfig entry.
 
 ## The `ImportMetaHot` surface
 

--- a/packages/vertz/__tests__/subpath-exports.test.ts
+++ b/packages/vertz/__tests__/subpath-exports.test.ts
@@ -142,6 +142,17 @@ describe('exports point to built artifacts', () => {
     expect(pkg.exports['./env']).toBeUndefined();
     expect(fs.existsSync(path.resolve(import.meta.dirname, '..', 'env.d.ts'))).toBe(false);
   });
+
+  it.each(['ui.d.ts', 'ui-components.d.ts', 'ui-primitives.d.ts', 'ui-auth.d.ts'])(
+    'dist/%s carries a triple-slash reference to vertz/client so ImportMeta.hot types auto-load',
+    async (file) => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const dts = path.resolve(import.meta.dirname, '..', 'dist', file);
+      const contents = fs.readFileSync(dts, 'utf-8');
+      expect(contents.startsWith('/// <reference types="vertz/client" />\n')).toBe(true);
+    },
+  );
 });
 
 describe('tree-shaking: subpaths are independent modules', () => {

--- a/packages/vertz/package.json
+++ b/packages/vertz/package.json
@@ -104,7 +104,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/inject-client-reference.mjs",
     "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json",
     "test": "vtz test"
   },

--- a/packages/vertz/scripts/inject-client-reference.mjs
+++ b/packages/vertz/scripts/inject-client-reference.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Prepend `/// <reference types="vertz/client" />` to every client-runtime
+ * `.d.ts` that users routinely import from. `tsc` strips the directive when
+ * the source (a bare `export * from '@vertz/*'`) doesn't use anything from
+ * `client.d.ts`, so we inject post-build. Any file that imports from one of
+ * these subpaths then pulls in the `ImportMeta.hot` augmentation automatically
+ * (#2893) — no tsconfig change required.
+ *
+ * The `.d.ts.map` mappings are shifted by one line so go-to-definition still
+ * lands correctly after the prepend.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIRECTIVE = '/// <reference types="vertz/client" />';
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const distDir = join(packageRoot, 'dist');
+
+// Client-runtime subpaths. Server-only subpaths (server, db, schema, cloudflare,
+// tui, fetch, errors, testing, ui-compiler, ui-server, ui-server-build-plugin)
+// don't need HMR types.
+const targets = ['ui.d.ts', 'ui-components.d.ts', 'ui-primitives.d.ts', 'ui-auth.d.ts'];
+
+for (const target of targets) {
+  const dtsPath = join(distDir, target);
+  if (!existsSync(dtsPath)) {
+    console.error(`[inject-client-reference] ${target} missing — did tsc run first?`);
+    process.exit(1);
+  }
+
+  const contents = readFileSync(dtsPath, 'utf-8');
+  if (contents.startsWith(DIRECTIVE)) continue;
+
+  writeFileSync(dtsPath, `${DIRECTIVE}\n${contents}`);
+
+  // Shift the sourcemap's `mappings` field by one line so declarationMap
+  // stays accurate after the prepend. Mappings uses `;` as the line
+  // separator — adding one extra `;` at the start offsets everything by 1.
+  const mapPath = `${dtsPath}.map`;
+  if (existsSync(mapPath)) {
+    const map = JSON.parse(readFileSync(mapPath, 'utf-8'));
+    if (typeof map.mappings === 'string') {
+      map.mappings = `;${map.mappings}`;
+      writeFileSync(mapPath, JSON.stringify(map));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2893 (follow-up to #2777).

The `vertz/client` augmentation shipped in #2822 required users to add `"types": ["vertz/client"]` to their tsconfig — easy to miss, so the issue came back.

Post-`tsc` step prepends `/// <reference types="vertz/client" />` to every client-runtime `.d.ts` (`dist/ui.d.ts`, `dist/ui-components.d.ts`, `dist/ui-primitives.d.ts`, `dist/ui-auth.d.ts`). Any file importing from one of those subpaths now pulls in the `ImportMeta.hot` types automatically, so `import.meta.hot?.accept()` typechecks with no tsconfig changes. Declaration sourcemaps are shifted by one line so go-to-definition still lands correctly.

The explicit `"types": ["vertz/client"]` opt-in still works for files that don't touch those subpaths.

## Public API Changes

**Additive only:**
- Client-runtime `.d.ts` files carry a triple-slash reference to `vertz/client`. Transparent to callers.

## Why post-build injection

Inlining `declare global { interface ImportMeta { hot: ImportMetaHot | undefined } }` in `packages/vertz/src/ui.ts` collides with `bun-types`' own `ImportMeta.hot` during the monorepo's typecheck. Leaving the augmentation in `packages/vertz/client.d.ts` (out of any package's `include`) and injecting the reference post-build keeps the monorepo's typecheck clean while still surfacing the types to consumers.

## Verification

Manual end-to-end repro with `vertz@0.2.75` from npm:

- **Before fix** — `import.meta.hot.accept()` → `TS2339: Property 'hot' does not exist on type 'ImportMeta'.`
- **After fix (unguarded)** — `TS2532: Object is possibly 'undefined'` (the correct error, directing the user to `?.accept()`).
- **After fix (guarded)** — clean typecheck, no tsconfig changes required.

## Test plan

- [x] `vtz test` — `packages/vertz/__tests__/subpath-exports.test.ts` asserts each target `.d.ts` starts with the directive
- [x] `vtz ci build-typecheck` — full monorepo build + typecheck green
- [x] Pre-push hook (lint + oxfmt + full build-typecheck + full test + trojan-source) — all green
- [x] End-to-end repro with `vertz@0.2.75` from npm, patched `dist/ui.d.ts` → TS2339 gone
- [ ] GitHub CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)