### PR TITLE
feat(db): typed JSONB operators — path() + jsonContains / jsonContainedBy / hasKey [#2868]

### DIFF
--- a/.changeset/jsonb-typed-operators.md
+++ b/.changeset/jsonb-typed-operators.md
@@ -1,0 +1,19 @@
+---
+'@vertz/db': patch
+---
+
+feat(db): typed JSONB operators — `path()` builder, `jsonContains`, `jsonContainedBy`, `hasKey`
+
+Closes [#2868](https://github.com/vertz-dev/vertz/issues/2868).
+
+Adds the typed JSONB operator surface deferred from #2850:
+
+- **Typed `path()` builder** — `path((m: T) => m.x.y).eq(value)` preserves the payload's leaf type through the selector. Operator availability is conditional on the leaf: `contains` / `startsWith` / `endsWith` on strings, `gt` / `gte` / `lt` / `lte` on numbers, `bigint`, and `Date`. Numeric array indexing emits integer segments unquoted (`->0`), matching Postgres JSONB array semantics.
+- **Whole-payload operators** — `jsonContains` (emits `@>`, operand is `DeepPartial<T>` capped at depth 5), `jsonContainedBy` (emits `<@`), `hasKey` (emits `?`, operand is `keyof T & string` via a union-safe `JsonbKeyOf<T>` helper).
+- **Dialect gating** reuses the keyed-never brand mechanism from #2850. On SQLite, attempting any of these operators fails at compile time with `JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` — the type name IS the recovery sentence. Same diagnostic appears in `d.jsonb` JSDoc and mint-docs verbatim.
+
+The new `path` export lives at the package root (`import { path } from '@vertz/db'`). The string-keyed path filter (`'meta->k'`) remains as an escape hatch for dynamic paths; prefer `path()` for static paths.
+
+Follow-ups filed: #2885 (array-operator type gating), #2886 (`hasAllKeys` / `hasAnyKey`).
+
+**Callout for consumers with custom helpers over `FilterType<TColumns>`:** the column-value branch for JSONB columns is now `JsonbColumnValue<T, TDialect>` instead of the generic `ColumnFilterOperators`. Helpers that destructure or remap `FilterType` for JSONB columns may need minor adjustment to accept the new operator surface.

--- a/packages/db/src/__tests__/path.test.ts
+++ b/packages/db/src/__tests__/path.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@vertz/test';
+import { path } from '../path';
+
+describe('path() — Proxy-based selector', () => {
+  describe('segment recording', () => {
+    it('records a single top-level key', () => {
+      interface T {
+        a: string;
+      }
+      const d = path((m: T) => m.a).eq('x');
+      expect(d._tag).toBe('JsonbPathDescriptor');
+      expect(d.segments).toEqual([{ kind: 'key', value: 'a' }]);
+      expect(d.op).toEqual({ eq: 'x' });
+    });
+
+    it('records a nested path', () => {
+      interface T {
+        a: { b: { c: string } };
+      }
+      const d = path((m: T) => m.a.b.c).eq('x');
+      expect(d.segments).toEqual([
+        { kind: 'key', value: 'a' },
+        { kind: 'key', value: 'b' },
+        { kind: 'key', value: 'c' },
+      ]);
+    });
+
+    it('records integer segments as index kind for numeric array access', () => {
+      interface T {
+        tags: readonly string[];
+      }
+      const d = path((m: T) => m.tags[0]).eq('urgent');
+      expect(d.segments).toEqual([
+        { kind: 'key', value: 'tags' },
+        { kind: 'index', value: 0 },
+      ]);
+    });
+
+    it('treats leading-zero strings as text keys, not integer indices', () => {
+      interface T {
+        [k: string]: string;
+      }
+      const d = path((m: T) => m['007']).eq('agent');
+      expect(d.segments).toEqual([{ kind: 'key', value: '007' }]);
+    });
+  });
+
+  describe('terminal operators', () => {
+    it('ne produces { ne: value }', () => {
+      const d = path((m: { a: string }) => m.a).ne('x');
+      expect(d.op).toEqual({ ne: 'x' });
+    });
+
+    it('gt produces { gt: value }', () => {
+      const d = path((m: { a: number }) => m.a).gt(5);
+      expect(d.op).toEqual({ gt: 5 });
+    });
+
+    it('in produces { in: values }', () => {
+      const d = path((m: { a: string }) => m.a).in(['x', 'y']);
+      expect(d.op).toEqual({ in: ['x', 'y'] });
+    });
+
+    it('contains produces { contains: value }', () => {
+      const d = path((m: { a: string }) => m.a).contains('sub');
+      expect(d.op).toEqual({ contains: 'sub' });
+    });
+
+    it('isNull(true) produces { isNull: true }', () => {
+      const d = path((m: { a: string | null }) => m.a).isNull(true);
+      expect(d.op).toEqual({ isNull: true });
+    });
+  });
+
+  describe('hostile-callback safety', () => {
+    it('ignores Symbol keys (Symbol.toPrimitive, iterator, etc.)', () => {
+      interface T {
+        a: string;
+      }
+      // @ts-expect-error — intentionally abuse the proxy
+      const d = path(
+        (m: T) => ((m as unknown as { [Symbol.iterator]: unknown })[Symbol.iterator], m.a),
+      ).eq('x');
+      // Symbol access should not contaminate segments.
+      expect(d.segments).toEqual([{ kind: 'key', value: 'a' }]);
+    });
+
+    it('ignores internal string keys (then, toString, valueOf, etc.)', () => {
+      interface T {
+        a: string;
+      }
+      // Accessing .toString on the proxy should not be recorded as a segment.
+      const d = path((m: T) => {
+        // @ts-expect-error — probing internals intentionally
+        const _ = m.toString;
+        return m.a;
+      }).eq('x');
+      expect(d.segments).toEqual([{ kind: 'key', value: 'a' }]);
+    });
+
+    it('does not record toJSON access', () => {
+      interface T {
+        a: string;
+      }
+      const d = path((m: T) => {
+        // @ts-expect-error — probing internals intentionally
+        const _ = m.toJSON;
+        return m.a;
+      }).eq('x');
+      expect(d.segments).toEqual([{ kind: 'key', value: 'a' }]);
+    });
+  });
+});

--- a/packages/db/src/__tests__/path.test.ts
+++ b/packages/db/src/__tests__/path.test.ts
@@ -110,4 +110,30 @@ describe('path() — Proxy-based selector', () => {
       expect(d.segments).toEqual([{ kind: 'key', value: 'a' }]);
     });
   });
+
+  describe('invalid selectors throw with a descriptive message', () => {
+    it('rejects m.a + m.b (arithmetic) instead of emitting garbage segments', () => {
+      interface T {
+        a: number;
+        b: number;
+      }
+      expect(() => path((m: T) => m.a + m.b).eq(1)).toThrow(/direct property access/);
+    });
+
+    it('rejects `m` with no property access (depth zero)', () => {
+      interface T {
+        a: string;
+      }
+      // @ts-expect-error — m is not assignable to PathChain, but we probe runtime
+      expect(() => path((m: T) => m).eq('x')).toThrow();
+    });
+
+    it('rejects a selector returning a constant', () => {
+      interface T {
+        a: string;
+      }
+      // @ts-expect-error — 'const' is not a TLeaf — probing runtime
+      expect(() => path((_m: T) => 'const').eq('x')).toThrow(/direct property access/);
+    });
+  });
 });

--- a/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
+++ b/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
@@ -148,6 +148,40 @@ const pgPathArrayIndex: FilterType<InstallColumns, 'postgres'> = {
 };
 void pgPathArrayIndex;
 
+// String leaf exposes contains/startsWith/endsWith.
+const pgPathStringContains: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.displayName).contains('Ac'),
+};
+void pgPathStringContains;
+
+// ---------------------------------------------------------------------------
+// path() — per-leaf operator narrowing (negatives)
+// ---------------------------------------------------------------------------
+
+// .contains() is not available on numeric leaves.
+const pgPathNumContains: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.settings.count)
+    // @ts-expect-error — contains is not available on number leaf
+    .contains('1'),
+};
+void pgPathNumContains;
+
+// .gt() is not available on string leaves (use eq / ne / in / contains).
+const pgPathStringGt: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.settings.theme)
+    // @ts-expect-error — gt is not available on string leaf
+    .gt('dark'),
+};
+void pgPathStringGt;
+
+// .startsWith() is not available on numeric leaves.
+const pgPathNumStartsWith: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.settings.count)
+    // @ts-expect-error — startsWith is not available on number leaf
+    .startsWith('1'),
+};
+void pgPathNumStartsWith;
+
 // Path descriptor assignable on a path-shaped string key too (cross-form
 // doesn't apply — descriptors go into the column slot, not the 'col->k' slot).
 
@@ -227,4 +261,78 @@ void pgDb.install.list({
   where: {
     meta: { hasKey: 'settings' },
   },
+});
+
+// ---------------------------------------------------------------------------
+// Collision — hasKey on a payload whose natural keys collide with operator names
+// ---------------------------------------------------------------------------
+//
+// When the user DOES write `{ hasKey: ... }` on the collision payload, the
+// operand is restricted to `JsonbKeyOf<CollisionPayload>` = 'jsonContains' | 'hasKey'.
+// Direct equality against the payload is covered by `pgCollisionDirect` above;
+// this case confirms the operator-form still type-checks with a valid key.
+
+const pgCollisionHasKey: FilterType<InstallColumns, 'postgres'> = {
+  coll: { hasKey: 'jsonContains' },
+};
+void pgCollisionHasKey;
+
+const pgCollisionHasKeyInvalid: FilterType<InstallColumns, 'postgres'> = {
+  // @ts-expect-error — 'bogus' is not a key of CollisionPayload
+  coll: { hasKey: 'bogus' },
+};
+void pgCollisionHasKeyInvalid;
+
+// ---------------------------------------------------------------------------
+// Inference-perf canary — 20 JSONB-heavy models typecheck under budget
+// ---------------------------------------------------------------------------
+
+interface CanaryMeta {
+  a: string;
+  b: { c: number };
+}
+
+const canaryFor = <TName extends string>(name: TName) =>
+  d.table(name, {
+    id: d.uuid().primary({ generate: 'cuid' }),
+    title: d.text(),
+    meta: d.jsonb<CanaryMeta>(),
+  });
+
+const canaryModels = {
+  c01: d.model(canaryFor('c01')),
+  c02: d.model(canaryFor('c02')),
+  c03: d.model(canaryFor('c03')),
+  c04: d.model(canaryFor('c04')),
+  c05: d.model(canaryFor('c05')),
+  c06: d.model(canaryFor('c06')),
+  c07: d.model(canaryFor('c07')),
+  c08: d.model(canaryFor('c08')),
+  c09: d.model(canaryFor('c09')),
+  c10: d.model(canaryFor('c10')),
+  c11: d.model(canaryFor('c11')),
+  c12: d.model(canaryFor('c12')),
+  c13: d.model(canaryFor('c13')),
+  c14: d.model(canaryFor('c14')),
+  c15: d.model(canaryFor('c15')),
+  c16: d.model(canaryFor('c16')),
+  c17: d.model(canaryFor('c17')),
+  c18: d.model(canaryFor('c18')),
+  c19: d.model(canaryFor('c19')),
+  c20: d.model(canaryFor('c20')),
+};
+
+const canaryDb = createDb({
+  dialect: 'postgres',
+  url: 'postgres://u:p@localhost/db',
+  models: canaryModels,
+  _queryFn: (async () => ({ rows: [], rowCount: 0 })) as never,
+});
+
+// Exercise the JSONB column-value branch across several delegate options —
+// if threading blew up inference, tsgo compile time would balloon here.
+void canaryDb.c01.list({ where: { meta: { jsonContains: { a: 'x' } } } });
+void canaryDb.c10.list({ where: { meta: { hasKey: 'a' } } });
+void canaryDb.c20.list({
+  where: { meta: path((m: CanaryMeta) => m.b.c).gt(5) },
 });

--- a/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
+++ b/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
@@ -1,0 +1,230 @@
+/**
+ * Type-level tests for typed JSONB operators (#2868):
+ * - Payload operators: `jsonContains`, `jsonContainedBy`, `hasKey`.
+ * - Typed `path()` builder with leaf-type-driven operator availability.
+ * - Dialect gating via the `JsonbOperator_Error_…` brand on SQLite.
+ *
+ * Negatives use `@ts-expect-error` — if the directive becomes unused, the
+ * test fails, catching regressions that loosen the type surface.
+ */
+
+import { d } from '../../d';
+import { path } from '../../path';
+import type { FilterType } from '../../schema/inference';
+import { createDb } from '../database';
+
+interface InstallMeta {
+  displayName: string;
+  settings: { theme: 'light' | 'dark'; count: number };
+  tags: readonly string[];
+  capacity: number | null;
+  createdAt: Date;
+}
+
+type UnionPayload = { a: 1; x: string } | { b: 2; x: number };
+type PrimitivePayload = string;
+// Backcompat collision: natural keys collide with operator names.
+interface CollisionPayload {
+  jsonContains: string;
+  hasKey: boolean;
+}
+
+const installTable = d.table('install', {
+  id: d.uuid().primary({ generate: 'cuid' }),
+  meta: d.jsonb<InstallMeta>(),
+  union: d.jsonb<UnionPayload>(),
+  prim: d.jsonb<PrimitivePayload>(),
+  coll: d.jsonb<CollisionPayload>(),
+});
+
+type InstallColumns = (typeof installTable)['_columns'];
+
+// ---------------------------------------------------------------------------
+// Payload operators — Postgres positives
+// ---------------------------------------------------------------------------
+
+const pgJsonContains: FilterType<InstallColumns, 'postgres'> = {
+  meta: { jsonContains: { settings: { theme: 'dark' } } },
+};
+void pgJsonContains;
+
+const pgJsonContainedBy: FilterType<InstallColumns, 'postgres'> = {
+  meta: { jsonContainedBy: { displayName: 'Acme', settings: { theme: 'dark', count: 2 } } },
+};
+void pgJsonContainedBy;
+
+const pgHasKey: FilterType<InstallColumns, 'postgres'> = {
+  meta: { hasKey: 'displayName' },
+};
+void pgHasKey;
+
+// Union payload — distributive conditional yields union of all variants' keys.
+const pgUnionHasKeyA: FilterType<InstallColumns, 'postgres'> = {
+  union: { hasKey: 'a' },
+};
+void pgUnionHasKeyA;
+
+const pgUnionHasKeyX: FilterType<InstallColumns, 'postgres'> = {
+  union: { hasKey: 'x' },
+};
+void pgUnionHasKeyX;
+
+// ---------------------------------------------------------------------------
+// Payload operators — negatives
+// ---------------------------------------------------------------------------
+
+// Unknown key rejected.
+const pgHasKeyUnknown: FilterType<InstallColumns, 'postgres'> = {
+  meta: {
+    // @ts-expect-error — 'bogus' is not keyof InstallMeta
+    hasKey: 'bogus',
+  },
+};
+void pgHasKeyUnknown;
+
+// DeepPartial shape mismatch — wrong literal on a string-literal union leaf.
+const pgJsonContainsBad: FilterType<InstallColumns, 'postgres'> = {
+  meta: {
+    jsonContains: {
+      settings: {
+        // @ts-expect-error — 'foggy' is not 'light' | 'dark'
+        theme: 'foggy',
+      },
+    },
+  },
+};
+void pgJsonContainsBad;
+
+// Non-object JSONB payload — hasKey resolves to `never`, any operand rejected.
+const pgHasKeyOnPrimitive: FilterType<InstallColumns, 'postgres'> = {
+  prim: {
+    // @ts-expect-error — hasKey unavailable on primitive JSONB payloads (JsonbKeyOf<string> = never)
+    hasKey: 'anything',
+  },
+};
+void pgHasKeyOnPrimitive;
+
+// ---------------------------------------------------------------------------
+// Payload operators — SQLite negatives (brand diagnostic)
+// ---------------------------------------------------------------------------
+
+const sqliteJsonContains: FilterType<InstallColumns, 'sqlite'> = {
+  meta: {
+    // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+    jsonContains: { displayName: 'Acme' },
+  },
+};
+void sqliteJsonContains;
+
+const sqliteHasKey: FilterType<InstallColumns, 'sqlite'> = {
+  meta: {
+    // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+    hasKey: 'displayName',
+  },
+};
+void sqliteHasKey;
+
+// ---------------------------------------------------------------------------
+// path() builder — leaf-type flow
+// ---------------------------------------------------------------------------
+
+const pgPathStringEq: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.settings.theme).eq('dark'),
+};
+void pgPathStringEq;
+
+const pgPathNumericGt: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.settings.count).gt(5),
+};
+void pgPathNumericGt;
+
+const pgPathNullableIsNull: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.capacity).isNull(true),
+};
+void pgPathNullableIsNull;
+
+const pgPathArrayIndex: FilterType<InstallColumns, 'postgres'> = {
+  meta: path((m: InstallMeta) => m.tags[0]).eq('urgent'),
+};
+void pgPathArrayIndex;
+
+// Path descriptor assignable on a path-shaped string key too (cross-form
+// doesn't apply — descriptors go into the column slot, not the 'col->k' slot).
+
+// ---------------------------------------------------------------------------
+// path() builder — SQLite (descriptor slot is gated via JsonbColumnValue)
+// ---------------------------------------------------------------------------
+
+const sqlitePath: FilterType<InstallColumns, 'sqlite'> = {
+  // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+  meta: path((m: InstallMeta) => m.settings.theme).eq('dark'),
+};
+void sqlitePath;
+
+// ---------------------------------------------------------------------------
+// Backcompat: payloads whose natural keys collide with operator names
+// ---------------------------------------------------------------------------
+
+// Direct payload equality still accepted — the whole literal is a T, not ops.
+const pgCollisionDirect: FilterType<InstallColumns, 'postgres'> = {
+  coll: { jsonContains: 'literal', hasKey: true },
+};
+void pgCollisionDirect;
+
+// ---------------------------------------------------------------------------
+// createDb end-to-end inference
+// ---------------------------------------------------------------------------
+
+const sqliteDb = createDb({
+  dialect: 'sqlite',
+  path: ':memory:',
+  models: { install: d.model(installTable) },
+  migrations: { autoApply: true },
+});
+
+void sqliteDb.install.list({
+  where: {
+    // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_…
+    meta: { jsonContains: { displayName: 'Acme' } },
+  },
+});
+
+// Direct equality still works on SQLite.
+void sqliteDb.install.list({
+  where: {
+    meta: {
+      eq: {
+        displayName: 'Acme',
+        settings: { theme: 'dark', count: 1 },
+        tags: [],
+        capacity: null,
+        createdAt: new Date(),
+      },
+    },
+  },
+});
+
+const pgDb = createDb({
+  dialect: 'postgres',
+  url: 'postgres://u:p@localhost/db',
+  models: { install: d.model(installTable) },
+  _queryFn: (async () => ({ rows: [], rowCount: 0 })) as never,
+});
+
+void pgDb.install.list({
+  where: {
+    meta: { jsonContains: { settings: { theme: 'dark' } } },
+  },
+});
+
+void pgDb.install.list({
+  where: {
+    meta: path((m: InstallMeta) => m.settings.theme).eq('dark'),
+  },
+});
+
+void pgDb.install.list({
+  where: {
+    meta: { hasKey: 'settings' },
+  },
+});

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -64,15 +64,35 @@ export const d: {
   /**
    * JSONB column — stores a typed payload.
    *
-   * - **Postgres:** native JSONB type. Supports path filters (`'meta->k'`) and
-   *   array operators; both are available at the type level.
+   * - **Postgres:** native JSONB type. Supports string-keyed path filters
+   *   (`'meta->k'`), typed `path()` filters, and whole-payload operators
+   *   (`jsonContains`, `jsonContainedBy`, `hasKey`).
    * - **SQLite / Cloudflare D1:** stored as TEXT. On reads, values are
    *   automatically `JSON.parse`d into `T`. On writes, plain objects/arrays
    *   are automatically `JSON.stringify`d.
    *
-   * Path-based filters (`where: { 'meta->k': ... }`) are Postgres-only. On
-   * SQLite, fetch with `list()` and filter in application code. Inline the
-   * `where` object for the best TS diagnostic when the gate triggers.
+   * Path-based filters (`where: { 'meta->k': ... }`) and the typed operators
+   * are Postgres-only. On SQLite they resolve to a branded `never` type
+   * whose name reads as the recovery sentence. Fetch with `list()` and filter
+   * in application code, or switch dialects. Inline the `where` object for
+   * the best TS diagnostic when the gate triggers.
+   *
+   * Typed filter options (Postgres):
+   *
+   * ```ts
+   * import { path } from '@vertz/db';
+   * // Typed path — leaf type flows from the selector:
+   * where: { meta: path((m: InstallMeta) => m.settings.theme).eq('dark') }
+   * // Whole-payload subset containment (@>):
+   * where: { meta: { jsonContains: { settings: { theme: 'dark' } } } }
+   * // Top-level key existence (?):
+   * where: { meta: { hasKey: 'displayName' } }
+   * ```
+   *
+   * For `d.jsonb<string>()` (payloads that are themselves JSON-encoded strings),
+   * the column-level string `contains` operator does a text LIKE match on the
+   * raw JSON representation. Prefer `contains` for substring tests; `jsonContains`
+   * tests whole-payload subset containment.
    *
    * An optional `validator` (provided either as a `{ validator }` option or
    * as a schema-like object exposing `.parse()`) runs on both sides:

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -60,8 +60,9 @@ export type { createPostgresDriver, PostgresDriver } from './client/postgres-dri
 export { d } from './d';
 export type { EnumSchemaLike } from './d';
 // Typed JSONB path builder — `path((m: T) => m.x).eq(v)`
+// The descriptor shape and PathSegment are intentionally not exported —
+// they are internal AST; users compose via `path().<op>()` only.
 export { path } from './path';
-export type { JsonbPathDescriptor, PathSegment } from './path';
 // Update expressions
 export type { DbExpr } from './sql/expr';
 export { isDbExpr } from './sql/expr';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -59,6 +59,9 @@ export type { createPostgresDriver, PostgresDriver } from './client/postgres-dri
 // Schema builder
 export { d } from './d';
 export type { EnumSchemaLike } from './d';
+// Typed JSONB path builder — `path((m: T) => m.x).eq(v)`
+export { path } from './path';
+export type { JsonbPathDescriptor, PathSegment } from './path';
 // Update expressions
 export type { DbExpr } from './sql/expr';
 export { isDbExpr } from './sql/expr';

--- a/packages/db/src/path.ts
+++ b/packages/db/src/path.ts
@@ -54,21 +54,40 @@ export function isJsonbPathDescriptor(value: unknown): value is JsonbPathDescrip
   );
 }
 
-/** Terminal operator chain. Runtime shape is permissive; TS layer narrows per leaf. */
-export interface PathChain<TLeaf> {
+/** Operators available on every leaf type. */
+interface PathCommonOps<TLeaf> {
   eq(value: TLeaf): JsonbPathDescriptor;
   ne(value: TLeaf): JsonbPathDescriptor;
+  in(values: readonly TLeaf[]): JsonbPathDescriptor;
+  notIn(values: readonly TLeaf[]): JsonbPathDescriptor;
+  isNull(value: boolean): JsonbPathDescriptor;
+}
+
+/** String-only operators; available only when the leaf is assignable to string. */
+interface PathStringOps {
+  contains(value: string): JsonbPathDescriptor;
+  startsWith(value: string): JsonbPathDescriptor;
+  endsWith(value: string): JsonbPathDescriptor;
+}
+
+/** Comparison operators; available only when the leaf is number / bigint / Date. */
+interface PathNumericOps<TLeaf> {
   gt(value: NonNullable<TLeaf>): JsonbPathDescriptor;
   gte(value: NonNullable<TLeaf>): JsonbPathDescriptor;
   lt(value: NonNullable<TLeaf>): JsonbPathDescriptor;
   lte(value: NonNullable<TLeaf>): JsonbPathDescriptor;
-  in(values: readonly TLeaf[]): JsonbPathDescriptor;
-  notIn(values: readonly TLeaf[]): JsonbPathDescriptor;
-  contains(value: string): JsonbPathDescriptor;
-  startsWith(value: string): JsonbPathDescriptor;
-  endsWith(value: string): JsonbPathDescriptor;
-  isNull(value: boolean): JsonbPathDescriptor;
 }
+
+/**
+ * Terminal operator chain. Operator availability narrows per leaf type:
+ * - string / string literal / nullable-string → common + string ops.
+ * - number / bigint / Date → common + numeric comparison ops.
+ * - boolean / object / array → common ops only.
+ * The runtime shape (see `makeChain`) is permissive; the type narrows at the API surface.
+ */
+export type PathChain<TLeaf> = PathCommonOps<TLeaf> &
+  ([NonNullable<TLeaf>] extends [string] ? PathStringOps : unknown) &
+  ([NonNullable<TLeaf>] extends [number | bigint | Date] ? PathNumericOps<TLeaf> : unknown);
 
 /** Non-recording property accesses that JS runtimes probe on any object. */
 const INTERNAL_STRING_KEYS = new Set<string>([
@@ -77,12 +96,30 @@ const INTERNAL_STRING_KEYS = new Set<string>([
   'valueOf',
   'toJSON',
   'constructor',
-  'Symbol(Symbol.toPrimitive)',
 ]);
 
 const INTEGER_INDEX_RE = /^(?:0|[1-9]\d*)$/;
 
-function makeChain(segments: readonly PathSegment[]): PathChain<unknown> {
+/**
+ * Runtime-side permissive chain shape. Holds every terminal operator; the
+ * public `PathChain<TLeaf>` type narrows which subset is callable per leaf.
+ */
+interface PermissiveChain {
+  eq(value: unknown): JsonbPathDescriptor;
+  ne(value: unknown): JsonbPathDescriptor;
+  gt(value: unknown): JsonbPathDescriptor;
+  gte(value: unknown): JsonbPathDescriptor;
+  lt(value: unknown): JsonbPathDescriptor;
+  lte(value: unknown): JsonbPathDescriptor;
+  in(values: readonly unknown[]): JsonbPathDescriptor;
+  notIn(values: readonly unknown[]): JsonbPathDescriptor;
+  contains(value: string): JsonbPathDescriptor;
+  startsWith(value: string): JsonbPathDescriptor;
+  endsWith(value: string): JsonbPathDescriptor;
+  isNull(value: boolean): JsonbPathDescriptor;
+}
+
+function makeChain(segments: readonly PathSegment[]): PermissiveChain {
   const mk = (op: PathFilterOp): JsonbPathDescriptor => ({
     _tag: 'JsonbPathDescriptor',
     segments,
@@ -105,6 +142,39 @@ function makeChain(segments: readonly PathSegment[]): PathChain<unknown> {
 }
 
 /**
+ * Per-proxy segment registry — keyed on the proxy object itself. Each proxy
+ * is associated with its accumulated segment list at creation time; child
+ * proxies close over the parent's segments so every `get` appends correctly.
+ *
+ * If the selector returns anything other than a child proxy (a primitive
+ * from coercion, a plain object, `m.a + m.b` triggering valueOf coercion
+ * which throws), we reject the call instead of emitting garbage segments.
+ */
+const SEGMENTS_FOR_PROXY = new WeakMap<object, readonly PathSegment[]>();
+
+const INVALID_SELECTOR_MESSAGE =
+  'path() selector must be a direct property access like (m) => m.x.y — ' +
+  'arithmetic or other non-access expressions are not allowed.';
+
+function makeRecorderProxy(segments: readonly PathSegment[]): object {
+  const proxy: object = new Proxy(
+    {},
+    {
+      get(_target, key) {
+        if (typeof key === 'symbol') return undefined;
+        if (INTERNAL_STRING_KEYS.has(key)) return undefined;
+        const segment: PathSegment = INTEGER_INDEX_RE.test(key)
+          ? { kind: 'index', value: Number(key) }
+          : { kind: 'key', value: key };
+        return makeRecorderProxy([...segments, segment]);
+      },
+    },
+  );
+  SEGMENTS_FOR_PROXY.set(proxy, segments);
+  return proxy;
+}
+
+/**
  * Build a typed JSONB path filter.
  *
  * ```ts
@@ -117,22 +187,32 @@ function makeChain(segments: readonly PathSegment[]): PathChain<unknown> {
  * Pass the JSONB column's payload type as the selector parameter annotation.
  * The leaf type flows through to the terminal operator's operand via TS's
  * normal return-type inference — no explicit generic required.
+ *
+ * The selector MUST be a direct property access (`(m) => m.x.y`). Arithmetic
+ * or other expressions (`(m) => m.a + m.b`) throw because the Proxy can't
+ * unambiguously record the intended path.
  */
 export function path<T, TLeaf>(selector: (m: T) => TLeaf): PathChain<TLeaf> {
-  const segments: PathSegment[] = [];
-  const handler: ProxyHandler<object> = {
-    get(_target, key) {
-      if (typeof key === 'symbol') return undefined;
-      if (INTERNAL_STRING_KEYS.has(key)) return undefined;
-      if (INTEGER_INDEX_RE.test(key)) {
-        segments.push({ kind: 'index', value: Number(key) });
-      } else {
-        segments.push({ kind: 'key', value: key });
-      }
-      return new Proxy({}, handler);
-    },
-  };
-  const proxy = new Proxy({}, handler) as T;
-  selector(proxy);
-  return makeChain(segments) as PathChain<TLeaf>;
+  const root = makeRecorderProxy([]);
+  let returned: unknown;
+  try {
+    returned = selector(root as T);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`${INVALID_SELECTOR_MESSAGE} Cause: ${message}`);
+  }
+  if (typeof returned !== 'object' || returned === null) {
+    throw new Error(INVALID_SELECTOR_MESSAGE);
+  }
+  const segments = SEGMENTS_FOR_PROXY.get(returned);
+  if (!segments || segments.length === 0) {
+    throw new Error(
+      'path() selector must access at least one property — e.g. (m) => m.x, not (m) => m.',
+    );
+  }
+  // Runtime chain has every operator (PermissiveChain); the public type
+  // narrows the subset callable for TLeaf. Two `as` hops are needed because
+  // PathChain<TLeaf> is a conditional intersection, not a supertype of
+  // PermissiveChain.
+  return makeChain(segments) as unknown as PathChain<TLeaf>;
 }

--- a/packages/db/src/path.ts
+++ b/packages/db/src/path.ts
@@ -1,0 +1,138 @@
+/**
+ * Typed JSONB path builder — `path((m: T) => m.x.y).eq(value)`.
+ *
+ * Parameter-annotation inference drives `T`. Each property access on the
+ * proxy records a path segment; terminal operators (eq/ne/in/...) produce
+ * a JsonbPathDescriptor consumed by the WHERE clause builder.
+ *
+ * Postgres-only at the type level (the descriptor is dialect-branded via the
+ * filter-slot type). Runtime emits `col->'k'->>'leaf' <op> $1` (or unquoted
+ * integer segments for array indexing).
+ */
+
+/**
+ * A single path segment. `kind: 'key'` emits a quoted text key (`->'k'`);
+ * `kind: 'index'` emits an unquoted integer index (`->N`) for JSONB array
+ * access (Postgres semantics — `->'0'` on an array returns NULL).
+ */
+export type PathSegment =
+  | { readonly kind: 'key'; readonly value: string }
+  | { readonly kind: 'index'; readonly value: number };
+
+/** Terminal operator shape produced by a PathChain method. */
+export interface PathFilterOp {
+  readonly eq?: unknown;
+  readonly ne?: unknown;
+  readonly gt?: unknown;
+  readonly gte?: unknown;
+  readonly lt?: unknown;
+  readonly lte?: unknown;
+  readonly in?: readonly unknown[];
+  readonly notIn?: readonly unknown[];
+  readonly contains?: string;
+  readonly startsWith?: string;
+  readonly endsWith?: string;
+  readonly isNull?: boolean;
+}
+
+/**
+ * Descriptor produced by `path(...).<op>(value)`. Consumed by the WHERE
+ * builder when it encounters a value with `_tag: 'JsonbPathDescriptor'`
+ * in a filter slot.
+ */
+export interface JsonbPathDescriptor {
+  readonly _tag: 'JsonbPathDescriptor';
+  readonly segments: readonly PathSegment[];
+  readonly op: PathFilterOp;
+}
+
+export function isJsonbPathDescriptor(value: unknown): value is JsonbPathDescriptor {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { _tag?: unknown })._tag === 'JsonbPathDescriptor'
+  );
+}
+
+/** Terminal operator chain. Runtime shape is permissive; TS layer narrows per leaf. */
+export interface PathChain<TLeaf> {
+  eq(value: TLeaf): JsonbPathDescriptor;
+  ne(value: TLeaf): JsonbPathDescriptor;
+  gt(value: NonNullable<TLeaf>): JsonbPathDescriptor;
+  gte(value: NonNullable<TLeaf>): JsonbPathDescriptor;
+  lt(value: NonNullable<TLeaf>): JsonbPathDescriptor;
+  lte(value: NonNullable<TLeaf>): JsonbPathDescriptor;
+  in(values: readonly TLeaf[]): JsonbPathDescriptor;
+  notIn(values: readonly TLeaf[]): JsonbPathDescriptor;
+  contains(value: string): JsonbPathDescriptor;
+  startsWith(value: string): JsonbPathDescriptor;
+  endsWith(value: string): JsonbPathDescriptor;
+  isNull(value: boolean): JsonbPathDescriptor;
+}
+
+/** Non-recording property accesses that JS runtimes probe on any object. */
+const INTERNAL_STRING_KEYS = new Set<string>([
+  'then',
+  'toString',
+  'valueOf',
+  'toJSON',
+  'constructor',
+  'Symbol(Symbol.toPrimitive)',
+]);
+
+const INTEGER_INDEX_RE = /^(?:0|[1-9]\d*)$/;
+
+function makeChain(segments: readonly PathSegment[]): PathChain<unknown> {
+  const mk = (op: PathFilterOp): JsonbPathDescriptor => ({
+    _tag: 'JsonbPathDescriptor',
+    segments,
+    op,
+  });
+  return {
+    eq: (value) => mk({ eq: value }),
+    ne: (value) => mk({ ne: value }),
+    gt: (value) => mk({ gt: value }),
+    gte: (value) => mk({ gte: value }),
+    lt: (value) => mk({ lt: value }),
+    lte: (value) => mk({ lte: value }),
+    in: (values) => mk({ in: values }),
+    notIn: (values) => mk({ notIn: values }),
+    contains: (value) => mk({ contains: value }),
+    startsWith: (value) => mk({ startsWith: value }),
+    endsWith: (value) => mk({ endsWith: value }),
+    isNull: (value) => mk({ isNull: value }),
+  };
+}
+
+/**
+ * Build a typed JSONB path filter.
+ *
+ * ```ts
+ * import { path } from '@vertz/db';
+ * await pg.install.list({
+ *   where: { meta: path((m: InstallMeta) => m.settings.theme).eq('dark') },
+ * });
+ * ```
+ *
+ * Pass the JSONB column's payload type as the selector parameter annotation.
+ * The leaf type flows through to the terminal operator's operand via TS's
+ * normal return-type inference — no explicit generic required.
+ */
+export function path<T, TLeaf>(selector: (m: T) => TLeaf): PathChain<TLeaf> {
+  const segments: PathSegment[] = [];
+  const handler: ProxyHandler<object> = {
+    get(_target, key) {
+      if (typeof key === 'symbol') return undefined;
+      if (INTERNAL_STRING_KEYS.has(key)) return undefined;
+      if (INTEGER_INDEX_RE.test(key)) {
+        segments.push({ kind: 'index', value: Number(key) });
+      } else {
+        segments.push({ kind: 'key', value: key });
+      }
+      return new Proxy({}, handler);
+    },
+  };
+  const proxy = new Proxy({}, handler) as T;
+  selector(proxy);
+  return makeChain(segments) as PathChain<TLeaf>;
+}

--- a/packages/db/src/schema/inference.ts
+++ b/packages/db/src/schema/inference.ts
@@ -1,6 +1,7 @@
 import type { DialectName } from '../dialect/types';
 import type { ColumnBuilder, InferColumnType } from './column';
 import type { JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS } from './jsonb-filter-brand';
+import type { JsonbColumnValue } from './path-chain';
 import type { RelationDef } from './relation';
 import type {
   AllAnnotations,
@@ -92,27 +93,43 @@ type JsonbPathValue<TDialect extends DialectName> = TDialect extends 'postgres'
   : JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS;
 
 /**
+ * Detect whether a column has JSONB metadata (`sqlType: 'jsonb' | 'json'`).
+ * Used to route the column's filter value through `JsonbColumnValue` instead
+ * of the generic `ColumnFilterOperators`.
+ */
+type IsJsonbColumn<C> =
+  C extends ColumnBuilder<unknown, infer M>
+    ? M extends { readonly sqlType: 'jsonb' } | { readonly sqlType: 'json' }
+      ? true
+      : false
+    : false;
+
+/**
  * FilterType<TColumns, TDialect> — typed where clause, dialect-conditional.
  *
  * Each key is one of:
- * - A column name mapping to a value (shorthand for `{ eq: value }`) or
- *   an object with typed filter operators.
+ * - A JSONB column — its value resolves to `JsonbColumnValue<T, TDialect>`
+ *   (direct payload equality, simple comparison, `jsonContains` /
+ *   `jsonContainedBy` / `hasKey`, or a `path()` descriptor). On SQLite the
+ *   payload operators resolve to a keyed-never brand.
+ * - Any other column — value (shorthand for `{ eq: value }`) or operator object.
  * - A path-shaped JSONB key (`'meta->field'`) on Postgres. On SQLite the
  *   same key accepts only a keyed-never brand whose name reads as the
- *   recovery sentence, so assigning `{ 'meta->k': { eq: 'v' } }` fails
- *   with that sentence in the diagnostic.
+ *   recovery sentence.
  *
  * Array operators (`arrayContains`, etc.) are runtime-only today and not
- * yet part of the TS surface — tracked as a follow-up in #2868.
+ * yet part of the TS surface — tracked as a follow-up in #2885.
  */
 export type FilterType<
   TColumns extends ColumnRecord,
   TDialect extends DialectName = DialectName,
 > = {
   [K in keyof TColumns | JsonbPathKey<TColumns>]?: K extends keyof TColumns
-    ?
-        | InferColumnType<TColumns[K]>
-        | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+    ? IsJsonbColumn<TColumns[K]> extends true
+      ? JsonbColumnValue<InferColumnType<TColumns[K]>, TDialect>
+      :
+          | InferColumnType<TColumns[K]>
+          | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
     : JsonbPathValue<TDialect>;
 };
 

--- a/packages/db/src/schema/jsonb-filter-brand.ts
+++ b/packages/db/src/schema/jsonb-filter-brand.ts
@@ -24,3 +24,16 @@ declare const __JsonbPathFilterBrand: unique symbol;
 export interface JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS {
   readonly [__JsonbPathFilterBrand]: 'jsonb-path-filter-requires-postgres';
 }
+
+/**
+ * Brand for the typed-JSONB-operator surface introduced by #2868
+ * (`jsonContains`, `jsonContainedBy`, `hasKey`, and the `path()` builder).
+ * Resolves in the SQLite branch of the JSONB column filter value so that
+ * attempting any of these ops on a SQLite db produces a diagnostic that
+ * names this interface — the name IS the recovery sentence.
+ */
+declare const __JsonbOperatorBrand: unique symbol;
+
+export interface JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS {
+  readonly [__JsonbOperatorBrand]: 'jsonb-operator-requires-postgres';
+}

--- a/packages/db/src/schema/path-chain.ts
+++ b/packages/db/src/schema/path-chain.ts
@@ -1,0 +1,110 @@
+/**
+ * Type helpers for the typed JSONB operator surface (#2868).
+ *
+ * - `DeepPartial<T, D>` — depth-capped deep partial for `jsonContains`.
+ * - `JsonbKeyOf<T>` — top-level keys of a JSONB payload; `never` for non-object T.
+ * - `JsonbPayloadOperators<T, TDialect>` — dialect-gated operators for whole-payload
+ *   filters on a JSONB column.
+ * - `JsonbColumnValue<T, TDialect>` — union of all valid filter values for a
+ *   `d.jsonb<T>()` column slot.
+ *
+ * The runtime `PathChain` / `JsonbPathDescriptor` lives in `../path.ts`
+ * and is imported here for type composition.
+ */
+
+import type { DialectName } from '../dialect/types';
+import type { JsonbPathDescriptor } from '../path';
+import type { JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS } from './jsonb-filter-brand';
+
+// ---------------------------------------------------------------------------
+// DeepPartial<T, D> — depth-capped deep partial
+// ---------------------------------------------------------------------------
+
+type Decrement<D extends number> = [never, 0, 1, 2, 3, 4][D];
+
+/**
+ * Deep-partial `T` with a recursion depth cap (default 5).
+ * Beyond the cap the recursion stops and the operand widens to `T`.
+ * Cyclic types also degrade to `T` without inference blowup.
+ */
+export type DeepPartial<T, D extends number = 5> = [D] extends [never]
+  ? T
+  : T extends readonly (infer U)[]
+    ? readonly DeepPartial<U, Decrement<D>>[]
+    : T extends object
+      ? { readonly [K in keyof T]?: DeepPartial<T[K], Decrement<D>> }
+      : T;
+
+// ---------------------------------------------------------------------------
+// JsonbKeyOf<T> — safe key extractor
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level keys for a JSONB payload shape. Distribution happens because
+ * `T` is naked in the conditional (not because of `keyof` itself —
+ * `keyof (A | B)` would intersect, but a distributive conditional splits
+ * the union first and lets each variant contribute its own `keyof`).
+ *
+ * Primitive and array payloads resolve to `never`, so `hasKey` is not
+ * meaningful on them and the type surface rejects the call.
+ */
+export type JsonbKeyOf<T> = T extends readonly unknown[]
+  ? never
+  : T extends object
+    ? keyof T & string
+    : never;
+
+// ---------------------------------------------------------------------------
+// JsonbPayloadOperators — whole-payload operators on the JSONB column slot
+// ---------------------------------------------------------------------------
+
+/**
+ * Whole-payload JSONB operators, dialect-gated.
+ * On Postgres: typed operands (`DeepPartial<T>`, `JsonbKeyOf<T>`).
+ * On SQLite: the brand interface forces a diagnostic whose name IS the
+ * recovery sentence.
+ */
+export type JsonbPayloadOperators<T, TDialect extends DialectName> = TDialect extends 'postgres'
+  ? {
+      readonly jsonContains?: DeepPartial<T>;
+      readonly jsonContainedBy?: object;
+      readonly hasKey?: JsonbKeyOf<T>;
+    }
+  : {
+      readonly jsonContains?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly jsonContainedBy?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly hasKey?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+    };
+
+// ---------------------------------------------------------------------------
+// JsonbColumnValue — union of valid filter values for a d.jsonb<T>() slot
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter value for a `d.jsonb<T>()` column slot.
+ *
+ * On Postgres, accepts:
+ * - The direct payload (shorthand for `{ eq: T }`).
+ * - Simple comparison operators against full `T` (retained for back-compat).
+ * - Payload operators (`jsonContains` / `jsonContainedBy` / `hasKey`).
+ * - A `JsonbPathDescriptor` produced by the `path()` builder.
+ *
+ * On SQLite, the payload operators and descriptor slot resolve to the brand
+ * type. Direct equality against `T` remains valid.
+ *
+ * NOTE: Union-member ordering in TS excess-property checks is not fully
+ * deterministic across compiler versions. If the collision snapshot test
+ * (`d.jsonb<{ jsonContains: string }>()` with payload-shape equality) flips,
+ * the fallback is to reorder members or add explicit `& {}` marker
+ * intersections. The snapshot is the source of truth.
+ */
+export type JsonbColumnValue<T, TDialect extends DialectName> = TDialect extends 'postgres'
+  ?
+      | T
+      | { readonly eq?: T; readonly ne?: T; readonly isNull?: boolean }
+      | JsonbPayloadOperators<T, 'postgres'>
+      | JsonbPathDescriptor
+  :
+      | T
+      | { readonly eq?: T; readonly ne?: T; readonly isNull?: boolean }
+      | JsonbPayloadOperators<T, 'sqlite'>;

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -283,4 +283,22 @@ describe('SQLite feature guards', () => {
     expect(result.sql).toBe('"metadata"->>\'role\' = $1');
     expect(result.params).toEqual(['admin']);
   });
+
+  it('throws descriptive error for jsonContains with SqliteDialect', () => {
+    expect(() =>
+      buildWhere({ meta: { jsonContains: { a: 1 } } }, 0, undefined, sqliteDialect),
+    ).toThrow('jsonContains requires dialect: postgres');
+  });
+
+  it('throws descriptive error for jsonContainedBy with SqliteDialect', () => {
+    expect(() =>
+      buildWhere({ meta: { jsonContainedBy: { a: 1 } } }, 0, undefined, sqliteDialect),
+    ).toThrow('jsonContainedBy requires dialect: postgres');
+  });
+
+  it('throws descriptive error for hasKey with SqliteDialect', () => {
+    expect(() =>
+      buildWhere({ meta: { hasKey: 'a' } }, 0, undefined, sqliteDialect),
+    ).toThrow('hasKey requires dialect: postgres');
+  });
 });

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -297,8 +297,8 @@ describe('SQLite feature guards', () => {
   });
 
   it('throws descriptive error for hasKey with SqliteDialect', () => {
-    expect(() =>
-      buildWhere({ meta: { hasKey: 'a' } }, 0, undefined, sqliteDialect),
-    ).toThrow('hasKey requires dialect: postgres');
+    expect(() => buildWhere({ meta: { hasKey: 'a' } }, 0, undefined, sqliteDialect)).toThrow(
+      'hasKey requires dialect: postgres',
+    );
   });
 });

--- a/packages/db/src/sql/__tests__/where.test.ts
+++ b/packages/db/src/sql/__tests__/where.test.ts
@@ -434,7 +434,7 @@ describe('buildWhere', () => {
           op: { eq: 'dark' },
         } as unknown,
       });
-      expect(result.sql).toBe('"meta"->\'settings\'->>\'theme\' = $1');
+      expect(result.sql).toBe("\"meta\"->'settings'->>'theme' = $1");
       expect(result.params).toEqual(['dark']);
     });
 

--- a/packages/db/src/sql/__tests__/where.test.ts
+++ b/packages/db/src/sql/__tests__/where.test.ts
@@ -376,6 +376,107 @@ describe('buildWhere', () => {
       expect(result.params).toEqual([['ts', 'js']]);
     });
   });
+
+  describe('JSONB payload operators', () => {
+    it('jsonContains generates @> operator with ::jsonb cast and stringified param', () => {
+      const result = buildWhere({
+        meta: { jsonContains: { settings: { theme: 'dark' } } },
+      });
+      expect(result.sql).toBe('"meta" @> $1::jsonb');
+      expect(result.params).toEqual(['{"settings":{"theme":"dark"}}']);
+    });
+
+    it('jsonContainedBy generates <@ operator with ::jsonb cast', () => {
+      const result = buildWhere({
+        meta: { jsonContainedBy: { a: 1, b: 2 } },
+      });
+      expect(result.sql).toBe('"meta" <@ $1::jsonb');
+      expect(result.params).toEqual(['{"a":1,"b":2}']);
+    });
+
+    it('hasKey generates ? operator with text operand', () => {
+      const result = buildWhere({ meta: { hasKey: 'settings' } });
+      expect(result.sql).toBe('"meta" ? $1');
+      expect(result.params).toEqual(['settings']);
+    });
+
+    it('combines jsonContains with other filters', () => {
+      const result = buildWhere({
+        status: 'active',
+        meta: { jsonContains: { role: 'admin' } },
+      });
+      expect(result.sql).toBe('"status" = $1 AND "meta" @> $2::jsonb');
+      expect(result.params).toEqual(['active', '{"role":"admin"}']);
+    });
+  });
+
+  describe('JsonbPathDescriptor from path()', () => {
+    it('emits single-key path with text key and ->> final + eq operator', () => {
+      const result = buildWhere({
+        meta: {
+          _tag: 'JsonbPathDescriptor',
+          segments: [{ kind: 'key', value: 'settings' }],
+          op: { eq: 'dark' },
+        } as unknown,
+      });
+      expect(result.sql).toBe('"meta"->>\'settings\' = $1');
+      expect(result.params).toEqual(['dark']);
+    });
+
+    it('emits nested path with intermediate -> and final ->>', () => {
+      const result = buildWhere({
+        meta: {
+          _tag: 'JsonbPathDescriptor',
+          segments: [
+            { kind: 'key', value: 'settings' },
+            { kind: 'key', value: 'theme' },
+          ],
+          op: { eq: 'dark' },
+        } as unknown,
+      });
+      expect(result.sql).toBe('"meta"->\'settings\'->>\'theme\' = $1');
+      expect(result.params).toEqual(['dark']);
+    });
+
+    it('emits integer segments unquoted for array indexing', () => {
+      const result = buildWhere({
+        meta: {
+          _tag: 'JsonbPathDescriptor',
+          segments: [
+            { kind: 'key', value: 'tags' },
+            { kind: 'index', value: 0 },
+          ],
+          op: { eq: 'urgent' },
+        } as unknown,
+      });
+      expect(result.sql).toBe('"meta"->\'tags\'->>0 = $1');
+      expect(result.params).toEqual(['urgent']);
+    });
+
+    it('emits single integer segment unquoted as final', () => {
+      const result = buildWhere({
+        tags: {
+          _tag: 'JsonbPathDescriptor',
+          segments: [{ kind: 'index', value: 2 }],
+          op: { eq: 'x' },
+        } as unknown,
+      });
+      expect(result.sql).toBe('"tags"->>2 = $1');
+      expect(result.params).toEqual(['x']);
+    });
+
+    it('applies comparison operators (gt) to path leaves', () => {
+      const result = buildWhere({
+        meta: {
+          _tag: 'JsonbPathDescriptor',
+          segments: [{ kind: 'key', value: 'count' }],
+          op: { gt: 5 },
+        } as unknown,
+      });
+      expect(result.sql).toBe('"meta"->>\'count\' > $1');
+      expect(result.params).toEqual([5]);
+    });
+  });
 });
 
 describe('edge cases: empty IN/NOT IN arrays (Issue #1)', () => {

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -15,7 +15,7 @@
  */
 
 import { type Dialect, defaultPostgresDialect } from '../dialect';
-import { isJsonbPathDescriptor, type JsonbPathDescriptor, type PathSegment } from '../path';
+import { isJsonbPathDescriptor, type PathSegment } from '../path';
 import { type CasingOverrides, camelToSnake } from './casing';
 
 export interface WhereResult {
@@ -94,6 +94,23 @@ function escapeSingleQuotes(str: string): string {
  */
 function escapeLikeValue(str: string): string {
   return str.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+/**
+ * Stringify a JSONB operand (for `@>` / `<@` params). Wraps `JSON.stringify`
+ * so BigInt / circular inputs surface a descriptive error naming the
+ * operator, instead of an opaque `TypeError` from V8.
+ */
+function stringifyJsonbOperand(value: unknown, operator: string): string {
+  try {
+    return JSON.stringify(value);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      `${operator} operand is not JSON-serializable: ${message}. ` +
+        'BigInt, circular references, and non-plain values are not supported.',
+    );
+  }
 }
 
 /**
@@ -280,7 +297,7 @@ function buildOperatorCondition(
       );
     }
     clauses.push(`${columnRef} @> ${dialect.param(idx + 1)}::jsonb`);
-    params.push(JSON.stringify(operators.jsonContains));
+    params.push(stringifyJsonbOperand(operators.jsonContains, 'jsonContains'));
     idx++;
   }
   if (operators.jsonContainedBy !== undefined) {
@@ -290,7 +307,7 @@ function buildOperatorCondition(
       );
     }
     clauses.push(`${columnRef} <@ ${dialect.param(idx + 1)}::jsonb`);
-    params.push(JSON.stringify(operators.jsonContainedBy));
+    params.push(stringifyJsonbOperand(operators.jsonContainedBy, 'jsonContainedBy'));
     idx++;
   }
   if (operators.hasKey !== undefined) {
@@ -326,9 +343,8 @@ function buildFilterClauses(
     // (carrying _tag + segments + op) isn't mistaken for a direct equality
     // value.
     if (isJsonbPathDescriptor(value)) {
-      const descriptor = value as JsonbPathDescriptor;
-      const columnRef = resolveColumnRefFromSegments(key, descriptor.segments, overrides, dialect);
-      const result = buildOperatorCondition(columnRef, descriptor.op, idx, dialect);
+      const columnRef = resolveColumnRefFromSegments(key, value.segments, overrides, dialect);
+      const result = buildOperatorCondition(columnRef, value.op, idx, dialect);
       clauses.push(...result.clauses);
       allParams.push(...result.params);
       idx = result.nextIndex;

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -15,6 +15,7 @@
  */
 
 import { type Dialect, defaultPostgresDialect } from '../dialect';
+import { isJsonbPathDescriptor, type JsonbPathDescriptor, type PathSegment } from '../path';
 import { type CasingOverrides, camelToSnake } from './casing';
 
 export interface WhereResult {
@@ -38,6 +39,9 @@ interface FilterOperators {
   readonly arrayContains?: readonly unknown[];
   readonly arrayContainedBy?: readonly unknown[];
   readonly arrayOverlaps?: readonly unknown[];
+  readonly jsonContains?: unknown;
+  readonly jsonContainedBy?: unknown;
+  readonly hasKey?: string;
 }
 
 interface WhereFilter {
@@ -63,6 +67,9 @@ const OPERATOR_KEYS = new Set([
   'arrayContains',
   'arrayContainedBy',
   'arrayOverlaps',
+  'jsonContains',
+  'jsonContainedBy',
+  'hasKey',
 ]);
 
 function isOperatorObject(value: unknown): value is FilterOperators {
@@ -98,6 +105,34 @@ function escapeLikeValue(str: string): string {
  * Regular columns are just quoted with double quotes.
  * Single quotes in JSONB path segments are escaped to prevent SQL injection.
  */
+/**
+ * Resolve a column reference from a base column + typed path segments.
+ * Integer segments emit unquoted (`->N`) to match Postgres JSONB array semantics
+ * (Postgres `->'0'` on an array returns NULL; `->0` does not).
+ */
+function resolveColumnRefFromSegments(
+  baseKey: string,
+  segments: readonly PathSegment[],
+  overrides: CasingOverrides | undefined,
+  dialect: Dialect,
+): string {
+  if (!dialect.supportsJsonbPath) {
+    throw new Error(
+      'JSONB path operators (->>, ->) are not supported on SQLite. ' +
+        'Use json_extract() via raw SQL or switch to Postgres.',
+    );
+  }
+  const column = `"${camelToSnake(baseKey, overrides)}"`;
+  if (segments.length === 0) return column;
+  const emitIntermediate = (seg: PathSegment): string =>
+    seg.kind === 'index' ? `->${seg.value}` : `->'${escapeSingleQuotes(seg.value)}'`;
+  const emitFinal = (seg: PathSegment): string =>
+    seg.kind === 'index' ? `->>${seg.value}` : `->>'${escapeSingleQuotes(seg.value)}'`;
+  const intermediate = segments.slice(0, -1).map(emitIntermediate).join('');
+  const final = emitFinal(segments[segments.length - 1] as PathSegment);
+  return `${column}${intermediate}${final}`;
+}
+
 function resolveColumnRef(key: string, overrides?: CasingOverrides, dialect?: Dialect): string {
   if (key.includes('->')) {
     if (dialect && !dialect.supportsJsonbPath) {
@@ -238,6 +273,36 @@ function buildOperatorCondition(
     params.push(operators.arrayOverlaps);
     idx++;
   }
+  if (operators.jsonContains !== undefined) {
+    if (!dialect.supportsJsonbPath) {
+      throw new Error(
+        'jsonContains requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+      );
+    }
+    clauses.push(`${columnRef} @> ${dialect.param(idx + 1)}::jsonb`);
+    params.push(JSON.stringify(operators.jsonContains));
+    idx++;
+  }
+  if (operators.jsonContainedBy !== undefined) {
+    if (!dialect.supportsJsonbPath) {
+      throw new Error(
+        'jsonContainedBy requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+      );
+    }
+    clauses.push(`${columnRef} <@ ${dialect.param(idx + 1)}::jsonb`);
+    params.push(JSON.stringify(operators.jsonContainedBy));
+    idx++;
+  }
+  if (operators.hasKey !== undefined) {
+    if (!dialect.supportsJsonbPath) {
+      throw new Error(
+        'hasKey requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+      );
+    }
+    clauses.push(`${columnRef} ? ${dialect.param(idx + 1)}`);
+    params.push(operators.hasKey);
+    idx++;
+  }
 
   return { clauses, params, nextIndex: idx };
 }
@@ -254,6 +319,19 @@ function buildFilterClauses(
 
   for (const [key, value] of Object.entries(filter)) {
     if (key === 'OR' || key === 'AND' || key === 'NOT') {
+      continue;
+    }
+
+    // Descriptor branch runs BEFORE isOperatorObject so a path() result
+    // (carrying _tag + segments + op) isn't mistaken for a direct equality
+    // value.
+    if (isJsonbPathDescriptor(value)) {
+      const descriptor = value as JsonbPathDescriptor;
+      const columnRef = resolveColumnRefFromSegments(key, descriptor.segments, overrides, dialect);
+      const result = buildOperatorCondition(columnRef, descriptor.op, idx, dialect);
+      clauses.push(...result.clauses);
+      allParams.push(...result.params);
+      idx = result.nextIndex;
       continue;
     }
 

--- a/packages/mint-docs/guides/db/schema.mdx
+++ b/packages/mint-docs/guides/db/schema.mdx
@@ -418,6 +418,76 @@ On SQLite, fetch with `list()` and filter in application code, or switch dialect
   runtime throw still catches the problem, but the error happens later.
 </Tip>
 
+### Typed path filters with `path()`
+
+String-keyed path filters (`'meta->field'`) are an escape hatch — they work, but lose the payload's leaf type. For static paths, prefer `path()`: the selector preserves `T` through the leaf and conditionally exposes the operators that make sense for that leaf type.
+
+```ts
+import { path } from '@vertz/db';
+
+interface InstallMeta {
+  displayName: string;
+  settings: { theme: 'light' | 'dark'; count: number };
+  tags: readonly string[];
+}
+
+// Leaf type flows:
+await pgDb.install.list({
+  where: { meta: path((m: InstallMeta) => m.settings.theme).eq('dark') },
+});
+
+// TypeScript rejects an invalid literal at the leaf:
+await pgDb.install.list({
+  where: { meta: path((m: InstallMeta) => m.settings.theme).eq('foggy') },
+  //                                                              ^^^^^^^
+  // Error: 'foggy' is not assignable to 'light' | 'dark'.
+});
+
+// Operator availability matches the leaf type — string operators on strings:
+await pgDb.install.list({
+  where: { meta: path((m: InstallMeta) => m.displayName).contains('Acme') },
+});
+
+// Numeric comparisons on numbers:
+await pgDb.install.list({
+  where: { meta: path((m: InstallMeta) => m.settings.count).gt(5) },
+});
+
+// Numeric array indexing — Postgres emits integer index unquoted (->0 not ->'0'):
+await pgDb.install.list({
+  where: { meta: path((m: InstallMeta) => m.tags[0]).eq('urgent') },
+});
+```
+
+Pass the JSONB column's payload type as the selector parameter annotation (the same type you declared at `d.jsonb<T>()`). TypeScript infers the leaf type from the selector's return, so no explicit generic is needed on `path<T>()`.
+
+`path()` filters are Postgres-only — they resolve to `JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` on SQLite, with the same recovery-sentence-in-the-type-name mechanism as string-keyed path filters. Reach for the string-keyed form only when the path is computed at runtime.
+
+### Whole-payload JSONB operators
+
+Three operators filter against the payload as a whole, without a path:
+
+```ts
+// jsonContains (@>) — subset containment. Operand is DeepPartial<T>.
+await pgDb.install.list({
+  where: { meta: { jsonContains: { settings: { theme: 'dark' } } } },
+});
+
+// jsonContainedBy (<@) — reverse containment.
+await pgDb.install.list({
+  where: { meta: { jsonContainedBy: { displayName: 'Acme', settings: { theme: 'dark', count: 1 } } } },
+});
+
+// hasKey (?) — top-level key existence. Operand is keyof T & string.
+await pgDb.install.list({
+  where: { meta: { hasKey: 'displayName' } },
+});
+```
+
+`jsonContains` operands are deep-partials of `T` (recursion capped at 5 levels). `hasKey` checks **top-level** keys only — for nested key presence, use `path((m: T) => m.nested.key).isNull(false)`.
+
+All three are Postgres-only; on SQLite they resolve to the same `JsonbOperator_Error_…` brand.
+
 ## Multi-tenancy
 
 Declare the tenant root by calling `.tenant()` on the root table definition. The framework automatically derives all tenant scoping from the relation graph — no per-model configuration needed.

--- a/packages/mint-docs/guides/db/schema.mdx
+++ b/packages/mint-docs/guides/db/schema.mdx
@@ -475,7 +475,9 @@ await pgDb.install.list({
 
 // jsonContainedBy (<@) — reverse containment.
 await pgDb.install.list({
-  where: { meta: { jsonContainedBy: { displayName: 'Acme', settings: { theme: 'dark', count: 1 } } } },
+  where: {
+    meta: { jsonContainedBy: { displayName: 'Acme', settings: { theme: 'dark', count: 1 } } },
+  },
 });
 
 // hasKey (?) — top-level key existence. Operand is keyof T & string.


### PR DESCRIPTION
## Summary

Implements the typed JSONB operator surface per [plans/jsonb-typed-operators.md](https://github.com/vertz-dev/vertz/blob/main/plans/jsonb-typed-operators.md) (design PR #2884).

- **Typed `path()` builder** — `path((m: T) => m.x.y).<op>(v)` preserves the payload's leaf type through the selector. Proxy-based runtime recorder with per-proxy segment accumulation (WeakMap keyed on the proxy) rejects garbage-segment selectors (`m.a + m.b`). Operator availability narrows per leaf: `contains`/`startsWith`/`endsWith` on strings, `gt`/`gte`/`lt`/`lte` on `number | bigint | Date`. Integer array indices emit unquoted (`->0`) to match Postgres JSONB array semantics.
- **Whole-payload operators** — `jsonContains` (`@>`, operand `DeepPartial<T>` capped at depth 5), `jsonContainedBy` (`<@`), `hasKey` (`?`, operand `JsonbKeyOf<T>` — union-safe via distributive conditional, `never` for non-object payloads).
- **Dialect gating** — new `JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` brand extends #2850's keyed-never mechanism. SQLite compile-time diagnostic names the recovery sentence verbatim.
- **`path` export** from package root; `JsonbPathDescriptor` / `PathSegment` kept internal.

## Review

Adversarial review found three blockers — all addressed in commit `e11a86447`:
1. Proxy garbage segments from `m.a + m.b` — fixed via per-proxy WeakMap + try/catch on primitive coercion.
2. `PathChain<TLeaf>` operator narrowing — conditional operator availability per leaf type.
3. Missing test coverage — added garbage-selector rejection tests, per-leaf narrowing negatives, collision-hasKey, and 20-model JSONB canary.

Plus should-fixes: dropped public exports of internal descriptor types, wrapped `JSON.stringify` for descriptive errors on BigInt/circular inputs.

## Follow-ups

- #2885 — array-operator type gating (scope-split from #2868 per product review)
- #2886 — `hasAllKeys` / `hasAnyKey` helpers (deferred; can be composed via `AND: [{ hasKey: 'a' }, …]`)

## Test plan

- [x] `vtz test` in `packages/db` — 1736 passed, 1 skipped
- [x] `tsgo --noEmit` for @vertz/db + @vertz/server — clean
- [x] `oxlint packages/` — 0 errors
- [x] `oxfmt --check packages/` — clean
- [x] Pre-push gates — all green (lint / test / trojan-source / build-typecheck)
- [ ] Human review of the typed-path ergonomics + `path` naming sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)