### PR TITLE
feat(ui): add @vertz/ui/client subpath for UI-only HMR types [#2813]

### DIFF
--- a/.changeset/ui-client-subpath-2813.md
+++ b/.changeset/ui-client-subpath-2813.md
@@ -1,0 +1,19 @@
+---
+'@vertz/ui': patch
+'vertz': patch
+---
+
+feat(ui): add `@vertz/ui/client` subpath for UI-only consumers of `import.meta.hot` types [#2813]
+
+Apps that install `@vertz/ui` directly — component-library authors, or frontends that don't use the server/db layers — can now type `import.meta.hot` without pulling in the `vertz` meta-package:
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["@vertz/ui/client"],
+  },
+}
+```
+
+The canonical augmentation now lives in `@vertz/ui/client.d.ts`. `vertz/client` continues to work and resolves to the same shape — it re-exports `@vertz/ui/client` via a triple-slash reference, so the two subpaths cannot drift.

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -15,6 +15,9 @@ dist/
 # Keep config files
 !*.config.js
 
+# Keep hand-written client.d.ts at package roots (e.g. vertz/client, @vertz/ui/client)
+!*/client.d.ts
+
 # Environment
 .env
 .env.local

--- a/packages/mint-docs/guides/hmr-types.mdx
+++ b/packages/mint-docs/guides/hmr-types.mdx
@@ -7,13 +7,22 @@ description: 'Type `import.meta.hot` in a Vertz app using the `vertz/client` aug
 
 ## Explicit opt-in (optional)
 
-If a file uses `import.meta.hot` without importing from any of those subpaths (e.g. a standalone client entry that only imports from `@vertz/ui` directly), wire the types up explicitly:
+If a file uses `import.meta.hot` without importing from any of those subpaths (e.g. a standalone client entry that only imports from `@vertz/ui` directly), wire the types up explicitly. Pick the subpath that matches what you install:
 
 ```jsonc
-// tsconfig.json
+// tsconfig.json — apps on the full framework
 {
   "compilerOptions": {
     "types": ["vertz/client"],
+  },
+}
+```
+
+```jsonc
+// tsconfig.json — UI-only consumers (no `vertz` dependency)
+{
+  "compilerOptions": {
+    "types": ["@vertz/ui/client"],
   },
 }
 ```
@@ -22,10 +31,11 @@ Or, per-file:
 
 ```ts
 /// <reference types="vertz/client" />
+// or: /// <reference types="@vertz/ui/client" />
 import.meta.hot?.accept();
 ```
 
-Newly-scaffolded apps (via `create-vertz-app`) already include the tsconfig entry.
+Both subpaths resolve to the same augmentation — `vertz/client` re-exports `@vertz/ui/client` via a triple-slash reference, so they cannot drift. Newly-scaffolded apps (via `create-vertz-app`) already include the `vertz/client` tsconfig entry.
 
 ## The `ImportMetaHot` surface
 

--- a/packages/ui/client.d.ts
+++ b/packages/ui/client.d.ts
@@ -1,0 +1,75 @@
+/**
+ * Vertz client-side runtime type augmentations.
+ *
+ * This file is the canonical source for the `ImportMeta.hot` augmentation.
+ * `vertz/client` re-exports it via a triple-slash reference so the two
+ * subpaths cannot drift.
+ *
+ * Include in your tsconfig.json:
+ *   "types": ["@vertz/ui/client"]
+ *
+ * Or add a triple-slash reference:
+ *   /// <reference types="@vertz/ui/client" />
+ *
+ * Apps that install the `vertz` meta-package can keep using `vertz/client`
+ * — it resolves to the same augmentation.
+ */
+
+declare global {
+  /** Event names emitted by the vtz HMR runtime. */
+  type ImportMetaHotEvent =
+    | 'vertz:beforeUpdate'
+    | 'vertz:afterUpdate'
+    | 'vertz:beforeFullReload'
+    | 'vertz:invalidate'
+    | 'vertz:error';
+
+  /** Payload shape delivered to `hot.on()` listeners, per event. */
+  interface ImportMetaHotEventPayloads {
+    'vertz:beforeUpdate': { module: string };
+    'vertz:afterUpdate': { module: string };
+    'vertz:beforeFullReload': { reason?: string };
+    'vertz:invalidate': { module: string; message?: string };
+    'vertz:error': { module: string; error: unknown };
+  }
+
+  interface ImportMetaHot {
+    /** Accept the current module's HMR update. */
+    accept(): void;
+    /** Accept the current module's HMR update with a callback receiving the new module. */
+    accept(cb: (newModule: unknown) => void): void;
+    /** Accept updates for specific dependencies. */
+    accept(deps: string | readonly string[], cb?: (modules: unknown[]) => void): void;
+    /** Dispose callback — runs before module is replaced. */
+    dispose(cb: (data: Record<string, unknown>) => void): void;
+    /** Persistent data across HMR updates. */
+    data: Record<string, unknown>;
+    /**
+     * Mark the current module as unable to apply an HMR update. Triggers a full
+     * page reload with an optional explanatory message.
+     */
+    invalidate(message?: string): void;
+    /**
+     * Opt out of HMR for the current module. The next update targeting this
+     * module falls back to a full page reload.
+     */
+    decline(): void;
+    /** Subscribe to an HMR runtime event. */
+    on<E extends ImportMetaHotEvent>(
+      event: E,
+      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
+    ): void;
+    /** Remove a previously-registered listener. The callback must be the same reference. */
+    off<E extends ImportMetaHotEvent>(
+      event: E,
+      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
+    ): void;
+  }
+
+  interface ImportMeta {
+    /** Hot Module Replacement API. Only available in dev mode; undefined in production and SSR. */
+    readonly hot: ImportMetaHot | undefined;
+  }
+}
+
+export {};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "dist",
+    "client.d.ts",
     "reactivity.json"
   ],
   "type": "module",
@@ -62,6 +63,9 @@
     "./components": {
       "types": "./dist/components/index.d.ts",
       "import": "./dist/components/index.js"
+    },
+    "./client": {
+      "types": "./client.d.ts"
     },
     "./reactivity.json": "./reactivity.json"
   },

--- a/packages/ui/src/__tests__/client-subpath.test.ts
+++ b/packages/ui/src/__tests__/client-subpath.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@vertz/test';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #2813 — `@vertz/ui/client` subpath export.
+ *
+ * `@vertz/ui/client` is the canonical source for the `ImportMeta.hot`
+ * augmentation. `vertz/client` (in the meta-package) re-exports it via a
+ * triple-slash reference, so the two cannot drift.
+ */
+
+const uiRoot = resolve(import.meta.dirname, '../..');
+const vertzRoot = resolve(uiRoot, '../vertz');
+
+describe('@vertz/ui/client subpath', () => {
+  it('client.d.ts exists at the package root', () => {
+    expect(existsSync(resolve(uiRoot, 'client.d.ts'))).toBe(true);
+  });
+
+  it('package.json exposes ./client as a types-only export', () => {
+    const pkg = JSON.parse(readFileSync(resolve(uiRoot, 'package.json'), 'utf-8'));
+    const entry = pkg.exports['./client'];
+    expect(entry).toBeDefined();
+    expect(entry.types).toBe('./client.d.ts');
+    expect(entry.import).toBeUndefined();
+  });
+
+  it('package.json files array includes client.d.ts for publishing', () => {
+    const pkg = JSON.parse(readFileSync(resolve(uiRoot, 'package.json'), 'utf-8'));
+    expect(pkg.files).toContain('client.d.ts');
+  });
+
+  it('client.d.ts declares ImportMetaHot and the ImportMeta.hot member', () => {
+    const contents = readFileSync(resolve(uiRoot, 'client.d.ts'), 'utf-8');
+    expect(contents).toContain('declare global');
+    expect(contents).toContain('interface ImportMetaHot');
+    expect(contents).toContain('interface ImportMeta');
+    expect(contents).toContain('readonly hot: ImportMetaHot | undefined');
+  });
+});
+
+describe('@vertz/ui/client and vertz/client parity (anti-regression for #2813)', () => {
+  it('vertz/client re-exports @vertz/ui/client via triple-slash reference', () => {
+    const vertzClient = readFileSync(resolve(vertzRoot, 'client.d.ts'), 'utf-8');
+    expect(vertzClient).toContain('/// <reference types="@vertz/ui/client" />');
+  });
+
+  it('vertz/client does not declare its own augmentation (delegates to @vertz/ui/client)', () => {
+    const vertzClient = readFileSync(resolve(vertzRoot, 'client.d.ts'), 'utf-8');
+    expect(vertzClient).not.toContain('declare global');
+    expect(vertzClient).not.toContain('interface ImportMetaHot');
+  });
+});

--- a/packages/ui/src/__tests__/import-meta-hot.test-d.ts
+++ b/packages/ui/src/__tests__/import-meta-hot.test-d.ts
@@ -1,0 +1,111 @@
+/// <reference types="../../client.d.ts" />
+import { describe, expectTypeOf, it } from '@vertz/test';
+
+/**
+ * Type-flow tests for the `@vertz/ui/client` ambient augmentation.
+ *
+ * Mirrors `packages/vertz/src/__tests__/import-meta-hot.test-d.ts` — the two
+ * subpaths (`vertz/client` and `@vertz/ui/client`) MUST expose an identical
+ * `ImportMetaHot` shape. `vertz/client` re-exports this file via a
+ * triple-slash reference, so any drift here is caught by both test suites.
+ */
+
+describe('Feature: ImportMeta.hot is optional (dev-only)', () => {
+  it('Typed as ImportMetaHot | undefined', () => {
+    expectTypeOf(import.meta.hot).toEqualTypeOf<ImportMetaHot | undefined>();
+  });
+
+  it('Supports optional chaining for self-accept', () => {
+    expectTypeOf(import.meta.hot?.accept()).toEqualTypeOf<void | undefined>();
+  });
+});
+
+describe('Feature: accept() overloads', () => {
+  it('Zero-arg self-accept returns void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.accept()).toEqualTypeOf<void>();
+  });
+
+  it('Single-callback overload accepts (newModule) => void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.accept((_mod) => {})).toEqualTypeOf<void>();
+  });
+
+  it('Dependency-array overload accepts deps + callback', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.accept(['./other.ts'], (_mods) => {})).toEqualTypeOf<void>();
+    expectTypeOf(hot.accept('./single.ts')).toEqualTypeOf<void>();
+  });
+});
+
+describe('Feature: dispose and data', () => {
+  it('dispose() accepts a callback receiving data record', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.dispose((_data) => {})).toEqualTypeOf<void>();
+  });
+
+  it('data is typed Record<string, unknown>', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.data).toEqualTypeOf<Record<string, unknown>>();
+  });
+});
+
+describe('Feature: invalidate and decline', () => {
+  it('invalidate() accepts an optional message and returns void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.invalidate()).toEqualTypeOf<void>();
+    expectTypeOf(hot.invalidate('oops')).toEqualTypeOf<void>();
+  });
+
+  it('decline() takes no arguments and returns void', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    expectTypeOf(hot.decline()).toEqualTypeOf<void>();
+  });
+
+  it('decline() rejects any arguments at the type level', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — decline takes no arguments.
+    hot.decline('nope');
+  });
+});
+
+describe('Feature: on / off event subscription', () => {
+  it('vertz:beforeUpdate payload exposes the updated module string', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    hot.on('vertz:beforeUpdate', (payload) => {
+      expectTypeOf(payload).toEqualTypeOf<{ module: string }>();
+    });
+  });
+
+  it('vertz:beforeFullReload payload exposes an optional reason', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    hot.on('vertz:beforeFullReload', (payload) => {
+      expectTypeOf(payload).toEqualTypeOf<{ reason?: string }>();
+    });
+  });
+
+  it('off() requires the same callback reference', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    const cb = (_p: { module: string }) => {};
+    expectTypeOf(hot.off('vertz:afterUpdate', cb)).toEqualTypeOf<void>();
+  });
+
+  it('rejects unknown event names', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — 'vite:beforeUpdate' is not a vtz event.
+    hot.on('vite:beforeUpdate', () => {});
+  });
+
+  it('rejects wrong payload shape on listener', () => {
+    const hot = import.meta.hot as ImportMetaHot;
+    // @ts-expect-error — vertz:beforeUpdate payload does not expose `reason`.
+    hot.on('vertz:beforeUpdate', (p: { reason: string }) => p.reason);
+  });
+});
+
+describe('Feature: removed augmentations', () => {
+  it('ImportMeta.main is not declared by @vertz/ui/client', () => {
+    // @ts-expect-error — main is a Bun-ism, not provided by the vtz runtime.
+    const _main: boolean = import.meta.main;
+  });
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.local.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts", "**/*.local.ts"],
   "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/vertz/__tests__/subpath-exports.test.ts
+++ b/packages/vertz/__tests__/subpath-exports.test.ts
@@ -133,6 +133,20 @@ describe('exports point to built artifacts', () => {
     expect(fs.existsSync(fullPath)).toBe(true);
   });
 
+  it('vertz/client delegates to @vertz/ui/client to keep augmentations in sync (#2813)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const contents = fs.readFileSync(
+      path.resolve(import.meta.dirname, '..', 'client.d.ts'),
+      'utf-8',
+    );
+    expect(contents).toContain('/// <reference types="@vertz/ui/client" />');
+    // The canonical augmentation lives in @vertz/ui/client — vertz/client must
+    // not re-declare it locally, or the two subpaths could drift.
+    expect(contents).not.toContain('declare global');
+    expect(contents).not.toContain('interface ImportMetaHot');
+  });
+
   it('legacy vertz/env export does not exist (renamed to ./client)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');

--- a/packages/vertz/client.d.ts
+++ b/packages/vertz/client.d.ts
@@ -1,6 +1,12 @@
 /**
  * Vertz client-side runtime type augmentations.
  *
+ * The canonical augmentation lives in `@vertz/ui/client` so that apps which
+ * install `@vertz/ui` directly (without the meta-package) can opt into the
+ * same `ImportMeta.hot` types. This file re-exports it so `vertz/client`
+ * stays a valid tsconfig entry — both subpaths resolve to the same shape
+ * and cannot drift.
+ *
  * Include in your tsconfig.json:
  *   "types": ["vertz/client"]
  *
@@ -8,61 +14,6 @@
  *   /// <reference types="vertz/client" />
  */
 
-declare global {
-  /** Event names emitted by the vtz HMR runtime. */
-  type ImportMetaHotEvent =
-    | 'vertz:beforeUpdate'
-    | 'vertz:afterUpdate'
-    | 'vertz:beforeFullReload'
-    | 'vertz:invalidate'
-    | 'vertz:error';
-
-  /** Payload shape delivered to `hot.on()` listeners, per event. */
-  interface ImportMetaHotEventPayloads {
-    'vertz:beforeUpdate': { module: string };
-    'vertz:afterUpdate': { module: string };
-    'vertz:beforeFullReload': { reason?: string };
-    'vertz:invalidate': { module: string; message?: string };
-    'vertz:error': { module: string; error: unknown };
-  }
-
-  interface ImportMetaHot {
-    /** Accept the current module's HMR update. */
-    accept(): void;
-    /** Accept the current module's HMR update with a callback receiving the new module. */
-    accept(cb: (newModule: unknown) => void): void;
-    /** Accept updates for specific dependencies. */
-    accept(deps: string | readonly string[], cb?: (modules: unknown[]) => void): void;
-    /** Dispose callback — runs before module is replaced. */
-    dispose(cb: (data: Record<string, unknown>) => void): void;
-    /** Persistent data across HMR updates. */
-    data: Record<string, unknown>;
-    /**
-     * Mark the current module as unable to apply an HMR update. Triggers a full
-     * page reload with an optional explanatory message.
-     */
-    invalidate(message?: string): void;
-    /**
-     * Opt out of HMR for the current module. The next update targeting this
-     * module falls back to a full page reload.
-     */
-    decline(): void;
-    /** Subscribe to an HMR runtime event. */
-    on<E extends ImportMetaHotEvent>(
-      event: E,
-      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
-    ): void;
-    /** Remove a previously-registered listener. The callback must be the same reference. */
-    off<E extends ImportMetaHotEvent>(
-      event: E,
-      cb: (payload: ImportMetaHotEventPayloads[E]) => void,
-    ): void;
-  }
-
-  interface ImportMeta {
-    /** Hot Module Replacement API. Only available in dev mode; undefined in production and SSR. */
-    readonly hot: ImportMetaHot | undefined;
-  }
-}
+/// <reference types="@vertz/ui/client" />
 
 export {};


### PR DESCRIPTION
## Summary

Closes #2813.

- **Canonical source moves to `@vertz/ui/client`** — apps that install `@vertz/ui` directly (component libraries, UI-only consumers) can now opt into `import.meta.hot` types via `"types": ["@vertz/ui/client"]` without pulling in the `vertz` meta-package.
- **`vertz/client` becomes a re-export** — `packages/vertz/client.d.ts` shrinks to a single `/// <reference types="@vertz/ui/client" />`. Both subpaths resolve to the same file, so they cannot drift structurally.
- **Pre-existing `.test-d.ts` leak into `@vertz/ui`'s dist tarball is fixed** — added `**/*.test-d.ts` to `packages/ui/tsconfig.json` exclude. (Previously `mount.test-d.d.ts`, `removed-exports.test-d.d.ts`, `trusted-html.test-d.d.ts` were shipped to npm; they are test-only files.)

## Public API Changes

- **Additions:**
  - New subpath: `@vertz/ui/client` (types-only) — `"types": ["@vertz/ui/client"]` augments `ImportMeta.hot: ImportMetaHot | undefined`.
- **Unchanged:** `vertz/client` still works and resolves to the same augmentation — existing consumers (`packages/landing`, `packages/component-docs`, `create-vertz-app` scaffolds) need no changes.
- **No breaking changes.**

## Test plan

- [x] `vtz test` — 2464 tests pass in `@vertz/ui`, 28 pass in `vertz`
- [x] `vtz run typecheck` passes for both packages
- [x] `vtz run lint` + `vtzx oxfmt` clean
- [x] New anti-regression tests:
  - `packages/ui/src/__tests__/client-subpath.test.ts` — asserts `vertz/client` delegates to `@vertz/ui/client` via triple-slash reference and does not carry a duplicate augmentation
  - `packages/ui/src/__tests__/import-meta-hot.test-d.ts` — parallel type-level tests mirror the `vertz/client` shape
- [x] Existing `packages/vertz/src/__tests__/import-meta-hot.test-d.ts` still passes — exercises the reference chain end-to-end
- [x] Adversarial review run; blocker fixed (`.test-d.ts` dist leak)

## Docs

`packages/mint-docs/guides/hmr-types.mdx` updated to document both subpaths and clarify that UI-only consumers have no `vertz` dependency requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)