### PR TITLE
chore(ci): silence release workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       native: ${{ steps.filter.outputs.native }}
       db: ${{ steps.filter.outputs.db }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -217,7 +217,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Lint runs oxlint/oxfmt directly — no cargo build needed; pull a
       # published vtz binary just to drive `vtz install`.
@@ -251,7 +251,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -322,7 +322,7 @@ jobs:
     if: needs.changes.outputs.native == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -355,7 +355,7 @@ jobs:
     if: needs.changes.outputs.native == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       native: ${{ steps.filter.outputs.native }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -137,7 +137,7 @@ jobs:
             echo "Cross-compiled binary, skipping runtime version check"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.pkg }}
           path: packages/${{ matrix.pkg }}/vtz
@@ -178,7 +178,7 @@ jobs:
           codesign -s - "packages/${{ matrix.compiler_pkg }}/vertz-compiler.${PLATFORM_SUFFIX}.node"
 
       - name: Upload compiler artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.compiler_pkg }}
           path: packages/${{ matrix.compiler_pkg }}/vertz-compiler.*.node
@@ -200,7 +200,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve vtz version
         id: resolve-vtz
@@ -218,6 +218,9 @@ jobs:
         uses: vertz-dev/setup-vtz@v1
         with:
           version: ${{ steps.resolve-vtz.outputs.version }}
+          # Release runs don't reuse a .pipe/cache, and setup-vtz's cache step
+          # warns "Path Validation Error" when that path is absent at save time.
+          cache: 'false'
 
       # Bun is still required by `vtzx bun build` for the runtime selector and
       # by package scripts that invoke `bun run`. See ci.yml for context.
@@ -233,28 +236,28 @@ jobs:
           rm -f node_modules/.bin/vtz node_modules/.bin/vertz
 
       - name: Download darwin-arm64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: runtime-darwin-arm64
           path: packages/runtime-darwin-arm64/
         continue-on-error: true
 
       - name: Download darwin-x64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: runtime-darwin-x64
           path: packages/runtime-darwin-x64/
         continue-on-error: true
 
       - name: Download linux-x64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: runtime-linux-x64
           path: packages/runtime-linux-x64/
         continue-on-error: true
 
       - name: Download linux-arm64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: runtime-linux-arm64
           path: packages/runtime-linux-arm64/
@@ -270,28 +273,28 @@ jobs:
           done
 
       - name: Download native-compiler-darwin-arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: native-compiler-darwin-arm64
           path: packages/native-compiler-darwin-arm64/
         continue-on-error: true
 
       - name: Download native-compiler-darwin-x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: native-compiler-darwin-x64
           path: packages/native-compiler-darwin-x64/
         continue-on-error: true
 
       - name: Download native-compiler-linux-x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: native-compiler-linux-x64
           path: packages/native-compiler-linux-x64/
         continue-on-error: true
 
       - name: Download native-compiler-linux-arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: native-compiler-linux-arm64
           path: packages/native-compiler-linux-arm64/

--- a/native/vertz-compiler/turbo.json
+++ b/native/vertz-compiler/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["vertz-compiler.*.node"]
+    }
+  }
+}

--- a/packages/runtime/turbo.json
+++ b/packages/runtime/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["index.js"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Three warnings surfaced in recent release runs (e.g. [run 24674308547](https://github.com/vertz-dev/vertz/actions/runs/24674308547)). This PR addresses the ones we own:

- **Node 20 action deprecations** — GitHub is forcing Node 24 on 2026-06-02. Bumped `actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact` from `@v4` to `@v5` across `ci.yml`, `coverage.yml`, and `release.yml`.
- **Turbo "no output files found"** for `@vertz/native-compiler#build` and `@vertz/runtime#build` — root `turbo.json` only declares `dist/**`, which matches neither package. Added per-package `turbo.json` overrides pointing at the real artifacts (`vertz-compiler.*.node` and `index.js`).
- **`Path Validation Error` from setup-vtz** in the release job — the release flow never populates `.pipe/cache`, so there's nothing to save. Passed `cache: 'false'` to the release `setup-vtz` step.

## Out of scope

- `actions/cache@v4` is only reachable transitively via `Swatinem/rust-cache@v2` (still on v2.x); can't fix here.
- Node-internal `DEP0005` (Buffer) and `DEP0040` (punycode) warnings originate inside `gh` CLI / action internals, not our code.
- `::notice::A newer release already holds 'latest'` is intentional, from the #2860 fix.

## CI status

⚠️ The `Build, typecheck & test` job fails with an esbuild host/binary version mismatch. **This is pre-existing** — main has been red on this same error since PR #2909 merged. Filed as #2912. Unblocking that is a prerequisite for merging; my changes here are scoped strictly to the release-workflow warnings and don't touch the install path.

## Test plan

- [ ] Release workflow runs clean on the next merge to main (no Node 20 deprecation banner, no turbo "no output files" warnings for `@vertz/native-compiler` / `@vertz/runtime`, no "Path Validation Error" in Post Setup vtz).
- [ ] CI (ci.yml) continues to pass — action upgrades are drop-in for the inputs we use. (Blocked by #2912.)
- [x] `turbo run build` dry-run validates the new per-package outputs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)