### PR TITLE
feat(db): hasAllKeys / hasAnyKey JSONB operators [#2886]

### DIFF
--- a/.changeset/jsonb-plural-key-ops-2886.md
+++ b/.changeset/jsonb-plural-key-ops-2886.md
@@ -1,0 +1,16 @@
+---
+'@vertz/db': patch
+---
+
+feat(db): add `hasAllKeys` / `hasAnyKey` JSONB operators
+
+Closes [#2886](https://github.com/vertz-dev/vertz/issues/2886).
+
+Extends the typed JSONB operator surface shipped in #2868 with the plural-key helpers that were deferred:
+
+- `hasAllKeys` emits Postgres `col ?& $N::text[]` — row matches when the JSONB object contains every listed top-level key.
+- `hasAnyKey` emits Postgres `col ?| $N::text[]` — row matches when the JSONB object contains at least one listed top-level key.
+
+Operand type is `readonly JsonbKeyOf<T>[]`, so the key array is constrained to `keyof T & string` at compile time. Primitive and array JSONB payloads collapse the operand to `readonly never[]`, matching the existing `hasKey` behavior.
+
+Both operators are dialect-gated to Postgres through the existing keyed-never brand (`JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS`). On SQLite the diagnostic name itself carries the recovery guidance; the runtime throws a descriptive error that mirrors `hasKey`.

--- a/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
+++ b/packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts
@@ -69,6 +69,29 @@ const pgUnionHasKeyX: FilterType<InstallColumns, 'postgres'> = {
 };
 void pgUnionHasKeyX;
 
+// Plural-key operators — operand is a readonly array of JsonbKeyOf<T>.
+const pgHasAllKeys: FilterType<InstallColumns, 'postgres'> = {
+  meta: { hasAllKeys: ['displayName', 'settings'] },
+};
+void pgHasAllKeys;
+
+const pgHasAnyKey: FilterType<InstallColumns, 'postgres'> = {
+  meta: { hasAnyKey: ['displayName', 'capacity'] },
+};
+void pgHasAnyKey;
+
+// Readonly tuple / as-const input accepted.
+const pgHasAllKeysConst: FilterType<InstallColumns, 'postgres'> = {
+  meta: { hasAllKeys: ['displayName', 'tags'] as const },
+};
+void pgHasAllKeysConst;
+
+// Union payload — plural-key operands draw from each variant's keys.
+const pgUnionHasAllKeys: FilterType<InstallColumns, 'postgres'> = {
+  union: { hasAllKeys: ['a', 'x'] },
+};
+void pgUnionHasAllKeys;
+
 // ---------------------------------------------------------------------------
 // Payload operators — negatives
 // ---------------------------------------------------------------------------
@@ -104,6 +127,33 @@ const pgHasKeyOnPrimitive: FilterType<InstallColumns, 'postgres'> = {
 };
 void pgHasKeyOnPrimitive;
 
+// Unknown key rejected inside the plural-key array (readonly JsonbKeyOf<T>[]).
+const pgHasAllKeysUnknown: FilterType<InstallColumns, 'postgres'> = {
+  meta: {
+    // @ts-expect-error — 'bogus' is not keyof InstallMeta
+    hasAllKeys: ['displayName', 'bogus'],
+  },
+};
+void pgHasAllKeysUnknown;
+
+const pgHasAnyKeyUnknown: FilterType<InstallColumns, 'postgres'> = {
+  meta: {
+    // @ts-expect-error — 'bogus' is not keyof InstallMeta
+    hasAnyKey: ['bogus'],
+  },
+};
+void pgHasAnyKeyUnknown;
+
+// Non-object JSONB payload — JsonbKeyOf<string> is `never`, so the array type
+// collapses to `readonly never[]` and cannot accept any element.
+const pgHasAllKeysOnPrimitive: FilterType<InstallColumns, 'postgres'> = {
+  prim: {
+    // @ts-expect-error — hasAllKeys unavailable on primitive JSONB payloads
+    hasAllKeys: ['anything'],
+  },
+};
+void pgHasAllKeysOnPrimitive;
+
 // ---------------------------------------------------------------------------
 // Payload operators — SQLite negatives (brand diagnostic)
 // ---------------------------------------------------------------------------
@@ -123,6 +173,22 @@ const sqliteHasKey: FilterType<InstallColumns, 'sqlite'> = {
   },
 };
 void sqliteHasKey;
+
+const sqliteHasAllKeys: FilterType<InstallColumns, 'sqlite'> = {
+  meta: {
+    // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+    hasAllKeys: ['displayName'],
+  },
+};
+void sqliteHasAllKeys;
+
+const sqliteHasAnyKey: FilterType<InstallColumns, 'sqlite'> = {
+  meta: {
+    // @ts-expect-error — JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+    hasAnyKey: ['displayName'],
+  },
+};
+void sqliteHasAnyKey;
 
 // ---------------------------------------------------------------------------
 // path() builder — leaf-type flow

--- a/packages/db/src/schema/path-chain.ts
+++ b/packages/db/src/schema/path-chain.ts
@@ -69,11 +69,15 @@ export type JsonbPayloadOperators<T, TDialect extends DialectName> = TDialect ex
       readonly jsonContains?: DeepPartial<T>;
       readonly jsonContainedBy?: object;
       readonly hasKey?: JsonbKeyOf<T>;
+      readonly hasAllKeys?: readonly JsonbKeyOf<T>[];
+      readonly hasAnyKey?: readonly JsonbKeyOf<T>[];
     }
   : {
       readonly jsonContains?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
       readonly jsonContainedBy?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
       readonly hasKey?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly hasAllKeys?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly hasAnyKey?: JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
     };
 
 // ---------------------------------------------------------------------------

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -301,4 +301,16 @@ describe('SQLite feature guards', () => {
       'hasKey requires dialect: postgres',
     );
   });
+
+  it('throws descriptive error for hasAllKeys with SqliteDialect', () => {
+    expect(() =>
+      buildWhere({ meta: { hasAllKeys: ['a', 'b'] } }, 0, undefined, sqliteDialect),
+    ).toThrow('hasAllKeys requires dialect: postgres');
+  });
+
+  it('throws descriptive error for hasAnyKey with SqliteDialect', () => {
+    expect(() =>
+      buildWhere({ meta: { hasAnyKey: ['a', 'b'] } }, 0, undefined, sqliteDialect),
+    ).toThrow('hasAnyKey requires dialect: postgres');
+  });
 });

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -308,9 +308,21 @@ describe('SQLite feature guards', () => {
     ).toThrow('hasAllKeys requires dialect: postgres');
   });
 
+  it('hasAllKeys SQLite error suggests the AND+hasKey composition workaround', () => {
+    expect(() =>
+      buildWhere({ meta: { hasAllKeys: ['a', 'b'] } }, 0, undefined, sqliteDialect),
+    ).toThrow(/AND: \[\{ col: \{ hasKey: "a" \} \}, \{ col: \{ hasKey: "b" \} \}\]/);
+  });
+
   it('throws descriptive error for hasAnyKey with SqliteDialect', () => {
     expect(() =>
       buildWhere({ meta: { hasAnyKey: ['a', 'b'] } }, 0, undefined, sqliteDialect),
     ).toThrow('hasAnyKey requires dialect: postgres');
+  });
+
+  it('hasAnyKey SQLite error suggests the OR+hasKey composition workaround', () => {
+    expect(() =>
+      buildWhere({ meta: { hasAnyKey: ['a', 'b'] } }, 0, undefined, sqliteDialect),
+    ).toThrow(/OR: \[\{ col: \{ hasKey: "a" \} \}, \{ col: \{ hasKey: "b" \} \}\]/);
   });
 });

--- a/packages/db/src/sql/__tests__/where.test.ts
+++ b/packages/db/src/sql/__tests__/where.test.ts
@@ -400,6 +400,18 @@ describe('buildWhere', () => {
       expect(result.params).toEqual(['settings']);
     });
 
+    it('hasAllKeys generates ?& operator with text[] cast and array param', () => {
+      const result = buildWhere({ meta: { hasAllKeys: ['settings', 'displayName'] } });
+      expect(result.sql).toBe('"meta" ?& $1::text[]');
+      expect(result.params).toEqual([['settings', 'displayName']]);
+    });
+
+    it('hasAnyKey generates ?| operator with text[] cast and array param', () => {
+      const result = buildWhere({ meta: { hasAnyKey: ['capacity', 'createdAt'] } });
+      expect(result.sql).toBe('"meta" ?| $1::text[]');
+      expect(result.params).toEqual([['capacity', 'createdAt']]);
+    });
+
     it('combines jsonContains with other filters', () => {
       const result = buildWhere({
         status: 'active',

--- a/packages/db/src/sql/__tests__/where.test.ts
+++ b/packages/db/src/sql/__tests__/where.test.ts
@@ -412,6 +412,35 @@ describe('buildWhere', () => {
       expect(result.params).toEqual([['capacity', 'createdAt']]);
     });
 
+    it('hasAllKeys with empty array produces TRUE (universal over empty set)', () => {
+      const result = buildWhere({ meta: { hasAllKeys: [] } });
+      expect(result.sql).toBe('TRUE');
+      expect(result.params).toEqual([]);
+    });
+
+    it('hasAnyKey with empty array produces FALSE (existential over empty set)', () => {
+      const result = buildWhere({ meta: { hasAnyKey: [] } });
+      expect(result.sql).toBe('FALSE');
+      expect(result.params).toEqual([]);
+    });
+
+    it('combines hasAllKeys with other top-level filters and numbers params correctly', () => {
+      const result = buildWhere({
+        status: 'active',
+        meta: { hasAllKeys: ['a', 'b'] },
+      });
+      expect(result.sql).toBe('"status" = $1 AND "meta" ?& $2::text[]');
+      expect(result.params).toEqual(['active', ['a', 'b']]);
+    });
+
+    it('combines hasAllKeys and hasAnyKey on the same column and advances param indices', () => {
+      const result = buildWhere({
+        meta: { hasAllKeys: ['a'], hasAnyKey: ['b', 'c'] },
+      });
+      expect(result.sql).toBe('"meta" ?& $1::text[] AND "meta" ?| $2::text[]');
+      expect(result.params).toEqual([['a'], ['b', 'c']]);
+    });
+
     it('combines jsonContains with other filters', () => {
       const result = buildWhere({
         status: 'active',

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -327,22 +327,34 @@ function buildOperatorCondition(
   if (operators.hasAllKeys !== undefined) {
     if (!dialect.supportsJsonbPath) {
       throw new Error(
-        'hasAllKeys requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+        'hasAllKeys requires dialect: postgres. On SQLite, fetch with list() and filter in application code, ' +
+          'or compose AND: [{ col: { hasKey: "a" } }, { col: { hasKey: "b" } }].',
       );
     }
-    clauses.push(`${columnRef} ?& ${dialect.param(idx + 1)}::text[]`);
-    params.push(operators.hasAllKeys);
-    idx++;
+    if (operators.hasAllKeys.length === 0) {
+      // Universal quantifier over empty set is TRUE — matches in/notIn convention.
+      clauses.push('TRUE');
+    } else {
+      clauses.push(`${columnRef} ?& ${dialect.param(idx + 1)}::text[]`);
+      params.push(operators.hasAllKeys);
+      idx++;
+    }
   }
   if (operators.hasAnyKey !== undefined) {
     if (!dialect.supportsJsonbPath) {
       throw new Error(
-        'hasAnyKey requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+        'hasAnyKey requires dialect: postgres. On SQLite, fetch with list() and filter in application code, ' +
+          'or compose OR: [{ col: { hasKey: "a" } }, { col: { hasKey: "b" } }].',
       );
     }
-    clauses.push(`${columnRef} ?| ${dialect.param(idx + 1)}::text[]`);
-    params.push(operators.hasAnyKey);
-    idx++;
+    if (operators.hasAnyKey.length === 0) {
+      // Existential quantifier over empty set is FALSE — matches in/notIn convention.
+      clauses.push('FALSE');
+    } else {
+      clauses.push(`${columnRef} ?| ${dialect.param(idx + 1)}::text[]`);
+      params.push(operators.hasAnyKey);
+      idx++;
+    }
   }
 
   return { clauses, params, nextIndex: idx };

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -42,6 +42,8 @@ interface FilterOperators {
   readonly jsonContains?: unknown;
   readonly jsonContainedBy?: unknown;
   readonly hasKey?: string;
+  readonly hasAllKeys?: readonly string[];
+  readonly hasAnyKey?: readonly string[];
 }
 
 interface WhereFilter {
@@ -70,6 +72,8 @@ const OPERATOR_KEYS = new Set([
   'jsonContains',
   'jsonContainedBy',
   'hasKey',
+  'hasAllKeys',
+  'hasAnyKey',
 ]);
 
 function isOperatorObject(value: unknown): value is FilterOperators {
@@ -318,6 +322,26 @@ function buildOperatorCondition(
     }
     clauses.push(`${columnRef} ? ${dialect.param(idx + 1)}`);
     params.push(operators.hasKey);
+    idx++;
+  }
+  if (operators.hasAllKeys !== undefined) {
+    if (!dialect.supportsJsonbPath) {
+      throw new Error(
+        'hasAllKeys requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+      );
+    }
+    clauses.push(`${columnRef} ?& ${dialect.param(idx + 1)}::text[]`);
+    params.push(operators.hasAllKeys);
+    idx++;
+  }
+  if (operators.hasAnyKey !== undefined) {
+    if (!dialect.supportsJsonbPath) {
+      throw new Error(
+        'hasAnyKey requires dialect: postgres. On SQLite, fetch with list() and filter in application code.',
+      );
+    }
+    clauses.push(`${columnRef} ?| ${dialect.param(idx + 1)}::text[]`);
+    params.push(operators.hasAnyKey);
     idx++;
   }
 

--- a/reviews/2886-jsonb-plural-key-ops/phase-01-operators.md
+++ b/reviews/2886-jsonb-plural-key-ops/phase-01-operators.md
@@ -1,0 +1,158 @@
+# Phase 1: hasAllKeys / hasAnyKey JSONB Operators
+
+- **Author:** vertz-tech-lead bot (commit `42c765533`)
+- **Reviewer:** adversarial-review bot (Opus 4.7 1M)
+- **Commits:** `42c765533` (single commit)
+- **Date:** 2026-04-21
+
+## Changes
+
+- `packages/db/src/sql/where.ts` (modified) — adds `hasAllKeys` / `hasAnyKey` to `FilterOperators`, `OPERATOR_KEYS`, and `buildOperatorCondition`. Emits `col ?& $N::text[]` / `col ?| $N::text[]` on Postgres; throws on SQLite.
+- `packages/db/src/schema/path-chain.ts` (modified) — adds `readonly hasAllKeys?` / `readonly hasAnyKey?` to `JsonbPayloadOperators<T, 'postgres'>` as `readonly JsonbKeyOf<T>[]`; adds keyed-never brand fallback on the SQLite branch.
+- `packages/db/src/sql/__tests__/where.test.ts` (modified) — two unit tests asserting the emitted SQL and params for each operator.
+- `packages/db/src/sql/__tests__/sqlite-builders.test.ts` (modified) — two throw tests asserting the dialect-gate error on SQLite.
+- `packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts` (modified) — positives (plain, readonly `as const`, union payload), negatives (unknown key, primitive payload), SQLite brand diagnostics.
+- `.changeset/jsonb-plural-key-ops-2886.md` (new) — patch changeset describing the feature.
+
+## CI Status
+
+- [ ] Quality gates passed at `42c765533` — **not verified by reviewer.** Author asserts the phase is green; no CI log attached to this review. The reviewer did not execute `vtz test && vtz run typecheck && vtz run lint` because this review is a static inspection only.
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for — mostly yes, modulo the exact SQL shape called out in the acceptance criterion (see Finding F-1).
+- [x] TDD compliance — runtime behaviors have unit tests; type surface has `.test-d.ts` positives and negatives; dialect gating has throw tests. No integration test against a real Postgres, which mirrors the existing `hasKey` pattern.
+- [x] No type gaps in the basic happy path — operand element correctly constrained to `JsonbKeyOf<T>`; primitive/array payloads collapse to `readonly never[]` so the key cannot be spelled.
+- [x] No obvious security issues — operand is parameter-bound; the raw array never enters the SQL string; only the literal SQL cast `::text[]` is concatenated into the query.
+- [x] Public API changes match design doc (#2868 parent + #2886 scope).
+
+## Findings
+
+### Changes Requested
+
+#### F-1 — SHOULD-FIX — Emitted SQL does not literally match issue #2886 acceptance
+
+The issue's **Acceptance** section (quote: _"Concrete integration test: `where: { meta: { hasAllKeys: ['a', 'b'] } }` emits `"meta" ?& $1`."_) states the expected SQL as `"meta" ?& $1`. The actual emission in `packages/db/src/sql/where.ts:333` / `:343` is `"meta" ?& $1::text[]` (and `?|` variant).
+
+The **Scope** section of the same issue does separately say _"with the operand bound as `text[]`"_, which justifies the cast. But the acceptance criterion is the literal pass/fail gate, and it is not met byte-for-byte.
+
+Two paths forward:
+- (A) Keep the cast and update the issue to reflect the final shape before closing (preferred — the cast is justified; see next paragraph).
+- (B) Drop the cast.
+
+Recommendation: keep (A). Without `::text[]`, porsager/postgres' `sql.unsafe()` with `prepare: true` has to infer the element type from the JS array; for a JSON array of strings this usually works but can produce `text[]` or `varchar[]` depending on driver heuristics. The explicit `::text[]` cast is safer and locks the server-side planner to the right operator overload. The reviewer agrees with keeping the cast. This finding is a SHOULD-FIX on **issue hygiene** (update the acceptance text to reflect the cast, or call out the deviation in the PR description), not on the code itself.
+
+Cite: `packages/db/src/sql/where.ts:333`, `packages/db/src/sql/where.ts:343`; tests at `packages/db/src/sql/__tests__/where.test.ts:405,411`.
+
+---
+
+#### F-2 — SHOULD-FIX — No test for empty-array semantics; diverges from `in` / `notIn` short-circuit
+
+`buildWhere({ meta: { hasAllKeys: [] } })` emits `"meta" ?& $1::text[]` bound to `[]`. At the Postgres level this is `jsonb ?& '{}'::text[]`, which returns **TRUE for every row** (vacuously true over the empty key set). `hasAnyKey: []` symmetrically returns **FALSE for every row**.
+
+This is a silently meaningful semantic. Compare to the existing `in` / `notIn` handling at `packages/db/src/sql/where.ts:239–260`, which explicitly short-circuits the empty-array case to `FALSE` / `TRUE` at SQL-build time — precisely to avoid this class of surprise (and also to avoid emitting parameterized SQL with no elements on dialects that reject it).
+
+Two concerns:
+1. **Behavioral inconsistency** with `in` / `notIn`. A developer who already internalized "empty-set filter = safe no-op" will get a "match everything" from `hasAllKeys: []`. That's a footgun in user-supplied filter construction (e.g., a UI that synthesizes `hasAllKeys` from a selected-tag list — an empty selection should almost certainly NOT mean "match every row").
+2. **Undocumented and untested.** Neither behavior appears in any test in this PR, nor in the changeset, nor in the commit message.
+
+Options:
+- (A) Short-circuit: `hasAllKeys: []` → `TRUE`, `hasAnyKey: []` → `FALSE` in the builder (mirrors Postgres semantics explicitly and consolidates the rule with `in`/`notIn`).
+- (B) Keep current behavior and add a test that **asserts** it (so the semantics are locked down), plus a line in the changeset.
+- (C) Reject at the builder with a thrown error ("`hasAllKeys` requires at least one key").
+
+Recommended minimum: option (B) — add two unit tests asserting what happens for `[]` on each operator, and document the trap in the changeset. Option (C) is the most DX-correct if there is no known legitimate use case for an empty plural-key filter.
+
+Cite: `packages/db/src/sql/where.ts:327–346` (no length check); empty-array tests exist for `in`/`notIn` at `packages/db/src/sql/__tests__/where.test.ts` — verify symmetry.
+
+---
+
+#### F-3 — SHOULD-FIX — Missing combined-operator test for param-index correctness
+
+Every operator's `if` block in `buildOperatorCondition` bumps `idx` independently. The new operators are appended at the end of the chain (lines 327 and 337). There is **no test** exercising the case where `hasAllKeys` and `hasAnyKey` both appear on the same column, e.g.:
+
+```ts
+buildWhere({ meta: { hasAllKeys: ['a'], hasAnyKey: ['b'] } })
+```
+
+Expected SQL: `"meta" ?& $1::text[] AND "meta" ?| $2::text[]` with params `[['a'], ['b']]`. The code obviously *looks* correct, but the parent review criterion here is "every new branch's param-index interaction is under test." The existing jsonb tests all test operators in isolation; adding a combined case would close the gap.
+
+Additionally: the positive tests call `buildWhere(..., paramOffset=0)` implicitly. A test at `paramOffset != 0` (as is done for some other operators elsewhere) would catch an off-by-one regression in `idx + 1` placeholder math.
+
+Cite: `packages/db/src/sql/__tests__/where.test.ts:403–413` — two tests, each with a single operator in isolation.
+
+---
+
+#### F-4 — SHOULD-FIX — Missing mixed-with-other-filters test; `hasKey`/`jsonContains` have one, the new ops do not
+
+At `packages/db/src/sql/__tests__/where.test.ts:415–422`, there is a dedicated "combines jsonContains with other filters" test. The new plural-key operators do not have the analogous `"status": 'active', meta: { hasAllKeys: [...] }` test. Given the parent ticket explicitly lists `"hasAllKeys('a','b')` equivalent: `AND: [{ meta: { hasKey: 'a' } }, { meta: { hasKey: 'b' } }]"`, developers WILL mix these operators with surrounding filter clauses. Test it.
+
+---
+
+#### F-5 — NIT — Collision-payload plural-key case not exercised at the type level
+
+`CollisionPayload` has natural keys `'jsonContains'` and `'hasKey'`. The existing test at line 341 covers `{ hasKey: 'jsonContains' }`. There is no companion `{ hasAllKeys: ['jsonContains', 'hasKey'] }` test. Operand element type would be `'jsonContains' | 'hasKey'`, so the positive case `{ hasAllKeys: ['jsonContains', 'hasKey'] }` should compile and `{ hasAllKeys: ['bogus'] }` should be rejected. One-liner positive + `@ts-expect-error` negative closes the parity gap with `hasKey`.
+
+Cite: `packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts:341–350`.
+
+---
+
+#### F-6 — NIT — Error message does not mention the AND/OR + hasKey composition workaround
+
+The issue body itself documents the workaround for environments stuck on SQLite:
+
+```
+hasAllKeys('a','b') equivalent: AND: [{ meta: { hasKey: 'a' } }, { meta: { hasKey: 'b' } }]
+hasAnyKey('a','b')  equivalent: OR:  [{ meta: { hasKey: 'a' } }, { meta: { hasKey: 'b' } }]
+```
+
+The runtime error on SQLite copies the `hasKey` message verbatim: _"On SQLite, fetch with list() and filter in application code."_ A more actionable message for the plural forms would be:
+
+```
+hasAllKeys requires dialect: postgres. On SQLite, compose with AND of hasKey checks per key, or fetch with list() and filter in application code.
+```
+
+Same shape for `hasAnyKey` → "compose with OR of hasKey checks per key". This is a NIT because consistency with `hasKey` has its own value, but the plural operators have a cleaner in-framework workaround worth surfacing.
+
+Cite: `packages/db/src/sql/where.ts:330,340`.
+
+---
+
+#### F-7 — NIT — Dialect branch of `JsonbPayloadOperators` now has five `?: Brand` properties with identical type — opportunity to DRY
+
+Every key on the SQLite branch of `path-chain.ts:75–81` has the same type (`JsonbOperator_Error_…`). This is fine and mirrors the existing shape, but as the surface grows it becomes worth a helper:
+
+```ts
+type GatedOps<K extends string> = { readonly [P in K]?: JsonbOperator_Error_… };
+```
+
+Not blocking — pure refactor — but worth noting before the shape grows further in #2885 (`jsonb()` operator expansion).
+
+---
+
+#### F-8 — NIT — `.changeset` says _"On SQLite the diagnostic name itself carries the recovery guidance; the runtime throws a descriptive error that mirrors hasKey."_ but the issue's acceptance text doesn't promise a runtime throw
+
+The changeset correctly describes what landed, but future readers may wonder whether SQLite runtime emission is explicitly supported. Consider adding one sentence: _"Users hitting the runtime error on SQLite should use AND/OR composition with `hasKey`, or switch to Postgres."_ Again, a documentation polish, not a blocker.
+
+---
+
+## What is NOT a finding (explicitly considered and dismissed)
+
+- **Driver array binding correctness.** porsager/postgres (`postgres` v3) binds JS `string[]` to Postgres `text[]` correctly when the position has an explicit `::text[]` cast. `arrayContains` has been shipping in this codebase WITHOUT a cast and with no known driver-binding bug report, so the explicit cast here is strictly safer. This is fine.
+- **Readonly vs mutable operand.** TS widens mutable `['a','b']` to a type assignable to `readonly string[]`; positive tests confirm this works. No change needed.
+- **OPERATOR_KEYS membership.** Both new keys are present in the set at `where.ts:75,76`, so `isOperatorObject` recognizes them.
+- **Union payload distribution.** `JsonbKeyOf<A | B>` distributes to `keyof A | keyof B`; operand type `readonly ('a' | 'b' | 'x')[]` lets a user combine keys from different variants, which is semantically correct (the SQL runs a per-row test on the actual JSONB, which may match any variant).
+- **`?&` / `?|` with `prepare: true` in porsager/postgres.** The parent `hasKey` operator already uses `?` with the same `prepare: true` setting, so any driver-level question here is pre-existing in #2868, not introduced by this PR.
+
+## Resolution
+
+Addressed in a follow-up commit on the same branch before PR:
+
+- **F-2** — Short-circuit adopted (option A): `hasAllKeys: []` → `TRUE`, `hasAnyKey: []` → `FALSE`, matching the `in`/`notIn` identity convention (universal-over-empty = TRUE, existential-over-empty = FALSE). Two new unit tests lock this down (`packages/db/src/sql/__tests__/where.test.ts`). Inline comments cite the quantifier identity.
+- **F-3** — Two combined-operator tests added: (a) `meta: { hasAllKeys: [...], hasAnyKey: [...] }` asserts correct `$1`/`$2` advancement on the same column, (b) mixed-with-top-level (`status: 'x', meta: { hasAllKeys: [...] }`) asserts the offset against sibling filters.
+- **F-4** — Covered by the mixed-with-top-level test above.
+- **F-6** — Runtime SQLite errors now name the framework-native workaround (`AND: [{ col: { hasKey: "a" } }, ...]` / `OR: [...]`). Two throw tests pin the workaround text.
+- **F-1** — Cast kept; called out in the PR description.
+- **F-5, F-7, F-8** — Deferred as nits (not required for the ticket; would bloat this PR with unrelated refactors).
+
+No re-review required; blockers never existed.


### PR DESCRIPTION
Closes #2886.

## Summary

Extends the typed JSONB operator surface shipped in #2868 with the plural-key helpers that were deferred:

- `hasAllKeys` → Postgres `col ?& $N::text[]` — row matches when the JSONB object contains every listed top-level key.
- `hasAnyKey`  → Postgres `col ?| $N::text[]` — row matches when the JSONB object contains at least one listed top-level key.

Operand is `readonly JsonbKeyOf<T>[]`, so the array element is constrained to `keyof T & string` at compile time. Primitive and array payloads collapse to `readonly never[]`, matching `hasKey`. Dialect-gated to Postgres through the existing `JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` brand.

## Public API changes

- **Addition**: `JsonbPayloadOperators<T, TDialect>` gains `hasAllKeys?: readonly JsonbKeyOf<T>[]` and `hasAnyKey?: readonly JsonbKeyOf<T>[]` on the Postgres branch, branded to the gate type on SQLite.
- **No breaking changes**.

## Deviations from issue acceptance text

The issue literally spells the expected SQL as `"meta" ?& $1`. The emitted SQL is `"meta" ?& $1::text[]` — the explicit `text[]` cast is added to lock the server-side planner onto the right operator overload regardless of driver heuristics for JS `string[]` → Postgres array-element type. The issue's **Scope** section asks for _"the operand bound as `text[]`"_; the explicit cast is the most defensive way to satisfy that. The literal acceptance example is updated in the unit tests to reflect the cast.

## Empty-array semantics

- `hasAllKeys: []` → `TRUE` (universal-over-empty).
- `hasAnyKey: []` → `FALSE` (existential-over-empty).

Matches the existing `in: []` / `notIn: []` short-circuit convention in `buildOperatorCondition`. Locked down with dedicated tests.

## Review

Single adversarial review at [`reviews/2886-jsonb-plural-key-ops/phase-01-operators.md`](https://github.com/vertz-dev/vertz/blob/feat/2886-jsonb-plural-key-ops/reviews/2886-jsonb-plural-key-ops/phase-01-operators.md). No blockers; three SHOULD-FIX findings (empty-array semantics, combined-operator param indexing, mixed-with-sibling-filter coverage) were resolved in the follow-up commit on this branch. Remaining NITs are documented and deferred.

## Test plan

- [x] Unit tests for SQL emission on both operators, including combined `hasAllKeys + hasAnyKey` on the same column and mixed with sibling filters (`packages/db/src/sql/__tests__/where.test.ts`).
- [x] Empty-array short-circuit tests (`TRUE` / `FALSE`).
- [x] SQLite runtime throw tests + workaround-suggestion regex checks (`packages/db/src/sql/__tests__/sqlite-builders.test.ts`).
- [x] Type-level positives (plain, `as const`, union payload), negatives (unknown key, primitive payload), and SQLite brand diagnostics (`packages/db/src/client/__tests__/jsonb-typed-operators.test-d.ts`).
- [x] `vtz test` on `@vertz/db` (1791 passing) + `vtz run typecheck` + `oxlint packages/db/` (0 errors).
- [x] Full pre-push CI (build-typecheck, lint, test, trojan-source) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)