### PR TITLE
fix(db): type-gate array operators (arrayContains/arrayContainedBy/arrayOverlaps) to Postgres [#2885]

### DIFF
--- a/.changeset/array-op-type-gating-2885.md
+++ b/.changeset/array-op-type-gating-2885.md
@@ -1,0 +1,19 @@
+---
+'@vertz/db': patch
+---
+
+feat(db): type-gate array operators (`arrayContains` / `arrayContainedBy` / `arrayOverlaps`) to Postgres
+
+Closes [#2885](https://github.com/vertz-dev/vertz/issues/2885).
+
+The three Postgres array operators are now part of the typed filter surface on `d.textArray()`, `d.integerArray()`, and `d.vector(n)` columns. They ship on `dialect: 'postgres'` with operand element type flowing from column metadata:
+
+- `d.textArray()` → `readonly string[]`
+- `d.integerArray()` → `readonly number[]`
+- `d.vector(n)` → `readonly number[]`
+
+On `dialect: 'sqlite'` all three slots resolve to `ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` — a branded `never` whose type-alias name IS the recovery sentence (same convention as the two existing JSONB brands from #2850 / #2868).
+
+Runtime SQL emission is unchanged — the existing `@>` / `<@` / `&&` output on Postgres already worked. The runtime throw on SQLite now mirrors the JSONB message (`"require dialect: postgres. On SQLite, fetch with list() and filter in application code."`).
+
+Users with custom helpers over `FilterType<TColumns>` may need to thread `TDialect` (same guidance as #2850).

--- a/packages/db/src/client/__tests__/array-operators.test-d.ts
+++ b/packages/db/src/client/__tests__/array-operators.test-d.ts
@@ -148,31 +148,31 @@ void pgPlainNoArrayOps;
 // ---------------------------------------------------------------------------
 
 const liteContains: FilterType<PostColumns, 'sqlite'> = {
-  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
   tags: { arrayContains: ['typescript'] },
 };
 void liteContains;
 
 const liteContainedBy: FilterType<PostColumns, 'sqlite'> = {
-  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
   tags: { arrayContainedBy: ['typescript'] },
 };
 void liteContainedBy;
 
 const liteOverlaps: FilterType<PostColumns, 'sqlite'> = {
-  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
   tags: { arrayOverlaps: ['typescript'] },
 };
 void liteOverlaps;
 
 const liteIntContains: FilterType<PostColumns, 'sqlite'> = {
-  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
   ratings: { arrayContains: [5] },
 };
 void liteIntContains;
 
 const liteVectorOverlaps: FilterType<PostColumns, 'sqlite'> = {
-  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
   embedding: { arrayOverlaps: [0.5] },
 };
 void liteVectorOverlaps;
@@ -209,7 +209,7 @@ const sqliteDb = createDb({
 
 void sqliteDb.post.list({
   where: {
-    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
     tags: { arrayContains: ['typescript'] },
   },
 });
@@ -217,7 +217,7 @@ void sqliteDb.post.list({
 void sqliteDb.post.aggregate({
   _count: true,
   where: {
-    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
     ratings: { arrayOverlaps: [5] },
   },
 });

--- a/packages/db/src/client/__tests__/array-operators.test-d.ts
+++ b/packages/db/src/client/__tests__/array-operators.test-d.ts
@@ -1,0 +1,252 @@
+/**
+ * Type-level tests for typed Postgres array operators (#2885):
+ * - `arrayContains`, `arrayContainedBy`, `arrayOverlaps` on
+ *   `d.textArray()` / `d.integerArray()` / `d.vector()` columns.
+ * - Element-type flow from column metadata (`d.textArray() → string`,
+ *   `d.integerArray() → number`, `d.vector(n) → number`).
+ * - Dialect gating via the `ArrayFilter_Error_…` brand on SQLite.
+ *
+ * Negatives use `@ts-expect-error` — if the directive becomes unused, the
+ * test fails, catching regressions that loosen the type surface.
+ */
+
+import { d } from '../../d';
+import type { FilterType } from '../../schema/inference';
+import { createDb } from '../database';
+
+const postTable = d.table('post', {
+  id: d.uuid().primary({ generate: 'cuid' }),
+  tags: d.textArray(),
+  ratings: d.integerArray(),
+  embedding: d.vector(3),
+  // Nullable array column — isNull should still be available alongside array ops.
+  labels: d.textArray().nullable(),
+});
+
+type PostColumns = (typeof postTable)['_columns'];
+
+// ---------------------------------------------------------------------------
+// Postgres — positives per operand element type
+// ---------------------------------------------------------------------------
+
+const pgTextContains: FilterType<PostColumns, 'postgres'> = {
+  tags: { arrayContains: ['typescript'] },
+};
+void pgTextContains;
+
+const pgTextContainedBy: FilterType<PostColumns, 'postgres'> = {
+  tags: { arrayContainedBy: ['typescript', 'rust', 'go'] },
+};
+void pgTextContainedBy;
+
+const pgTextOverlaps: FilterType<PostColumns, 'postgres'> = {
+  tags: { arrayOverlaps: ['ts', 'js'] },
+};
+void pgTextOverlaps;
+
+const pgIntContains: FilterType<PostColumns, 'postgres'> = {
+  ratings: { arrayContains: [5] },
+};
+void pgIntContains;
+
+const pgIntOverlaps: FilterType<PostColumns, 'postgres'> = {
+  ratings: { arrayOverlaps: [5, 4, 3] },
+};
+void pgIntOverlaps;
+
+const pgVectorContainedBy: FilterType<PostColumns, 'postgres'> = {
+  embedding: { arrayContainedBy: [0.1, 0.2, 0.3] },
+};
+void pgVectorContainedBy;
+
+// Readonly `as const` operand accepted.
+const pgTextAsConst: FilterType<PostColumns, 'postgres'> = {
+  tags: { arrayContains: ['typescript', 'rust'] as const },
+};
+void pgTextAsConst;
+
+// ---------------------------------------------------------------------------
+// Postgres — direct-value shorthand still works on array columns
+// ---------------------------------------------------------------------------
+
+const pgTagsDirect: FilterType<PostColumns, 'postgres'> = {
+  tags: ['typescript', 'rust'],
+};
+void pgTagsDirect;
+
+const pgRatingsDirect: FilterType<PostColumns, 'postgres'> = {
+  ratings: [5, 4],
+};
+void pgRatingsDirect;
+
+// ---------------------------------------------------------------------------
+// Postgres — existing operators still work (eq/ne/in/notIn/isNull)
+// ---------------------------------------------------------------------------
+
+const pgTagsEq: FilterType<PostColumns, 'postgres'> = {
+  tags: { eq: ['typescript'] },
+};
+void pgTagsEq;
+
+const pgLabelsIsNull: FilterType<PostColumns, 'postgres'> = {
+  labels: { isNull: true },
+};
+void pgLabelsIsNull;
+
+// Mixing standard + array operators in one object is accepted — TS's union
+// contextual typing permits excess properties across arms, and the runtime
+// processes every recognized operator key (producing an AND of the clauses).
+// The 3-way union (direct | ColumnFilterOperators | ArrayOperatorSlots) is
+// what keeps element-type errors narrow per property; it does not aim to
+// reject the mixed form.
+const pgMixedOps: FilterType<PostColumns, 'postgres'> = {
+  tags: { eq: ['typescript'], arrayOverlaps: ['ts'] },
+};
+void pgMixedOps;
+
+// ---------------------------------------------------------------------------
+// Postgres — element-type negatives (operand element type flow)
+// ---------------------------------------------------------------------------
+
+const pgTagsWrongElem: FilterType<PostColumns, 'postgres'> = {
+  // @ts-expect-error — number is not assignable to string (arrayContains operand element)
+  tags: { arrayContains: [42] },
+};
+void pgTagsWrongElem;
+
+const pgRatingsWrongElem: FilterType<PostColumns, 'postgres'> = {
+  // @ts-expect-error — string is not assignable to number (arrayOverlaps operand element)
+  ratings: { arrayOverlaps: ['five'] },
+};
+void pgRatingsWrongElem;
+
+const pgVectorWrongElem: FilterType<PostColumns, 'postgres'> = {
+  // @ts-expect-error — string is not assignable to number (arrayContainedBy operand element)
+  embedding: { arrayContainedBy: ['0.1'] },
+};
+void pgVectorWrongElem;
+
+// ---------------------------------------------------------------------------
+// Postgres — array operators NOT available on non-array columns
+// ---------------------------------------------------------------------------
+
+const plainTable = d.table('plain', {
+  id: d.uuid().primary({ generate: 'cuid' }),
+  name: d.text(),
+  count: d.integer(),
+});
+type PlainColumns = (typeof plainTable)['_columns'];
+
+const pgPlainNoArrayOps: FilterType<PlainColumns, 'postgres'> = {
+  // @ts-expect-error — arrayContains is not available on non-array (text) columns
+  name: { arrayContains: ['a'] },
+};
+void pgPlainNoArrayOps;
+
+// ---------------------------------------------------------------------------
+// SQLite — brand diagnostic on each of the three array operators
+// ---------------------------------------------------------------------------
+
+const liteContains: FilterType<PostColumns, 'sqlite'> = {
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  tags: { arrayContains: ['typescript'] },
+};
+void liteContains;
+
+const liteContainedBy: FilterType<PostColumns, 'sqlite'> = {
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  tags: { arrayContainedBy: ['typescript'] },
+};
+void liteContainedBy;
+
+const liteOverlaps: FilterType<PostColumns, 'sqlite'> = {
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  tags: { arrayOverlaps: ['typescript'] },
+};
+void liteOverlaps;
+
+const liteIntContains: FilterType<PostColumns, 'sqlite'> = {
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  ratings: { arrayContains: [5] },
+};
+void liteIntContains;
+
+const liteVectorOverlaps: FilterType<PostColumns, 'sqlite'> = {
+  // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+  embedding: { arrayOverlaps: [0.5] },
+};
+void liteVectorOverlaps;
+
+// ---------------------------------------------------------------------------
+// SQLite — direct value and existing operators still compile
+// ---------------------------------------------------------------------------
+
+const liteDirect: FilterType<PostColumns, 'sqlite'> = {
+  tags: ['typescript'],
+};
+void liteDirect;
+
+const liteEq: FilterType<PostColumns, 'sqlite'> = {
+  tags: { eq: ['typescript'] },
+};
+void liteEq;
+
+const liteLabelsIsNull: FilterType<PostColumns, 'sqlite'> = {
+  labels: { isNull: true },
+};
+void liteLabelsIsNull;
+
+// ---------------------------------------------------------------------------
+// createDb end-to-end — gate fires through list() / aggregate() on SQLite
+// ---------------------------------------------------------------------------
+
+const sqliteDb = createDb({
+  dialect: 'sqlite',
+  path: ':memory:',
+  models: { post: d.model(postTable) },
+  migrations: { autoApply: true },
+});
+
+void sqliteDb.post.list({
+  where: {
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    tags: { arrayContains: ['typescript'] },
+  },
+});
+
+void sqliteDb.post.aggregate({
+  _count: true,
+  where: {
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    ratings: { arrayOverlaps: [5] },
+  },
+});
+
+// Direct equality still works on SQLite.
+void sqliteDb.post.list({
+  where: { tags: ['typescript'] },
+});
+
+const pgDb = createDb({
+  dialect: 'postgres',
+  url: 'postgres://u:p@localhost/db',
+  models: { post: d.model(postTable) },
+  _queryFn: (async () => ({ rows: [], rowCount: 0 })) as never,
+});
+
+void pgDb.post.list({
+  where: { tags: { arrayContains: ['typescript'] } },
+});
+
+void pgDb.post.list({
+  where: { ratings: { arrayOverlaps: [5] } },
+});
+
+void pgDb.post.list({
+  where: { embedding: { arrayContainedBy: [0.1, 0.2, 0.3] } },
+});
+
+void pgDb.post.aggregate({
+  _count: true,
+  where: { tags: { arrayOverlaps: ['ts'] } },
+});

--- a/packages/db/src/schema/array-filter-brand.ts
+++ b/packages/db/src/schema/array-filter-brand.ts
@@ -7,8 +7,8 @@
  * of these ops on a SQLite db produces a diagnostic that names this
  * interface — the alias name IS the recovery sentence.
  *
- * Same pattern as `JsonbPathFilter_Error_…` (#2850) and
- * `JsonbOperator_Error_…` (#2868). See `jsonb-filter-brand.ts` for the
+ * Same pattern and naming convention as `JsonbPathFilter_Error_…` (#2850)
+ * and `JsonbOperator_Error_…` (#2868). See `jsonb-filter-brand.ts` for the
  * rationale on why the diagnostic name encodes the recovery sentence.
  *
  * Known limitation: excess-property checks only fire on fresh object
@@ -18,6 +18,6 @@
  */
 declare const __ArrayFilterBrand: unique symbol;
 
-export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported {
+export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS {
   readonly [__ArrayFilterBrand]: 'array-filter-requires-postgres';
 }

--- a/packages/db/src/schema/array-filter-brand.ts
+++ b/packages/db/src/schema/array-filter-brand.ts
@@ -1,0 +1,23 @@
+/**
+ * Brand for the typed array-operator surface introduced by #2885
+ * (`arrayContains`, `arrayContainedBy`, `arrayOverlaps` on
+ * `d.textArray()` / `d.integerArray()` / `d.vector()` columns).
+ *
+ * Resolves in the SQLite branch of `ArrayOperatorSlots` so attempting any
+ * of these ops on a SQLite db produces a diagnostic that names this
+ * interface — the alias name IS the recovery sentence.
+ *
+ * Same pattern as `JsonbPathFilter_Error_…` (#2850) and
+ * `JsonbOperator_Error_…` (#2868). See `jsonb-filter-brand.ts` for the
+ * rationale on why the diagnostic name encodes the recovery sentence.
+ *
+ * Known limitation: excess-property checks only fire on fresh object
+ * literals; the `where.ts` runtime throw at
+ * `packages/db/src/sql/where.ts:264-296` remains the backstop for the
+ * widened-variable case (`const dialect: DialectName = ...`).
+ */
+declare const __ArrayFilterBrand: unique symbol;
+
+export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported {
+  readonly [__ArrayFilterBrand]: 'array-filter-requires-postgres';
+}

--- a/packages/db/src/schema/inference.ts
+++ b/packages/db/src/schema/inference.ts
@@ -1,4 +1,5 @@
 import type { DialectName } from '../dialect/types';
+import type { ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported } from './array-filter-brand';
 import type { ColumnBuilder, InferColumnType } from './column';
 import type { JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS } from './jsonb-filter-brand';
 import type { JsonbColumnValue } from './path-chain';
@@ -105,6 +106,54 @@ type IsJsonbColumn<C> =
     : false;
 
 /**
+ * Detect whether a column is a native array/vector column — the three types
+ * that admit Postgres `@>` / `<@` / `&&` operators. Matched by `sqlType`
+ * (not by inferred TS type) to avoid accidentally enabling array ops for any
+ * future column whose inferred type happens to be `readonly U[]`.
+ *
+ * `d.bytea()` (`Uint8Array`) is deliberately excluded — it's an opaque byte
+ * blob, not a typed element sequence.
+ */
+type IsArrayColumn<C> =
+  C extends ColumnBuilder<unknown, infer M>
+    ? M extends
+        | { readonly sqlType: 'text[]' }
+        | { readonly sqlType: 'integer[]' }
+        | { readonly sqlType: 'vector' }
+      ? true
+      : false
+    : false;
+
+/**
+ * Extract the element type from an array column's inferred TS type. Resolves
+ * to `string` for `d.textArray()` and to `number` for `d.integerArray()` and
+ * `d.vector()`.
+ */
+type ArrayElementOf<C> =
+  C extends ColumnBuilder<infer T, infer _M> ? (T extends readonly (infer U)[] ? U : never) : never;
+
+/**
+ * Dialect-gated operand slots for the three Postgres array operators.
+ *
+ * On Postgres: typed operand `readonly TElem[]` where `TElem` flows from the
+ * column's inferred element type.
+ * On SQLite: the three slots resolve to the brand interface so attempting
+ * any of them produces a TS diagnostic whose name reads as the recovery
+ * sentence.
+ */
+type ArrayOperatorSlots<TElem, TDialect extends DialectName> = TDialect extends 'postgres'
+  ? {
+      readonly arrayContains?: readonly TElem[];
+      readonly arrayContainedBy?: readonly TElem[];
+      readonly arrayOverlaps?: readonly TElem[];
+    }
+  : {
+      readonly arrayContains?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
+      readonly arrayContainedBy?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
+      readonly arrayOverlaps?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
+    };
+
+/**
  * FilterType<TColumns, TDialect> — typed where clause, dialect-conditional.
  *
  * Each key is one of:
@@ -112,13 +161,19 @@ type IsJsonbColumn<C> =
  *   (direct payload equality, simple comparison, `jsonContains` /
  *   `jsonContainedBy` / `hasKey`, or a `path()` descriptor). On SQLite the
  *   payload operators resolve to a keyed-never brand.
+ * - An array / vector column (`d.textArray()`, `d.integerArray()`,
+ *   `d.vector()`) — direct payload equality, OR the standard
+ *   `ColumnFilterOperators`, OR the three Postgres array operators
+ *   (`arrayContains` / `arrayContainedBy` / `arrayOverlaps`) with operand
+ *   element type flowing from column metadata. The three forms are distinct
+ *   union arms so per-property diagnostics stay narrow; TS's union contextual
+ *   typing still permits combining keys across arms in one object, which the
+ *   runtime processes as an AND of clauses. On SQLite the array operators
+ *   resolve to a keyed-never brand whose name reads as the recovery sentence.
  * - Any other column — value (shorthand for `{ eq: value }`) or operator object.
  * - A path-shaped JSONB key (`'meta->field'`) on Postgres. On SQLite the
  *   same key accepts only a keyed-never brand whose name reads as the
  *   recovery sentence.
- *
- * Array operators (`arrayContains`, etc.) are runtime-only today and not
- * yet part of the TS surface — tracked as a follow-up in #2885.
  */
 export type FilterType<
   TColumns extends ColumnRecord,
@@ -127,9 +182,14 @@ export type FilterType<
   [K in keyof TColumns | JsonbPathKey<TColumns>]?: K extends keyof TColumns
     ? IsJsonbColumn<TColumns[K]> extends true
       ? JsonbColumnValue<InferColumnType<TColumns[K]>, TDialect>
-      :
-          | InferColumnType<TColumns[K]>
-          | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+      : IsArrayColumn<TColumns[K]> extends true
+        ?
+            | InferColumnType<TColumns[K]>
+            | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+            | ArrayOperatorSlots<ArrayElementOf<TColumns[K]>, TDialect>
+        :
+            | InferColumnType<TColumns[K]>
+            | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
     : JsonbPathValue<TDialect>;
 };
 

--- a/packages/db/src/schema/inference.ts
+++ b/packages/db/src/schema/inference.ts
@@ -1,5 +1,5 @@
 import type { DialectName } from '../dialect/types';
-import type { ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported } from './array-filter-brand';
+import type { ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS } from './array-filter-brand';
 import type { ColumnBuilder, InferColumnType } from './column';
 import type { JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS } from './jsonb-filter-brand';
 import type { JsonbColumnValue } from './path-chain';
@@ -148,9 +148,9 @@ type ArrayOperatorSlots<TElem, TDialect extends DialectName> = TDialect extends 
       readonly arrayOverlaps?: readonly TElem[];
     }
   : {
-      readonly arrayContains?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
-      readonly arrayContainedBy?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
-      readonly arrayOverlaps?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported;
+      readonly arrayContains?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly arrayContainedBy?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
+      readonly arrayOverlaps?: ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS;
     };
 
 /**

--- a/packages/db/src/sql/__tests__/sqlite-builders.test.ts
+++ b/packages/db/src/sql/__tests__/sqlite-builders.test.ts
@@ -234,7 +234,7 @@ describe('SQLite feature guards', () => {
     expect(() =>
       buildWhere({ tags: { arrayContains: ['admin'] } }, 0, undefined, sqliteDialect),
     ).toThrow(
-      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres',
     );
   });
 
@@ -242,7 +242,7 @@ describe('SQLite feature guards', () => {
     expect(() =>
       buildWhere({ tags: { arrayContainedBy: ['admin'] } }, 0, undefined, sqliteDialect),
     ).toThrow(
-      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres',
     );
   });
 
@@ -250,7 +250,7 @@ describe('SQLite feature guards', () => {
     expect(() =>
       buildWhere({ tags: { arrayOverlaps: ['admin'] } }, 0, undefined, sqliteDialect),
     ).toThrow(
-      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite',
+      'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres',
     );
   });
 

--- a/packages/db/src/sql/where.ts
+++ b/packages/db/src/sql/where.ts
@@ -264,8 +264,8 @@ function buildOperatorCondition(
   if (operators.arrayContains !== undefined) {
     if (!dialect.supportsArrayOps) {
       throw new Error(
-        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite. ' +
-          'Use a different filter strategy or switch to Postgres.',
+        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres. ' +
+          'On SQLite, fetch with list() and filter in application code.',
       );
     }
     clauses.push(`${columnRef} @> ${dialect.param(idx + 1)}`);
@@ -275,8 +275,8 @@ function buildOperatorCondition(
   if (operators.arrayContainedBy !== undefined) {
     if (!dialect.supportsArrayOps) {
       throw new Error(
-        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite. ' +
-          'Use a different filter strategy or switch to Postgres.',
+        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres. ' +
+          'On SQLite, fetch with list() and filter in application code.',
       );
     }
     clauses.push(`${columnRef} <@ ${dialect.param(idx + 1)}`);
@@ -286,8 +286,8 @@ function buildOperatorCondition(
   if (operators.arrayOverlaps !== undefined) {
     if (!dialect.supportsArrayOps) {
       throw new Error(
-        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) are not supported on SQLite. ' +
-          'Use a different filter strategy or switch to Postgres.',
+        'Array operators (arrayContains, arrayContainedBy, arrayOverlaps) require dialect: postgres. ' +
+          'On SQLite, fetch with list() and filter in application code.',
       );
     }
     clauses.push(`${columnRef} && ${dialect.param(idx + 1)}`);

--- a/plans/2885-array-op-type-gating.md
+++ b/plans/2885-array-op-type-gating.md
@@ -1,0 +1,289 @@
+# `@vertz/db` — Array Operator Type Gating (`arrayContains`, `arrayContainedBy`, `arrayOverlaps`)
+
+**Issue:** [#2885](https://github.com/vertz-dev/vertz/issues/2885)
+**Status:** Design (single revision — small scope)
+**Builds on:** [#2850](https://github.com/vertz-dev/vertz/issues/2850) (TDialect thread + keyed-never brand mechanism), [#2868](https://github.com/vertz-dev/vertz/issues/2868) (JSONB typed operators — established brand pattern), [#2886](https://github.com/vertz-dev/vertz/issues/2886) (JSONB plural-key ops — same gating approach).
+
+## Context & Problem
+
+`packages/db/src/sql/where.ts:264-296` already emits `@>` / `<@` / `&&` on Postgres for the runtime operators `arrayContains` / `arrayContainedBy` / `arrayOverlaps`. The runtime gate (`dialect.supportsArrayOps`) throws on SQLite.
+
+**The type layer is silent.** `FilterType<TColumns, TDialect>` never mentions the three operators. `ColumnFilterOperators<TType, TNullable>` doesn't offer them. Calling `where: { tags: { arrayContains: [...] } }` on `d.textArray()` compiles (the value widens through the `ColumnFilterOperators` union branch) and throws at runtime on SQLite.
+
+The gap mirrors exactly what #2850 fixed for JSONB path filters and what #2868 extended for `jsonContains` / `hasKey`. Same brand mechanism, different column set.
+
+## Goals
+
+1. **Typed array operators** available on `d.textArray()`, `d.integerArray()`, and `d.vector(n)` columns.
+2. **Operand element type flows** from column metadata: `d.textArray() → readonly string[]`, `d.integerArray() → readonly number[]`, `d.vector(n) → readonly number[]`.
+3. **Dialect gating via brand.** On `dialect: 'postgres'`: typed operands. On `dialect: 'sqlite'`: resolve to a keyed-never brand whose name reads as the recovery sentence.
+4. **No runtime change.** SQL emission on Postgres is already correct; the runtime throw on SQLite remains as the backstop for widened-variable cases (same pattern as #2850 / #2868 call out).
+
+## Non-Goals
+
+- **Removing the runtime throw.** It stays — excess-property checks only fire on fresh literals, so the widened-dialect case (`const dialect: DialectName = ...`) still needs the runtime guard.
+- **Range / min-max array constraints.** Out of scope; `arrayContains` etc. are set-containment operators, not element-predicate filters.
+- **Postgres ANY / ALL / array-subscript.** Out of scope.
+- **Extending `arrayContains` to `d.jsonb<T[]>()` payloads.** JSONB arrays go through `jsonContains` (already typed). Array operators here are for native Postgres array columns only.
+- **Mixing dialect-conditional operand shapes on the same operator key.** Not a concern — these three keys exist nowhere else in the filter surface.
+
+## Unknowns
+
+None identified. The design is a direct mechanical application of the #2850 / #2868 / #2886 keyed-never brand pattern; the runtime code is unchanged. No POC required.
+
+## API Surface
+
+### 1. Column detection (internal)
+
+Array columns are identified by `sqlType`:
+
+```ts
+type IsArrayColumn<C> =
+  C extends ColumnBuilder<unknown, infer M>
+    ? M extends
+        | { readonly sqlType: 'text[]' }
+        | { readonly sqlType: 'integer[]' }
+        | { readonly sqlType: 'vector' }
+      ? true
+      : false
+    : false;
+```
+
+`d.bytea()` (sqlType `'bytea'`, inferred type `Uint8Array`) is deliberately excluded — it's a byte blob, not a typed element sequence.
+
+### 2. Element extraction (internal)
+
+```ts
+type ArrayElementOf<C> =
+  C extends ColumnBuilder<infer T, ColumnMetadata>
+    ? T extends readonly (infer U)[]
+      ? U
+      : never
+    : never;
+```
+
+Resolves to `string` / `number` for the three supported array column types.
+
+### 3. New brand (Postgres-only surface)
+
+```ts
+declare const __ArrayFilterBrand: unique symbol;
+
+export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported {
+  readonly [__ArrayFilterBrand]: 'array-filter-requires-postgres';
+}
+```
+
+Placed in a new file `packages/db/src/schema/array-filter-brand.ts` (mirrors the module boundary of `jsonb-filter-brand.ts`).
+
+### 4. `ArrayOperatorSlots<TElem, TDialect>`
+
+```ts
+export type ArrayOperatorSlots<TElem, TDialect extends DialectName> = TDialect extends 'postgres'
+  ? {
+      readonly arrayContains?: readonly TElem[];
+      readonly arrayContainedBy?: readonly TElem[];
+      readonly arrayOverlaps?: readonly TElem[];
+    }
+  : {
+      readonly arrayContains?: ArrayFilter_Error_…;
+      readonly arrayContainedBy?: ArrayFilter_Error_…;
+      readonly arrayOverlaps?: ArrayFilter_Error_…;
+    };
+```
+
+### 5. `FilterType` extension
+
+Current branching in `inference.ts:123-134`:
+
+```ts
+[K in keyof TColumns | JsonbPathKey<TColumns>]?: K extends keyof TColumns
+  ? IsJsonbColumn<TColumns[K]> extends true
+    ? JsonbColumnValue<InferColumnType<TColumns[K]>, TDialect>
+    :
+        | InferColumnType<TColumns[K]>
+        | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+  : JsonbPathValue<TDialect>;
+```
+
+New shape:
+
+```ts
+[K in keyof TColumns | JsonbPathKey<TColumns>]?: K extends keyof TColumns
+  ? IsJsonbColumn<TColumns[K]> extends true
+    ? JsonbColumnValue<InferColumnType<TColumns[K]>, TDialect>
+    : IsArrayColumn<TColumns[K]> extends true
+      ?
+          | InferColumnType<TColumns[K]>
+          | (ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>> &
+              ArrayOperatorSlots<ArrayElementOf<TColumns[K]>, TDialect>)
+      :
+          | InferColumnType<TColumns[K]>
+          | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+  : JsonbPathValue<TDialect>;
+```
+
+Array column value is the direct payload shorthand OR a composite operator object with **both** standard operators (`eq` / `ne` / `in` / `notIn` / `isNull` when nullable) **and** the three array operators. Intersection is safe — the key sets don't overlap.
+
+### 6. Example usage (Postgres)
+
+```ts
+const tagsTable = d.table('post', {
+  id: d.uuid().primary({ generate: 'uuid' }),
+  tags: d.textArray(),
+  ratings: d.integerArray(),
+  embedding: d.vector(1536),
+});
+
+// ✓ typed positives
+await pg.post.list({ where: { tags: { arrayContains: ['typescript'] } } });
+await pg.post.list({ where: { ratings: { arrayOverlaps: [5, 4] } } });
+await pg.post.list({ where: { embedding: { arrayContainedBy: [0.1, 0.2 /* … */] } } });
+
+// ✓ still works: direct equality, existing operators
+await pg.post.list({ where: { tags: ['typescript', 'rust'] } });
+await pg.post.list({ where: { tags: { eq: ['typescript'] } } });
+
+// ✗ operand element type is enforced
+await pg.post.list({
+  where: {
+    tags: {
+      // @ts-expect-error — number is not assignable to string
+      arrayContains: [42],
+    },
+  },
+});
+```
+
+### 7. Example — SQLite rejection
+
+```ts
+const sqliteTagsTable = /* same table */;
+const lite = createDb({ dialect: 'sqlite', path: ':memory:', models: { post: d.model(sqliteTagsTable) } });
+
+await lite.post.list({
+  where: {
+    tags: {
+      // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+      arrayContains: ['typescript'],
+    },
+  },
+});
+```
+
+The brand name appears verbatim in the TS diagnostic — the **type alias name IS the recovery sentence** (same convention as `JsonbPathFilter_Error_…` and `JsonbOperator_Error_…`).
+
+## Manifesto Alignment
+
+- **Type Safety Wins.** The runtime already rejects SQLite on these operators — moving the gate to the type layer means the error surfaces at build time instead of first-run.
+- **One Way to Do Things.** The brand mechanism is the established pattern for dialect-conditional operators (`JsonbPathFilter_Error_…`, `JsonbOperator_Error_…`). Adding a third (`ArrayFilter_Error_…`) is a mechanical extension of the same idiom — no new concept.
+- **Explicit over implicit.** Array-column filter shapes are now explicit in `FilterType` rather than being accidentally permitted by a wildcard `ColumnFilterOperators` union.
+
+Rejected alternative: **deriving array-ness from `InferColumnType<C> extends readonly U[]`**. This would also accept a hypothetical future `d.bytea()`-like column typed as `readonly number[]`. Using `sqlType` is narrower and aligns with how `IsJsonbColumn` already works.
+
+Rejected alternative: **making `ArrayOperatorSlots` a standalone union member in `FilterType`** (alongside the existing `InferColumnType<TColumns[K]> | ColumnFilterOperators<…>`). Intersection with `ColumnFilterOperators` composes better: users can write `{ eq: [...], arrayOverlaps: [...] }` in one object. A standalone branch would force an either/or.
+
+## Type Flow Map
+
+| Generic                         | Source                              | Flows to                                                   |
+| ------------------------------- | ----------------------------------- | ---------------------------------------------------------- |
+| `TDialect` (of `FilterType`)    | `createDb({ dialect })`             | `ArrayOperatorSlots<_, TDialect>` → brand-vs-typed branch |
+| `TColumns[K]` (column builder)  | `d.table({ tags: d.textArray() })`  | `IsArrayColumn`, `ArrayElementOf`                          |
+| `InferColumnType<TColumns[K]>`  | Column phantom type (`string[]`)    | Direct-payload shorthand slot                              |
+| `ArrayElementOf<TColumns[K]>`   | `string[]` → `string`                | Operand element of `arrayContains` etc.                    |
+
+Every generic terminates at a consumer. `TDialect` in particular now reaches array columns in addition to JSONB path and payload operators.
+
+## E2E Acceptance Test
+
+```ts
+// packages/db/src/client/__tests__/array-operators.test-d.ts (new)
+
+import { d } from '@vertz/db';
+import type { FilterType } from '@vertz/db/schema/inference';
+
+const post = d.table('post', {
+  id: d.uuid().primary({ generate: 'uuid' }),
+  tags: d.textArray(),
+  ratings: d.integerArray(),
+  embedding: d.vector(3),
+});
+
+type Cols = (typeof post)['_columns'];
+
+// Postgres: positives
+const pgContains: FilterType<Cols, 'postgres'> = {
+  tags: { arrayContains: ['typescript'] },
+};
+void pgContains;
+
+const pgIntOverlap: FilterType<Cols, 'postgres'> = {
+  ratings: { arrayOverlaps: [5, 4] },
+};
+void pgIntOverlap;
+
+const pgVectorContained: FilterType<Cols, 'postgres'> = {
+  embedding: { arrayContainedBy: [0.1, 0.2, 0.3] },
+};
+void pgVectorContained;
+
+// Postgres: element-type negatives
+const pgWrongElem: FilterType<Cols, 'postgres'> = {
+  tags: {
+    // @ts-expect-error — number is not assignable to string
+    arrayContains: [42],
+  },
+};
+void pgWrongElem;
+
+// Composition with existing ops (intersection)
+const pgMixed: FilterType<Cols, 'postgres'> = {
+  tags: { eq: ['a', 'b'], arrayOverlaps: ['c'] },
+};
+void pgMixed;
+
+// SQLite: brand diagnostic
+const liteContains: FilterType<Cols, 'sqlite'> = {
+  tags: {
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    arrayContains: ['typescript'],
+  },
+};
+void liteContains;
+
+const liteContainedBy: FilterType<Cols, 'sqlite'> = {
+  tags: {
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    arrayContainedBy: ['typescript'],
+  },
+};
+void liteContainedBy;
+
+const liteOverlaps: FilterType<Cols, 'sqlite'> = {
+  tags: {
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    arrayOverlaps: ['typescript'],
+  },
+};
+void liteOverlaps;
+
+// Direct value still works on SQLite
+const liteDirect: FilterType<Cols, 'sqlite'> = {
+  tags: ['typescript'],
+};
+void liteDirect;
+```
+
+And the runtime SQL emission is already covered by `packages/db/src/sql/__tests__/where.test.ts:361-377` — no new runtime tests required beyond confirming the existing assertions still pass.
+
+## Definition of Done
+
+- [ ] `IsArrayColumn`, `ArrayElementOf`, `ArrayOperatorSlots` defined
+- [ ] `ArrayFilter_Error_…` brand defined in its own module
+- [ ] `FilterType` routes array columns through the new branch
+- [ ] `.test-d.ts` coverage: positive Postgres (per element type), negative Postgres (wrong element), negative SQLite (brand), direct-value fallback, mixed-operator intersection
+- [ ] Existing runtime tests remain green (`where.test.ts`, `sqlite-builders.test.ts`)
+- [ ] Quality gates green (`vtz test && vtz run typecheck && vtz run lint` on `packages/db`)
+- [ ] Adversarial review in `reviews/2885-array-op-type-gating/phase-01-operators.md`
+- [ ] Changeset added under `.changeset/`
+- [ ] PR to `main` opened; CI green

--- a/plans/2885-array-op-type-gating.md
+++ b/plans/2885-array-op-type-gating.md
@@ -69,7 +69,7 @@ Resolves to `string` / `number` for the three supported array column types.
 ```ts
 declare const __ArrayFilterBrand: unique symbol;
 
-export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported {
+export interface ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS {
   readonly [__ArrayFilterBrand]: 'array-filter-requires-postgres';
 }
 ```
@@ -106,7 +106,7 @@ Current branching in `inference.ts:123-134`:
   : JsonbPathValue<TDialect>;
 ```
 
-New shape:
+New shape — a **3-way union** for the array-column branch:
 
 ```ts
 [K in keyof TColumns | JsonbPathKey<TColumns>]?: K extends keyof TColumns
@@ -115,15 +115,15 @@ New shape:
     : IsArrayColumn<TColumns[K]> extends true
       ?
           | InferColumnType<TColumns[K]>
-          | (ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>> &
-              ArrayOperatorSlots<ArrayElementOf<TColumns[K]>, TDialect>)
+          | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
+          | ArrayOperatorSlots<ArrayElementOf<TColumns[K]>, TDialect>
       :
           | InferColumnType<TColumns[K]>
           | ColumnFilterOperators<InferColumnType<TColumns[K]>, IsNullable<TColumns[K]>>
   : JsonbPathValue<TDialect>;
 ```
 
-Array column value is the direct payload shorthand OR a composite operator object with **both** standard operators (`eq` / `ne` / `in` / `notIn` / `isNull` when nullable) **and** the three array operators. Intersection is safe — the key sets don't overlap.
+The array column value is the direct payload shorthand OR `ColumnFilterOperators` (eq / ne / in / notIn / isNull-when-nullable) OR `ArrayOperatorSlots` (arrayContains / arrayContainedBy / arrayOverlaps). TypeScript's union contextual typing is still permissive enough to accept a mixed literal (`{ eq: [...], arrayOverlaps: [...] }`) — excess-property checking across union arms is not strict when every arm's properties are optional — and the runtime processes every recognized operator key as an AND of clauses, so mixing works end-to-end.
 
 ### 6. Example usage (Postgres)
 
@@ -164,7 +164,7 @@ const lite = createDb({ dialect: 'sqlite', path: ':memory:', models: { post: d.m
 await lite.post.list({
   where: {
     tags: {
-      // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+      // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
       arrayContains: ['typescript'],
     },
   },
@@ -181,16 +181,16 @@ The brand name appears verbatim in the TS diagnostic — the **type alias name I
 
 Rejected alternative: **deriving array-ness from `InferColumnType<C> extends readonly U[]`**. This would also accept a hypothetical future `d.bytea()`-like column typed as `readonly number[]`. Using `sqlType` is narrower and aligns with how `IsJsonbColumn` already works.
 
-Rejected alternative: **making `ArrayOperatorSlots` a standalone union member in `FilterType`** (alongside the existing `InferColumnType<TColumns[K]> | ColumnFilterOperators<…>`). Intersection with `ColumnFilterOperators` composes better: users can write `{ eq: [...], arrayOverlaps: [...] }` in one object. A standalone branch would force an either/or.
+Rejected alternative: **intersection arm (`ColumnFilterOperators & ArrayOperatorSlots`) as a single non-direct union member.** Empirically, TypeScript reports operand-element mismatches at the outer-level property (`TS2322` on `tags: { arrayContains: [42] }` as a whole, not on the inner `arrayContains:` line) for _both_ the intersection form and the 3-way union form — neither enables inner-line `@ts-expect-error` placement. The 3-way union ships because it's slightly easier to read and it keeps each semantic cluster (direct payload / standard ops / array ops) as its own named arm, which matches how JSONB already models `JsonbColumnValue<T, TDialect>` — same precedent, same shape. Both forms accept a mixed-ops literal (`{ eq: [...], arrayOverlaps: [...] }`); the runtime processes such a literal as an AND of clauses, which is correct.
 
 ## Type Flow Map
 
-| Generic                         | Source                              | Flows to                                                   |
-| ------------------------------- | ----------------------------------- | ---------------------------------------------------------- |
-| `TDialect` (of `FilterType`)    | `createDb({ dialect })`             | `ArrayOperatorSlots<_, TDialect>` → brand-vs-typed branch |
-| `TColumns[K]` (column builder)  | `d.table({ tags: d.textArray() })`  | `IsArrayColumn`, `ArrayElementOf`                          |
-| `InferColumnType<TColumns[K]>`  | Column phantom type (`string[]`)    | Direct-payload shorthand slot                              |
-| `ArrayElementOf<TColumns[K]>`   | `string[]` → `string`                | Operand element of `arrayContains` etc.                    |
+| Generic                        | Source                             | Flows to                                                  |
+| ------------------------------ | ---------------------------------- | --------------------------------------------------------- |
+| `TDialect` (of `FilterType`)   | `createDb({ dialect })`            | `ArrayOperatorSlots<_, TDialect>` → brand-vs-typed branch |
+| `TColumns[K]` (column builder) | `d.table({ tags: d.textArray() })` | `IsArrayColumn`, `ArrayElementOf`                         |
+| `InferColumnType<TColumns[K]>` | Column phantom type (`string[]`)   | Direct-payload shorthand slot                             |
+| `ArrayElementOf<TColumns[K]>`  | `string[]` → `string`              | Operand element of `arrayContains` etc.                   |
 
 Every generic terminates at a consumer. `TDialect` in particular now reaches array columns in addition to JSONB path and payload operators.
 
@@ -245,7 +245,7 @@ void pgMixed;
 // SQLite: brand diagnostic
 const liteContains: FilterType<Cols, 'sqlite'> = {
   tags: {
-    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
     arrayContains: ['typescript'],
   },
 };
@@ -253,7 +253,7 @@ void liteContains;
 
 const liteContainedBy: FilterType<Cols, 'sqlite'> = {
   tags: {
-    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
     arrayContainedBy: ['typescript'],
   },
 };
@@ -261,7 +261,7 @@ void liteContainedBy;
 
 const liteOverlaps: FilterType<Cols, 'sqlite'> = {
   tags: {
-    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported
+    // @ts-expect-error — ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
     arrayOverlaps: ['typescript'],
   },
 };

--- a/reviews/2885-array-op-type-gating/phase-01-operators.md
+++ b/reviews/2885-array-op-type-gating/phase-01-operators.md
@@ -1,0 +1,162 @@
+# Phase 1: arrayContains / arrayContainedBy / arrayOverlaps type gating
+
+- **Author:** vertz-tech-lead bot (commit `83247f814`)
+- **Reviewer:** adversarial-review bot (Opus 4.7 1M)
+- **Commits:** `83247f814` (single commit)
+- **Date:** 2026-04-21
+
+## Changes
+
+- `packages/db/src/schema/inference.ts` (modified) — adds `IsArrayColumn`, `ArrayElementOf`, `ArrayOperatorSlots`; routes array columns through a 3-way union branch in `FilterType`.
+- `packages/db/src/schema/array-filter-brand.ts` (new) — keyed-never brand interface.
+- `packages/db/src/client/__tests__/array-operators.test-d.ts` (new) — type tests for the new surface.
+- `plans/2885-array-op-type-gating.md` (new) — design doc.
+
+## CI Status
+
+- [x] Reviewer ran `npx tsc --noEmit -p packages/db/tsconfig.typecheck.json` — clean (only pre-existing `postgres-integration.local.ts` noise, unrelated).
+- [ ] `vtz test` not run by reviewer (no runtime change; existing `where.test.ts` / `sqlite-builders.test.ts` suites cover the SQL emission and throw path).
+
+## Review Checklist
+
+- [x] Delivers what the ticket asks for — typed `arrayContains` / `arrayContainedBy` / `arrayOverlaps` with brand gating on SQLite, per-element-type operand enforcement, routes through `FilterType`.
+- [x] TDD compliance — type tests include positives per column type, negatives for wrong element types, brand negatives per operator, nullable `isNull` retention, direct-value shorthand, end-to-end via `createDb()`.
+- [x] No type gaps on the happy path — reviewer empirically verified `IsArrayColumn` matches only the three supported sqlTypes; `ArrayElementOf` extracts correct element types; the nested-include path (`include.posts.where`) correctly propagates the gate; `jsonb<string[]>()` does NOT spuriously match the array branch.
+- [x] No security issues — pure type surface, no new runtime/binding path.
+- [ ] Public API changes match design doc — **deviates silently**; see F-1.
+
+## Findings
+
+### Changes Requested
+
+#### F-1 — SHOULD-FIX — Design doc promises intersection, implementation ships a 3-way union
+
+The design doc at `plans/2885-array-op-type-gating.md:117-119` specifies the new `FilterType` branch as:
+
+```ts
+| InferColumnType<TColumns[K]>
+| (ColumnFilterOperators<...> & ArrayOperatorSlots<...>)
+```
+
+And explicitly rejects the standalone-union alternative at line 184:
+> _"Rejected alternative: making `ArrayOperatorSlots` a standalone union member in `FilterType` ... Intersection with `ColumnFilterOperators` composes better: users can write `{ eq: [...], arrayOverlaps: [...] }` in one object. A standalone branch would force an either/or."_
+
+The shipped code at `packages/db/src/schema/inference.ts:186-189` is the rejected alternative:
+
+```ts
+| InferColumnType<TColumns[K]>
+| ColumnFilterOperators<...>
+| ArrayOperatorSlots<...>
+```
+
+The test file acknowledges the switch in a comment at `array-operators.test-d.ts:96-101` and the commit message hints at it (_"The 3-way union ... is what keeps element-type errors narrow per property"_), but the design doc was **not updated** to reflect the decision reversal.
+
+Two concerns:
+
+1. **The design doc's justification for rejecting union is now wrong.** It claimed union "would force an either/or." Empirically that is false — TS's union contextual typing accepts `{ eq: [...], arrayOverlaps: [...] }` on the union form (confirmed by `pgMixedOps` passing in the test file). The real reason to choose union was different — something about per-property diagnostic narrowing — and the design doc needs to state it correctly.
+2. **Reviewer double-checked intersection vs union for element-type errors empirically.** Both forms fire `TS2322: Type 'number' is not assignable to type 'string'` for `arrayContains: [42]` on a `string[]` column. The "keeps element-type errors narrow" claim is plausible but under-specified — what concrete case does intersection handle worse than union? If the answer is "none," the design-doc reversal is cosmetic and the union is fine. If the answer is a specific case, the test file should assert it.
+
+**Recommended fix:** Update `plans/2885-array-op-type-gating.md` to (a) reflect the shipped 3-way union shape in section 5, (b) flip the "Rejected alternative" at line 184 to instead reject the intersection form, with the concrete reason, (c) add one sentence to the PR description calling out the deviation. If no concrete reason exists, either revert to intersection (matches the design doc as sold) or document that the choice is DX-neutral.
+
+Cite: `plans/2885-array-op-type-gating.md:117-119,184`; `packages/db/src/schema/inference.ts:186-189`; `packages/db/src/client/__tests__/array-operators.test-d.ts:96-105`.
+
+---
+
+#### F-2 — SHOULD-FIX — Brand name does not give actionable recovery
+
+The convention established in #2850 and #2868 is that "the alias name IS the recovery sentence":
+
+- `JsonbPathFilter_Error_Requires_Dialect_Postgres_On_SQLite_Use_list_And_Filter_In_JS` — tells you the recovery.
+- `JsonbOperator_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` — tells you the recovery.
+
+New brand: `ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Not_Supported` — says "not supported" and stops. No recovery guidance is encoded.
+
+The runtime throw in `packages/db/src/sql/where.ts:267-269` says _"Use a different filter strategy or switch to Postgres"_ — which is also vague. Contrast the `hasAllKeys` SQLite throw resolution in #2886 F-6 which called out the in-framework composition workaround.
+
+There IS a natural recovery: fetch with `list()` and filter in application code (same as JSONB). So the brand should read:
+
+```
+ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS
+```
+
+Matching the JSONB convention, and the runtime throw message should be updated to the same guidance (and tested in `sqlite-builders.test.ts`). Today the brand and the runtime message are both vague, which is a DX regression relative to #2850/#2868.
+
+This is a **rename + one-line runtime message update** — small change, but affects the public brand name which is exactly what gets quoted into the LLM retrieval surface per the "alias name IS the recovery sentence" rationale at `packages/db/src/schema/jsonb-filter-brand.ts:1-11`.
+
+Cite: `packages/db/src/schema/array-filter-brand.ts:21`; `packages/db/src/sql/where.ts:267-269,278-280,289-291`; `packages/db/src/sql/__tests__/sqlite-builders.test.ts:237,245,253`.
+
+---
+
+#### F-3 — SHOULD-FIX — No changeset under `.changeset/`
+
+The design doc's own Definition of Done at `plans/2885-array-op-type-gating.md:288` lists _"Changeset added under `.changeset/`"_. No changeset file was added in this commit. Compare to `.changeset/jsonb-plural-key-ops-2886.md` which landed with the parent #2886 PR.
+
+Add `.changeset/array-op-type-gating-2885.md` (patch — per `.claude/rules/policies.md` _"Every changeset = `patch`"_).
+
+---
+
+### Nits
+
+#### F-4 — NIT — Test file is missing the combined-operator param-index sanity case
+
+Pre-existing parallel with #2886 review F-3: the new operator keys all live in the same `buildOperatorCondition` chain (`where.ts:264-296`) and each bumps `idx` independently. There's no runtime test asserting that `tags: { arrayContains: [...], arrayOverlaps: [...] }` produces `$1`/`$2` correctly (type layer now permits mixing these on Postgres per the union decision in F-1). If the current `where.test.ts` doesn't exercise this already for array ops, one 3-line unit test closes the gap — completely analogous to what #2886 resolution F-3 added for `hasAllKeys`/`hasAnyKey`.
+
+This is a NIT because the code obviously looks correct and each operator was tested in isolation when array-ops first landed; but the PR actively promotes mixing (union comment at `array-operators.test-d.ts:96-101`), so the mixed case deserves a unit test.
+
+Cite: `packages/db/src/sql/where.ts:264-296`; `packages/db/src/sql/__tests__/where.test.ts` (no combined array-op test at time of review).
+
+---
+
+#### F-5 — NIT — Dialect branch of `ArrayOperatorSlots` repeats the brand three times — opportunity to DRY (also called out in #2886 F-7)
+
+`packages/db/src/schema/inference.ts:150-154` spells the brand three times. `packages/db/src/schema/path-chain.ts:75-81` spelled it five times. This is fine for now, but a small helper would reduce the visual noise as the surface grows:
+
+```ts
+type GatedOps<K extends string, B> = { readonly [P in K]?: B };
+```
+
+Not blocking; cosmetic. Same comment as #2886 F-7 — worth a small follow-up refactor once the pattern appears three times.
+
+---
+
+#### F-6 — NIT — `pgPlainNoArrayOps` test asserts ONE operator, not all three
+
+`array-operators.test-d.ts:140-144` checks that `name: { arrayContains: ['a'] }` is rejected on a `d.text()` column. The check is valid, but it only exercises `arrayContains`. If a future refactor accidentally loosened one of the three slots (e.g., moved `arrayOverlaps` to `ColumnFilterOperators`), the current test would miss it. A three-operator sweep (`arrayContains` / `arrayContainedBy` / `arrayOverlaps`) on `name: d.text()` AND `count: d.integer()` would close the gap.
+
+Same critique applies to the `pgPlainNoArrayOps` absence on `d.integer()` — the negative is only tested on `d.text()`.
+
+Cite: `packages/db/src/client/__tests__/array-operators.test-d.ts:133-144`.
+
+---
+
+#### F-7 — NIT — Design doc's Type Flow Map omits `TDialect → ArrayOperatorSlots → brand` reverse flow
+
+The Type Flow Map at `plans/2885-array-op-type-gating.md:188-194` lists how TDialect flows but does not trace which diagnostic the user sees on the SQLite branch. The JSONB design docs added a "Diagnostic Shape" sub-section after the Type Flow Map. Consider adding a two-line snippet showing the actual TS2322 output (as reviewer captured empirically: `Type '{ arrayContains: string[]; }' is not assignable to type 'string[] | { readonly arrayContains?: ArrayFilter_Error_... ; ... } | ...'`).
+
+This is mainly documentation polish and aligns the doc with how #2850/#2868 captured the error shape. Not blocking.
+
+---
+
+## What is NOT a finding (explicitly considered and dismissed)
+
+- **`IsArrayColumn` matching by `sqlType` vs by inferred TS type.** Correct choice. `d.bytea()` inferred as `Uint8Array` wouldn't match `readonly U[]` anyway, but the explicit `sqlType`-based narrowing matches the existing `IsJsonbColumn` pattern and is the right precedent.
+- **Readonly vs mutable operand.** `readonly TElem[]` accepts both `string[]` and `readonly string[] as const` — verified by `pgTextAsConst` test and empirically by reviewer.
+- **Vector dimension not enforced on operand length.** Same semantics as the pre-existing runtime — `d.vector(3)` accepts an operand of any length. Future work if needed, not a regression.
+- **Widened-dialect case (`const d: DialectName = ...`).** The runtime throw at `where.ts:264-296` remains the backstop per the design doc and `array-filter-brand.ts:14-17` — intentional, not a gap.
+- **`isNull` on nullable array columns.** Verified: `labels: d.textArray().nullable()` still accepts `{ isNull: true }`; non-nullable `tags` correctly rejects it. The union + `ColumnFilterOperators` + nullable gating composes correctly.
+- **Nested `include.where` propagates the gate.** Empirically verified via a probe script — `user.list({ include: { posts: { where: { tags: { arrayContains: [...] } } } } })` fires the brand on SQLite.
+- **`jsonb<string[]>()` does not accidentally match `IsArrayColumn`.** Verified — routed through the JSONB branch; `arrayContains` is rejected as an unknown operator. `IsJsonbColumn` fires first in the conditional chain.
+- **`ArrayElementOf<ColumnBuilder<string[], _>>`.** Returns `string` — verified; `number[]` → `number` for integer arrays and vectors.
+- **`@ts-expect-error` placement.** TS reports wrong-element errors on the OUTER property (`tags:` line) for array columns but on the INNER operator (`arrayContains:` line) for non-array columns. The test file places `@ts-expect-error` on the line immediately above the property assignment, which works for both cases (the directive suppresses any error on the next non-comment line). Verified empirically — no unused-directive errors when typecheck runs.
+- **Compile-time cost.** The new conditional branch adds ~40% work to `FilterType[K]` resolution for columns that ARE array columns. Negligible; no instantiation-depth issue given `IsArrayColumn` is a shallow distributive conditional.
+- **Intersection-vs-union contextual typing on `pgMixedOps`.** Both forms accept `{ eq: [...], arrayOverlaps: [...] }`. See F-1 for why this matters for the design doc text.
+
+## Resolution
+
+No blockers; three SHOULD-FIX items recommended before PR:
+
+- **F-1** — Update design doc to reflect the shipped union shape + flip "Rejected alternative" with a concrete reason (or revert to intersection). At minimum, mention the deviation in the PR description.
+- **F-2** — Rename brand to `ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` and update the runtime throw message symmetrically. This is the **public diagnostic surface** — pre-v1 policy in `.claude/rules/policies.md` says consolidate aggressively, and the three brands should match their convention.
+- **F-3** — Add `.changeset/array-op-type-gating-2885.md` (patch).
+
+Nits (F-4 through F-7) can be deferred as follow-ups; none block the PR.


### PR DESCRIPTION
## Summary

Closes #2885.

- Adds `arrayContains` / `arrayContainedBy` / `arrayOverlaps` to `FilterType`'s column-value branch for `d.textArray()`, `d.integerArray()`, and `d.vector(n)`.
- Operand element type flows from column metadata: `d.textArray() → readonly string[]`, `d.integerArray() → readonly number[]`, `d.vector(n) → readonly number[]`.
- Dialect-gated to Postgres via a new keyed-never brand (`ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS`) — the alias name IS the recovery sentence, same convention as the JSONB brands from #2850 / #2868.
- No runtime change — SQL emission is already correct. Runtime throw message updated symmetrically with the JSONB wording (`"require dialect: postgres. On SQLite, fetch with list() and filter in application code."`).

## Public API Changes

- **Added:** typed array operators in `FilterType<TColumns, 'postgres'>` for the three supported array column types.
- **Added:** `ArrayFilter_Error_Requires_Dialect_Postgres_On_SQLite_Fetch_And_Filter_In_JS` brand interface (exposed via `@vertz/db`'s dist but not intended for direct construction — it only appears in TS diagnostics).
- **Changed:** runtime throw message on SQLite for array operators now reads `"Array operators ... require dialect: postgres. On SQLite, fetch with list() and filter in application code."` (was: `"are not supported on SQLite. Use a different filter strategy or switch to Postgres."`). The brand name change is user-visible in TS error diagnostics.
- **No breaking changes.** Users who call the array operators today on Postgres see no behavioral change; SQLite users who were hitting the runtime throw get the same failure mode plus a compile-time error with a more actionable message. Users with custom helpers over `FilterType<TColumns>` may need to thread `TDialect` (same guidance as #2850).

## Phase summary

Single phase — small scope. Implementation: one new brand module, one new conditional branch in `FilterType`, one new `.test-d.ts`. Runtime unchanged.

- Design: [plans/2885-array-op-type-gating.md](https://github.com/vertz-dev/vertz/blob/fix/2885-array-op-type-gating/plans/2885-array-op-type-gating.md)
- Review: [reviews/2885-array-op-type-gating/phase-01-operators.md](https://github.com/vertz-dev/vertz/blob/fix/2885-array-op-type-gating/reviews/2885-array-op-type-gating/phase-01-operators.md) — 3 SHOULD-FIX addressed (design-doc honesty, brand rename, changeset); 4 NITs deferred.

## Test plan

- [x] `vtz test` in `packages/db` — 1792 passed, 1 skipped (type-check ✓, runtime ✓).
- [x] `tsgo --noEmit -p tsconfig.typecheck.json` — clean.
- [x] `oxlint` on changed files — no new warnings.
- [x] `oxfmt --check` — clean.
- [x] Type tests cover: positive per operand element type (`string` / `number` arrays + vector), element-type negatives, SQLite brand diagnostic per operator, nullable array column `isNull` retention, non-array column rejection, end-to-end via `createDb().list()` and `createDb().aggregate()`.
- [x] Runtime emission unchanged — existing `where.test.ts:361-377` assertions still pass for `@>` / `<@` / `&&`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)