### PR TITLE
fix(ui,theme-shadcn,component-docs): radius scale vars, __conditional thunk unwrap, sidebar scroll preservation

### DIFF
--- a/.changeset/fix-conditional-unwrap-thunks-2899.md
+++ b/.changeset/fix-conditional-unwrap-thunks-2899.md
@@ -1,0 +1,10 @@
+---
+'@vertz/ui': patch
+'@vertz/ui-server': patch
+---
+
+fix(ui,ui-server): unwrap function thunks in __conditional and SSR normalizeChildren [#2899]
+
+The compiler wraps `children ?? value` as `__conditional(..., () => children, () => value)`, but `children` can itself be a reactive getter (`() => __staticText("Apple")`). `trueFn()` then returns a function instead of a Node, which `String()` stringifies into the function's source code and ships as visible text — breaking every `<Select.Item>Apple</Select.Item>` on the component-docs site.
+
+Fix: `insertContentBefore` / `appendBranchContent` in `@vertz/ui`'s `__conditional` now unwrap nested function thunks before inserting. Same fix landed on `@vertz/ui-server`'s SSR `normalizeChildren` so library code that uses classic JSX factories (ui-primitives) is safe too.

--- a/.changeset/fix-radius-scale-vars-2898.md
+++ b/.changeset/fix-radius-scale-vars-2898.md
@@ -1,0 +1,11 @@
+---
+'@vertz/theme-shadcn': patch
+---
+
+fix(theme-shadcn): emit `--radius-*` scale vars in `configureThemeBase()` [#2898]
+
+`token.radius.sm|md|lg|xl|full` compile to `var(--radius-*)`, but only the single
+`--radius` was being emitted — so every consumer shipped with `border-radius: 0`
+(squared buttons, cards, inputs, and squared radios/avatars/switches/badges that
+should be circles). Emit the full shadcn-style calc-based scale plus
+`--radius-full: 9999px` alongside `--radius`.

--- a/packages/component-docs/src/app.tsx
+++ b/packages/component-docs/src/app.tsx
@@ -1,5 +1,6 @@
 import { getInjectedCSS, ThemeProvider } from '@vertz/ui';
-import { createRouter, defineRoutes, RouterView } from '@vertz/ui/router';
+import { createRouter, defineRoutes, RouterContext, RouterView } from '@vertz/ui/router';
+import { DocsLayout } from './components/docs-layout';
 import {
   applyAccent,
   applyPalette,
@@ -22,6 +23,9 @@ export const theme = docsTheme;
 export const styles = [themeGlobals.css, appGlobals.css];
 
 // ── Routes ─────────────────────────────────────────────────
+// DocsLayout is hoisted to App (see below) so the sidebar DOM node persists
+// across navigations. Routes only render the content area — RouterView
+// replaces the <main> children, the <aside> stays mounted.
 export const routes = defineRoutes({
   '/': {
     component: () => <IndexRedirect />,
@@ -68,7 +72,11 @@ export function App() {
   return (
     <ThemeContext.Provider value={{ theme: currentTheme, toggle }}>
       <ThemeProvider theme={currentTheme}>
-        <RouterView router={router} fallback={() => <div>Page not found</div>} />
+        <RouterContext.Provider value={router}>
+          <DocsLayout>
+            <RouterView router={router} fallback={() => <div>Page not found</div>} />
+          </DocsLayout>
+        </RouterContext.Provider>
       </ThemeProvider>
     </ThemeContext.Provider>
   );

--- a/packages/component-docs/src/components/command-palette.tsx
+++ b/packages/component-docs/src/components/command-palette.tsx
@@ -1,4 +1,4 @@
-import { onCleanup } from '@vertz/ui';
+import { onMount } from '@vertz/ui';
 import { useRouter } from '@vertz/ui/router';
 import { type ComponentEntry, components } from '../manifest';
 
@@ -81,10 +81,10 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   }
 
   // Component-scoped listener with cleanup — no duplicates on re-mount
-  if (typeof document !== 'undefined') {
+  onMount(() => {
     document.addEventListener('keydown', handleKeyDown, true);
-    onCleanup(() => document.removeEventListener('keydown', handleKeyDown, true));
-  }
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  });
 
   function handleInput(e: Event) {
     query = (e.target as HTMLInputElement).value;

--- a/packages/component-docs/src/components/docs-layout.tsx
+++ b/packages/component-docs/src/components/docs-layout.tsx
@@ -50,9 +50,7 @@ export function DocsLayout({ children }: DocsLayoutProps) {
         style={{ display: 'flex', flex: '1', maxWidth: '1400px', margin: '0 auto', width: '100%' }}
       >
         <Sidebar />
-        <main style={{ flex: '1', minWidth: '0', padding: '32px 48px', maxWidth: '800px' }}>
-          {children}
-        </main>
+        <main style={{ flex: '1', minWidth: '0' }}>{children}</main>
       </div>
       <CommandPalette open={searchOpen} onClose={closeSearch} />
     </div>

--- a/packages/component-docs/src/components/docs-layout.tsx
+++ b/packages/component-docs/src/components/docs-layout.tsx
@@ -1,14 +1,13 @@
-import { onCleanup } from '@vertz/ui';
+import { onMount } from '@vertz/ui';
 import { CommandPalette } from './command-palette';
 import { Header } from './header';
 import { Sidebar } from './sidebar';
 
 interface DocsLayoutProps {
-  activeName?: string;
   children?: unknown;
 }
 
-export function DocsLayout({ activeName, children }: DocsLayoutProps) {
+export function DocsLayout({ children }: DocsLayoutProps) {
   let searchOpen = false;
 
   function openSearch() {
@@ -31,8 +30,9 @@ export function DocsLayout({ activeName, children }: DocsLayoutProps) {
     }
   }
 
-  // Global keyboard shortcut: Cmd+K / Ctrl+K — scoped with cleanup
-  if (typeof window !== 'undefined') {
+  // Global keyboard shortcut: Cmd+K / Ctrl+K — wired on mount so the
+  // cleanup lands in a proper disposal scope (required at the App root).
+  onMount(() => {
     function handleCmdK(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
@@ -40,8 +40,8 @@ export function DocsLayout({ activeName, children }: DocsLayoutProps) {
       }
     }
     window.addEventListener('keydown', handleCmdK);
-    onCleanup(() => window.removeEventListener('keydown', handleCmdK));
-  }
+    return () => window.removeEventListener('keydown', handleCmdK);
+  });
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -49,7 +49,7 @@ export function DocsLayout({ activeName, children }: DocsLayoutProps) {
       <div
         style={{ display: 'flex', flex: '1', maxWidth: '1400px', margin: '0 auto', width: '100%' }}
       >
-        <Sidebar activeName={activeName} />
+        <Sidebar />
         <main style={{ flex: '1', minWidth: '0', padding: '32px 48px', maxWidth: '800px' }}>
           {children}
         </main>

--- a/packages/component-docs/src/components/sidebar.tsx
+++ b/packages/component-docs/src/components/sidebar.tsx
@@ -1,12 +1,17 @@
-import { Link } from '@vertz/ui/router';
+import { Link, useRouter } from '@vertz/ui/router';
 import { getComponentsByCategory } from '../manifest';
 
-interface SidebarProps {
-  activeName?: string;
-}
-
-export function Sidebar({ activeName }: SidebarProps) {
+export function Sidebar() {
   const grouped = getComponentsByCategory();
+  const router = useRouter();
+
+  // Derive active state from the reactive route match so the sidebar DOM
+  // node stays mounted across navigations while the active link still updates.
+  function isActive(name: string): boolean {
+    const match = router.current;
+    if (name === '__overview') return match?.route.pattern === '/overview';
+    return match?.params.name === name;
+  }
 
   return (
     <aside
@@ -23,12 +28,12 @@ export function Sidebar({ activeName }: SidebarProps) {
     >
       <Link
         href="/overview"
-        className={activeName === '__overview' ? 'sidebar-link-active' : 'sidebar-link'}
+        className={isActive('__overview') ? 'sidebar-link-active' : 'sidebar-link'}
       >
         Overview
       </Link>
       <div style={{ height: '8px' }} />
-      {Array.from(grouped.entries()).map(([category, entries]) => (
+      {Array.from(grouped.entries()).map((group) => (
         <div>
           <div
             style={{
@@ -40,12 +45,12 @@ export function Sidebar({ activeName }: SidebarProps) {
               letterSpacing: '0.05em',
             }}
           >
-            {category}
+            {group[0]}
           </div>
-          {entries.map((entry) => (
+          {group[1].map((entry) => (
             <Link
               href={`/components/${entry.name}`}
-              className={entry.name === activeName ? 'sidebar-link-active' : 'sidebar-link'}
+              className={isActive(entry.name) ? 'sidebar-link-active' : 'sidebar-link'}
             >
               {entry.title}
             </Link>

--- a/packages/component-docs/src/components/sidebar.tsx
+++ b/packages/component-docs/src/components/sidebar.tsx
@@ -1,17 +1,8 @@
-import { Link, useRouter } from '@vertz/ui/router';
+import { Link } from '@vertz/ui/router';
 import { getComponentsByCategory } from '../manifest';
 
 export function Sidebar() {
   const grouped = getComponentsByCategory();
-  const router = useRouter();
-
-  // Derive active state from the reactive route match so the sidebar DOM
-  // node stays mounted across navigations while the active link still updates.
-  function isActive(name: string): boolean {
-    const match = router.current;
-    if (name === '__overview') return match?.route.pattern === '/overview';
-    return match?.params.name === name;
-  }
 
   return (
     <aside
@@ -26,10 +17,7 @@ export function Sidebar() {
         flexShrink: '0',
       }}
     >
-      <Link
-        href="/overview"
-        className={isActive('__overview') ? 'sidebar-link-active' : 'sidebar-link'}
-      >
+      <Link href="/overview" className="sidebar-link" activeClass="sidebar-link-active">
         Overview
       </Link>
       <div style={{ height: '8px' }} />
@@ -50,7 +38,8 @@ export function Sidebar() {
           {group[1].map((entry) => (
             <Link
               href={`/components/${entry.name}`}
-              className={isActive(entry.name) ? 'sidebar-link-active' : 'sidebar-link'}
+              className="sidebar-link"
+              activeClass="sidebar-link-active"
             >
               {entry.title}
             </Link>

--- a/packages/component-docs/src/pages/component-page.tsx
+++ b/packages/component-docs/src/pages/component-page.tsx
@@ -1,5 +1,4 @@
 import { useParams } from '@vertz/ui/router';
-import { DocsLayout } from '../components/docs-layout';
 import { PrevNext } from '../components/prev-next';
 import { PrevNextCompact } from '../components/prev-next-compact';
 import { Content as AccordionContent } from '../content/accordion-content';
@@ -114,7 +113,7 @@ export function ComponentPage() {
 
   if (!entry) {
     return (
-      <DocsLayout>
+      <>
         <h1
           style={{
             fontSize: '30px',
@@ -136,20 +135,15 @@ export function ComponentPage() {
         >
           The component "{name}" does not exist in the documentation.
         </p>
-      </DocsLayout>
+      </>
     );
   }
 
   const description = descriptions[name];
   const ContentComponent = contentMap[name];
 
-  // Reset scroll position when navigating to a new component
-  if (typeof window !== 'undefined') {
-    window.scrollTo(0, 0);
-  }
-
   return (
-    <DocsLayout activeName={name}>
+    <>
       <h1
         style={{
           fontSize: '30px',
@@ -174,6 +168,6 @@ export function ComponentPage() {
       <PrevNextCompact prev={prev} next={next} />
       {ContentComponent ? <ContentComponent /> : null}
       <PrevNext prev={prev} next={next} />
-    </DocsLayout>
+    </>
   );
 }

--- a/packages/component-docs/src/pages/component-page.tsx
+++ b/packages/component-docs/src/pages/component-page.tsx
@@ -1,3 +1,4 @@
+import { onMount } from '@vertz/ui';
 import { useParams } from '@vertz/ui/router';
 import { PrevNext } from '../components/prev-next';
 import { PrevNextCompact } from '../components/prev-next-compact';
@@ -106,14 +107,25 @@ const contentMap: Record<
   'toggle-group': ToggleGroupContent,
 };
 
+const PAGE_STYLE: Record<string, string> = {
+  padding: '32px 48px',
+  maxWidth: '800px',
+};
+
 export function ComponentPage() {
   const { name } = useParams<'/components/:name'>();
   const entry = findComponent(name);
   const { prev, next } = getAdjacentComponents(name);
 
+  // Reset window scroll on every component-page mount — runs after the new
+  // page is in the DOM, so each component nav starts at the top.
+  onMount(() => {
+    window.scrollTo(0, 0);
+  });
+
   if (!entry) {
     return (
-      <>
+      <div style={PAGE_STYLE}>
         <h1
           style={{
             fontSize: '30px',
@@ -135,7 +147,7 @@ export function ComponentPage() {
         >
           The component "{name}" does not exist in the documentation.
         </p>
-      </>
+      </div>
     );
   }
 
@@ -143,7 +155,7 @@ export function ComponentPage() {
   const ContentComponent = contentMap[name];
 
   return (
-    <>
+    <div style={PAGE_STYLE}>
       <h1
         style={{
           fontSize: '30px',
@@ -168,6 +180,6 @@ export function ComponentPage() {
       <PrevNextCompact prev={prev} next={next} />
       {ContentComponent ? <ContentComponent /> : null}
       <PrevNext prev={prev} next={next} />
-    </>
+    </div>
   );
 }

--- a/packages/component-docs/src/pages/overview-page.tsx
+++ b/packages/component-docs/src/pages/overview-page.tsx
@@ -24,7 +24,6 @@ import {
   Toggle,
   ToggleGroup,
 } from '@vertz/ui/components';
-import { Header } from '../components/header';
 
 // ── Shared styles ────────────────────────────────────────────
 const cardStyle: Record<string, string> = {
@@ -887,7 +886,6 @@ function TeamCardDemo() {
 export function OverviewPage() {
   return (
     <div>
-      <Header />
       <div
         style={{
           maxWidth: '1200px',

--- a/packages/component-docs/src/styles/globals.ts
+++ b/packages/component-docs/src/styles/globals.ts
@@ -26,10 +26,7 @@ export const appGlobals = globalCss({
     fontSize: '14px',
     color: 'var(--color-muted-foreground)',
   },
-  '.sidebar-link-active': {
-    display: 'block',
-    padding: '4px 24px',
-    fontSize: '14px',
+  '.sidebar-link.sidebar-link-active': {
     color: 'var(--color-foreground)',
     fontWeight: '500',
   },

--- a/packages/theme-shadcn/src/__tests__/globals.test.ts
+++ b/packages/theme-shadcn/src/__tests__/globals.test.ts
@@ -8,6 +8,22 @@ describe('theme globals', () => {
     expect(globals.css).toContain('dialog:not([open])');
     expect(globals.css).toContain('display: none');
   });
+
+  // Regression guard: `token.radius.lg` compiles to `var(--radius-lg)`, but
+  // only `--radius` was being emitted — so `border-radius` fell back to 0 and
+  // every button/card shipped with squared corners. Emit the shadcn-style
+  // calc-based scale plus `full` so the radius tokens resolve out of the box.
+  it('emits shadcn-style calc-based radius scale vars so token.radius.* resolves', () => {
+    const { globals } = configureThemeBase();
+    expect(globals.css).toContain('--radius-xs: calc(var(--radius) - 6px)');
+    expect(globals.css).toContain('--radius-sm: calc(var(--radius) - 4px)');
+    expect(globals.css).toContain('--radius-md: calc(var(--radius) - 2px)');
+    expect(globals.css).toContain('--radius-lg: var(--radius)');
+    expect(globals.css).toContain('--radius-xl: calc(var(--radius) + 4px)');
+    expect(globals.css).toContain('--radius-2xl: calc(var(--radius) + 8px)');
+    expect(globals.css).toContain('--radius-3xl: calc(var(--radius) + 12px)');
+    expect(globals.css).toContain('--radius-full: 9999px');
+  });
 });
 
 describe('configureThemeBase() default scales', () => {

--- a/packages/theme-shadcn/src/__tests__/globals.test.ts
+++ b/packages/theme-shadcn/src/__tests__/globals.test.ts
@@ -15,6 +15,7 @@ describe('theme globals', () => {
   // calc-based scale plus `full` so the radius tokens resolve out of the box.
   it('emits shadcn-style calc-based radius scale vars so token.radius.* resolves', () => {
     const { globals } = configureThemeBase();
+    expect(globals.css).toContain('--radius-none: 0');
     expect(globals.css).toContain('--radius-xs: calc(var(--radius) - 6px)');
     expect(globals.css).toContain('--radius-sm: calc(var(--radius) - 4px)');
     expect(globals.css).toContain('--radius-md: calc(var(--radius) - 2px)');

--- a/packages/theme-shadcn/src/base.ts
+++ b/packages/theme-shadcn/src/base.ts
@@ -208,6 +208,18 @@ export function configureThemeBase(config?: ThemeConfig): ResolvedThemeBase {
     },
     ':root': {
       '--radius': RADIUS_VALUES[radius] ?? '0.375rem',
+      // shadcn-style radius scale: `token.radius.xs|sm|md|lg|xl|2xl|3xl|full`
+      // compiles to `var(--radius-*)`, so these must resolve out of the box —
+      // otherwise `border-radius` falls back to 0 and components ship with
+      // squared corners (including radios, avatars, and other `full` shapes).
+      '--radius-xs': 'calc(var(--radius) - 6px)',
+      '--radius-sm': 'calc(var(--radius) - 4px)',
+      '--radius-md': 'calc(var(--radius) - 2px)',
+      '--radius-lg': 'var(--radius)',
+      '--radius-xl': 'calc(var(--radius) + 4px)',
+      '--radius-2xl': 'calc(var(--radius) + 8px)',
+      '--radius-3xl': 'calc(var(--radius) + 12px)',
+      '--radius-full': '9999px',
     },
     body: {
       fontFamily:

--- a/packages/theme-shadcn/src/base.ts
+++ b/packages/theme-shadcn/src/base.ts
@@ -212,6 +212,7 @@ export function configureThemeBase(config?: ThemeConfig): ResolvedThemeBase {
       // compiles to `var(--radius-*)`, so these must resolve out of the box —
       // otherwise `border-radius` falls back to 0 and components ship with
       // squared corners (including radios, avatars, and other `full` shapes).
+      '--radius-none': '0',
       '--radius-xs': 'calc(var(--radius) - 6px)',
       '--radius-sm': 'calc(var(--radius) - 4px)',
       '--radius-md': 'calc(var(--radius) - 2px)',

--- a/packages/ui-server/src/__tests__/server-jsx-runtime.test.ts
+++ b/packages/ui-server/src/__tests__/server-jsx-runtime.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from '@vertz/test';
 import { jsx } from '../jsx-runtime/index';
 
+// Regression guard: the Vertz reactive compiler passes children as
+// getter functions — e.g., `<Select.Item>Apple</Select.Item>` compiles to
+// `Select.Item({ children: () => __staticText("Apple") })`. ui-primitives'
+// libraries are compiled with the classic automatic JSX transform, so their
+// internal calls land in this server runtime. `normalizeChildren` must
+// invoke function children (like the client runtime does) — otherwise SSR
+// emits the function's source code as literal text, which survives
+// hydration and ships as visible garbage like `() => __staticText("Apple")`.
+describe('Server JSX Runtime — reactive getter children', () => {
+  it('invokes function children instead of stringifying them', () => {
+    const vnode = jsx('div', { children: () => 'Apple' });
+    expect(vnode.children).toEqual(['Apple']);
+  });
+
+  it('invokes function children that return VNodes', () => {
+    const child = jsx('span', { children: 'inner' });
+    const vnode = jsx('div', { children: () => child });
+    expect(vnode.children).toEqual([child]);
+  });
+
+  it('invokes function children inside arrays (children ?? value pattern)', () => {
+    const vnode = jsx('div', { children: [() => 'Apple', jsx('span', { children: 'icon' })] });
+    expect(vnode.children[0]).toBe('Apple');
+    expect((vnode.children[1] as { tag: string }).tag).toBe('span');
+  });
+});
+
 describe('Server JSX Runtime — className support', () => {
   it('should map className to class attribute in VNode attrs', () => {
     const vnode = jsx('div', { className: 'wrapper' });

--- a/packages/ui-server/src/__tests__/server-jsx-runtime.test.ts
+++ b/packages/ui-server/src/__tests__/server-jsx-runtime.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from '@vertz/test';
 import { jsx } from '../jsx-runtime/index';
+import { renderToStream } from '../render-to-stream';
+import { streamToString } from '../streaming';
 
 // Regression guard: the Vertz reactive compiler passes children as
 // getter functions — e.g., `<Select.Item>Apple</Select.Item>` compiles to
@@ -25,6 +27,28 @@ describe('Server JSX Runtime — reactive getter children', () => {
     const vnode = jsx('div', { children: [() => 'Apple', jsx('span', { children: 'icon' })] });
     expect(vnode.children[0]).toBe('Apple');
     expect((vnode.children[1] as { tag: string }).tag).toBe('span');
+  });
+
+  it('unwraps nested thunks (thunk returning a thunk)', () => {
+    const vnode = jsx('div', { children: () => () => 'Deep' });
+    expect(vnode.children).toEqual(['Deep']);
+  });
+
+  it('renders function children to correct HTML via renderToStream (E2E guard)', async () => {
+    const vnode = jsx('div', {
+      role: 'option',
+      children: [() => 'Apple', jsx('span', { 'data-part': 'indicator' })],
+    });
+    const html = await streamToString(renderToStream(vnode));
+    expect(html).toBe('<div role="option">Apple<span data-part="indicator"></span></div>');
+    expect(html).not.toContain('=>');
+    expect(html).not.toContain('function');
+  });
+
+  it('caps recursion to catch circular thunks instead of hanging', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional circular thunk
+    const cyclic: any = () => cyclic;
+    expect(() => jsx('div', { children: cyclic })).toThrow(/max thunk depth/);
   });
 });
 

--- a/packages/ui-server/src/jsx-runtime/index.ts
+++ b/packages/ui-server/src/jsx-runtime/index.ts
@@ -35,7 +35,8 @@ function unwrapSignal(value: unknown): unknown {
  * Flattens nested arrays.
  * Converts numbers and other primitives to strings.
  */
-function normalizeChildren(children: unknown): (VNode | string | RawHtml)[] {
+const MAX_THUNK_DEPTH = 10;
+function normalizeChildren(children: unknown, depth = 0): (VNode | string | RawHtml)[] {
   if (children == null || children === false || children === true) {
     return [];
   }
@@ -45,11 +46,14 @@ function normalizeChildren(children: unknown): (VNode | string | RawHtml)[] {
   // server, invoke once and normalize the result. Without this, SSR emits the
   // function's source code as text and ships it to the client.
   if (typeof children === 'function') {
-    return normalizeChildren((children as () => unknown)());
+    if (depth >= MAX_THUNK_DEPTH) {
+      throw new Error('normalizeChildren: max thunk depth exceeded — possible circular thunk');
+    }
+    return normalizeChildren((children as () => unknown)(), depth + 1);
   }
 
   if (Array.isArray(children)) {
-    return children.flatMap(normalizeChildren);
+    return children.flatMap((c) => normalizeChildren(c, depth));
   }
 
   // VNode or RawHtml object

--- a/packages/ui-server/src/jsx-runtime/index.ts
+++ b/packages/ui-server/src/jsx-runtime/index.ts
@@ -40,6 +40,14 @@ function normalizeChildren(children: unknown): (VNode | string | RawHtml)[] {
     return [];
   }
 
+  // Reactive getter children — the Vertz compiler wraps text/expressions as
+  // `() => __staticText(...)` so they re-run reactively on the client. On the
+  // server, invoke once and normalize the result. Without this, SSR emits the
+  // function's source code as text and ships it to the client.
+  if (typeof children === 'function') {
+    return normalizeChildren((children as () => unknown)());
+  }
+
   if (Array.isArray(children)) {
     return children.flatMap(normalizeChildren);
   }

--- a/packages/ui/src/dom/__tests__/conditional.test.ts
+++ b/packages/ui/src/dom/__tests__/conditional.test.ts
@@ -106,6 +106,54 @@ describe('__conditional', () => {
     expect(container.innerHTML).not.toContain('=>');
   });
 
+  it('unwraps nested thunks (thunk returning a thunk returning a Node)', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () =>
+        (() => () => {
+          const span = document.createElement('span');
+          span.textContent = 'Deep';
+          return span;
+        }) as unknown as Node,
+      () => null,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toBe('Deep');
+  });
+
+  it('caps thunk recursion to catch circular thunks', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional circular thunk
+    const cyclic: any = () => cyclic;
+    expect(() => {
+      const fragment = __conditional(
+        () => show.value,
+        () => cyclic as Node,
+        () => null,
+      );
+      container.appendChild(fragment);
+    }).toThrow(/max thunk depth/);
+  });
+
+  it('preserves thunk unwrap across branch switches', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () => (() => 'yes') as unknown as Node,
+      () => (() => 'no') as unknown as Node,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toBe('yes');
+
+    show.value = false;
+    expect(container.textContent).toBe('no');
+    expect(container.innerHTML).not.toContain('=>');
+  });
+
   it('null branch leaves only anchor and end marker (adjacent)', () => {
     const show = signal(true);
     const container = document.createElement('div');

--- a/packages/ui/src/dom/__tests__/conditional.test.ts
+++ b/packages/ui/src/dom/__tests__/conditional.test.ts
@@ -69,6 +69,43 @@ describe('__conditional', () => {
     expect((container.childNodes[2] as Comment).data).toBe('/conditional');
   });
 
+  // Regression guard: the compiler wraps `children ?? value` in __conditional,
+  // but `children` is itself a reactive getter — `() => __staticText("Apple")`.
+  // So trueFn() returns that inner thunk, not a Node. The conditional must
+  // unwrap thunks before inserting — otherwise the function's source code
+  // gets stringified and ships as visible text (see component-docs Select bug).
+  it('unwraps function branch results (thunked children returning a Node)', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () =>
+        (() => {
+          const span = document.createElement('span');
+          span.textContent = 'Apple';
+          return span;
+        }) as unknown as Node,
+      () => null,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toBe('Apple');
+    expect(container.innerHTML).not.toContain('=>');
+    expect(container.innerHTML).not.toContain('function');
+  });
+
+  it('unwraps function branch results that return primitives', () => {
+    const show = signal(true);
+    const container = document.createElement('div');
+    const fragment = __conditional(
+      () => show.value,
+      () => (() => 'Banana') as unknown as Node,
+      () => null,
+    );
+    container.appendChild(fragment);
+    expect(container.textContent).toBe('Banana');
+    expect(container.innerHTML).not.toContain('=>');
+  });
+
   it('null branch leaves only anchor and end marker (adjacent)', () => {
     const show = signal(true);
     const container = document.createElement('div');

--- a/packages/ui/src/dom/conditional.ts
+++ b/packages/ui/src/dom/conditional.ts
@@ -23,20 +23,35 @@ function clearBetween(start: Node, end: Node): void {
 }
 
 /**
+ * Unwrap reactive thunks (`() => value`) to their concrete value. The compiler
+ * wraps JSX expressions like `children ?? value` in __conditional, but the
+ * inner `children` may itself be a reactive getter (`() => __staticText(...)`).
+ * Without this, `trueFn()` returns a function and `String(fn)` ships the
+ * function's source code as visible text.
+ */
+function unwrapThunk(value: unknown): unknown {
+  while (typeof value === 'function') {
+    value = (value as () => unknown)();
+  }
+  return value;
+}
+
+/**
  * Insert content before the end marker.
  * Handles: null/boolean (nothing), Node/DocumentFragment (insertBefore),
  * primitives (text node).
  * No-ops if endMarker is not yet attached to the DOM.
  */
 function insertContentBefore(endMarker: Node, branchResult: unknown): void {
-  if (branchResult == null || typeof branchResult === 'boolean') return;
+  const resolved = unwrapThunk(branchResult);
+  if (resolved == null || typeof resolved === 'boolean') return;
   const parent = endMarker.parentNode;
   if (!parent) return;
-  if (isRenderNode(branchResult)) {
-    parent.insertBefore(branchResult as Node, endMarker);
+  if (isRenderNode(resolved)) {
+    parent.insertBefore(resolved as Node, endMarker);
     return;
   }
-  const text = getAdapter().createTextNode(String(branchResult)) as unknown as Node;
+  const text = getAdapter().createTextNode(String(resolved)) as unknown as Node;
   parent.insertBefore(text, endMarker);
 }
 
@@ -46,12 +61,13 @@ function insertContentBefore(endMarker: Node, branchResult: unknown): void {
  * primitives (text node).
  */
 function appendBranchContent(fragment: DocumentFragment, branchResult: unknown): void {
-  if (branchResult == null || typeof branchResult === 'boolean') return;
-  if (isRenderNode(branchResult)) {
-    fragment.appendChild(branchResult as Node);
+  const resolved = unwrapThunk(branchResult);
+  if (resolved == null || typeof resolved === 'boolean') return;
+  if (isRenderNode(resolved)) {
+    fragment.appendChild(resolved as Node);
     return;
   }
-  fragment.appendChild(getAdapter().createTextNode(String(branchResult)) as unknown as Node);
+  fragment.appendChild(getAdapter().createTextNode(String(resolved)) as unknown as Node);
 }
 
 /**

--- a/packages/ui/src/dom/conditional.ts
+++ b/packages/ui/src/dom/conditional.ts
@@ -28,9 +28,17 @@ function clearBetween(start: Node, end: Node): void {
  * inner `children` may itself be a reactive getter (`() => __staticText(...)`).
  * Without this, `trueFn()` returns a function and `String(fn)` ships the
  * function's source code as visible text.
+ *
+ * Matches the safety contract of `resolveAndInsert` in `element.ts`: caps
+ * recursion to catch circular thunks instead of hanging the isolate.
  */
+const MAX_THUNK_DEPTH = 10;
 function unwrapThunk(value: unknown): unknown {
+  let depth = 0;
   while (typeof value === 'function') {
+    if (depth++ >= MAX_THUNK_DEPTH) {
+      throw new Error('__conditional: max thunk depth exceeded — possible circular thunk');
+    }
     value = (value as () => unknown)();
   }
   return value;
@@ -127,9 +135,13 @@ function hydrateConditional(
 
     if (isFirstRun) {
       isFirstRun = false;
-      // The branch function claims its SSR nodes via the hydration path
+      // The branch function claims its SSR nodes via the hydration path.
+      // Unwrap any nested thunk before the claim-text check — otherwise a
+      // `() => __staticText(...)` branch result looks like a primitive and
+      // we'd call claimText() here without the inner __staticText ever
+      // running to claim its own SSR text.
       const scope = pushScope();
-      const branchResult = show ? trueFn() : falseFn();
+      const branchResult = unwrapThunk(show ? trueFn() : falseFn());
       popScope();
       branchCleanups = scope;
 


### PR DESCRIPTION
Three independent bug fixes surfaced while inspecting the `@vertz/component-docs` site to verify default styles. Each has its own issue, dedicated regression tests, and an adversarial review under `reviews/`.

## Summary

- **#2898** — `configureThemeBase()` only emitted `--radius`; `token.radius.{xs,sm,md,lg,xl,2xl,3xl,full,none}` all compile to `var(--radius-*)` with no backing declaration. Every consumer shipped `border-radius: 0` — squared buttons/cards/inputs and squared-instead-of-round radios/avatars/switches/badges.
- **#2899** — The compiler wraps `children ?? value` in `__conditional`, but `children` can itself be a reactive getter (`() => __staticText("Apple")`). `trueFn()` returned the thunk, `String(fn)` stringified the arrow-function source, and every `<Select.Item>Apple</Select.Item>` on the site rendered as `() => __staticText("Apple")`.
- **#2903** — Sidebar scroll reset on every SPA navigation because `DocsLayout` lived inside the routed leaf component (the Vertz router fully re-renders same-chain leaves on param change — [router-view.ts:85-101](https://github.com/vertz-dev/vertz/blob/main/packages/ui/src/router/router-view.ts#L85-L101)). Hoisted `DocsLayout` above `RouterView`.

## Public API Changes

**Additions (no breakage):**
- `@vertz/theme-shadcn`: `configureThemeBase()` globalCss now includes `--radius-none|xs|sm|md|lg|xl|2xl|3xl|full` alongside the existing `--radius`. Purely additive.

**Breaking:**
- None.

**Internal (reviewed for compat):**
- `@vertz/ui`'s `__conditional` helpers (`insertContentBefore`, `appendBranchContent`) and its `hydrateConditional` first-run path now unwrap function-thunk branch results. Capped at `MAX_THUNK_DEPTH = 10` (matches `resolveAndInsert` in `element.ts`) to catch circular thunks. Primitives and ternaries that previously worked keep working — thunks that previously shipped as stringified text now render correctly.
- `@vertz/ui-server`'s SSR `normalizeChildren` gained the same function-thunk unwrap (defensive — covers library code that goes through the SSR-specific jsx factory).

## What each commit does

```
04137ad01 fix(component-docs): address review — overview layout, window-scroll reset, reactive activeClass [#2903]
5f0af7f33 fix(component-docs): preserve sidebar scroll on SPA navigation [#2903]
1e41aafc5 fix(ui,ui-server): address review — hydration path, depth cap, E2E test [#2899]
01afe1a77 fix(ui,ui-server): unwrap function thunks in __conditional + SSR normalizeChildren [#2899]
50a7a1b65 fix(theme-shadcn): also emit --radius-none so token.radius.none resolves [#2898]
2b7d36d3e fix(theme-shadcn): emit --radius-* scale vars so token.radius.* resolves [#2898]
```

## Tests

Each fix ships with regression tests covering the bug class, not just the reproducer:

- `packages/theme-shadcn/src/__tests__/globals.test.ts` — every scale var (including `full` and `none`) is emitted by `configureThemeBase()`.
- `packages/ui/src/dom/__tests__/conditional.test.ts` — thunked Node branch, thunked primitive branch, nested thunks (2-level), circular thunks cap, branch-switch preserves unwrap.
- `packages/ui-server/src/__tests__/server-jsx-runtime.test.ts` — thunks in children arrays, nested thunks, E2E `renderToStream` → HTML assertion (would catch any future regression where the bug reappears in shipped HTML), circular-thunk cap.
- Component-docs verified in a live browser: sidebar DOM node identity preserved across navigations, scroll position holds, active-link highlight transfers via Link's built-in `activeClass`, `/overview` still renders with 3-column grid, `window.scrollTo(0, 0)` runs on each component-page mount.

## Adversarial reviews

Each fix was reviewed by an independent agent. Reviews live under `reviews/fix-2898/`, `reviews/fix-2899/`, `reviews/fix-2903/` and were addressed with follow-up commits:

- **#2898 review** flagged `--radius-none` missing → added.
- **#2899 review** flagged the hydration path also needed the unwrap, missing depth cap, missing E2E HTML test → all fixed in `1e41aafc5`.
- **#2903 review** flagged `/overview` layout broken by 800px main, silent `window.scrollTo(0,0)` removal, fragile unkeyed `__list` reactivity → all fixed in `04137ad01`.

## Test plan

- [ ] CI green — monorepo tests + typecheck + lint
- [ ] `packages/component-docs` Select page: click trigger → options render as "Apple", "Banana", "Cherry" (not arrow-function source)
- [ ] `packages/component-docs` Button page: every variant has rounded corners
- [ ] `packages/component-docs` RadioGroup / Avatar: circles, not squares
- [ ] `packages/component-docs` sidebar: scroll to the bottom, click a link near the top of the list, confirm sidebar scroll position is preserved and the active-link highlight transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)