### PR TITLE
fix(vtz): dedup redundant package versions [#2894]

### DIFF
--- a/.changeset/fix-install-dedup-2894.md
+++ b/.changeset/fix-install-dedup-2894.md
@@ -1,0 +1,13 @@
+---
+'vtz': patch
+---
+
+fix(vtz): dedup redundant package versions when a single version satisfies every declared range
+
+Closes [#2894](https://github.com/vertz-dev/vertz/issues/2894).
+
+`vtz install` used to nest a transitive copy of a package even when the root's already-hoisted version satisfied the transitive range. Scenario that triggered it: a root exact pin (`"@vertz/schema": "0.2.73"`) plus a transitive range (`"^0.2.68"` declared by `@vertz/agents`) produced two graph entries — 0.2.73 at root, 0.2.76 nested under `node_modules/@vertz/agents/node_modules/@vertz/schema/`. The resolver's BFS treated the two distinct range strings as separate resolution tasks and never checked whether they could share a version.
+
+TypeScript's structural typing treats module identity by file path, so any exported type with a private/protected field (including `ParseContext` in `@vertz/schema`) became two incompatible types — one per path — and consumers hit opaque `Types have separate declarations of a private property` errors at compile time.
+
+Fix: a new `resolver::dedup()` pass runs before `hoist()`. For each package name with multiple versions, it collects every declared range (root deps + every transitive `dependencies`/`optionalDependencies`) and, when a single version in the graph satisfies all of them, drops the redundant versions. Packages with any non-semver range (`github:`, `link:`, dist-tags) are skipped — they can't be reasoned about from the range string alone. When no version satisfies every range, the graph is left untouched and the existing hoist algorithm decides nesting as before.

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -356,6 +356,13 @@ pub async fn install(
 
     output.resolve_complete(graph.packages.len());
 
+    // Collapse redundant versions before hoisting — see resolver::dedup (#2894).
+    // When a root exact pin and a transitive range can share a single version,
+    // we must drop the extra so TypeScript sees one module path per package.
+    // Pass `all_deps` (deps + devDeps + optionalDeps) so a root optional
+    // range still participates in the satisfies-all check.
+    resolver::dedup(&mut graph, &all_deps);
+
     // Apply hoisting
     resolver::hoist(&mut graph);
 

--- a/native/vtz/src/pm/resolver.rs
+++ b/native/vtz/src/pm/resolver.rs
@@ -487,6 +487,93 @@ async fn resolve_one_task<'a>(
     Ok((true, deps))
 }
 
+/// Collapse redundant versions of the same package when a single version
+/// can satisfy every declared range.
+///
+/// Without this pass, a root exact-pin (`"@vertz/schema": "0.2.73"`) and a
+/// transitive range (`"^0.2.68"` from a dependency) produce two separate graph
+/// entries — the exact version at root and the highest matching version nested
+/// under the transitive parent. TypeScript then sees two distinct module paths
+/// for the same package and treats types with private/protected fields as
+/// incompatible (see #2894).
+///
+/// Runs BEFORE `hoist()`. For each package name with multiple versions, if a
+/// single version in the graph satisfies every declared range (root deps +
+/// every transitive `dependencies`/`optional_dependencies` entry), the other
+/// versions are dropped from the graph and from `graph.scripts`. Ties pick the
+/// highest version.
+///
+/// Skipped for packages where any declared range is a non-semver spec
+/// (`github:`, `link:`, dist-tags) — those can't be reasoned about from the
+/// range string alone.
+pub fn dedup(graph: &mut ResolvedGraph, root_deps: &BTreeMap<String, String>) {
+    // Group graph keys by package name
+    let mut by_name: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (key, pkg) in &graph.packages {
+        by_name
+            .entry(pkg.name.clone())
+            .or_default()
+            .push(key.clone());
+    }
+
+    // Collect every declared range per name: root-level (deps + devDeps +
+    // optionalDeps, merged by the caller) plus every transitive.
+    let mut ranges_by_name: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (name, range) in root_deps {
+        ranges_by_name
+            .entry(name.clone())
+            .or_default()
+            .push(range.clone());
+    }
+    for pkg in graph.packages.values() {
+        for (dep_name, dep_range) in pkg
+            .dependencies
+            .iter()
+            .chain(pkg.optional_dependencies.iter())
+        {
+            ranges_by_name
+                .entry(dep_name.clone())
+                .or_default()
+                .push(dep_range.clone());
+        }
+    }
+
+    for (name, keys) in &by_name {
+        if keys.len() < 2 {
+            continue;
+        }
+
+        let Some(ranges) = ranges_by_name.get(name) else {
+            continue;
+        };
+
+        // Non-semver specs (dist-tags, github:, link:) can't be checked against
+        // a version string — bail out rather than guess.
+        if ranges.iter().any(|r| is_non_semver_spec(r)) {
+            continue;
+        }
+
+        // Pick the highest version that satisfies every declared range.
+        let winner = keys
+            .iter()
+            .filter(|k| {
+                let v = &graph.packages[*k].version;
+                ranges.iter().all(|r| version_satisfies_range(v, r))
+            })
+            .max_by_key(|k| Version::parse(&graph.packages[*k].version).ok())
+            .cloned();
+
+        if let Some(winner_key) = winner {
+            for key in keys {
+                if key != &winner_key {
+                    graph.packages.remove(key);
+                    graph.scripts.remove(key);
+                }
+            }
+        }
+    }
+}
+
 /// Hoisting algorithm: determine which packages go at root vs nested
 ///
 /// Two-pass approach:
@@ -1103,6 +1190,278 @@ mod tests {
             lockfile_entry_satisfies_range(&fresh, "^0.27.3"),
             "fresh lockfile entry pinned to 0.27.3 must satisfy ^0.27.3"
         );
+    }
+
+    // #2894: if the root declares an exact pin and a transitive dep declares a
+    // range that would be satisfied by the same pinned version, the resolver
+    // must NOT install a second, newer copy nested under the transitive parent.
+    // Prior behavior: two graph entries — one hoisted (root), one nested
+    // (transitive) — which broke TypeScript's structural-typing for any type
+    // with a private field (private/protected declarations tie identity to
+    // module path; two file paths → two incompatible types).
+    #[test]
+    fn test_dedup_collapses_when_root_pin_satisfies_transitive_range() {
+        let mut graph = ResolvedGraph::default();
+
+        // Root picks @vertz/schema@0.2.73 (exact pin)
+        graph.packages.insert(
+            "@vertz/schema@0.2.73".to_string(),
+            ResolvedPackage {
+                name: "@vertz/schema".to_string(),
+                version: "0.2.73".to_string(),
+                tarball_url: "schema-0.2.73-url".to_string(),
+                integrity: "schema-0.2.73-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // Transitive from agents picks @vertz/schema@0.2.76 (latest matching ^0.2.68)
+        graph.packages.insert(
+            "@vertz/schema@0.2.76".to_string(),
+            ResolvedPackage {
+                name: "@vertz/schema".to_string(),
+                version: "0.2.76".to_string(),
+                tarball_url: "schema-0.2.76-url".to_string(),
+                integrity: "schema-0.2.76-integrity".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // @vertz/agents@0.2.47 declares "@vertz/schema": "^0.2.68"
+        let mut agents_deps = BTreeMap::new();
+        agents_deps.insert("@vertz/schema".to_string(), "^0.2.68".to_string());
+        graph.packages.insert(
+            "@vertz/agents@0.2.47".to_string(),
+            ResolvedPackage {
+                name: "@vertz/agents".to_string(),
+                version: "0.2.47".to_string(),
+                tarball_url: "agents-url".to_string(),
+                integrity: "agents-integrity".to_string(),
+                dependencies: agents_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // Root declares "@vertz/schema": "0.2.73" (exact) and "@vertz/agents": "0.2.47"
+        let mut root_deps = BTreeMap::new();
+        root_deps.insert("@vertz/schema".to_string(), "0.2.73".to_string());
+        root_deps.insert("@vertz/agents".to_string(), "0.2.47".to_string());
+        dedup(&mut graph, &root_deps);
+
+        // After dedup: only 0.2.73 remains (it satisfies both "0.2.73" and "^0.2.68")
+        assert!(
+            graph.packages.contains_key("@vertz/schema@0.2.73"),
+            "exact-pin version must be kept — it satisfies both ranges"
+        );
+        assert!(
+            !graph.packages.contains_key("@vertz/schema@0.2.76"),
+            "redundant transitive version must be dropped when the root pin covers its range"
+        );
+        assert!(
+            graph.packages.contains_key("@vertz/agents@0.2.47"),
+            "unrelated packages must be preserved"
+        );
+    }
+
+    // Dedup must NOT merge when no single version satisfies all declared ranges.
+    #[test]
+    fn test_dedup_keeps_both_when_ranges_are_incompatible() {
+        let mut graph = ResolvedGraph::default();
+
+        graph.packages.insert(
+            "zod@3.24.4".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "3.24.4".to_string(),
+                tarball_url: "zod3-url".to_string(),
+                integrity: "zod3".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+        graph.packages.insert(
+            "zod@4.0.0".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "4.0.0".to_string(),
+                tarball_url: "zod4-url".to_string(),
+                integrity: "zod4".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // foo@1.0.0 depends on zod@^4.0.0
+        let mut foo_deps = BTreeMap::new();
+        foo_deps.insert("zod".to_string(), "^4.0.0".to_string());
+        graph.packages.insert(
+            "foo@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "foo".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "foo-url".to_string(),
+                integrity: "foo".to_string(),
+                dependencies: foo_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // Root: "zod": "^3.0.0" and "foo": "^1.0.0"
+        let mut root_deps = BTreeMap::new();
+        root_deps.insert("zod".to_string(), "^3.0.0".to_string());
+        root_deps.insert("foo".to_string(), "^1.0.0".to_string());
+        dedup(&mut graph, &root_deps);
+
+        assert!(graph.packages.contains_key("zod@3.24.4"));
+        assert!(graph.packages.contains_key("zod@4.0.0"));
+    }
+
+    // #2894 follow-up: root `optionalDependencies` ranges must participate in
+    // the satisfies-all check. Caller (`pm::mod`) merges deps + devDeps +
+    // optionalDeps into one map, so root optional pins aren't silently ignored
+    // when a transitive would otherwise let a newer version win.
+    #[test]
+    fn test_dedup_respects_root_optional_dep_pin() {
+        let mut graph = ResolvedGraph::default();
+
+        // Root optional declares `"some-pkg": "1.0.0"` (exact pin).
+        graph.packages.insert(
+            "some-pkg@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "some-pkg".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "url-1.0.0".to_string(),
+                integrity: "i-1.0.0".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // A transitive parent declares `"some-pkg": "^1.0.0"` → picked 1.2.0.
+        graph.packages.insert(
+            "some-pkg@1.2.0".to_string(),
+            ResolvedPackage {
+                name: "some-pkg".to_string(),
+                version: "1.2.0".to_string(),
+                tarball_url: "url-1.2.0".to_string(),
+                integrity: "i-1.2.0".to_string(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut parent_deps = BTreeMap::new();
+        parent_deps.insert("some-pkg".to_string(), "^1.0.0".to_string());
+        graph.packages.insert(
+            "parent@1.0.0".to_string(),
+            ResolvedPackage {
+                name: "parent".to_string(),
+                version: "1.0.0".to_string(),
+                tarball_url: "parent-url".to_string(),
+                integrity: "parent-i".to_string(),
+                dependencies: parent_deps,
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // Caller passes a merged map with the root optional range included.
+        let mut root_deps = BTreeMap::new();
+        root_deps.insert("parent".to_string(), "^1.0.0".to_string());
+        root_deps.insert("some-pkg".to_string(), "1.0.0".to_string());
+
+        dedup(&mut graph, &root_deps);
+
+        assert!(
+            graph.packages.contains_key("some-pkg@1.0.0"),
+            "root optional pin must be preserved by dedup"
+        );
+        assert!(
+            !graph.packages.contains_key("some-pkg@1.2.0"),
+            "transitive version must be dropped when root pin covers its range"
+        );
+    }
+
+    // Dist-tag ranges (e.g. "latest") cannot be reasoned about after resolution —
+    // dedup must be a no-op rather than guess.
+    #[test]
+    fn test_dedup_skips_when_any_range_is_dist_tag() {
+        let mut graph = ResolvedGraph::default();
+
+        graph.packages.insert(
+            "zod@3.24.4".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "3.24.4".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+        graph.packages.insert(
+            "zod@4.0.0".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "4.0.0".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let mut root_deps = BTreeMap::new();
+        root_deps.insert("zod".to_string(), "latest".to_string());
+        dedup(&mut graph, &root_deps);
+
+        // Both remain — we can't verify "latest" satisfaction from a range string alone
+        assert_eq!(graph.packages.len(), 2);
     }
 
     #[test]

--- a/reviews/fix-2894/phase-01-dedup.md
+++ b/reviews/fix-2894/phase-01-dedup.md
@@ -1,0 +1,43 @@
+# Phase 1: install-time version dedup (#2894)
+
+- **Author:** Vinicius (with Claude Opus 4.7)
+- **Reviewer:** general-purpose adversarial review
+- **Date:** 2026-04-21
+
+## Changes
+
+- `native/vtz/src/pm/resolver.rs` — new `dedup()` function + 4 unit tests
+- `native/vtz/src/pm/mod.rs` — call `resolver::dedup(&mut graph, &all_deps)` before `resolver::hoist()`
+- `.changeset/fix-install-dedup-2894.md` — patch changeset for `vtz`
+
+## CI Status
+
+- [x] `cargo test --all` — all pm tests pass (605 pm + 16 pm_integration + full workspace)
+- [x] `cargo clippy --all-targets -- -D warnings` — clean
+- [x] `cargo fmt --all -- --check` — clean
+- [x] Live repro verified: `@vertz/agents@0.2.47` + `@vertz/schema@0.2.73` at root → single `node_modules/@vertz/schema@0.2.73`, no nested copy
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for — single physical copy when a version satisfies every declared range
+- [x] TDD compliance — RED state captured (compile error: `dedup` missing), then GREEN
+- [x] No type gaps — `BTreeMap<String, String>` inputs, no generic leakage
+- [x] No security issues — pure in-memory graph mutation
+- [x] No behavior change when versions genuinely differ (test_dedup_keeps_both_when_ranges_are_incompatible)
+
+## Findings
+
+### Adversarial review found one SHOULD-FIX
+
+**Root `optionalDependencies` were not collected** — first revision passed `(resolved_deps, resolved_dev_deps)` to `dedup()`, omitting `resolved_optional_deps`. Result would have been: a root optional pin could be silently dropped in favor of a newer transitive version, then `graph_to_lockfile` would fail to wire the optional range.
+
+**Resolution:** changed `dedup()` signature to take a single `root_deps: &BTreeMap<String, String>`, and in `mod.rs` we pass `all_deps` (the caller-merged map of deps + devDeps + optionalDeps, already assembled above for other purposes). Added `test_dedup_respects_root_optional_dep_pin` to lock this in.
+
+### Non-blocker notes
+
+- **Transitive descendants of dropped versions** may linger in the graph without a live parent path. In practice these are either identical to the surviving version's children (same tarball, installed once) or benign extras. Not fixed here — would warrant an orphan sweep pass, tracked implicitly by the existing hoist algorithm which only touches nest_path.
+- **Non-semver specs (`github:`, `link:`, dist-tags)** force a no-op skip per-package — we can't check satisfaction from a range string alone, so leaving the graph as-is is the safe default. Covered by `test_dedup_skips_when_any_range_is_dist_tag`.
+
+## Resolution
+
+Approved. Root-optional gap fixed in the same commit; all 4 dedup tests pass; full Rust suite green.


### PR DESCRIPTION
## Summary

`vtz install` created two physical copies of a package — one at root, one nested under a transitive parent — when a root exact pin and a transitive range could share a version. TypeScript saw two module paths and broke structural typing on types with private/protected fields (e.g. `ParseContext` in `@vertz/schema`), producing confusing `separate declarations of a private property` errors for anyone depending on `@vertz/agents` + `@vertz/schema` at the same time.

Adds a new `resolver::dedup()` pass that runs before `hoist()`. For each package name with multiple resolved versions, it collects every declared range (root deps + devDeps + optionalDeps + every transitive `dependencies`/`optionalDependencies`) and drops all but the highest version that satisfies every range. Non-semver ranges (`github:`, `link:`, dist-tags) trigger a safe no-op skip.

Closes #2894.

## Public API changes

- None. Internal resolver-only change in the `vtz` crate.

## Test plan

- [x] `cargo test --all` — 605 pm + 16 pm_integration + full workspace green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 4 new unit tests in `pm::resolver::tests`:
  - `test_dedup_collapses_when_root_pin_satisfies_transitive_range` — the exact repro from the issue
  - `test_dedup_respects_root_optional_dep_pin` — root `optionalDependencies` participate in the satisfies-all check
  - `test_dedup_keeps_both_when_ranges_are_incompatible` — regression guard
  - `test_dedup_skips_when_any_range_is_dist_tag` — non-semver safe fallback
- [x] Live repro verified against release binary: `@vertz/agents@0.2.47` + `@vertz/schema@0.2.73` at root → single `node_modules/@vertz/schema@0.2.73`, no nested copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)