### PR TITLE
feat(db): d.bytea() column type for binary storage [#2843]

### DIFF
--- a/.changeset/add-bytea-column-type-2843.md
+++ b/.changeset/add-bytea-column-type-2843.md
@@ -1,0 +1,22 @@
+---
+'@vertz/db': patch
+---
+
+feat(db): add `d.bytea()` column type for binary storage
+
+Closes [#2843](https://github.com/vertz-dev/vertz/issues/2843).
+
+New `d.bytea()` column maps to Postgres `BYTEA` and SQLite/D1 `BLOB`, inferring `Uint8Array` at the TypeScript level. Round-trips losslessly: on SQLite reads, `Buffer` and `ArrayBuffer` returned by different drivers are normalized to a plain `Uint8Array` so callers never see backend-specific objects. `.min(n)` / `.max(n)` validate byte length (reuses the `_minLength` / `_maxLength` pipeline — they refine the `@vertz/schema` `instanceof(Uint8Array)` schema).
+
+```ts
+const tenant = d.table('tenant', {
+  id: d.uuid().primary(),
+  encryptedDek: d.bytea(),           // required, any length
+  sig: d.bytea().min(64).max(64),    // exactly 64 bytes
+  nonce: d.bytea().nullable(),
+});
+```
+
+Previously, the only options were to base64-encode into `d.text()` (33% size bloat plus an encoding boundary that could corrupt bytes) or abuse `d.jsonb<Uint8Array>()` (JSONB is not designed for opaque bytes). `d.bytea()` removes the encoding step entirely. The migration codegen now emits `d.bytea()` for introspected `BYTEA`/`BLOB` columns instead of `d.text() // TODO: binary type`.
+
+Unblocks the `triagebot` dogfood consumer (`tenant.encryptedDek`, `install.encryptedCredentials`) and any other downstream with AES-GCM ciphertext, compressed payloads, pre-hashed image thumbnails, etc.

--- a/packages/db/src/__tests__/integration-sqlite.test.ts
+++ b/packages/db/src/__tests__/integration-sqlite.test.ts
@@ -121,4 +121,108 @@ describe('SQLite integration (via D1 mock)', () => {
     // Value conversion: SQLite returned ISO string, JS gets Date
     expect(result[0].createdAt).toBeInstanceOf(Date);
   });
+
+  // -------------------------------------------------------------------------
+  // d.bytea() round-trip (issue #2843)
+  // -------------------------------------------------------------------------
+
+  const secretsTable = d.table('secrets', {
+    id: d.uuid().primary(),
+    dek: d.bytea(),
+    nonce: d.bytea().nullable(),
+  });
+  const byteaModels = { secrets: d.model(secretsTable) };
+
+  function createByteaMockD1(listRow: Record<string, unknown>): {
+    d1: D1Database;
+    bindCalls: unknown[][];
+  } {
+    const bindCalls: unknown[][] = [];
+    const d1: D1Database = {
+      prepare: mock(() => {
+        const stmt: D1PreparedStatement = {
+          bind: mock(function (this: D1PreparedStatement, ...values: unknown[]) {
+            bindCalls.push(values);
+            return this;
+          }),
+          all: mock(async () => ({
+            results: [listRow],
+            success: true,
+          })),
+          run: mock(async () => ({
+            results: [listRow],
+            success: true,
+            meta: { changes: 1 },
+          })),
+          first: mock(async () => null),
+        } as unknown as D1PreparedStatement;
+        return stmt;
+      }),
+    } as unknown as D1Database;
+    return { d1, bindCalls };
+  }
+
+  it('SQLite bytea: round-trips a small Uint8Array with Buffer → Uint8Array normalization', async () => {
+    const stored = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0xff]);
+    // Simulate Node-style drivers returning a Buffer; the converter must
+    // normalize it to a plain Uint8Array on read.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Buffer probe
+    const asBuffer = (globalThis as any).Buffer?.from(stored) ?? stored;
+    const { d1, bindCalls } = createByteaMockD1({ id: 'bytea-1', dek: asBuffer, nonce: null });
+
+    const db = createDb({ dialect: 'sqlite', d1, models: byteaModels });
+    const created = unwrap(await db.secrets.create({ data: { id: 'bytea-1', dek: stored } }));
+    expect(created.dek).toBeInstanceOf(Uint8Array);
+    expect(Array.from(created.dek)).toEqual(Array.from(stored));
+
+    const sawBytea = bindCalls.some((params) =>
+      params.some(
+        (p) => p instanceof Uint8Array && Array.from(p).join(',') === '222,173,190,239,0,255',
+      ),
+    );
+    expect(sawBytea).toBe(true);
+
+    const [row] = unwrap(await db.secrets.list());
+    expect(row.dek).toBeInstanceOf(Uint8Array);
+    expect(Object.getPrototypeOf(row.dek)).toBe(Uint8Array.prototype);
+    expect(Array.from(row.dek)).toEqual(Array.from(stored));
+  });
+
+  it('SQLite bytea: empty Uint8Array(0) round-trips as zero-length buffer', async () => {
+    const empty = new Uint8Array(0);
+    const { d1 } = createByteaMockD1({ id: 'empty-1', dek: empty, nonce: null });
+
+    const db = createDb({ dialect: 'sqlite', d1, models: byteaModels });
+    const created = unwrap(await db.secrets.create({ data: { id: 'empty-1', dek: empty } }));
+    expect(created.dek).toBeInstanceOf(Uint8Array);
+    expect(created.dek.byteLength).toBe(0);
+  });
+
+  it('SQLite bytea: large (~256 KB) payload round-trips without truncation', async () => {
+    const size = 256 * 1024;
+    const payload = new Uint8Array(size);
+    for (let i = 0; i < size; i++) payload[i] = i & 0xff;
+    const { d1 } = createByteaMockD1({ id: 'big-1', dek: payload, nonce: null });
+
+    const db = createDb({ dialect: 'sqlite', d1, models: byteaModels });
+    const created = unwrap(await db.secrets.create({ data: { id: 'big-1', dek: payload } }));
+    expect(created.dek.byteLength).toBe(size);
+    expect(created.dek[0]).toBe(0);
+    expect(created.dek[size - 1]).toBe((size - 1) & 0xff);
+  });
+
+  it('SQLite bytea: nullable column passes null through on reads', async () => {
+    const { d1 } = createByteaMockD1({
+      id: 'nullable-1',
+      dek: new Uint8Array([1, 2, 3]),
+      nonce: null,
+    });
+    const db = createDb({ dialect: 'sqlite', d1, models: byteaModels });
+    const created = unwrap(
+      await db.secrets.create({
+        data: { id: 'nullable-1', dek: new Uint8Array([1, 2, 3]), nonce: null },
+      }),
+    );
+    expect(created.nonce).toBe(null);
+  });
 });

--- a/packages/db/src/__tests__/public-exports.test-d.ts
+++ b/packages/db/src/__tests__/public-exports.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, it } from '@vertz/test';
 import {
   d,
+  type BytesColumnBuilder,
   type ColumnBuilder,
   type ColumnRecord,
   type DefaultMeta,
@@ -42,6 +43,11 @@ describe('Public API exports — issue #2778', () => {
   it('SerialMeta names the return metadata of d.serial()', () => {
     type SerialReturn = ReturnType<typeof d.serial>;
     type _t1 = Expect<Equal<SerialReturn, NumericColumnBuilder<number, SerialMeta>>>;
+  });
+
+  it('BytesColumnBuilder names the return type of d.bytea()', () => {
+    type ByteaReturn = ReturnType<typeof d.bytea>;
+    type _t1 = Expect<Equal<ByteaReturn, BytesColumnBuilder<Uint8Array, DefaultMeta<'bytea'>>>>;
   });
 
   it('VectorMeta names the return metadata of d.vector()', () => {

--- a/packages/db/src/client/__tests__/sqlite-value-converter.test.ts
+++ b/packages/db/src/client/__tests__/sqlite-value-converter.test.ts
@@ -162,4 +162,50 @@ describe('fromSqliteValue', () => {
   it('throws JsonbParseError on invalid JSON for jsonb columns', () => {
     expect(() => fromSqliteValue('not json', 'jsonb')).toThrow(JsonbParseError);
   });
+
+  describe('bytea columns', () => {
+    it('passes through Uint8Array unchanged for bytea columns', () => {
+      const buf = new Uint8Array([1, 2, 3, 255]);
+      const result = fromSqliteValue(buf, 'bytea');
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(Array.from(result as Uint8Array)).toEqual([1, 2, 3, 255]);
+    });
+
+    it('normalizes Node Buffer to plain Uint8Array for bytea columns', () => {
+      // Buffer is a Uint8Array subclass; normalize so callers don't receive
+      // Node-specific objects.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Buffer is a test-only subclass probe
+      const Buffer = (globalThis as any).Buffer as { from(arr: number[]): Uint8Array } | undefined;
+      if (!Buffer) return;
+      const buf = Buffer.from([1, 2, 3]);
+      const result = fromSqliteValue(buf, 'bytea');
+      expect(result).toBeInstanceOf(Uint8Array);
+      // Strict Uint8Array, not Buffer
+      expect(Object.getPrototypeOf(result)).toBe(Uint8Array.prototype);
+      expect(Array.from(result as Uint8Array)).toEqual([1, 2, 3]);
+    });
+
+    it('converts ArrayBuffer to Uint8Array for bytea columns', () => {
+      const ab = new ArrayBuffer(3);
+      new Uint8Array(ab).set([7, 8, 9]);
+      const result = fromSqliteValue(ab, 'bytea');
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(Array.from(result as Uint8Array)).toEqual([7, 8, 9]);
+    });
+
+    it('passes through null for bytea columns', () => {
+      expect(fromSqliteValue(null, 'bytea')).toBe(null);
+    });
+
+    it('passes through undefined for bytea columns', () => {
+      expect(fromSqliteValue(undefined, 'bytea')).toBe(undefined);
+    });
+
+    it('passes through non-bytes values unchanged for bytea columns', () => {
+      // Defensive: if a driver ever returns a string/number, return it as-is
+      // rather than silently constructing a Uint8Array from it.
+      expect(fromSqliteValue('not-bytes', 'bytea')).toBe('not-bytes');
+      expect(fromSqliteValue(42, 'bytea')).toBe(42);
+    });
+  });
 });

--- a/packages/db/src/client/sqlite-value-converter.ts
+++ b/packages/db/src/client/sqlite-value-converter.ts
@@ -53,5 +53,33 @@ export function fromSqliteValue(value: unknown, columnType: string): unknown {
       throw new JsonbParseError({ columnType, cause });
     }
   }
+  if (columnType === 'bytea') {
+    return normalizeBytea(value);
+  }
+  return value;
+}
+
+/**
+ * Normalize a driver-returned BLOB value to a plain `Uint8Array`.
+ *
+ * Different SQLite bindings return different concrete types:
+ *   - `Buffer` (a `Uint8Array` subclass) — better-sqlite3 / node
+ *   - `Uint8Array` — bun:sqlite / @vertz/sqlite
+ *   - `ArrayBuffer` — Cloudflare D1
+ *
+ * Callers always see a plain `Uint8Array` regardless of backend.
+ */
+function normalizeBytea(value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    // Strip Buffer (and other subclass) prototypes so consumers always see a
+    // plain Uint8Array. `slice()` allocates a fresh Uint8Array view.
+    if (Object.getPrototypeOf(value) === Uint8Array.prototype) {
+      return value;
+    }
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value).slice();
+  }
   return value;
 }

--- a/packages/db/src/d.ts
+++ b/packages/db/src/d.ts
@@ -1,4 +1,5 @@
 import type {
+  BytesColumnBuilder,
   ColumnBuilder,
   DecimalMeta,
   DefaultMeta,
@@ -113,6 +114,43 @@ export const d: {
   jsonb<T = unknown>(
     schemaOrOpts?: SchemaLike<T> | { validator: JsonbValidator<T> },
   ): ColumnBuilder<T, DefaultMeta<'jsonb'>>;
+  /**
+   * Binary column — stores an opaque byte sequence.
+   *
+   * - **Postgres:** native `BYTEA` type.
+   * - **SQLite / Cloudflare D1:** native `BLOB` type.
+   *
+   * TypeScript infers `Uint8Array`. Reads round-trip losslessly on both
+   * dialects:
+   * - SQLite read path normalizes driver output (`Buffer`, `ArrayBuffer`) to a
+   *   plain `Uint8Array` so callers never see backend-specific objects.
+   * - Postgres (via the `postgres` package / `pg`) returns `Buffer`, which *is*
+   *   a `Uint8Array` subclass — `instanceof Uint8Array` is `true` and all
+   *   `Uint8Array` methods work — but keeps its `Buffer` prototype rather than
+   *   being slice-copied. Reference checks like
+   *   `Object.getPrototypeOf(v) === Uint8Array.prototype` will be `false` on
+   *   Postgres.
+   *
+   * `.min(n)` and `.max(n)` validate byte length (reuses the string-length
+   * constraint pipeline).
+   *
+   * **Driver support:** Cloudflare D1, `better-sqlite3`, `bun:sqlite`, and the
+   * `postgres` / `pg` packages all handle `BYTEA`/`BLOB` parameters natively.
+   * The built-in `vtz` runtime's native SQLite binding (`@vertz/sqlite`) does
+   * not yet support binary parameters — see [#2920](https://github.com/vertz-dev/vertz/issues/2920).
+   * Use a Node / Bun / Workers target when you need `d.bytea()` in a local
+   * SQLite file today.
+   *
+   * @example
+   * ```ts
+   * const tenant = d.table('tenant', {
+   *   id: d.uuid().primary(),
+   *   encryptedDek: d.bytea(),
+   *   sig: d.bytea().min(64).max(64), // exactly 64 bytes
+   * });
+   * ```
+   */
+  bytea(): BytesColumnBuilder<Uint8Array, DefaultMeta<'bytea'>>;
   textArray(): ColumnBuilder<string[], DefaultMeta<'text[]'>>;
   integerArray(): ColumnBuilder<number[], DefaultMeta<'integer[]'>>;
   vector<TDimensions extends number>(
@@ -223,6 +261,11 @@ export const d: {
       opts?.validator ? { validator: opts.validator } : {},
     );
   },
+  bytea: () =>
+    createColumn<Uint8Array, DefaultMeta<'bytea'>>('bytea') as unknown as BytesColumnBuilder<
+      Uint8Array,
+      DefaultMeta<'bytea'>
+    >,
   vector: <TDimensions extends number>(dimensions: TDimensions) => {
     if (!Number.isInteger(dimensions) || dimensions < 1 || dimensions > 16000) {
       throw new Error(

--- a/packages/db/src/dialect/__tests__/postgres-dialect.test.ts
+++ b/packages/db/src/dialect/__tests__/postgres-dialect.test.ts
@@ -96,6 +96,14 @@ describe('PostgresDialect', () => {
     expect(dialect.mapColumnType('vector')).toBe('vector');
   });
 
+  it('mapColumnType: bytea -> BYTEA', () => {
+    expect(dialect.mapColumnType('bytea')).toBe('BYTEA');
+  });
+
+  it('mapColumnType: blob (snapshot alias) -> BYTEA', () => {
+    expect(dialect.mapColumnType('blob')).toBe('BYTEA');
+  });
+
   it('mapColumnType: unknown type -> TEXT', () => {
     expect(dialect.mapColumnType('unknown')).toBe('TEXT');
   });

--- a/packages/db/src/dialect/__tests__/sqlite-dialect.test.ts
+++ b/packages/db/src/dialect/__tests__/sqlite-dialect.test.ts
@@ -65,6 +65,14 @@ describe('SqliteDialect', () => {
       expect(dialect.mapColumnType('serial')).toBe('INTEGER');
     });
 
+    it('maps bytea to BLOB', () => {
+      expect(dialect.mapColumnType('bytea')).toBe('BLOB');
+    });
+
+    it('maps introspect alias "blob" to BLOB (SQLite introspect emits lowercase blob)', () => {
+      expect(dialect.mapColumnType('blob')).toBe('BLOB');
+    });
+
     it('maps unknown types to TEXT', () => {
       expect(dialect.mapColumnType('unknown')).toBe('TEXT');
     });

--- a/packages/db/src/dialect/postgres.ts
+++ b/packages/db/src/dialect/postgres.ts
@@ -49,6 +49,9 @@ export class PostgresDialect implements Dialect {
         return meta?.enumName ?? 'TEXT';
       case 'vector':
         return meta?.dimensions ? `vector(${meta.dimensions})` : 'vector';
+      case 'bytea':
+      case 'blob':
+        return 'BYTEA';
       default:
         return 'TEXT';
     }

--- a/packages/db/src/dialect/sqlite.ts
+++ b/packages/db/src/dialect/sqlite.ts
@@ -44,6 +44,9 @@ export class SqliteDialect implements Dialect {
         return 'INTEGER';
       case 'serial':
         return 'INTEGER';
+      case 'bytea':
+      case 'blob':
+        return 'BLOB';
       default:
         return 'TEXT';
     }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -139,6 +139,7 @@ export { createSnapshot } from './migration/snapshot';
 export { validateIndexes } from './migration/validate-indexes';
 // Schema types
 export type {
+  BytesColumnBuilder,
   ColumnBuilder,
   ColumnMetadata,
   DecimalMeta,

--- a/packages/db/src/migration/__tests__/codegen.test.ts
+++ b/packages/db/src/migration/__tests__/codegen.test.ts
@@ -446,7 +446,7 @@ describe('generateSchemaCode — Postgres type mapping', () => {
     expect(file.content).not.toContain('// TODO');
   });
 
-  it('maps bytea to d.text() with binary TODO comment', () => {
+  it('maps bytea to d.bytea() (native binary column)', () => {
     const snapshot = makeSnapshot({
       files: {
         columns: {
@@ -466,8 +466,8 @@ describe('generateSchemaCode — Postgres type mapping', () => {
     });
 
     const [file] = generateSchemaCode(snapshot, { dialect: 'postgres', mode: 'single-file' });
-    expect(file.content).toContain('d.text().nullable()');
-    expect(file.content).toContain('// TODO: binary type');
+    expect(file.content).toContain('d.bytea().nullable()');
+    expect(file.content).not.toContain('// TODO: binary type');
   });
 
   it('escapes single quotes in enum values', () => {
@@ -546,7 +546,8 @@ describe('generateSchemaCode — SQLite type mapping', () => {
     expect(file.content).toContain('id: d.integer().primary()');
     expect(file.content).toContain('name: d.text()');
     expect(file.content).toContain('score: d.real().nullable()');
-    expect(file.content).toContain('// TODO: binary type');
+    expect(file.content).toContain('data: d.bytea().nullable()');
+    expect(file.content).not.toContain('// TODO: binary type');
   });
 });
 

--- a/packages/db/src/migration/codegen.ts
+++ b/packages/db/src/migration/codegen.ts
@@ -206,8 +206,6 @@ function generateColumnCode(
     comment = '// Source: timestamp without time zone';
   } else if (col.type === 'bigint' && col.default?.startsWith('nextval(')) {
     comment = '// Source: bigserial';
-  } else if (builder.isBinary) {
-    comment = '// TODO: binary type';
   } else if (builder.fallback) {
     comment = `// TODO: unmapped type "${col.type}"`;
   }
@@ -244,7 +242,6 @@ interface BuilderResult {
   code: string;
   fallback?: boolean;
   skipDefault?: boolean;
-  isBinary?: boolean;
 }
 
 function mapColumnType(col: ColumnSnapshot, snapshot: SchemaSnapshot): BuilderResult {
@@ -305,7 +302,7 @@ function mapColumnType(col: ColumnSnapshot, snapshot: SchemaSnapshot): BuilderRe
       return { code: 'd.text()' };
     case 'blob':
     case 'bytea':
-      return { code: 'd.text()', isBinary: true };
+      return { code: 'd.bytea()' };
     default:
       return { code: 'd.text()', fallback: true };
   }

--- a/packages/db/src/schema-derive/column-mapper.ts
+++ b/packages/db/src/schema-derive/column-mapper.ts
@@ -1,5 +1,5 @@
 import type { SchemaAny } from '@vertz/schema';
-import { NumberSchema, StringSchema, s } from '@vertz/schema';
+import { InstanceOfSchema, NumberSchema, StringSchema, s } from '@vertz/schema';
 import type { ColumnMetadata } from '../schema/column';
 
 /**
@@ -56,6 +56,8 @@ function mapSqlType(meta: ColumnMetadata): SchemaAny {
       return s.string();
     case 'jsonb':
       return s.unknown();
+    case 'bytea':
+      return s.instanceof(Uint8Array);
     case 'text[]':
       return s.array(s.string());
     case 'integer[]':
@@ -91,6 +93,24 @@ function applyConstraints(schema: SchemaAny, meta: ColumnMetadata): SchemaAny {
     }
     if (meta._maxValue != null) {
       result = (result as NumberSchema).max(meta._maxValue);
+    }
+  }
+
+  // Byte-length constraints for bytea (reuse _minLength / _maxLength).
+  if (meta.sqlType === 'bytea' && result instanceof InstanceOfSchema) {
+    const min = meta._minLength;
+    const max = meta._maxLength;
+    if (min != null) {
+      result = result.refine(
+        (v: Uint8Array) => v instanceof Uint8Array && v.byteLength >= min,
+        `Byte length must be at least ${min}`,
+      );
+    }
+    if (max != null) {
+      result = result.refine(
+        (v: Uint8Array) => v instanceof Uint8Array && v.byteLength <= max,
+        `Byte length must be at most ${max}`,
+      );
     }
   }
 

--- a/packages/db/src/schema-derive/table-to-schemas.test.ts
+++ b/packages/db/src/schema-derive/table-to-schemas.test.ts
@@ -536,6 +536,61 @@ describe('tableToSchemas', () => {
     });
   });
 
+  describe('bytea columns', () => {
+    const withBytea = d.table('with_bytea', {
+      id: d.uuid().primary(),
+      payload: d.bytea(),
+      sig: d.bytea().min(2).max(4),
+    });
+
+    it('accepts Uint8Array for bytea columns', () => {
+      const { createBody } = tableToSchemas(withBytea);
+      const result = createBody.safeParse({
+        payload: new Uint8Array([1, 2, 3]),
+        sig: new Uint8Array([9, 9]),
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects non-Uint8Array values for bytea columns', () => {
+      const { createBody } = tableToSchemas(withBytea);
+      expect(createBody.safeParse({ payload: 'not bytes', sig: new Uint8Array([1, 2]) }).ok).toBe(
+        false,
+      );
+      expect(createBody.safeParse({ payload: [1, 2, 3], sig: new Uint8Array([1, 2]) }).ok).toBe(
+        false,
+      );
+    });
+
+    it('enforces min byte length for bytea columns', () => {
+      const { createBody } = tableToSchemas(withBytea);
+      const result = createBody.safeParse({
+        payload: new Uint8Array([0]),
+        sig: new Uint8Array([9]), // 1 byte, below min=2
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('enforces max byte length for bytea columns', () => {
+      const { createBody } = tableToSchemas(withBytea);
+      const result = createBody.safeParse({
+        payload: new Uint8Array([0]),
+        sig: new Uint8Array([1, 2, 3, 4, 5]), // 5 bytes, above max=4
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts boundary byte lengths (inclusive min/max)', () => {
+      const { createBody } = tableToSchemas(withBytea);
+      expect(
+        createBody.safeParse({ payload: new Uint8Array(0), sig: new Uint8Array([1, 2]) }).ok,
+      ).toBe(true);
+      expect(
+        createBody.safeParse({ payload: new Uint8Array(0), sig: new Uint8Array([1, 2, 3, 4]) }).ok,
+      ).toBe(true);
+    });
+  });
+
   describe('email with constraints', () => {
     const withEmail = d.table('with_email', {
       id: d.uuid().primary(),

--- a/packages/db/src/schema/__tests__/column.test-d.ts
+++ b/packages/db/src/schema/__tests__/column.test-d.ts
@@ -96,6 +96,16 @@ describe('column type inference', () => {
     const col = d.enum('role', ['admin', 'editor']);
     type _t1 = Expect<Equal<InferColumnType<typeof col>, 'admin' | 'editor'>>;
   });
+
+  it('d.bytea() infers Uint8Array', () => {
+    const col = d.bytea();
+    type _t1 = Expect<Equal<InferColumnType<typeof col>, Uint8Array>>;
+  });
+
+  it('d.bytea().nullable() infers Uint8Array | null', () => {
+    const col = d.bytea().nullable();
+    type _t1 = Expect<Equal<InferColumnType<typeof col>, Uint8Array | null>>;
+  });
 });
 
 describe('chainable builder type inference', () => {
@@ -248,6 +258,33 @@ describe('validation constraint type scoping', () => {
   it('d.uuid() does NOT support .min()', () => {
     // @ts-expect-error — uuid has no min
     d.uuid().min(1);
+  });
+
+  it('d.bytea() supports .min() and .max() for byte-length constraints', () => {
+    d.bytea().min(32);
+    d.bytea().max(1024);
+    d.bytea().min(1).max(64);
+  });
+
+  it('d.bytea() does NOT support .regex()', () => {
+    // @ts-expect-error — bytea has no regex
+    d.bytea().regex(/abc/);
+  });
+
+  it('d.bytea() rejects non-Uint8Array assignment at the type level', () => {
+    const col = d.bytea();
+    type T = InferColumnType<typeof col>;
+    const _valid: T = new Uint8Array([1, 2, 3]);
+    // @ts-expect-error — string is not assignable to Uint8Array
+    const _s: T = 'bytes';
+    // @ts-expect-error — number is not assignable to Uint8Array
+    const _n: T = 42;
+    // @ts-expect-error — number[] is not assignable to Uint8Array
+    const _arr: T = [1, 2, 3];
+    void _valid;
+    void _s;
+    void _n;
+    void _arr;
   });
 
   it('constraint methods survive chaining with base methods', () => {

--- a/packages/db/src/schema/__tests__/column.test.ts
+++ b/packages/db/src/schema/__tests__/column.test.ts
@@ -95,6 +95,14 @@ describe('column type primitives', () => {
     expect(col._meta.sqlType).toBe('integer[]');
   });
 
+  it('d.bytea() creates a column with sqlType bytea', () => {
+    const col = d.bytea();
+    expect(col._meta.sqlType).toBe('bytea');
+    expect(col._meta.primary).toBe(false);
+    expect(col._meta.nullable).toBe(false);
+    expect(col._meta.hasDefault).toBe(false);
+  });
+
   it('d.enum(name, values) creates a column with enum type', () => {
     const col = d.enum('user_role', ['admin', 'editor', 'viewer']);
     expect(col._meta.sqlType).toBe('enum');
@@ -318,6 +326,27 @@ describe('string validation constraints', () => {
     const withMin = original.min(3);
     expect(original._meta._minLength).toBeUndefined();
     expect(withMin._meta._minLength).toBe(3);
+  });
+});
+
+describe('bytes validation constraints', () => {
+  it('d.bytea().min(n) stores _minLength in metadata (byte length)', () => {
+    const col = d.bytea().min(32);
+    expect(col._meta._minLength).toBe(32);
+    expect(col._meta.sqlType).toBe('bytea');
+  });
+
+  it('d.bytea().max(n) stores _maxLength in metadata (byte length)', () => {
+    const col = d.bytea().max(1024);
+    expect(col._meta._maxLength).toBe(1024);
+  });
+
+  it('d.bytea() chains .min() and .max() with other builders', () => {
+    const col = d.bytea().min(1).max(32).nullable().is('sensitive');
+    expect(col._meta._minLength).toBe(1);
+    expect(col._meta._maxLength).toBe(32);
+    expect(col._meta.nullable).toBe(true);
+    expect(col._meta._annotations.sensitive).toBe(true);
   });
 });
 

--- a/packages/db/src/schema/column.ts
+++ b/packages/db/src/schema/column.ts
@@ -144,6 +144,63 @@ export interface StringColumnBuilder<
   check(sql: string): StringColumnBuilder<TType, Omit<TMeta, 'check'> & { readonly check: string }>;
 }
 
+/** Bytes column builder — adds .min(), .max() for byte-length constraints. */
+export interface BytesColumnBuilder<
+  TType,
+  TMeta extends ColumnMetadata = ColumnMetadata,
+> extends ColumnBuilder<TType, TMeta> {
+  min(n: number): BytesColumnBuilder<TType, TMeta>;
+  max(n: number): BytesColumnBuilder<TType, TMeta>;
+
+  // Redeclare base methods to preserve BytesColumnBuilder return type through chaining
+  primary(options?: {
+    generate?: 'cuid' | 'uuid' | 'nanoid';
+    generated?: boolean;
+  }): BytesColumnBuilder<
+    TType,
+    Omit<TMeta, 'primary' | 'hasDefault' | 'generate'> & {
+      readonly primary: true;
+      readonly hasDefault: true;
+      readonly generate?: 'cuid' | 'uuid' | 'nanoid';
+    }
+  >;
+  unique(): BytesColumnBuilder<TType, Omit<TMeta, 'unique'> & { readonly unique: true }>;
+  nullable(): BytesColumnBuilder<
+    TType | null,
+    Omit<TMeta, 'nullable'> & { readonly nullable: true }
+  >;
+  default(
+    value: TType | 'now',
+  ): BytesColumnBuilder<
+    TType,
+    Omit<TMeta, 'hasDefault'> & { readonly hasDefault: true; readonly defaultValue: TType | 'now' }
+  >;
+  is<TFlag extends string>(
+    flag: TFlag,
+  ): BytesColumnBuilder<
+    TType,
+    Omit<TMeta, '_annotations'> & {
+      readonly _annotations: TMeta['_annotations'] & { readonly [K in TFlag]: true };
+    }
+  >;
+  hidden(): BytesColumnBuilder<
+    TType,
+    Omit<TMeta, '_annotations'> & {
+      readonly _annotations: TMeta['_annotations'] & { readonly hidden: true };
+    }
+  >;
+  readOnly(): BytesColumnBuilder<TType, Omit<TMeta, 'isReadOnly'> & { readonly isReadOnly: true }>;
+  autoUpdate(): BytesColumnBuilder<
+    TType,
+    Omit<TMeta, 'isAutoUpdate' | 'isReadOnly' | 'hasDefault'> & {
+      readonly isAutoUpdate: true;
+      readonly isReadOnly: true;
+      readonly hasDefault: true;
+    }
+  >;
+  check(sql: string): BytesColumnBuilder<TType, Omit<TMeta, 'check'> & { readonly check: string }>;
+}
+
 /** Numeric column builder — adds .min(), .max() for numeric-type columns. */
 export interface NumericColumnBuilder<
   TType,
@@ -333,14 +390,14 @@ function createColumnWithMeta(meta: ColumnMetadata): ColumnBuilderImpl {
     },
     min(n: number) {
       const sqlType = this._meta.sqlType;
-      if (sqlType === 'text' || sqlType === 'varchar') {
+      if (sqlType === 'text' || sqlType === 'varchar' || sqlType === 'bytea') {
         return cloneWith(this, { _minLength: n });
       }
       return cloneWith(this, { _minValue: n });
     },
     max(n: number) {
       const sqlType = this._meta.sqlType;
-      if (sqlType === 'text' || sqlType === 'varchar') {
+      if (sqlType === 'text' || sqlType === 'varchar' || sqlType === 'bytea') {
         return cloneWith(this, { _maxLength: n });
       }
       return cloneWith(this, { _maxValue: n });


### PR DESCRIPTION
Closes #2843.

## Summary

Adds `d.bytea()` — a native binary column type. Maps to Postgres `BYTEA` and SQLite/D1 `BLOB`, inferring `Uint8Array` in `$infer` / `$create_input` / `$update_input`. Replaces the base64-over-`d.text()` and `d.jsonb<Uint8Array>()` workarounds that were the status quo.

```ts
const tenant = d.table('tenant', {
  id: d.uuid().primary(),
  encryptedDek: d.bytea(),           // required, any length
  sig: d.bytea().min(64).max(64),    // exactly 64 bytes
  nonce: d.bytea().nullable(),
});
```

## Public API changes

**Added** (all additive, no breaking changes):

- `d.bytea()` — returns `BytesColumnBuilder<Uint8Array, DefaultMeta<'bytea'>>`.
- `BytesColumnBuilder<T, M>` — new column builder interface, re-exported from `@vertz/db`. Exposes `.min(n)` / `.max(n)` for byte-length constraints and redeclares the standard chain methods to preserve the builder type through `.primary()` / `.unique()` / `.nullable()` / `.default()` / `.is()` / `.hidden()` / `.readOnly()` / `.autoUpdate()` / `.check()`. `.regex()` is absent by design.

## Behavior details

- **SQLite reads** normalize backend-specific types to a plain `Uint8Array`:
  - `Buffer` (Node / better-sqlite3) → `new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength).slice()`
  - `ArrayBuffer` (Cloudflare D1) → `new Uint8Array(ab).slice()`
  - `Uint8Array` (bun:sqlite / @vertz/sqlite) → passthrough when prototype is already plain
- **Postgres reads** return the `postgres` package's `Buffer` (a `Uint8Array` subclass) without slice-copying. `instanceof Uint8Array` is `true`; `Object.getPrototypeOf(v) === Uint8Array.prototype` is `false`. Documented in the `d.bytea()` JSDoc.
- **Writes** pass `Uint8Array` through `toSqliteValue` unchanged (already covered by existing tests); postgres / pg accept `Uint8Array` / `Buffer` natively.
- **Dialects** accept both the canonical `'bytea'` sqlType and the introspect-snapshot alias `'blob'` so the *introspect → codegen → re-migrate* round-trip on SQLite no longer silently widens BLOB to TEXT.
- **`.min()` / `.max()`** on a bytea column store `_minLength` / `_maxLength` (reusing the string-length pipeline) and refine the derived `s.instanceof(Uint8Array)` schema with a byte-length predicate.
- **Migration codegen** now emits `d.bytea()` for introspected `bytea` / `blob` columns instead of `d.text() // TODO: binary type`.

## Known limitation

The vtz runtime's native `@vertz/sqlite` binding does not yet bind `Uint8Array` params (the Rust op layer declares params as `Vec<serde_json::Value>`, which has no byte-array variant). Tracked as #2920. Every other binding — Cloudflare D1, `better-sqlite3`, `bun:sqlite`, `postgres`, `pg` — works correctly. Documented in the `d.bytea()` JSDoc.

## Tests

- **3** new schema/column runtime tests — sqlType, `_minLength`/`_maxLength`, chaining with annotations.
- **2** new inference tests + **2** negative-type tests (`.regex()` rejected, non-`Uint8Array` assignment rejected).
- **1** new public-exports type test — `BytesColumnBuilder` reachable from `@vertz/db`.
- **2** new dialect unit tests each for Postgres and SQLite — `bytea` → native type, `blob` alias maps through.
- **6** new converter tests — Buffer / ArrayBuffer / Uint8Array / null / undefined / non-bytes passthrough.
- **5** new schema-derive validation tests — `s.instanceof(Uint8Array)` accept/reject, min/max boundary.
- **5** new integration tests (D1 mock) — small payload with Buffer normalization, empty `Uint8Array(0)`, ~256 KB payload, nullable column with `null`, pass-through to driver bindings.
- **2** updated migration codegen tests — `d.bytea()` output for `bytea` and SQLite `blob`.

## Review

Adversarial review in `reviews/db-bytea-column-2843/phase-01-impl.md` (not committed to main per local-phase-workflow). Initial verdict: Changes Requested. Three should-fix findings resolved in the same PR (docstring accuracy, `'blob'` alias in both dialects, strengthened integration test coverage). Post-fix verdict: Approved.

## Test plan

- [x] `vtz test packages/db` → 1760 passed, 1 skipped
- [x] `vtz run typecheck` on `@vertz/db` → clean
- [x] `oxlint packages/db` → 180 pre-existing warnings, 0 new, 0 errors
- [x] `oxfmt --check packages/db` → clean
- [x] Pre-push hook: build-typecheck / lint / test / trojan-source all green
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)