### PR TITLE
fix(db): route SQLite writes without RETURNING through execute() [#2890]

### DIFF
--- a/.changeset/fix-sqlite-rowcount-2890.md
+++ b/.changeset/fix-sqlite-rowcount-2890.md
@@ -1,0 +1,11 @@
+---
+'@vertz/db': patch
+---
+
+fix(db): route SQLite writes without RETURNING through `execute()` so `rowCount` is accurate
+
+Closes [#2890](https://github.com/vertz-dev/vertz/issues/2890).
+
+Writes that don't carry a `RETURNING` clause (`createMany` / `updateMany` / `deleteMany`) used to collapse to `rowCount: 0` on SQLite: the queryFn wrapper routed every statement through `driver.query()` (`stmt.all()`), which returns an empty result set for write-without-RETURNING. A `createMany({ data: [...] })` call would therefore report `count: 0` even when the rows had been persisted.
+
+The fix adds an exported `isWriteWithoutReturning(sql)` helper — a single-pass normalizer that blanks out string literals and comments (line + block, leading + trailing + mid-statement) before checking whether the top-level verb is `INSERT` / `UPDATE` / `DELETE` / `REPLACE` / `TRUNCATE` and whether a `RETURNING` clause is present. Both SQLite queryFn wrappers (D1 binding and local-file dialect) now dispatch write-without-RETURNING through `driver.execute()` (`stmt.run()`), surfacing `changes` as `rowCount`. Postgres routing and the `RETURNING` path are unchanged.

--- a/packages/db/src/client/__tests__/sqlite-rowcount.test.ts
+++ b/packages/db/src/client/__tests__/sqlite-rowcount.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression tests for #2890 — SQLite rowCount on write-without-RETURNING.
+ *
+ * Writes that don't carry a RETURNING clause (createMany / updateMany /
+ * deleteMany) must still surface an accurate `count`. Before the fix, the
+ * SQLite queryFn wrapper routed every statement through `driver.query()`
+ * (`stmt.all()`), which returns an empty result set for write statements,
+ * so `{ rows, rowCount: rows.length }` collapsed to `rowCount: 0`.
+ */
+
+import { describe, expect, it, mock } from '@vertz/test';
+import { createDb, isWriteWithoutReturning } from '../database';
+import type { D1Database, D1PreparedStatement } from '../sqlite-driver';
+import { d } from '../../d';
+
+// ---------------------------------------------------------------------------
+// Local SQLite (real driver via :memory:) — the repro from the issue
+// ---------------------------------------------------------------------------
+
+describe('Feature: SQLite rowCount for write-without-RETURNING (#2890)', () => {
+  describe('Given a local :memory: SQLite database', () => {
+    describe('When createMany inserts N rows without RETURNING', () => {
+      it('Then returns { count: N } matching rows actually persisted', async () => {
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+        });
+        const db = createDb({
+          dialect: 'sqlite',
+          path: ':memory:',
+          models: { plain: d.model(plain) },
+          migrations: { autoApply: true },
+        });
+
+        const res = await db.plain.createMany({
+          data: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+        });
+
+        expect(res.ok).toBe(true);
+        if (!res.ok) throw new TypeError('createMany failed');
+        expect(res.data.count).toBe(3);
+
+        const listed = await db.plain.list({});
+        if (!listed.ok) throw new TypeError('list failed');
+        expect(listed.data).toHaveLength(3);
+      });
+    });
+
+    describe('When updateMany matches N rows without RETURNING', () => {
+      it('Then returns { count: N } matching the rows actually updated', async () => {
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+          status: d.text().default('draft'),
+        });
+        const db = createDb({
+          dialect: 'sqlite',
+          path: ':memory:',
+          models: { plain: d.model(plain) },
+          migrations: { autoApply: true },
+        });
+
+        await db.plain.createMany({
+          data: [
+            { name: 'a', status: 'draft' },
+            { name: 'b', status: 'draft' },
+            { name: 'c', status: 'published' },
+          ],
+        });
+
+        const res = await db.plain.updateMany({
+          where: { status: 'draft' },
+          data: { status: 'archived' },
+        });
+
+        expect(res.ok).toBe(true);
+        if (!res.ok) throw new TypeError('updateMany failed');
+        expect(res.data.count).toBe(2);
+      });
+    });
+
+    describe('When deleteMany matches N rows without RETURNING', () => {
+      it('Then returns { count: N } matching the rows actually deleted', async () => {
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+          status: d.text().default('draft'),
+        });
+        const db = createDb({
+          dialect: 'sqlite',
+          path: ':memory:',
+          models: { plain: d.model(plain) },
+          migrations: { autoApply: true },
+        });
+
+        await db.plain.createMany({
+          data: [
+            { name: 'a', status: 'draft' },
+            { name: 'b', status: 'draft' },
+            { name: 'c', status: 'published' },
+          ],
+        });
+
+        const res = await db.plain.deleteMany({ where: { status: 'draft' } });
+
+        expect(res.ok).toBe(true);
+        if (!res.ok) throw new TypeError('deleteMany failed');
+        expect(res.data.count).toBe(2);
+
+        const remaining = await db.plain.list({});
+        if (!remaining.ok) throw new TypeError('list failed');
+        expect(remaining.data).toHaveLength(1);
+      });
+    });
+
+    describe('When createManyAndReturn inserts with RETURNING *', () => {
+      it('Then still returns all inserted rows (RETURNING path unchanged)', async () => {
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+        });
+        const db = createDb({
+          dialect: 'sqlite',
+          path: ':memory:',
+          models: { plain: d.model(plain) },
+          migrations: { autoApply: true },
+        });
+
+        const res = await db.plain.createManyAndReturn({
+          data: [{ name: 'a' }, { name: 'b' }],
+        });
+
+        expect(res.ok).toBe(true);
+        if (!res.ok) throw new TypeError('createManyAndReturn failed');
+        expect(res.data).toHaveLength(2);
+        expect(res.data.map((r) => r.name).sort()).toEqual(['a', 'b']);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // D1 binding — writes without RETURNING must call run(), not all()
+  // -------------------------------------------------------------------------
+
+  describe('Given a D1 binding', () => {
+    describe('When createMany issues an INSERT without RETURNING', () => {
+      it('Then the driver invokes run() (not all()) and surfaces meta.changes as count', async () => {
+        const allCalls: string[] = [];
+        const runCalls: string[] = [];
+        let lastSql = '';
+
+        const mockD1: D1Database = {
+          prepare: (sql: string) => {
+            lastSql = sql;
+            const stmt: D1PreparedStatement = {
+              bind(this: D1PreparedStatement) {
+                return this;
+              },
+              all: mock(async () => {
+                allCalls.push(lastSql);
+                return { results: [] };
+              }),
+              run: mock(async () => {
+                runCalls.push(lastSql);
+                return { meta: { changes: 3 } };
+              }),
+            };
+            return stmt;
+          },
+        } as unknown as D1Database;
+
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+        });
+
+        const db = createDb({
+          dialect: 'sqlite',
+          d1: mockD1,
+          models: { plain: d.model(plain) },
+        });
+
+        const res = await db.plain.createMany({
+          data: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+        });
+
+        expect(res.ok).toBe(true);
+        if (!res.ok) throw new TypeError('createMany failed');
+        expect(res.data.count).toBe(3);
+
+        // The INSERT without RETURNING must go through run(), not all()
+        const writeSqlAll = allCalls.filter((s) => /^INSERT\s/i.test(s));
+        const writeSqlRun = runCalls.filter((s) => /^INSERT\s/i.test(s));
+        expect(writeSqlAll).toHaveLength(0);
+        expect(writeSqlRun.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isWriteWithoutReturning helper — unit tests
+  // -------------------------------------------------------------------------
+
+  describe('isWriteWithoutReturning helper', () => {
+    it('returns true for plain INSERT / UPDATE / DELETE', () => {
+      expect(isWriteWithoutReturning('INSERT INTO t (a) VALUES (1)')).toBe(true);
+      expect(isWriteWithoutReturning('UPDATE t SET a = 1')).toBe(true);
+      expect(isWriteWithoutReturning('DELETE FROM t WHERE id = 1')).toBe(true);
+    });
+
+    it('returns false for writes that include a RETURNING clause', () => {
+      expect(isWriteWithoutReturning('INSERT INTO t (a) VALUES (1) RETURNING *')).toBe(false);
+      expect(isWriteWithoutReturning('UPDATE t SET a = 1 RETURNING id')).toBe(false);
+      expect(isWriteWithoutReturning('DELETE FROM t WHERE id = 1 RETURNING id')).toBe(false);
+      expect(isWriteWithoutReturning('insert into t (a) values (1) returning id')).toBe(false);
+    });
+
+    it('returns false for SELECT and DDL statements', () => {
+      expect(isWriteWithoutReturning('SELECT 1')).toBe(false);
+      expect(isWriteWithoutReturning('CREATE TABLE t (id INTEGER)')).toBe(false);
+      expect(isWriteWithoutReturning('DROP TABLE t')).toBe(false);
+      expect(isWriteWithoutReturning('PRAGMA foreign_keys = ON')).toBe(false);
+    });
+
+    it('strips leading comments before checking the verb', () => {
+      expect(isWriteWithoutReturning('-- a comment\nINSERT INTO t (a) VALUES (1)')).toBe(true);
+      expect(isWriteWithoutReturning('/* block comment */ UPDATE t SET a = 1 RETURNING id')).toBe(
+        false,
+      );
+    });
+
+    it('ignores the literal word RETURNING when it appears inside a quoted string', () => {
+      expect(
+        isWriteWithoutReturning("INSERT INTO t (note) VALUES ('RETURNING is just text')"),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/db/src/client/__tests__/sqlite-rowcount.test.ts
+++ b/packages/db/src/client/__tests__/sqlite-rowcount.test.ts
@@ -234,5 +234,83 @@ describe('Feature: SQLite rowCount for write-without-RETURNING (#2890)', () => {
         isWriteWithoutReturning("INSERT INTO t (note) VALUES ('RETURNING is just text')"),
       ).toBe(true);
     });
+
+    it('ignores RETURNING inside trailing line or block comments', () => {
+      // Trailing line comment — real statement has no RETURNING
+      expect(isWriteWithoutReturning('INSERT INTO t VALUES (1) -- RETURNING is fake')).toBe(true);
+      // Mid-statement block comment — real statement has no RETURNING
+      expect(isWriteWithoutReturning('UPDATE t SET a = 1 /* RETURNING x */')).toBe(true);
+      // Block comment before the verb — real RETURNING still present
+      expect(
+        isWriteWithoutReturning('/* note: RETURNING is inline */ UPDATE t SET a = 1 RETURNING id'),
+      ).toBe(false);
+    });
+
+    it('recognises REPLACE INTO (SQLite write verb) without RETURNING', () => {
+      expect(isWriteWithoutReturning('REPLACE INTO t (id, a) VALUES (1, 2)')).toBe(true);
+      expect(isWriteWithoutReturning('replace into t (id, a) values (1, 2) returning id')).toBe(
+        false,
+      );
+    });
+
+    it('does not classify writable CTEs as write-without-RETURNING (outer wrapper is SELECT)', () => {
+      expect(
+        isWriteWithoutReturning(
+          'WITH cte AS (INSERT INTO t VALUES (1) RETURNING id) SELECT * FROM cte',
+        ),
+      ).toBe(false);
+      expect(
+        isWriteWithoutReturning('with cte as (insert into t values (1)) select * from cte'),
+      ).toBe(false);
+      expect(
+        isWriteWithoutReturning('WITH cte AS (DELETE FROM t WHERE id = 1) SELECT * FROM cte'),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Transactions — the new routing must also apply inside db.transaction()
+  // -------------------------------------------------------------------------
+
+  describe('Given a local :memory: SQLite database inside a transaction', () => {
+    describe('When createMany / updateMany run via tx delegates', () => {
+      it('Then each call surfaces accurate { count } and the writes commit', async () => {
+        const plain = d.table('plain', {
+          id: d.uuid().primary({ generate: 'cuid' }),
+          name: d.text(),
+          status: d.text().default('draft'),
+        });
+        const db = createDb({
+          dialect: 'sqlite',
+          path: ':memory:',
+          models: { plain: d.model(plain) },
+          migrations: { autoApply: true },
+        });
+
+        const result = await db.transaction(async (tx) => {
+          const created = await tx.plain.createMany({
+            data: [
+              { name: 'a', status: 'draft' },
+              { name: 'b', status: 'draft' },
+              { name: 'c', status: 'published' },
+            ],
+          });
+          if (!created.ok) throw new TypeError('createMany failed');
+          const updated = await tx.plain.updateMany({
+            where: { status: 'draft' },
+            data: { status: 'archived' },
+          });
+          if (!updated.ok) throw new TypeError('updateMany failed');
+          return { createdCount: created.data.count, updatedCount: updated.data.count };
+        });
+
+        expect(result.createdCount).toBe(3);
+        expect(result.updatedCount).toBe(2);
+
+        const listed = await db.plain.list({});
+        if (!listed.ok) throw new TypeError('list failed');
+        expect(listed.data).toHaveLength(3);
+      });
+    });
   });
 });

--- a/packages/db/src/client/database.ts
+++ b/packages/db/src/client/database.ts
@@ -109,6 +109,88 @@ export function isReadQuery(sqlStr: string): boolean {
   return upper.startsWith('SELECT');
 }
 
+/**
+ * Strip leading SQL comments (`--`, `/* ... * /`, `//`) and whitespace.
+ * Returns the first non-comment / non-whitespace slice of `sql`. If a comment
+ * is unterminated, returns the empty string — callers treat that as "no
+ * detectable verb" and fall back to their safe default.
+ */
+function stripLeadingSqlComments(sql: string): string {
+  let s = sql.trim();
+  while (s.startsWith('--') || s.startsWith('/*') || s.startsWith('//')) {
+    if (s.startsWith('--') || s.startsWith('//')) {
+      const nl = s.indexOf('\n');
+      if (nl === -1) return '';
+      s = s.slice(nl + 1).trim();
+    } else {
+      const end = s.indexOf('*/');
+      if (end === -1) return '';
+      s = s.slice(end + 2).trim();
+    }
+  }
+  return s;
+}
+
+/**
+ * Strip SQL string literals (both `'...'` and `"..."`) from a statement so
+ * word-boundary scans don't match keywords that appear inside values /
+ * identifiers. Doubled quotes (`''`, `""`) are treated as escapes.
+ */
+function stripSqlStringLiterals(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql.charCodeAt(i);
+    if (ch === 39 /* ' */ || ch === 34 /* " */) {
+      const quote = sql[i]!;
+      i++;
+      while (i < sql.length) {
+        if (sql[i] === quote) {
+          if (sql[i + 1] === quote) {
+            // Escaped quote — skip both and keep scanning inside the literal.
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += sql[i];
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Detect a top-level write statement (`INSERT` / `UPDATE` / `DELETE` /
+ * `TRUNCATE`) that does **not** carry a `RETURNING` clause.
+ *
+ * The SQLite queryFn wrapper uses this to dispatch such statements through
+ * `driver.execute()` (`stmt.run()`), which reports `changes` — rather than
+ * `driver.query()` (`stmt.all()`), which returns an empty result set for
+ * writes without a RETURNING clause, causing `rowCount` to collapse to `0`.
+ *
+ * Writable CTEs (`WITH ... INSERT/UPDATE/DELETE`) are NOT classified as
+ * write-without-RETURNING by this helper, because their outer wrapper is a
+ * `SELECT` that must still go through `query()` to surface rows.
+ */
+export function isWriteWithoutReturning(sql: string): boolean {
+  const trimmed = stripLeadingSqlComments(sql);
+  if (!trimmed) return false;
+  const upper = trimmed.toUpperCase();
+  const startsWithWrite =
+    upper.startsWith('INSERT ') ||
+    upper.startsWith('UPDATE ') ||
+    upper.startsWith('DELETE ') ||
+    upper.startsWith('TRUNCATE ');
+  if (!startsWithWrite) return false;
+  const withoutStrings = stripSqlStringLiterals(trimmed);
+  return !/\bRETURNING\b/i.test(withoutStrings);
+}
+
 // ---------------------------------------------------------------------------
 // Pool configuration
 // ---------------------------------------------------------------------------
@@ -1003,11 +1085,20 @@ export function createDb<TModels extends Record<string, ModelEntry>>(
       const tableSchema = buildTableSchema(models);
       sqliteDriver = createSqliteDriver(options.d1, tableSchema);
 
-      // Return a query function that wraps the SQLite driver
-      // SQLite driver returns rows[], but QueryFn expects { rows, rowCount }
+      // Return a query function that wraps the SQLite driver.
+      //
+      // SQLite driver splits rows vs. changes between two methods: `query()`
+      // (`stmt.all()`) returns rows and cannot see `changes`; `execute()`
+      // (`stmt.run()`) reports `changes` but returns no rows. Writes without
+      // a RETURNING clause therefore MUST go through `execute()` — otherwise
+      // `rowCount` collapses to the length of an empty row array (see #2890).
       return async <T>(sqlStr: string, params: readonly unknown[]) => {
         if (!sqliteDriver) {
           throw new Error('SQLite driver not initialized');
+        }
+        if (isWriteWithoutReturning(sqlStr)) {
+          const res = await sqliteDriver.execute(sqlStr, params as unknown[]);
+          return { rows: [] as T[], rowCount: res.rowsAffected };
         }
         const rows = await sqliteDriver.query<T>(sqlStr, params as unknown[]);
         return { rows, rowCount: rows.length };
@@ -1057,6 +1148,10 @@ export function createDb<TModels extends Record<string, ModelEntry>>(
       return async <T>(sqlStr: string, params: readonly unknown[]) => {
         const driver = await ensureDriver();
         await ensureMigrated();
+        if (isWriteWithoutReturning(sqlStr)) {
+          const res = await driver.execute(sqlStr, params as unknown[]);
+          return { rows: [] as T[], rowCount: res.rowsAffected };
+        }
         const rows = await driver.query<T>(sqlStr, params as unknown[]);
         return { rows, rowCount: rows.length };
       };

--- a/packages/db/src/client/database.ts
+++ b/packages/db/src/client/database.ts
@@ -110,55 +110,65 @@ export function isReadQuery(sqlStr: string): boolean {
 }
 
 /**
- * Strip leading SQL comments (`--`, `/* ... * /`, `//`) and whitespace.
- * Returns the first non-comment / non-whitespace slice of `sql`. If a comment
- * is unterminated, returns the empty string — callers treat that as "no
- * detectable verb" and fall back to their safe default.
+ * Strip SQL comments (`--`, `/* ... * /`) AND string literals (`'...'`,
+ * `"..."`) in a single left-to-right pass, replacing each with an equivalent
+ * amount of whitespace so column positions (and therefore `\b` word
+ * boundaries) are preserved. Doubled quotes (`''`, `""`) escape.
+ *
+ * Unterminated comments / strings consume the remaining tail. Used by the
+ * write-routing heuristic below so trailing / mid-statement comments don't
+ * produce false-negatives when they happen to contain SQL keywords.
  */
-function stripLeadingSqlComments(sql: string): string {
-  let s = sql.trim();
-  while (s.startsWith('--') || s.startsWith('/*') || s.startsWith('//')) {
-    if (s.startsWith('--') || s.startsWith('//')) {
-      const nl = s.indexOf('\n');
-      if (nl === -1) return '';
-      s = s.slice(nl + 1).trim();
-    } else {
-      const end = s.indexOf('*/');
-      if (end === -1) return '';
-      s = s.slice(end + 2).trim();
-    }
-  }
-  return s;
-}
-
-/**
- * Strip SQL string literals (both `'...'` and `"..."`) from a statement so
- * word-boundary scans don't match keywords that appear inside values /
- * identifiers. Doubled quotes (`''`, `""`) are treated as escapes.
- */
-function stripSqlStringLiterals(sql: string): string {
+function stripSqlCommentsAndStrings(sql: string): string {
   let out = '';
   let i = 0;
   while (i < sql.length) {
-    const ch = sql.charCodeAt(i);
-    if (ch === 39 /* ' */ || ch === 34 /* " */) {
-      const quote = sql[i]!;
+    const a = sql[i];
+    const b = sql[i + 1];
+    // Line comment: -- ... \n
+    if (a === '-' && b === '-') {
+      const nl = sql.indexOf('\n', i + 2);
+      if (nl === -1) {
+        out += ' '.repeat(sql.length - i);
+        return out;
+      }
+      out += ' '.repeat(nl - i);
+      i = nl; // keep the newline
+      continue;
+    }
+    // Block comment: /* ... */
+    if (a === '/' && b === '*') {
+      const end = sql.indexOf('*/', i + 2);
+      if (end === -1) {
+        out += ' '.repeat(sql.length - i);
+        return out;
+      }
+      out += ' '.repeat(end + 2 - i);
+      i = end + 2;
+      continue;
+    }
+    // String literal: '...' or "..."
+    if (a === "'" || a === '"') {
+      const quote = a;
+      out += ' ';
       i++;
       while (i < sql.length) {
         if (sql[i] === quote) {
           if (sql[i + 1] === quote) {
-            // Escaped quote — skip both and keep scanning inside the literal.
+            out += '  ';
             i += 2;
             continue;
           }
+          out += ' ';
           i++;
           break;
         }
+        out += ' ';
         i++;
       }
       continue;
     }
-    out += sql[i];
+    out += a;
     i++;
   }
   return out;
@@ -166,7 +176,7 @@ function stripSqlStringLiterals(sql: string): string {
 
 /**
  * Detect a top-level write statement (`INSERT` / `UPDATE` / `DELETE` /
- * `TRUNCATE`) that does **not** carry a `RETURNING` clause.
+ * `TRUNCATE` / `REPLACE`) that does **not** carry a `RETURNING` clause.
  *
  * The SQLite queryFn wrapper uses this to dispatch such statements through
  * `driver.execute()` (`stmt.run()`), which reports `changes` — rather than
@@ -178,17 +188,17 @@ function stripSqlStringLiterals(sql: string): string {
  * `SELECT` that must still go through `query()` to surface rows.
  */
 export function isWriteWithoutReturning(sql: string): boolean {
-  const trimmed = stripLeadingSqlComments(sql);
-  if (!trimmed) return false;
-  const upper = trimmed.toUpperCase();
+  const normalized = stripSqlCommentsAndStrings(sql).trim();
+  if (!normalized) return false;
+  const upper = normalized.toUpperCase();
   const startsWithWrite =
     upper.startsWith('INSERT ') ||
     upper.startsWith('UPDATE ') ||
     upper.startsWith('DELETE ') ||
+    upper.startsWith('REPLACE ') ||
     upper.startsWith('TRUNCATE ');
   if (!startsWithWrite) return false;
-  const withoutStrings = stripSqlStringLiterals(trimmed);
-  return !/\bRETURNING\b/i.test(withoutStrings);
+  return !/\bRETURNING\b/i.test(normalized);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/db/src/query/__tests__/crud-jsonb-validator-writes.test.ts
+++ b/packages/db/src/query/__tests__/crud-jsonb-validator-writes.test.ts
@@ -541,9 +541,8 @@ describe('Feature: d.jsonb validator on writes', () => {
         const rows = Array.from({ length: 100 }, (_, i) => ({ name: `r${i}` }));
         const res = await db.plain.createMany({ data: rows });
         expect(res.ok).toBe(true);
-        // Note: SQLite's INSERT-without-RETURNING path doesn't surface a
-        // driver-level rowCount today (separate issue from this ticket), so we
-        // verify persistence via list() rather than `res.data.count`.
+        if (!res.ok) throw new TypeError('createMany failed');
+        expect(res.data.count).toBe(100);
         const listed = await db.plain.list({});
         expect(listed.ok).toBe(true);
         if (!listed.ok) throw new TypeError('list failed');

--- a/reviews/sqlite-rowcount-2890/phase-01-fix.md
+++ b/reviews/sqlite-rowcount-2890/phase-01-fix.md
@@ -1,0 +1,94 @@
+# Phase 1: Fix SQLite rowCount for write-without-RETURNING (#2890)
+
+- **Author:** claude (fix branch)
+- **Reviewer:** claude (adversarial review)
+- **Commits:** 454a5e78c
+- **Date:** 2026-04-21
+
+## Changes
+
+- `packages/db/src/client/database.ts` (modified) — two new helpers (`stripLeadingSqlComments`, `stripSqlStringLiterals`), exported `isWriteWithoutReturning`, routing in both SQLite queryFn wrappers (D1 + local-file).
+- `packages/db/src/client/__tests__/sqlite-rowcount.test.ts` (new) — regression tests.
+- `packages/db/src/query/__tests__/crud-jsonb-validator-writes.test.ts` (modified) — replaces the old workaround comment with a real assertion that `res.data.count === 100`.
+
+## CI Status
+
+- [x] `vtz test packages/db` passes locally (1725 passed, 1 skipped).
+- [x] New test file — all 10 cases pass, including helper unit tests, local `:memory:` integration, and a D1 mock verifying `.run()` is invoked instead of `.all()`.
+
+## Review Checklist
+
+- [x] Delivers what #2890 asks for — `createMany` / `updateMany` / `deleteMany` surface accurate `count` on SQLite (local + D1).
+- [x] Postgres path untouched (verified — only the two SQLite branches in `createDb` gained routing, Postgres branch returns `driver.queryFn<T>` as before).
+- [x] TDD compliance — the fast-path test in `crud-jsonb-validator-writes.test.ts` was previously a workaround; it is now flipped to assert `count` directly. Positive regression coverage for the issue is present.
+- [x] `createManyAndReturn` still works — explicit test at line 116 proves the RETURNING path is unchanged.
+- [x] No type gaps — exported helper has a narrow `(sql: string) => boolean` signature.
+
+## Findings
+
+### Blockers
+
+_None._ The fix is correct for every SQL statement the ORM itself generates. All 1725 db tests pass, the issue repro from #2890 passes, and Postgres routing is untouched.
+
+### Should-fix
+
+**F1 — False-negative on trailing / mid-statement comments containing the word `RETURNING`.**
+
+`stripLeadingSqlComments` only consumes comments at the very start of the statement. After it returns, non-leading comments (trailing `-- ...` or mid-statement `/* ... */`) remain in the string. `stripSqlStringLiterals` then strips string literals but leaves comments alone. The final `\bRETURNING\b` regex matches the word inside the comment, so the statement is classified as "has RETURNING" → dispatched through `query()` → `rowCount` collapses back to `0`.
+
+Reproduced (verified with a local Node script against the extracted helpers):
+
+| SQL | Expected | Actual |
+|-----|----------|--------|
+| `INSERT INTO t VALUES (1) -- RETURNING is fake` | `true` (write-without-RETURNING) | **`false`** |
+| `UPDATE t SET a = 1 /* RETURNING x */` | `true` | **`false`** |
+
+The ORM itself never generates SQL with trailing comments, so this does not affect `db.users.createMany()` etc. But `db.query(sql\`...\`)` is a public surface, and a user who passes a statement with a trailing comment gets the original #2890 bug back. The fix is inexpensive — strip ALL comments (not just leading), or run `stripSqlStringLiterals` before a comment-stripping pass that handles `--` / `/* */` anywhere.
+
+**F2 — `REPLACE INTO` (SQLite-only write verb) is not recognised.**
+
+`isWriteWithoutReturning` only tests `INSERT `, `UPDATE `, `DELETE `, `TRUNCATE `. SQLite also supports `REPLACE INTO` (equivalent to `INSERT OR REPLACE`). The ORM does not generate `REPLACE INTO`, but a user passing `db.query(sql\`REPLACE INTO ...\`)` hits the original bug. Add `REPLACE ` to the prefix list and a unit test. TRUNCATE is a no-op on SQLite anyway; `REPLACE` is a real SQLite verb that probably matters more.
+
+**F3 — No transaction coverage for the new routing.**
+
+The SQLite fallback `transaction()` path routes `BEGIN` / `COMMIT` / `ROLLBACK` + inner statements through the same queryFn wrapper. `BEGIN`/`COMMIT`/`ROLLBACK` fall through to `query()` (`stmt.all()`), which is what they did before the fix — so transactions almost certainly still work. But the new test file doesn't prove it: the existing `transaction.test.ts` uses a custom `_queryFn` stub that bypasses this code entirely. A `db.transaction(async (tx) => { await tx.plain.createMany(...); await tx.plain.updateMany(...); })` test on `:memory:` asserting both the per-call `count` and the final persisted state would close this gap and defend against future refactors.
+
+**F4 — No test for writable CTEs.**
+
+The docstring on `isWriteWithoutReturning` makes an explicit claim about writable CTEs:
+
+> Writable CTEs (`WITH ... INSERT/UPDATE/DELETE`) are NOT classified as write-without-RETURNING by this helper, because their outer wrapper is a SELECT that must still go through `query()` to surface rows.
+
+There is no test that locks in this behaviour. A one-line unit test against the helper (`expect(isWriteWithoutReturning('WITH cte AS (INSERT INTO t VALUES (1) RETURNING id) SELECT * FROM cte')).toBe(false)`) plus a negative case without inner RETURNING would be enough to catch a future regression that mistakenly starts classifying CTEs by their inner verb.
+
+### Nits
+
+**N1 — Test description is slightly off.**
+
+The block-comment assertion in `isWriteWithoutReturning helper` uses:
+```ts
+expect(isWriteWithoutReturning('/* block comment */ UPDATE t SET a = 1 RETURNING id')).toBe(false);
+```
+
+This exercises the happy path (`RETURNING` really is present), not the edge case that was concerning — namely, a block comment containing the word RETURNING wrapping a write that doesn't actually have RETURNING. It's a fine test, just doesn't defend against F1.
+
+**N2 — `stripSqlStringLiterals` doesn't handle backtick identifiers.**
+
+SQLite accepts backtick-quoted identifiers for MySQL compatibility. Exotic edge; no behaviour change needed given that the helper operates at word boundaries and `RETURNING` inside a backtick-quoted identifier is extraordinarily unlikely. Note for posterity only.
+
+**N3 — Duplication with `isReadQuery`'s own comment-stripping.**
+
+`isReadQuery` (lines 52-110) has its own inlined comment-stripping loop that is structurally identical to `stripLeadingSqlComments`. A future pass could extract a single shared helper; low priority, purely stylistic.
+
+## Resolution
+
+All four should-fix findings addressed in follow-up commit:
+
+- **F1** — Replaced the two-pass helper pair (`stripLeadingSqlComments` + `stripSqlStringLiterals`) with a single-pass `stripSqlCommentsAndStrings` state machine that blanks out line comments, block comments, and string literals anywhere in the statement while preserving column positions. Added 3 unit tests covering trailing `--` comments and mid-statement `/* ... */` comments.
+- **F2** — Added `REPLACE ` to the write-verb prefix list and a unit test for `REPLACE INTO ...` (with and without RETURNING).
+- **F3** — Added a `db.transaction(tx => { createMany + updateMany })` integration test on `:memory:` asserting per-call `count` and final persisted state.
+- **F4** — Added three unit tests for writable CTEs (`WITH ... INSERT/DELETE RETURNING`) verifying the helper returns `false` so the outer SELECT still routes through `query()`.
+
+Nits (N1–N3) left for follow-up as originally classified.
+
+All 1750 db tests pass, typecheck clean, formatting clean.


### PR DESCRIPTION
## Summary

Closes #2890.

`createMany` / `updateMany` / `deleteMany` on SQLite used to surface `rowCount: 0` even when the rows had actually been written. The SQLite `queryFn` wrapper in `packages/db/src/client/database.ts` routed *every* statement through `driver.query()` (`stmt.all()`), which returns an empty result set for INSERT/UPDATE/DELETE without `RETURNING` — so `{ rows, rowCount: rows.length }` collapsed to zero on the hot path.

The fix adds an exported `isWriteWithoutReturning(sql)` helper and dispatches such statements through `driver.execute()` (`stmt.run()`) instead, using `rowsAffected` as the count. Postgres routing and every `RETURNING` path are unchanged.

### Changes

- **`packages/db/src/client/database.ts`** — new `stripSqlCommentsAndStrings` single-pass normalizer (blanks comments + string literals while preserving column positions) + exported `isWriteWithoutReturning`. Both SQLite `queryFn` wrappers (D1 binding and local-file dialect) now dispatch writes-without-`RETURNING` through `execute()`.
- **`packages/db/src/client/__tests__/sqlite-rowcount.test.ts`** — new file. 14 cases: `:memory:` integration for `createMany` / `updateMany` / `deleteMany` / `createManyAndReturn`, D1-mock test proving `.run()` is called (not `.all()`), transaction test, helper unit tests covering RETURNING in comments, `REPLACE INTO`, and writable CTEs.
- **`packages/db/src/query/__tests__/crud-jsonb-validator-writes.test.ts`** — flip the workaround comment from the #2867 fast-path test into a real `res.data.count === 100` assertion.
- **`.changeset/fix-sqlite-rowcount-2890.md`** — patch changeset for `@vertz/db`.

### Adversarial review — all should-fix findings addressed

Review: [`reviews/sqlite-rowcount-2890/phase-01-fix.md`](https://github.com/vertz-dev/vertz/blob/fix/sqlite-rowcount-2890/reviews/sqlite-rowcount-2890/phase-01-fix.md)

- **F1** — trailing / mid-statement comments containing the word `RETURNING` could produce false-negatives. Fixed by replacing the two-pass comment+string helpers with a single-pass state machine that strips comments and literals anywhere in the statement.
- **F2** — `REPLACE INTO` (SQLite-only write verb) added to the prefix list.
- **F3** — transaction integration test added (`db.transaction(tx => { createMany + updateMany })`).
- **F4** — writable CTE tests locked in (`WITH ... INSERT ... RETURNING ...`) to assert they stay on the `query()` path so the outer SELECT surfaces rows.

### Public API changes

- New export `isWriteWithoutReturning` from `@vertz/db` (internal routing helper — exported so the test suite can cover it directly).
- No behavioural change for Postgres, D1 with RETURNING, `createManyAndReturn`, or any SELECT path.

### Quality gates

- `vtz test` — 1750 passed, 1 skipped (packages/db).
- `vtz run typecheck` — clean across `@vertz/db` + `@vertz/server`.
- `vtzx oxfmt` — clean.

## Test plan

- [ ] CI green on GitHub
- [ ] Integration repro from issue verified locally (`createMany` of 3 rows returns `{ count: 3 }` on `:memory:`)
- [ ] Existing jsonb-validator tests still pass (they use `createMany` on SQLite extensively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)