### PR TITLE
feat(vertz): Vite-parity HMR API — invalidate/decline/on/off [#2812]

### DIFF
--- a/.changeset/hmr-api-parity-2812.md
+++ b/.changeset/hmr-api-parity-2812.md
@@ -1,0 +1,17 @@
+---
+'vertz': patch
+---
+
+feat(vertz): add `invalidate`, `decline`, `on`, `off` to `import.meta.hot`
+
+Closes [#2812](https://github.com/vertz-dev/vertz/issues/2812).
+
+The `vtz` compiler previously stripped `import.meta.hot` references entirely at build time, so calls to `accept()` / `dispose()` were no-ops under `vtz dev`. The compiler now rewrites `import.meta.hot` to a runtime lookup (`globalThis.__vtz_hot?.(import.meta.url)`) that resolves to a real per-module hot context exposed by the HMR client.
+
+New methods on `ImportMetaHot`:
+
+- `invalidate(message?)` — trigger a full page reload with an optional reason.
+- `decline()` — opt out of HMR for the current module; the next update targeting it falls back to a full reload.
+- `on(event, cb)` / `off(event, cb)` — subscribe to runtime events: `vertz:beforeUpdate`, `vertz:afterUpdate`, `vertz:beforeFullReload`, `vertz:invalidate`, `vertz:error`.
+
+`send()` (custom client → server events) and `prune()` (cleanup on module removal) are tracked as a follow-up — they require bidirectional WebSocket support and module-removal tracking.

--- a/native/vtz/src/assets/hmr-client.js
+++ b/native/vtz/src/assets/hmr-client.js
@@ -29,6 +29,114 @@
   var toastEl = null;
   var toastTimer = null;
 
+  // moduleUrl → HotContext. Keyed by normalized URL-relative pathname.
+  var hotContexts = Object.create(null);
+
+  // ── Hot Context API (import.meta.hot) ──────────────────────────
+
+  /**
+   * Normalize any module URL into a URL-relative pathname.
+   * The compiler passes `import.meta.url` (a full http(s) URL in the browser).
+   * The server broadcasts URL-relative paths (e.g. "/src/app.tsx").
+   * This converts both into the same key form: the pathname, without query/hash.
+   */
+  function normalizeModuleUrl(raw) {
+    if (typeof raw !== 'string') return '';
+    if (raw.indexOf('://') !== -1) {
+      try {
+        return new URL(raw).pathname;
+      } catch (_) {
+        return raw;
+      }
+    }
+    var q = raw.indexOf('?');
+    if (q !== -1) raw = raw.slice(0, q);
+    var h = raw.indexOf('#');
+    if (h !== -1) raw = raw.slice(0, h);
+    return raw;
+  }
+
+  /**
+   * Create a per-module hot context. Stores dispose callbacks, event
+   * listeners, persistent data, and the declined flag. Returned object
+   * is the runtime shape of `import.meta.hot` (matches ImportMetaHot in
+   * vertz/client type declarations).
+   */
+  function createHotContext(moduleUrl) {
+    var disposeCallbacks = [];
+    var listeners = Object.create(null);
+    var declined = false;
+    var data = {};
+
+    var ctx = {
+      accept: function(_depsOrCb, _cb) {
+        // The vtz dev server self-accepts via the globalThis Fast Refresh
+        // registry; per-module accept callbacks are not invoked. Kept as a
+        // no-op so code written against the Vite/Bun HMR API still loads.
+      },
+      dispose: function(cb) {
+        if (typeof cb === 'function') disposeCallbacks.push(cb);
+      },
+      data: data,
+      invalidate: function(message) {
+        var reason = '[vertz-hmr] Invalidated' + (message ? ': ' + message : '');
+        console.log(reason, '(' + moduleUrl + ')');
+        showToast('Invalidated — reloading');
+        setTimeout(function() { location.reload(); }, 50);
+      },
+      decline: function() {
+        declined = true;
+      },
+      on: function(event, cb) {
+        if (typeof event !== 'string' || typeof cb !== 'function') return;
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(cb);
+      },
+      off: function(event, cb) {
+        var subs = listeners[event];
+        if (!subs) return;
+        var filtered = [];
+        for (var i = 0; i < subs.length; i++) {
+          if (subs[i] !== cb) filtered.push(subs[i]);
+        }
+        listeners[event] = filtered;
+      },
+    };
+
+    // Internal hooks used by the HMR transport. Prefixed with `_` so they are
+    // visible as developer-facing API only if someone explicitly looks for
+    // them; they are not part of ImportMetaHot.
+    ctx._emit = function(event, payload) {
+      var subs = listeners[event];
+      if (!subs) return;
+      for (var i = 0; i < subs.length; i++) {
+        try { subs[i](payload); } catch (err) {
+          console.error('[vertz-hmr] Listener for', event, 'threw:', err);
+        }
+      }
+    };
+    ctx._runDispose = function() {
+      while (disposeCallbacks.length) {
+        var cb = disposeCallbacks.shift();
+        try { cb(data); } catch (err) {
+          console.error('[vertz-hmr] dispose callback threw:', err);
+        }
+      }
+    };
+    ctx._isDeclined = function() { return declined; };
+
+    return ctx;
+  }
+
+  function getHotContext(moduleUrl) {
+    var key = normalizeModuleUrl(moduleUrl);
+    if (!hotContexts[key]) hotContexts[key] = createHotContext(key);
+    return hotContexts[key];
+  }
+
+  // Expose for compiler-rewritten `import.meta.hot` references.
+  globalThis.__vtz_hot = getHotContext;
+
   // ── Reconnect Tracking ─────────────────────────────────────────
 
   function trackReconnect() {
@@ -136,17 +244,34 @@
     var timestamp = data.timestamp || Date.now();
     var errors = [];
 
+    // If any module in this batch has been marked declined by user code, fall
+    // back to a full page reload — the module owner has opted out of HMR.
+    for (var d = 0; d < modules.length; d++) {
+      var declinedKey = normalizeModuleUrl(modules[d]);
+      var declinedCtx = hotContexts[declinedKey];
+      if (declinedCtx && declinedCtx._isDeclined()) {
+        console.log('[vertz-hmr] Module declined HMR — full reload:', declinedKey);
+        handleFullReload({ reason: 'module declined HMR: ' + declinedKey });
+        return;
+      }
+    }
+
     for (var i = 0; i < modules.length; i++) {
       var mod = modules[i];
+      var ctx = getHotContext(mod);
+      ctx._emit('vertz:beforeUpdate', { module: normalizeModuleUrl(mod) });
       try {
+        ctx._runDispose();
         // Dynamic re-import with cache-bust timestamp
         await import(mod + '?t=' + timestamp);
         // Trigger Fast Refresh for the updated module
         performFastRefresh(mod);
+        ctx._emit('vertz:afterUpdate', { module: normalizeModuleUrl(mod) });
       } catch (err) {
         var errMsg = err.message || String(err);
         console.error('[vertz-hmr] Failed to import', mod, err);
         errors.push({ message: errMsg, file: mod });
+        ctx._emit('vertz:error', { module: normalizeModuleUrl(mod), error: err });
       }
     }
 
@@ -208,6 +333,11 @@
   function handleFullReload(data) {
     showToast('Full reload');
     console.log('[vertz-hmr] Full reload:', data.reason);
+    // Emit beforeFullReload on every known hot context so user code can
+    // snapshot state or clean up before the page is destroyed.
+    for (var key in hotContexts) {
+      hotContexts[key]._emit('vertz:beforeFullReload', { reason: data.reason });
+    }
     // Small delay to show the toast
     setTimeout(function() {
       location.reload();

--- a/native/vtz/src/assets/hmr-client.js
+++ b/native/vtz/src/assets/hmr-client.js
@@ -64,25 +64,37 @@
    */
   function createHotContext(moduleUrl) {
     var disposeCallbacks = [];
+    var selfAcceptCallbacks = [];
     var listeners = Object.create(null);
     var declined = false;
     var data = {};
 
     var ctx = {
-      accept: function(_depsOrCb, _cb) {
-        // The vtz dev server self-accepts via the globalThis Fast Refresh
-        // registry; per-module accept callbacks are not invoked. Kept as a
-        // no-op so code written against the Vite/Bun HMR API still loads.
+      accept: function(depsOrCb, cb) {
+        // Self-accept with no callback — no-op beyond "this module handles
+        // its own updates." vtz always self-accepts via the Fast Refresh
+        // registry, so the bare form is purely informational.
+        if (typeof depsOrCb === 'function') {
+          selfAcceptCallbacks.push(depsOrCb);
+        } else if (typeof depsOrCb !== 'undefined' && typeof cb === 'function') {
+          // Dependency-array form. We don't currently track per-dependency
+          // accept chains; invoke the callback with an empty module list when
+          // this module updates, matching the self-accept semantics.
+          selfAcceptCallbacks.push(function(_newModule) { cb([]); });
+        }
       },
       dispose: function(cb) {
         if (typeof cb === 'function') disposeCallbacks.push(cb);
       },
       data: data,
       invalidate: function(message) {
-        var reason = '[vertz-hmr] Invalidated' + (message ? ': ' + message : '');
-        console.log(reason, '(' + moduleUrl + ')');
-        showToast('Invalidated — reloading');
-        setTimeout(function() { location.reload(); }, 50);
+        // Notify listeners on this context so they can react before reload.
+        ctx._emit('vertz:invalidate', { module: moduleUrl, message: message });
+        // Route through the main full-reload path so `vertz:beforeFullReload`
+        // fires on every context — keeps a single reload entry point.
+        handleFullReload({
+          reason: 'invalidated: ' + moduleUrl + (message ? ' (' + message + ')' : ''),
+        });
       },
       decline: function() {
         declined = true;
@@ -115,11 +127,27 @@
         }
       }
     };
-    ctx._runDispose = function() {
-      while (disposeCallbacks.length) {
-        var cb = disposeCallbacks.shift();
-        try { cb(data); } catch (err) {
+    // Snapshot-and-clear the pre-import callback lists so the new module
+    // evaluation can freely register a new generation without racing the
+    // old one. Returns the snapshot for the caller to fire after import.
+    ctx._takeSnapshot = function() {
+      var disposed = disposeCallbacks;
+      var accepted = selfAcceptCallbacks;
+      disposeCallbacks = [];
+      selfAcceptCallbacks = [];
+      return { dispose: disposed, accept: accepted };
+    };
+    ctx._fireDispose = function(list) {
+      for (var i = 0; i < list.length; i++) {
+        try { list[i](data); } catch (err) {
           console.error('[vertz-hmr] dispose callback threw:', err);
+        }
+      }
+    };
+    ctx._fireAccept = function(list, newModule) {
+      for (var i = 0; i < list.length; i++) {
+        try { list[i](newModule); } catch (err) {
+          console.error('[vertz-hmr] accept callback threw:', err);
         }
       }
     };
@@ -260,10 +288,15 @@
       var mod = modules[i];
       var ctx = getHotContext(mod);
       ctx._emit('vertz:beforeUpdate', { module: normalizeModuleUrl(mod) });
+      // Snapshot old-generation dispose + accept callbacks BEFORE the import
+      // so the new module's top-level can register a fresh generation.
+      var prev = ctx._takeSnapshot();
+      ctx._fireDispose(prev.dispose);
       try {
-        ctx._runDispose();
         // Dynamic re-import with cache-bust timestamp
-        await import(mod + '?t=' + timestamp);
+        var newModule = await import(mod + '?t=' + timestamp);
+        // Fire the previous-generation accept callbacks with the new module.
+        ctx._fireAccept(prev.accept, newModule);
         // Trigger Fast Refresh for the updated module
         performFastRefresh(mod);
         ctx._emit('vertz:afterUpdate', { module: normalizeModuleUrl(mod) });

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -1382,21 +1382,128 @@ fn remove_cross_specifier_duplicates(code: &str) -> String {
     result.join("\n")
 }
 
-/// Strip `import.meta.hot` lines entirely.
+/// Rewrite `import.meta.hot` references to the Vertz runtime hot-context lookup.
 ///
-/// `import.meta.hot` is Bun's bundler-level HMR API (accept/decline/dispose).
-/// Our native server uses WebSocket-based HMR — this API doesn't apply.
-/// We strip the lines entirely instead of shimming them.
-fn strip_import_meta_hot(code: &str) -> String {
-    let lines: Vec<&str> = code.lines().collect();
-    let mask = template_literal_mask(&lines);
-    lines
-        .iter()
-        .enumerate()
-        .filter(|(idx, line)| mask[*idx] || !line.trim().starts_with("import.meta.hot"))
-        .map(|(_, line)| *line)
-        .collect::<Vec<_>>()
-        .join("\n")
+/// The native vtz dev server doesn't use Bun's bundler-level `import.meta.hot`
+/// API. Instead, the HMR client runtime exposes a per-module hot context via
+/// `globalThis.__vtz_hot(moduleUrl)`. We rewrite source references so that code
+/// written against the standard `import.meta.hot` API resolves to our runtime
+/// at evaluation time.
+///
+/// In production (no HMR runtime present) `globalThis.__vtz_hot` is undefined,
+/// so the optional-call chain short-circuits to `undefined` — preserving the
+/// `ImportMetaHot | undefined` type contract exposed in `vertz/client`.
+///
+/// Rewrite rules:
+/// - Replace every `import.meta.hot` occurrence with
+///   `globalThis.__vtz_hot?.(import.meta.url)`.
+/// - Skip occurrences inside string literals (`'…'`, `"…"`), template literals
+///   (backticks), and comments (`// …`, `/* … */`).
+fn rewrite_import_meta_hot(code: &str) -> String {
+    const NEEDLE: &str = "import.meta.hot";
+    const REPLACEMENT: &str = "globalThis.__vtz_hot?.(import.meta.url)";
+
+    let bytes = code.as_bytes();
+    let len = bytes.len();
+    let mut result = String::with_capacity(len);
+    let mut i = 0;
+
+    // Advance `i` past the next char starting at byte `i`, pushing that char's
+    // bytes to `result` verbatim. Preserves UTF-8 multi-byte sequences because
+    // we advance by the full codepoint width each step.
+    let step = |result: &mut String, i: &mut usize| {
+        let start = *i;
+        let byte = bytes[start];
+        let width = if byte < 0x80 {
+            1
+        } else if byte < 0xC0 {
+            // Continuation byte appearing outside a multi-byte sequence — treat
+            // as a single byte so we never slice in the middle of a codepoint.
+            1
+        } else if byte < 0xE0 {
+            2
+        } else if byte < 0xF0 {
+            3
+        } else {
+            4
+        };
+        let end = (start + width).min(len);
+        result.push_str(&code[start..end]);
+        *i = end;
+    };
+
+    while i < len {
+        let c = bytes[i];
+
+        // Line comment: preserve verbatim to end of line.
+        if c == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            while i < len && bytes[i] != b'\n' {
+                step(&mut result, &mut i);
+            }
+            continue;
+        }
+
+        // Block comment: preserve verbatim through closing `*/`.
+        if c == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            result.push_str("/*");
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                step(&mut result, &mut i);
+            }
+            if i + 1 < len {
+                result.push_str("*/");
+                i += 2;
+            }
+            continue;
+        }
+
+        // String or template literal: preserve contents verbatim.
+        if c == b'\'' || c == b'"' || c == b'`' {
+            result.push(c as char);
+            i += 1;
+            while i < len && bytes[i] != c {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    // Copy escape byte + next char (may be multi-byte).
+                    result.push('\\');
+                    i += 1;
+                    if i < len {
+                        step(&mut result, &mut i);
+                    }
+                    continue;
+                }
+                step(&mut result, &mut i);
+            }
+            if i < len {
+                result.push(c as char);
+                i += 1;
+            }
+            continue;
+        }
+
+        // Replace `import.meta.hot` when it appears as a bare token.
+        if i + NEEDLE.len() <= len
+            && &bytes[i..i + NEEDLE.len()] == NEEDLE.as_bytes()
+            && !is_ident_char(bytes[i.saturating_sub(1)])
+            && (i + NEEDLE.len() == len || !is_ident_char(bytes[i + NEEDLE.len()]))
+        {
+            // Guard: if preceded by `.` it's a property lookup like `foo.import.meta.hot`
+            // — extremely rare, but skip to be safe.
+            if i == 0 || bytes[i - 1] != b'.' {
+                result.push_str(REPLACEMENT);
+                i += NEEDLE.len();
+                continue;
+            }
+        }
+
+        step(&mut result, &mut i);
+    }
+
+    result
+}
+
+/// True if `b` is a valid continuation character for a JavaScript identifier.
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }
 
 /// Fix the `__$moduleId` to use a URL-relative path instead of an absolute filesystem path.
@@ -1426,12 +1533,12 @@ pub fn fix_module_id(code: &str, file_path: &Path, root_dir: &Path) -> String {
 /// These are framework-agnostic transforms that any plugin can use:
 /// 1. Strip leftover TypeScript syntax artifacts
 /// 2. Deduplicate imports to prevent "already been declared" errors
-/// 3. Strip import.meta.hot (Bun HMR API)
+/// 3. Rewrite `import.meta.hot` references to the Vertz runtime hot-context lookup
 pub fn generic_post_process(code: &str) -> String {
     let cleaned = strip_leftover_typescript(code);
     let deduped = deduplicate_imports(&cleaned);
     let no_cross_dupes = remove_cross_specifier_duplicates(&deduped);
-    strip_import_meta_hot(&no_cross_dupes)
+    rewrite_import_meta_hot(&no_cross_dupes)
 }
 
 /// Apply all post-processing fixes including Vertz-specific ones.
@@ -2325,31 +2432,117 @@ export function App() {
         assert!(result.contains("function domEffect()"));
     }
 
-    // ── strip_import_meta_hot ───────────────────────────────────────
+    // ── rewrite_import_meta_hot ─────────────────────────────────────
 
     #[test]
-    fn test_strip_import_meta_hot() {
-        let code = "const x = 1;\nimport.meta.hot.accept();\nconst y = 2;";
-        let result = strip_import_meta_hot(code);
-        assert!(!result.contains("import.meta.hot"));
+    fn test_rewrite_import_meta_hot_replaces_reference() {
+        let code = "const x = 1;\nimport.meta.hot?.accept();\nconst y = 2;";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            !result.contains("import.meta.hot"),
+            "raw import.meta.hot should be rewritten, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.accept();"),
+            "expected rewritten call, got:\n{}",
+            result
+        );
         assert!(result.contains("const x = 1;"));
         assert!(result.contains("const y = 2;"));
     }
 
     #[test]
-    fn test_strip_import_meta_hot_none() {
+    fn test_rewrite_import_meta_hot_no_references_passthrough() {
         let code = "const x = 1;";
-        let result = strip_import_meta_hot(code);
+        let result = rewrite_import_meta_hot(code);
         assert_eq!(result, code);
     }
 
     #[test]
-    fn test_strip_import_meta_hot_preserves_template_literal() {
+    fn test_rewrite_import_meta_hot_preserves_template_literal() {
         let code = "const tpl = `\nimport.meta.hot.accept();\n`;";
-        let result = strip_import_meta_hot(code);
+        let result = rewrite_import_meta_hot(code);
         assert!(
-            result.contains("import.meta.hot"),
+            result.contains("`\nimport.meta.hot.accept();\n`"),
             "import.meta.hot inside template literal should be preserved. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_preserves_string_literals() {
+        let code = "const msg = \"import.meta.hot is cool\";\nimport.meta.hot?.accept();";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            result.contains("\"import.meta.hot is cool\""),
+            "string literal contents should be untouched, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.accept();"),
+            "code reference should be rewritten, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_preserves_comments() {
+        let code = "// example: import.meta.hot.accept()\nimport.meta.hot?.decline();";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            result.contains("// example: import.meta.hot.accept()"),
+            "comment contents should be untouched, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.decline();"),
+            "code reference should be rewritten, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_preserves_utf8() {
+        let code = "const greeting = '日本語';\nimport.meta.hot?.accept();\n// comment 🎉\nconst emoji = \"🎨\";";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            result.contains("'日本語'"),
+            "UTF-8 string contents must survive rewrite intact, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("🎉"),
+            "UTF-8 in comments must survive rewrite intact, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("\"🎨\""),
+            "UTF-8 in double-quoted strings must survive, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.accept();"),
+            "rewrite should still apply, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_rewrites_inside_if_guard() {
+        let code = "if (import.meta.hot) { import.meta.hot.accept(); }";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            !result.contains("import.meta.hot)"),
+            "raw import.meta.hot in guard should be rewritten, got:\n{}",
+            result
+        );
+        assert_eq!(
+            result
+                .matches("globalThis.__vtz_hot?.(import.meta.url)")
+                .count(),
+            2,
+            "both occurrences on one line should be rewritten, got:\n{}",
             result
         );
     }
@@ -2396,8 +2589,9 @@ export function App() {
         let result = generic_post_process(code);
         // import type stripped
         assert!(!result.contains("import type"));
-        // import.meta.hot stripped
-        assert!(!result.contains("import.meta.hot"));
+        // import.meta.hot rewritten to runtime hot-context lookup
+        assert!(!result.contains(" import.meta.hot"));
+        assert!(result.contains("globalThis.__vtz_hot?.(import.meta.url).accept();"));
         // duplicates removed
         assert!(result.contains("const y = 1"));
         // Does NOT fix Vertz-specific API names (that's not generic)
@@ -2417,10 +2611,14 @@ export function App() {
     // ── post_process_compiled (integration) ─────────────────────────
 
     #[test]
-    fn test_post_process_strips_import_meta_hot() {
+    fn test_post_process_rewrites_import_meta_hot() {
         let code = "const x = 1;\nimport.meta.hot.accept();\nexport { x };";
         let result = post_process_compiled(code);
-        assert!(!result.contains("import.meta.hot"));
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url).accept();"),
+            "expected rewritten call, got:\n{}",
+            result
+        );
         assert!(result.contains("const x = 1;"));
     }
 
@@ -2432,8 +2630,8 @@ export function App() {
         assert!(!result.contains("import type"));
         // effect renamed to domEffect and moved to internals
         assert!(result.contains("domEffect"));
-        // import.meta.hot stripped
-        assert!(!result.contains("import.meta.hot"));
+        // import.meta.hot rewritten to runtime hot-context lookup
+        assert!(result.contains("globalThis.__vtz_hot?.(import.meta.url).accept();"));
         // signal deduped
         assert!(result.contains("signal"));
     }

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -1480,25 +1480,106 @@ fn rewrite_import_meta_hot(code: &str) -> String {
             continue;
         }
 
+        // Regex literal: preserve verbatim. Uses the classic "previous token is
+        // an operator" heuristic to distinguish from division. If this `/` does
+        // not start a regex (i.e. it is division), we fall through to the normal
+        // step and the rewrite check.
+        if c == b'/' && is_regex_start(bytes, i) {
+            let end = skip_regex_literal(bytes, i);
+            result.push_str(&code[i..end]);
+            i = end;
+            continue;
+        }
+
         // Replace `import.meta.hot` when it appears as a bare token.
+        let prev_is_ident = i > 0 && is_ident_char(bytes[i - 1]);
+        let prev_is_dot = i > 0 && bytes[i - 1] == b'.';
         if i + NEEDLE.len() <= len
             && &bytes[i..i + NEEDLE.len()] == NEEDLE.as_bytes()
-            && !is_ident_char(bytes[i.saturating_sub(1)])
+            && !prev_is_ident
+            && !prev_is_dot
             && (i + NEEDLE.len() == len || !is_ident_char(bytes[i + NEEDLE.len()]))
         {
-            // Guard: if preceded by `.` it's a property lookup like `foo.import.meta.hot`
-            // — extremely rare, but skip to be safe.
-            if i == 0 || bytes[i - 1] != b'.' {
-                result.push_str(REPLACEMENT);
-                i += NEEDLE.len();
-                continue;
-            }
+            result.push_str(REPLACEMENT);
+            i += NEEDLE.len();
+            continue;
         }
 
         step(&mut result, &mut i);
     }
 
     result
+}
+
+/// True if `/` at `pos` in `bytes` starts a regex literal (versus a division
+/// operator). Classic heuristic: the previous non-whitespace token must not
+/// produce a value (identifier, number, `)`, `]`, `}`).
+fn is_regex_start(bytes: &[u8], pos: usize) -> bool {
+    if pos + 1 >= bytes.len() {
+        return false;
+    }
+    let next = bytes[pos + 1];
+    // Comments have already been handled earlier; a regex body can't begin
+    // with `*` or `/`.
+    if next == b'/' || next == b'*' {
+        return false;
+    }
+    // Walk back to the previous non-whitespace byte.
+    let mut j = pos;
+    loop {
+        if j == 0 {
+            return true;
+        }
+        j -= 1;
+        if !matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r') {
+            break;
+        }
+    }
+    let prev = bytes[j];
+    // If the previous token ends with a value-producing char, `/` is division.
+    if is_ident_char(prev) || matches!(prev, b')' | b']') {
+        return false;
+    }
+    // `}` is ambiguous (block close vs object-literal close). Regex after `}`
+    // is rare in practice; treat as division to stay conservative — matches
+    // the existing heuristic in `vertz-compiler-core/src/import_injection.rs`.
+    if prev == b'}' {
+        return false;
+    }
+    true
+}
+
+/// Walk past a regex literal starting at `pos` (where `bytes[pos] == b'/'`).
+/// Returns the byte index one past the closing `/` + flags. Handles escapes
+/// and character classes (brackets) so that `/[^/]*/` is read as one regex.
+fn skip_regex_literal(bytes: &[u8], pos: usize) -> usize {
+    let len = bytes.len();
+    let mut i = pos + 1;
+    let mut in_class = false;
+    while i < len {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < len {
+            i += 2;
+            continue;
+        }
+        if c == b'[' {
+            in_class = true;
+        } else if c == b']' {
+            in_class = false;
+        } else if c == b'/' && !in_class {
+            i += 1;
+            // Skip trailing flags (letters).
+            while i < len && bytes[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            return i;
+        } else if c == b'\n' {
+            // Unterminated regex — bail out at end of line.
+            return i;
+        }
+        i += 1;
+    }
+    len
 }
 
 /// True if `b` is a valid continuation character for a JavaScript identifier.
@@ -2524,6 +2605,55 @@ export function App() {
         assert!(
             result.contains("globalThis.__vtz_hot?.(import.meta.url)?.accept();"),
             "rewrite should still apply, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_preserves_regex_literal() {
+        let code = "const re = /import\\.meta\\.hot/g;\nimport.meta.hot?.accept();";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            result.contains("/import\\.meta\\.hot/g"),
+            "regex literal should be preserved, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.accept();"),
+            "code reference should still be rewritten, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_rewrites_at_file_start() {
+        let code = "import.meta.hot?.accept();";
+        let result = rewrite_import_meta_hot(code);
+        assert_eq!(result, "globalThis.__vtz_hot?.(import.meta.url)?.accept();");
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_skips_character_class_with_slashes() {
+        // Regex with `/` inside a [class] must read as one regex, not split.
+        let code = "const re = /[/]import\\.meta\\.hot/;";
+        let result = rewrite_import_meta_hot(code);
+        assert_eq!(result, code, "regex with inner `/` got corrupted");
+    }
+
+    #[test]
+    fn test_rewrite_import_meta_hot_division_not_treated_as_regex() {
+        // After an identifier or `)` — `/` is division, so the `import.meta.hot`
+        // that follows must still be rewritten.
+        let code = "const q = x / y;\nimport.meta.hot?.decline();";
+        let result = rewrite_import_meta_hot(code);
+        assert!(
+            result.contains("const q = x / y;"),
+            "division should be preserved, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("globalThis.__vtz_hot?.(import.meta.url)?.decline();"),
+            "code reference should be rewritten, got:\n{}",
             result
         );
     }

--- a/native/vtz/src/server/html_shell.rs
+++ b/native/vtz/src/server/html_shell.rs
@@ -251,6 +251,34 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_html_shell_exposes_hot_context_api() {
+        let html = generate_html_shell(
+            &PathBuf::from("/project/src/app.tsx"),
+            &PathBuf::from("/project"),
+            &[],
+            None,
+            "Vertz App",
+            &test_plugin(),
+        );
+
+        // The hot-context lookup that compiler-rewritten `import.meta.hot`
+        // calls must be exposed by the HMR client asset.
+        assert!(
+            html.contains("globalThis.__vtz_hot = getHotContext"),
+            "HTML shell should expose globalThis.__vtz_hot"
+        );
+
+        // All Vite-parity methods on the hot context must be present.
+        for method in ["invalidate", "decline", "on", "off", "accept", "dispose"] {
+            assert!(
+                html.contains(method),
+                "HMR client asset should define `{}` method",
+                method
+            );
+        }
+    }
+
+    #[test]
     fn test_generate_html_shell_hmr_scripts_before_app_module() {
         let html = generate_html_shell(
             &PathBuf::from("/project/src/app.tsx"),

--- a/packages/mint-docs/guides/hmr-types.mdx
+++ b/packages/mint-docs/guides/hmr-types.mdx
@@ -29,17 +29,17 @@ Newly-scaffolded apps (via `create-vertz-app`) already include the tsconfig entr
 
 ## The `ImportMetaHot` surface
 
-| Member                 | Description                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| `accept()`             | Self-accept — this module handles its own HMR updates.                                   |
-| `accept(cb)`           | Self-accept with a callback receiving the new module.                                    |
-| `accept(deps, cb?)`    | Accept updates for specific dependency paths.                                            |
-| `dispose(cb)`          | Runs before this module is replaced. Receives a persistent `data` record.                |
-| `data`                 | `Record<string, unknown>` — persisted across HMR updates in the same session.            |
-| `invalidate(message?)` | Mark this module as unable to apply an update; triggers a full reload with the message.  |
-| `decline()`            | Opt out of HMR for this module. The next update targeting it falls back to a full reload.|
-| `on(event, cb)`        | Subscribe to an HMR runtime event (see below).                                           |
-| `off(event, cb)`       | Remove a previously-registered listener (must be the same callback reference).           |
+| Member                 | Description                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `accept()`             | Self-accept — this module handles its own HMR updates.                                    |
+| `accept(cb)`           | Self-accept with a callback receiving the new module.                                     |
+| `accept(deps, cb?)`    | Accept updates for specific dependency paths.                                             |
+| `dispose(cb)`          | Runs before this module is replaced. Receives a persistent `data` record.                 |
+| `data`                 | `Record<string, unknown>` — persisted across HMR updates in the same session.             |
+| `invalidate(message?)` | Mark this module as unable to apply an update; triggers a full reload with the message.   |
+| `decline()`            | Opt out of HMR for this module. The next update targeting it falls back to a full reload. |
+| `on(event, cb)`        | Subscribe to an HMR runtime event (see below).                                            |
+| `off(event, cb)`       | Remove a previously-registered listener (must be the same callback reference).            |
 
 ## Why `hot` is `| undefined`
 
@@ -67,13 +67,13 @@ const prev = import.meta.hot?.data.lastCount as number | undefined;
 
 `hot.on(event, cb)` subscribes to runtime events. Each event delivers a typed payload:
 
-| Event                       | Payload                     | When it fires                                                   |
-| --------------------------- | --------------------------- | --------------------------------------------------------------- |
-| `vertz:beforeUpdate`        | `{ module: string }`        | Before a module is re-imported for an HMR update.               |
-| `vertz:afterUpdate`         | `{ module: string }`        | After a module has been re-imported and Fast Refresh has run.   |
-| `vertz:beforeFullReload`    | `{ reason?: string }`       | Before `location.reload()` is invoked (any cause).              |
-| `vertz:invalidate`          | `{ module: string; message?: string }` | Another module called `hot.invalidate()`.             |
-| `vertz:error`               | `{ module: string; error: unknown }` | An HMR update failed to apply.                         |
+| Event                    | Payload                                | When it fires                                                 |
+| ------------------------ | -------------------------------------- | ------------------------------------------------------------- |
+| `vertz:beforeUpdate`     | `{ module: string }`                   | Before a module is re-imported for an HMR update.             |
+| `vertz:afterUpdate`      | `{ module: string }`                   | After a module has been re-imported and Fast Refresh has run. |
+| `vertz:beforeFullReload` | `{ reason?: string }`                  | Before `location.reload()` is invoked (any cause).            |
+| `vertz:invalidate`       | `{ module: string; message?: string }` | Another module called `hot.invalidate()`.                     |
+| `vertz:error`            | `{ module: string; error: unknown }`   | An HMR update failed to apply.                                |
 
 ```ts
 import.meta.hot?.on('vertz:beforeUpdate', (p) => {

--- a/packages/mint-docs/guides/hmr-types.mdx
+++ b/packages/mint-docs/guides/hmr-types.mdx
@@ -29,13 +29,17 @@ Newly-scaffolded apps (via `create-vertz-app`) already include the tsconfig entr
 
 ## The `ImportMetaHot` surface
 
-| Member              | Description                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- |
-| `accept()`          | Self-accept — this module handles its own HMR updates.                        |
-| `accept(cb)`        | Self-accept with a callback receiving the new module.                         |
-| `accept(deps, cb?)` | Accept updates for specific dependency paths.                                 |
-| `dispose(cb)`       | Runs before this module is replaced. Receives a persistent `data` record.     |
-| `data`              | `Record<string, unknown>` — persisted across HMR updates in the same session. |
+| Member                 | Description                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| `accept()`             | Self-accept — this module handles its own HMR updates.                                   |
+| `accept(cb)`           | Self-accept with a callback receiving the new module.                                    |
+| `accept(deps, cb?)`    | Accept updates for specific dependency paths.                                            |
+| `dispose(cb)`          | Runs before this module is replaced. Receives a persistent `data` record.                |
+| `data`                 | `Record<string, unknown>` — persisted across HMR updates in the same session.            |
+| `invalidate(message?)` | Mark this module as unable to apply an update; triggers a full reload with the message.  |
+| `decline()`            | Opt out of HMR for this module. The next update targeting it falls back to a full reload.|
+| `on(event, cb)`        | Subscribe to an HMR runtime event (see below).                                           |
+| `off(event, cb)`       | Remove a previously-registered listener (must be the same callback reference).           |
 
 ## Why `hot` is `| undefined`
 
@@ -59,13 +63,35 @@ import.meta.hot?.dispose((data) => {
 const prev = import.meta.hot?.data.lastCount as number | undefined;
 ```
 
+## Events
+
+`hot.on(event, cb)` subscribes to runtime events. Each event delivers a typed payload:
+
+| Event                       | Payload                     | When it fires                                                   |
+| --------------------------- | --------------------------- | --------------------------------------------------------------- |
+| `vertz:beforeUpdate`        | `{ module: string }`        | Before a module is re-imported for an HMR update.               |
+| `vertz:afterUpdate`         | `{ module: string }`        | After a module has been re-imported and Fast Refresh has run.   |
+| `vertz:beforeFullReload`    | `{ reason?: string }`       | Before `location.reload()` is invoked (any cause).              |
+| `vertz:invalidate`          | `{ module: string; message?: string }` | Another module called `hot.invalidate()`.             |
+| `vertz:error`               | `{ module: string; error: unknown }` | An HMR update failed to apply.                         |
+
+```ts
+import.meta.hot?.on('vertz:beforeUpdate', (p) => {
+  console.log('about to update', p.module);
+});
+```
+
+## Decline vs invalidate
+
+Both fall back to a full page reload, but at different times:
+
+- `decline()` marks a module as "do not try HMR." The next time the server pushes an update that includes this module, the client performs a full reload instead of a hot swap. Use when a module holds state that can't be re-created safely (e.g., a global WebSocket).
+- `invalidate(message?)` triggers a full reload immediately. Use from inside an `accept()` callback when you discover at runtime that the new module can't take over (e.g., a new dependency version is incompatible with live state).
+
 ## Runtime behavior
 
-- Under `vtz dev`, the runtime strips `import.meta.hot.*` lines server-side and handles HMR through its own WebSocket protocol.
-- Under the Bun build plugin, a guarded self-accept (`if (import.meta.hot) import.meta.hot.accept()`) is injected after user code.
-
-Both paths make `import.meta.hot?.*` calls a no-op when `hot` isn't real — safe in all environments.
+Under `vtz dev`, the compiler rewrites `import.meta.hot` references to a runtime hot-context lookup. In production (no HMR runtime present) the lookup is undefined, so `import.meta.hot?.*` remains a no-op — safe in all environments.
 
 ## What's not here
 
-The current surface matches the subset of Vite's HMR API that Vertz implements today. Extras like `invalidate()`, `on()`, `off()`, `send()`, `prune()`, and `decline()` are tracked as a follow-up (requires dev-server + build-plugin runtime support, not just types).
+`send()` (custom client → server events) and `prune()` (cleanup when a module is no longer imported anywhere) are not implemented yet. They require bidirectional WebSocket support and module-removal tracking respectively; tracked for a follow-up.

--- a/packages/vertz/client.d.ts
+++ b/packages/vertz/client.d.ts
@@ -9,6 +9,23 @@
  */
 
 declare global {
+  /** Event names emitted by the vtz HMR runtime. */
+  type ImportMetaHotEvent =
+    | 'vertz:beforeUpdate'
+    | 'vertz:afterUpdate'
+    | 'vertz:beforeFullReload'
+    | 'vertz:invalidate'
+    | 'vertz:error';
+
+  /** Payload shape delivered to `hot.on()` listeners, per event. */
+  interface ImportMetaHotEventPayloads {
+    'vertz:beforeUpdate': { module: string };
+    'vertz:afterUpdate': { module: string };
+    'vertz:beforeFullReload': { reason?: string };
+    'vertz:invalidate': { module: string; message?: string };
+    'vertz:error': { module: string; error: unknown };
+  }
+
   interface ImportMetaHot {
     /** Accept the current module's HMR update. */
     accept(): void;
@@ -20,6 +37,26 @@ declare global {
     dispose(cb: (data: Record<string, unknown>) => void): void;
     /** Persistent data across HMR updates. */
     data: Record<string, unknown>;
+    /**
+     * Mark the current module as unable to apply an HMR update. Triggers a full
+     * page reload with an optional explanatory message.
+     */
+    invalidate(message?: string): void;
+    /**
+     * Opt out of HMR for the current module. The next update targeting this
+     * module falls back to a full page reload.
+     */
+    decline(): void;
+    /** Subscribe to an HMR runtime event. */
+    on<E extends ImportMetaHotEvent>(
+      event: E,
+      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
+    ): void;
+    /** Remove a previously-registered listener. The callback must be the same reference. */
+    off<E extends ImportMetaHotEvent>(
+      event: E,
+      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
+    ): void;
   }
 
   interface ImportMeta {

--- a/packages/vertz/src/__tests__/import-meta-hot.test-d.ts
+++ b/packages/vertz/src/__tests__/import-meta-hot.test-d.ts
@@ -48,6 +48,59 @@ describe('Feature: dispose and data', () => {
   });
 });
 
+describe('Feature: invalidate and decline', () => {
+  it('invalidate() accepts an optional message and returns void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.invalidate()).toEqualTypeOf<void>();
+    expectTypeOf(hot.invalidate('oops')).toEqualTypeOf<void>();
+  });
+
+  it('decline() takes no arguments and returns void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.decline()).toEqualTypeOf<void>();
+  });
+
+  it('decline() rejects any arguments at the type level', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — decline takes no arguments.
+    hot.decline('nope');
+  });
+});
+
+describe('Feature: on / off event subscription', () => {
+  it('vertz:beforeUpdate payload exposes the updated module string', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    hot.on('vertz:beforeUpdate', (payload) => {
+      expectTypeOf(payload).toEqualTypeOf<{ module: string }>();
+    });
+  });
+
+  it('vertz:beforeFullReload payload exposes an optional reason', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    hot.on('vertz:beforeFullReload', (payload) => {
+      expectTypeOf(payload).toEqualTypeOf<{ reason?: string }>();
+    });
+  });
+
+  it('off() requires the same callback reference', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    const cb = (_p: { module: string }) => {};
+    expectTypeOf(hot.off('vertz:afterUpdate', cb)).toEqualTypeOf<void>();
+  });
+
+  it('rejects unknown event names', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — 'vite:beforeUpdate' is not a vtz event.
+    hot.on('vite:beforeUpdate', () => {});
+  });
+
+  it('rejects wrong payload shape on listener', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — vertz:beforeUpdate payload does not expose `reason`.
+    hot.on('vertz:beforeUpdate', (p: { reason: string }) => p.reason);
+  });
+});
+
 describe('Feature: removed augmentations', () => {
   it('ImportMeta.main is not declared by vertz/client', () => {
     // @ts-expect-error — main is a Bun-ism, not provided by the vtz runtime.


### PR DESCRIPTION
## Summary

Adds the Vite-parity HMR methods asked for in #2812: `invalidate(message?)`, `decline()`, `on(event, cb)`, `off(event, cb)`. `send()` and `prune()` are intentionally deferred.

Closes #2812.

## Public API Changes

### Additions to `ImportMetaHot` (in `packages/vertz/client.d.ts`)

- `invalidate(message?: string): void` — trigger a full reload with an optional explanatory message.
- `decline(): void` — opt out of HMR for the current module; next update targeting it falls back to a full reload.
- `on<E>(event: E, cb: (payload) => void): void` / `off` — subscribe to typed runtime events.

### New runtime events

- `vertz:beforeUpdate` — `{ module: string }`
- `vertz:afterUpdate` — `{ module: string }`
- `vertz:beforeFullReload` — `{ reason?: string }`
- `vertz:invalidate` — `{ module: string; message?: string }`
- `vertz:error` — `{ module: string; error: unknown }`

### Behavior changes

- `import.meta.hot` is no longer stripped at compile time under `vtz dev`. The compiler rewrites it to `globalThis.__vtz_hot?.(import.meta.url)` — a runtime lookup that resolves to a real per-module hot context.
- `accept(cb)` callbacks are now actually invoked with the new module namespace after a successful hot update (previously registered but never called).
- `dispose(cb)` callbacks are snapshotted before re-import so the new module generation doesn't race with the old one.

### Deferred (non-goals for this PR)

- `send(event, data?)` — requires bidirectional WebSocket protocol support.
- `prune(cb)` — requires module-removal tracking across rebuilds.

## Design notes

- Compiler: `native/vtz/src/compiler/pipeline.rs::rewrite_import_meta_hot` — UTF-8 safe byte-walker that skips string literals, template literals, regex literals, and line/block comments.
- Runtime: `native/vtz/src/assets/hmr-client.js::createHotContext` — per-module context keyed by normalized URL pathname (`new URL(moduleUrl).pathname` when `moduleUrl` is a full URL, otherwise the raw string with `?…#…` stripped). `globalThis.__vtz_hot` is set before the entry module loads (HMR client is injected into the HTML shell before the `<script type="module">` entry).
- Types: `ImportMetaHotEvent` + `ImportMetaHotEventPayloads` — generic `on<E>` ensures listener payload types are narrowed by event name.

## Adversarial review

One round of adversarial review (see commit `1383bf882`) caught 5 blockers, all fixed:

- **B1**: regex literals containing `import.meta.hot` were being corrupted (`/import\.meta\.hot/g` got rewritten inside the pattern). Added `is_regex_start` / `skip_regex_literal` helpers + tests for character-class-with-slash and division-vs-regex cases.
- **B2**: `vertz:invalidate` was typed/documented but never emitted. `ctx.invalidate()` now fires it before triggering the reload.
- **B3**: `hot.invalidate()` was bypassing `vertz:beforeFullReload`. It now routes through `handleFullReload` so all contexts see the event.
- **S1**: `accept(cb)` callbacks were registered but never invoked. `handleUpdate` now snapshots the pre-import generation of accept + dispose callbacks, fires dispose, imports the new module, then fires accept with the fresh namespace.
- **S4**: a file starting with `import.meta.hot` at byte 0 was not being rewritten because of a `saturating_sub(1)` off-by-one. Fixed with an explicit `i > 0` guard + test.

## Test plan

- [x] Rust unit tests: 11 new `test_rewrite_import_meta_hot_*` cases covering raw reference, template literal preservation, string literal preservation, comment preservation, regex literal preservation, character-class-with-slash regex, division-not-regex, UTF-8 codepoints, file-start edge case, if-guard pattern, no-references passthrough.
- [x] Rust integration test: `test_generate_html_shell_exposes_hot_context_api` asserts the HMR client asset exposes `globalThis.__vtz_hot` and all method names.
- [x] TypeScript type tests: positive checks for `invalidate`/`decline`/`on`/`off` return types and payload narrowing; negative checks (`@ts-expect-error`) for unknown event names, wrong payload shapes, arguments to `decline()`.
- [x] Full Rust suite: 3622 tests pass, clippy clean, fmt clean.
- [x] Vertz TS package: 27 tests pass.
- [x] Docs: `packages/mint-docs/guides/hmr-types.mdx` updated with the new surface + events table + decline-vs-invalidate section.
- [ ] End-to-end browser test with a real `vtz dev` instance — tracked as follow-up; Rust integration tests that spin up the dev server live in `.local.ts` / `tests/parity/` and would require a Playwright harness to assert the browser-side behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)