### PR TITLE
fix(ui-primitives): resolve no-narrowing-let warning in calendar-composed [#2802]

### DIFF
--- a/packages/ui-primitives/src/calendar/calendar-composed.tsx
+++ b/packages/ui-primitives/src/calendar/calendar-composed.tsx
@@ -255,11 +255,7 @@ function ComposedCalendarRoot({
 
   // Reactive state — compiler transforms `let` to signals
   let displayMonth = defaultMonthProp ?? now;
-  let value: Date | Date[] | { from: Date; to: Date } | null = (defaultValue ?? null) as
-    | Date
-    | Date[]
-    | { from: Date; to: Date }
-    | null;
+  let value: CalendarValue = (defaultValue ?? null) as CalendarValue;
 
   // Day headers (static — depends on weekStartsOn which is a prop, not reactive)
   const dayHeaders = Array.from({ length: 7 }, (_, i) => DAY_NAMES[(weekStartsOn + i) % 7] ?? '');


### PR DESCRIPTION
## Summary

Resolves the final remaining `no-narrowing-let` warning from #2802.

- Other 26 occurrences across the 14 files listed in the issue were already fixed by prior PRs (#2779 and follow-ups).
- The last one was in `packages/ui-primitives/src/calendar/calendar-composed.tsx:258`.

## Why the mechanical autofix didn't work here

The rule's self-fire guard compares the text of `node.init.typeAnnotation` to the text of the declared annotation. The existing code had both written in a multiline `| Date | Date[] | ... | null` form, but the declared annotation was on one line — textually different, so the guard failed.

Running `oxlint --fix` then appended a second `as T` that oxfmt re-wrapped to multiline, looping forever.

## Fix

Use the existing `CalendarValue` type alias (already defined at line 178) for both the annotation and the cast. `CalendarValue` is short, identical text on both sides, and survives oxfmt wrapping — the guard now matches and the warning is silenced.

## Public API Changes

None. Internal refactor of a `let` declaration in one component.

## Test plan

- [x] `vtz run lint 2>&1 | grep -c no-narrowing-let` returns `0`
- [x] `tsgo --noEmit` passes in `packages/ui-primitives`
- [x] No new test failures in `packages/ui-primitives` (36 pre-existing happy-dom `replaceChildren` failures remain, unrelated)
- [x] Diff is minimal: 1 insertion, 5 deletions

Closes #2802

🤖 Generated with [Claude Code](https://claude.com/claude-code)