### PR TITLE
fix(schema): user-friendly invalid-type messages for number/bigint/date [#2809]

### DIFF
--- a/.changeset/fix-schema-error-messages-2809.md
+++ b/.changeset/fix-schema-error-messages-2809.md
@@ -1,0 +1,24 @@
+---
+'@vertz/schema': patch
+---
+
+fix(schema): user-friendly invalid-type messages for `s.number()` / `s.bigint()` / `s.date()`
+
+Closes [#2809](https://github.com/vertz-dev/vertz/issues/2809).
+
+The form-data coercion layer (`coerceLeaf` in `@vertz/ui`) deliberately passes non-numeric / unparseable strings through to the schema unchanged so the schema's own validator owns the error message. That rested on the schema producing something end-user-readable, which it didn't — `s.number().parse('42a')` produced `"Expected number, received string"`, which is technically accurate but useless in a form field. `#2771` made FormData coercion implicit (users write `s.number()`, not `s.coerce.number()`), which put these messages directly in front of end users.
+
+The default messages are now:
+
+- `s.number()` → `"Must be a number"` (covers non-number values, NaN, and pass-through strings like `"42a"`)
+- `s.bigint()` → `"Must be an integer"`
+- `s.date()` → `"Must be a valid date"` (covers non-Date values and invalid `Date` objects with `NaN` time)
+
+Each schema also gets a `.message(msg)` chainable method so apps can localise or customise:
+
+```ts
+s.number().message('Age must be a number')
+s.date().message('Pick a valid date').min(new Date('2024-01-01'))
+```
+
+The custom message is preserved across clones (e.g. after `.gte()`, `.min()`).

--- a/packages/mint-docs/guides/errors.mdx
+++ b/packages/mint-docs/guides/errors.mdx
@@ -176,7 +176,7 @@ if (!result.ok) {
   for (const issue of result.error.issues) {
     console.log(`${issue.path.join('.')}: ${issue.message}`);
     // "name: String must contain at least 1 character(s)"
-    // "age: Expected number, received string"
+    // "age: Must be a number"
   }
 }
 ```

--- a/packages/schema/src/schemas/__tests__/bigint.test.ts
+++ b/packages/schema/src/schemas/__tests__/bigint.test.ts
@@ -29,4 +29,33 @@ describe('BigIntSchema', () => {
     expect(schema.metadata.description).toBe('bigint field');
     expect(schema.parse(1n).data).toBe(1n);
   });
+
+  it('produces user-friendly invalid-type message for non-integer strings', () => {
+    const schema = new BigIntSchema();
+    const result = schema.safeParse('abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Must be an integer');
+    }
+  });
+
+  it('produces user-friendly invalid-type message for non-bigint values', () => {
+    const schema = new BigIntSchema();
+    for (const value of [42, 'hello', true, null, undefined]) {
+      const result = schema.safeParse(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.issues[0]?.message).toBe('Must be an integer');
+      }
+    }
+  });
+
+  it('.message() overrides the invalid-type message', () => {
+    const schema = new BigIntSchema().message('Enter a whole number');
+    const result = schema.safeParse('abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a whole number');
+    }
+  });
 });

--- a/packages/schema/src/schemas/__tests__/date.test.ts
+++ b/packages/schema/src/schemas/__tests__/date.test.ts
@@ -48,4 +48,51 @@ describe('DateSchema', () => {
     const schema = new DateSchema();
     expect(schema.toJSONSchema()).toEqual({ type: 'string', format: 'date-time' });
   });
+
+  it('produces user-friendly invalid-type message for unparseable strings', () => {
+    const schema = new DateSchema();
+    const result = schema.safeParse('not-a-date');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Must be a valid date');
+    }
+  });
+
+  it('produces user-friendly invalid-type message for non-Date values', () => {
+    const schema = new DateSchema();
+    for (const value of ['2024-01-01', 1234567890, true, null, undefined]) {
+      const result = schema.safeParse(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.issues[0]?.message).toBe('Must be a valid date');
+      }
+    }
+  });
+
+  it('produces user-friendly message for an invalid Date (NaN time)', () => {
+    const schema = new DateSchema();
+    const result = schema.safeParse(new Date('not a date'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Must be a valid date');
+    }
+  });
+
+  it('.message() overrides the invalid-type message', () => {
+    const schema = new DateSchema().message('Enter a valid date');
+    const result = schema.safeParse('not-a-date');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a valid date');
+    }
+  });
+
+  it('.message() is preserved across clones (e.g. after .min())', () => {
+    const schema = new DateSchema().message('Enter a valid date').min(new Date('2024-01-01'));
+    const result = schema.safeParse('nope');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a valid date');
+    }
+  });
 });

--- a/packages/schema/src/schemas/__tests__/number.test.ts
+++ b/packages/schema/src/schemas/__tests__/number.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@vertz/test';
 import { ParseError } from '../../core/errors';
+import { s } from '../../index';
 import { NumberSchema } from '../number';
 
 describe('NumberSchema', () => {
@@ -97,6 +98,52 @@ describe('NumberSchema', () => {
     expect(ltResult.ok).toBe(false);
     if (!ltResult.ok) {
       expect(ltResult.error.issues[0]?.message).toBe('Must be below 10');
+    }
+  });
+
+  it('produces user-friendly invalid-type message for non-numeric strings', () => {
+    const schema = new NumberSchema();
+    const result = schema.safeParse('42a');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Must be a number');
+    }
+  });
+
+  it('produces user-friendly invalid-type message for non-number values', () => {
+    const schema = new NumberSchema();
+    for (const value of ['hello', true, null, {}, NaN]) {
+      const result = schema.safeParse(value);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.issues[0]?.message).toBe('Must be a number');
+      }
+    }
+  });
+
+  it('.message() overrides the invalid-type message', () => {
+    const schema = new NumberSchema().message('Enter a number');
+    const result = schema.safeParse('abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a number');
+    }
+  });
+
+  it('s.number().message() is reachable through the public facade', () => {
+    const result = s.number().message('Enter a number').safeParse('abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a number');
+    }
+  });
+
+  it('.message() is preserved across clones (e.g. after .gte())', () => {
+    const schema = new NumberSchema().message('Enter a number').gte(5);
+    const result = schema.safeParse('abc');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.issues[0]?.message).toBe('Enter a number');
     }
   });
 

--- a/packages/schema/src/schemas/bigint.ts
+++ b/packages/schema/src/schemas/bigint.ts
@@ -5,15 +5,23 @@ import { SchemaType } from '../core/types';
 import type { JSONSchemaObject, RefTracker } from '../introspection/json-schema';
 
 export class BigIntSchema extends Schema<bigint> {
+  private _invalidTypeMessage: string | undefined;
+
   _parse(value: unknown, ctx: ParseContext): bigint {
     if (typeof value !== 'bigint') {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: `Expected bigint, received ${typeof value}`,
+        message: this._invalidTypeMessage ?? 'Must be an integer',
       });
       return value as bigint;
     }
     return value;
+  }
+
+  message(msg: string): BigIntSchema {
+    const clone = this._clone();
+    clone._invalidTypeMessage = msg;
+    return clone;
   }
 
   _schemaType(): SchemaType {
@@ -25,6 +33,8 @@ export class BigIntSchema extends Schema<bigint> {
   }
 
   _clone(): BigIntSchema {
-    return this._cloneBase(new BigIntSchema());
+    const clone = this._cloneBase(new BigIntSchema());
+    clone._invalidTypeMessage = this._invalidTypeMessage;
+    return clone;
   }
 }

--- a/packages/schema/src/schemas/date.ts
+++ b/packages/schema/src/schemas/date.ts
@@ -9,17 +9,21 @@ export class DateSchema extends Schema<Date> {
   private _minMessage: string | undefined;
   private _max: Date | undefined;
   private _maxMessage: string | undefined;
+  private _invalidTypeMessage: string | undefined;
 
   _parse(value: unknown, ctx: ParseContext): Date {
     if (!(value instanceof Date)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: `Expected Date, received ${typeof value}`,
+        message: this._invalidTypeMessage ?? 'Must be a valid date',
       });
       return value as Date;
     }
     if (Number.isNaN(value.getTime())) {
-      ctx.addIssue({ code: ErrorCode.InvalidDate, message: 'Invalid date' });
+      ctx.addIssue({
+        code: ErrorCode.InvalidDate,
+        message: this._invalidTypeMessage ?? 'Must be a valid date',
+      });
       return value;
     }
     if (this._min !== undefined && value.getTime() < this._min.getTime()) {
@@ -51,6 +55,12 @@ export class DateSchema extends Schema<Date> {
     return clone;
   }
 
+  message(msg: string): DateSchema {
+    const clone = this._clone();
+    clone._invalidTypeMessage = msg;
+    return clone;
+  }
+
   _schemaType(): SchemaType {
     return SchemaType.Date;
   }
@@ -65,6 +75,7 @@ export class DateSchema extends Schema<Date> {
     clone._minMessage = this._minMessage;
     clone._max = this._max;
     clone._maxMessage = this._maxMessage;
+    clone._invalidTypeMessage = this._invalidTypeMessage;
     return clone;
   }
 }

--- a/packages/schema/src/schemas/number.ts
+++ b/packages/schema/src/schemas/number.ts
@@ -20,12 +20,13 @@ export class NumberSchema extends Schema<number> {
   private _nonpositive: boolean = false;
   private _multipleOf: number | undefined;
   private _finite: boolean = false;
+  private _invalidTypeMessage: string | undefined;
 
   _parse(value: unknown, ctx: ParseContext): number {
     if (typeof value !== 'number' || Number.isNaN(value)) {
       ctx.addIssue({
         code: ErrorCode.InvalidType,
-        message: `Expected number, received ${typeof value}`,
+        message: this._invalidTypeMessage ?? 'Must be a number',
       });
       return value as number;
     }
@@ -162,6 +163,12 @@ export class NumberSchema extends Schema<number> {
     return clone;
   }
 
+  message(msg: string): NumberSchema {
+    const clone = this._clone();
+    clone._invalidTypeMessage = msg;
+    return clone;
+  }
+
   _schemaType(): SchemaType {
     return SchemaType.Number;
   }
@@ -193,6 +200,7 @@ export class NumberSchema extends Schema<number> {
     clone._nonpositive = this._nonpositive;
     clone._multipleOf = this._multipleOf;
     clone._finite = this._finite;
+    clone._invalidTypeMessage = this._invalidTypeMessage;
     return clone;
   }
 }

--- a/packages/site/pages/guides/errors.mdx
+++ b/packages/site/pages/guides/errors.mdx
@@ -176,7 +176,7 @@ if (!result.ok) {
   for (const issue of result.error.issues) {
     console.log(`${issue.path.join('.')}: ${issue.message}`);
     // "name: String must contain at least 1 character(s)"
-    // "age: Expected number, received string"
+    // "age: Must be a number"
   }
 }
 ```


### PR DESCRIPTION
Closes #2809.

## Public API Changes

**Additions**
- `NumberSchema.message(msg: string)` — overrides the invalid-type error message.
- `BigIntSchema.message(msg: string)` — same.
- `DateSchema.message(msg: string)` — same.

**Changed defaults (no breaking API; message strings are not part of the contract)**
- `s.number()` invalid-type: `"Expected number, received <typeof>"` → `"Must be a number"`.
- `s.bigint()` invalid-type: `"Expected bigint, received <typeof>"` → `"Must be an integer"`.
- `s.date()` invalid-type / invalid-date: `"Expected Date, received <typeof>"` / `"Invalid date"` → `"Must be a valid date"`.

Existing tests only assert `ParseError` instance or the custom message on refinement methods (`.gte(n, msg)`), not the default invalid-type string — no regressions.

## Summary

- #2771 made FormData coercion implicit (users write `s.number()`, not `s.coerce.number()`). `coerceLeaf` deliberately passes unparseable strings through to the schema so the schema owns messaging — which left `"Expected number, received string"` in front of end users in form fields.
- This PR changes the defaults to end-user-readable copy and adds a `.message(...)` override on each of the three schemas. The override is preserved across clones, so chaining like `s.number().message('Enter a number').gte(5)` keeps the custom copy.

## Test plan

- [x] RED-phase tests added for each of the three schemas (new messages + override + clone preservation + `s.*` facade reachability).
- [x] `packages/schema`: 489/489 tests passing.
- [x] `packages/ui`: 179/179 form tests passing (validates end-to-end `coerceLeaf` → schema flow).
- [x] `@vertz/schema` + `@vertz/ui` typecheck clean.
- [x] oxlint + oxfmt clean.
- [x] Monorepo pre-existing failures (examples/linear, examples/entity-todo, og, build, calendar) verified unchanged on main.

## Follow-ups (not blocking)

- `CoercedNumberSchema` / `CoercedBigIntSchema` (the `s.coerce.*` legacy path) still emit the old `"Expected … received …"` copy and ignore `.message()` overrides. Out of scope — `#2771` moved implicit coercion to `coerceLeaf`, so user-facing forms don't hit that path. Worth a small follow-up to keep messaging consistent for callers still using `s.coerce.*` explicitly.
- `s.string()` / `s.boolean()` similarly have non-user-facing defaults. `#2809` scopes explicitly to number/bigint/date; extending `.message()` to the rest of the primitives is a good DX follow-up.

Local review: `reviews/fix-2809/review.md` (not committed — local artefact per workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)