### PR TITLE
feat(create-vertz-app): dev-server-tools rule docs vertz_browser_screenshot — Task 6 [#2865]

### DIFF
--- a/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
+++ b/packages/create-vertz-app/src/templates/__tests__/templates.test.ts
@@ -3,6 +3,7 @@ import {
   apiDevelopmentRuleTemplate,
   appComponentTemplate,
   claudeMdTemplate,
+  devServerToolsRuleTemplate,
   clientTemplate,
   dbTemplate,
   entryClientTemplate,
@@ -178,6 +179,38 @@ describe('templates', () => {
       expect(result).toContain('dist/');
       expect(result).toContain('.vertz/');
       expect(result).toContain('*.db');
+    });
+  });
+
+  describe('devServerToolsRuleTemplate', () => {
+    it('lists vertz_browser_screenshot in the tool table', () => {
+      const result = devServerToolsRuleTemplate();
+      expect(result).toContain('vertz_browser_screenshot');
+      expect(result).toContain('Headless pixel-perfect PNG');
+    });
+
+    it('includes the visual verification section', () => {
+      const result = devServerToolsRuleTemplate();
+      expect(result).toContain('Visual verification with screenshots');
+      expect(result).toContain("vertz_browser_screenshot({ url: '<the-affected-route>' })");
+    });
+
+    it('documents multi-viewport and component-isolated patterns', () => {
+      const result = devServerToolsRuleTemplate();
+      expect(result).toContain('375');
+      expect(result).toContain('1280');
+      expect(result).toContain("crop: '.my-component'");
+      expect(result).toContain("crop: { text: 'Save' }");
+    });
+
+    it('tells agents where screenshots are persisted', () => {
+      const result = devServerToolsRuleTemplate();
+      expect(result).toContain('.vertz/artifacts/screenshots/');
+    });
+
+    it('includes an explicit skip clause for non-UI changes', () => {
+      const result = devServerToolsRuleTemplate();
+      expect(result).toContain('When to skip screenshots');
     });
   });
 

--- a/packages/create-vertz-app/src/templates/index.ts
+++ b/packages/create-vertz-app/src/templates/index.ts
@@ -2015,6 +2015,40 @@ curl -X POST http://localhost:3001/command \\\\
 | \`vertz_browser_submit\` | Submit a form (waits for navigation) |
 | \`vertz_browser_press_key\` | Press a keyboard key (Enter, Escape, Tab, etc.) |
 | \`vertz_browser_wait\` | Wait for a condition (text, selector, URL, element removal) |
+| \`vertz_browser_screenshot\` | Headless pixel-perfect PNG of any public route — agent sees the image + a local URL |
+
+### Visual verification with screenshots
+
+Before claiming a UI change is complete, call:
+
+\`\`\`
+vertz_browser_screenshot({ url: '<the-affected-route>' })
+\`\`\`
+
+Compare the returned image against what the task asked for. The PNG renders
+inline in your UI, and the metadata includes a local file URL you can share
+with humans.
+
+**Multi-viewport check for layout changes:**
+
+\`\`\`
+vertz_browser_screenshot({ url: '<route>', viewport: { width: 375,  height: 667 } })  // mobile
+vertz_browser_screenshot({ url: '<route>', viewport: { width: 1280, height: 720 } })  // desktop
+\`\`\`
+
+**Component-isolated check:**
+
+\`\`\`
+vertz_browser_screenshot({ url: '<route>', crop: '.my-component' })       // CSS
+vertz_browser_screenshot({ url: '<route>', crop: { text: 'Save' } })       // text match
+\`\`\`
+
+Screenshots save to \`.vertz/artifacts/screenshots/\` — these are working
+artifacts, reference them in your replies to the human.
+
+**When to skip screenshots:** pure backend changes (API only, no UI touched),
+docs-only edits, test-only edits. If the user can't see the diff without
+opening a browser, skip. If they can, screenshot.
 
 ## MANDATORY: Verify Before Reporting Success
 


### PR DESCRIPTION
## Summary

Task **6** of Phase 1 (`plans/2865-phase-1-headless-screenshot.md`) — extends the template-generated `.claude/rules/dev-server-tools.md` so scaffolded apps ship with LLM guidance for the screenshot tool that landed in #2915.

Doc-only change to `devServerToolsRuleTemplate()`. No new runtime behavior.

## What changes

`packages/create-vertz-app/src/templates/index.ts`:
- `vertz_browser_screenshot` added to the Browser Interaction Tools table
- New "Visual verification with screenshots" section with three canonical patterns:
  - Default route verification
  - Multi-viewport (mobile 375x667 / desktop 1280x720)
  - Component-isolated via CSS selector or text match
- Tells agents screenshots persist at `.vertz/artifacts/screenshots/`
- Explicit "skip when" clause — pure backend / docs-only / test-only edits skip the screenshot step

## Tests

`templates.test.ts` gets a new `describe('devServerToolsRuleTemplate')` block with 5 assertions:
1. Tool appears in the table with its description
2. Visual verification section exists with canonical example
3. Multi-viewport + crop patterns documented
4. Persistence location documented
5. "When to skip" clause present

Package-local: **222 passed, 3 skipped**. Lint + fmt clean.

## Acceptance (plan Task 6)

- [x] Scaffold test verifies the new section appears in the generated file
- [x] Section text matches the block in the design doc
- [x] Section includes an explicit "skip when" clause

## Deferred with rationale

The design doc's security-review suggestion to scaffold a `.dockerignore` containing `.vertz/` is skipped because `create-vertz-app` doesn't generate any docker tooling today. `.vertz/` is already in the generated `.gitignore`, which covers the primary "don't commit seed-PII screenshots" threat. The dockerignore lands when create-vertz-app grows a Dockerfile template.

## Test plan

- [x] `vtz test` on package — 222 passed
- [x] `oxlint` + `oxfmt` on changed files — clean
- [x] Rebased on latest `main`
- [ ] GitHub CI green (monitoring after open)

Relates to #2865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)