### PR TITLE
fix(vtz): populate module graph in test watch mode [#2765]

### DIFF
--- a/native/vtz/src/test/watch.rs
+++ b/native/vtz/src/test/watch.rs
@@ -12,6 +12,58 @@ use super::executor::{execute_test_file_with_options, ExecuteOptions};
 use super::reporter::terminal::format_results_with_wall_clock;
 use super::runner::{TestRunConfig, TestRunResult};
 
+/// Recursively scan a file's local imports and record every discovered edge
+/// in the module graph. Used to seed the graph before the watch loop starts,
+/// so a later change to a source file deep in the import tree maps back to
+/// the test file(s) that transitively depend on it.
+///
+/// Paths are canonicalized to match the paths that `FileChange` events carry
+/// (which come from the OS watcher and are already canonicalized).
+pub(crate) fn populate_graph_from_entry(
+    entry_path: &Path,
+    graph: &mut ModuleGraph,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let canonical = match entry_path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if !visited.insert(canonical.clone()) {
+        return;
+    }
+
+    let source = match std::fs::read_to_string(&canonical) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let deps = crate::deps::scanner::scan_local_dependencies(&source, &canonical);
+    graph.update_module(&canonical, deps.clone());
+
+    for dep in deps {
+        populate_graph_from_entry(&dep, graph, visited);
+    }
+}
+
+/// Apply a file-change event to the module graph.
+///
+/// - `Modify`/`Create`: re-scan the file's local imports and update its edges.
+/// - `Remove`: remove the node and its reverse edges so deleted files don't
+///   leave ghost entries (matches the dev-server behavior introduced in #2764).
+pub(crate) fn update_graph_for_change(change: &FileChange, graph: &mut ModuleGraph) {
+    match change.kind {
+        FileChangeKind::Remove => {
+            graph.remove_module(&change.path);
+        }
+        FileChangeKind::Create | FileChangeKind::Modify => {
+            if let Ok(source) = std::fs::read_to_string(&change.path) {
+                let deps = crate::deps::scanner::scan_local_dependencies(&source, &change.path);
+                graph.update_module(&change.path, deps);
+            }
+        }
+    }
+}
+
 /// Determine which test files need to be re-run after a file change.
 ///
 /// - If the changed file is itself a test file, re-run only that file.
@@ -185,7 +237,16 @@ pub async fn run_watch_mode(config: TestRunConfig) -> Result<(), String> {
         .map_err(|e| format!("Failed to start file watcher: {}", e))?;
 
     let mut debouncer = Debouncer::new(100);
-    let graph = ModuleGraph::new();
+    let mut graph = ModuleGraph::new();
+
+    // Seed the module graph by recursively scanning each test file's local
+    // imports. Without this, `affected_test_files` always hits the
+    // `dependents.is_empty()` fallback on the first change and re-runs the
+    // full suite — defeating the whole point of per-file targeting. (#2765)
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    for test_file in &all_test_files {
+        populate_graph_from_entry(test_file, &mut graph, &mut visited);
+    }
 
     eprintln!("\nWatching for changes...\n");
 
@@ -206,6 +267,18 @@ pub async fn run_watch_mode(config: TestRunConfig) -> Result<(), String> {
                         &exclude,
                         DiscoveryMode::Unit,
                     );
+
+                    // Keep the module graph in sync with the filesystem before
+                    // computing the affected set, so renamed imports and
+                    // deletions don't leave ghost edges. (#2765 / #2764)
+                    for change in &changes {
+                        update_graph_for_change(change, &mut graph);
+                    }
+                    // Seed newly discovered test files so their deps become
+                    // part of the graph on the very next change.
+                    for test_file in &current_test_files {
+                        populate_graph_from_entry(test_file, &mut graph, &mut visited);
+                    }
 
                     let files_to_run = affected_test_files(&changes, &current_test_files, &graph);
 
@@ -534,5 +607,108 @@ mod tests {
 
         assert_eq!(affected.len(), 1);
         assert_eq!(affected[0], PathBuf::from("/src/a.test.ts"));
+    }
+
+    #[test]
+    fn test_populate_graph_from_entry_records_direct_and_transitive_deps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let utils_path = root.join("utils.ts");
+        std::fs::write(&utils_path, "export const x = 1;\n").unwrap();
+
+        let helper_path = root.join("helper.ts");
+        std::fs::write(
+            &helper_path,
+            "import { x } from './utils';\nexport const y = x;\n",
+        )
+        .unwrap();
+
+        let test_path = root.join("a.test.ts");
+        std::fs::write(&test_path, "import { y } from './helper';\n").unwrap();
+
+        let canonical_test = test_path.canonicalize().unwrap();
+        let canonical_helper = helper_path.canonicalize().unwrap();
+        let canonical_utils = utils_path.canonicalize().unwrap();
+
+        let mut graph = ModuleGraph::new();
+        let mut visited = HashSet::new();
+        populate_graph_from_entry(&test_path, &mut graph, &mut visited);
+
+        // Direct edge: test → helper
+        assert!(graph
+            .get_dependencies(&canonical_test)
+            .contains(&canonical_helper));
+        // Transitive edge: helper → utils (recorded because we recurse)
+        assert!(graph
+            .get_dependencies(&canonical_helper)
+            .contains(&canonical_utils));
+        // Reverse: changing utils must reach the test file through transitive dependents
+        let transitive = graph.get_transitive_dependents(&canonical_utils);
+        assert!(transitive.contains(&canonical_test));
+    }
+
+    #[test]
+    fn test_update_graph_for_change_modify_scans_and_updates_edges() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let dep_path = root.join("dep.ts");
+        std::fs::write(&dep_path, "export const x = 1;\n").unwrap();
+        let file_path = root.join("src.ts");
+        std::fs::write(&file_path, "import { x } from './dep';\n").unwrap();
+
+        let canonical_file = file_path.canonicalize().unwrap();
+        let canonical_dep = dep_path.canonicalize().unwrap();
+
+        let mut graph = ModuleGraph::new();
+        let change = FileChange {
+            kind: FileChangeKind::Modify,
+            path: canonical_file.clone(),
+        };
+        update_graph_for_change(&change, &mut graph);
+
+        assert!(graph
+            .get_dependencies(&canonical_file)
+            .contains(&canonical_dep));
+        assert!(graph
+            .get_dependents(&canonical_dep)
+            .contains(&canonical_file));
+    }
+
+    #[test]
+    fn test_update_graph_for_change_remove_cleans_ghost_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let dep_path = root.join("dep.ts");
+        std::fs::write(&dep_path, "export const x = 1;\n").unwrap();
+        let file_path = root.join("src.ts");
+        std::fs::write(&file_path, "import { x } from './dep';\n").unwrap();
+
+        let canonical_file = file_path.canonicalize().unwrap();
+        let canonical_dep = dep_path.canonicalize().unwrap();
+
+        let mut graph = ModuleGraph::new();
+        let mut visited = HashSet::new();
+        populate_graph_from_entry(&file_path, &mut graph, &mut visited);
+        assert!(graph.has_module(&canonical_file));
+
+        let change = FileChange {
+            kind: FileChangeKind::Remove,
+            path: canonical_file.clone(),
+        };
+        update_graph_for_change(&change, &mut graph);
+
+        assert!(
+            !graph.has_module(&canonical_file),
+            "removed file must not leave a ghost node"
+        );
+        assert!(
+            !graph
+                .get_dependents(&canonical_dep)
+                .contains(&canonical_file),
+            "reverse edge from dep → removed file must be cleaned"
+        );
     }
 }

--- a/native/vtz/src/test/watch.rs
+++ b/native/vtz/src/test/watch.rs
@@ -12,22 +12,38 @@ use super::executor::{execute_test_file_with_options, ExecuteOptions};
 use super::reporter::terminal::format_results_with_wall_clock;
 use super::runner::{TestRunConfig, TestRunResult};
 
+/// Best-effort canonicalization: returns the canonical form when available,
+/// otherwise the input path (e.g. for files that no longer exist on disk).
+///
+/// Paths from `walkdir` (used by `discover_test_files`) and paths from the
+/// OS file watcher can disagree on canonicalization — notably, macOS fsevent
+/// normalizes its events through `realpath` (so `/tmp/...` arrives as
+/// `/private/tmp/...`), while Linux inotify keeps paths as-registered and
+/// `walkdir` doesn't canonicalize either. Running every path through this
+/// helper before it enters the module graph or the test-file set keeps
+/// both sides of the eventual `contains()` / `get_transitive_dependents()`
+/// lookups in the same shape.
+pub(crate) fn canonicalize_or_same(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Recursively scan a file's local imports and record every discovered edge
 /// in the module graph. Used to seed the graph before the watch loop starts,
 /// so a later change to a source file deep in the import tree maps back to
 /// the test file(s) that transitively depend on it.
 ///
-/// Paths are canonicalized to match the paths that `FileChange` events carry
-/// (which come from the OS watcher and are already canonicalized).
+/// Paths are canonicalized internally so the graph's keys match the
+/// canonicalized paths that `run_watch_mode` feeds into `affected_test_files`.
+/// Callers may pass either canonical or non-canonical entry paths.
 pub(crate) fn populate_graph_from_entry(
     entry_path: &Path,
     graph: &mut ModuleGraph,
     visited: &mut HashSet<PathBuf>,
 ) {
-    let canonical = match entry_path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return,
-    };
+    let canonical = canonicalize_or_same(entry_path);
+    // If the file doesn't resolve to anything readable, skip — the canonical
+    // fallback returns the input verbatim, and `read_to_string` below will
+    // reject it cleanly.
     if !visited.insert(canonical.clone()) {
         return;
     }
@@ -50,15 +66,22 @@ pub(crate) fn populate_graph_from_entry(
 /// - `Modify`/`Create`: re-scan the file's local imports and update its edges.
 /// - `Remove`: remove the node and its reverse edges so deleted files don't
 ///   leave ghost entries (matches the dev-server behavior introduced in #2764).
+///
+/// This only re-scans the file named by `change`. If the file is a newly
+/// created intermediate (a source file in the middle of a chain a test file
+/// imports), the reverse edge from the test file to it won't exist until
+/// the test file itself is re-scanned — a `Modify` to the test file, or the
+/// next `run_watch_mode` startup, will heal the edge.
 pub(crate) fn update_graph_for_change(change: &FileChange, graph: &mut ModuleGraph) {
+    let path = canonicalize_or_same(&change.path);
     match change.kind {
         FileChangeKind::Remove => {
-            graph.remove_module(&change.path);
+            graph.remove_module(&path);
         }
         FileChangeKind::Create | FileChangeKind::Modify => {
-            if let Ok(source) = std::fs::read_to_string(&change.path) {
-                let deps = crate::deps::scanner::scan_local_dependencies(&source, &change.path);
-                graph.update_module(&change.path, deps);
+            if let Ok(source) = std::fs::read_to_string(&path) {
+                let deps = crate::deps::scanner::scan_local_dependencies(&source, &path);
+                graph.update_module(&path, deps);
             }
         }
     }
@@ -193,13 +216,16 @@ pub async fn run_watch_mode(config: TestRunConfig) -> Result<(), String> {
     });
 
     // Initial run
-    let all_test_files = discover_test_files(
+    let all_test_files: Vec<PathBuf> = discover_test_files(
         &config.root_dir,
         &paths,
         &include,
         &exclude,
         DiscoveryMode::Unit,
-    );
+    )
+    .into_iter()
+    .map(|p| canonicalize_or_same(&p))
+    .collect();
 
     if all_test_files.is_empty() {
         eprintln!("\nNo test files found.\n");
@@ -257,16 +283,31 @@ pub async fn run_watch_mode(config: TestRunConfig) -> Result<(), String> {
             }
             _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {
                 if debouncer.is_ready() && debouncer.has_pending() {
-                    let changes = debouncer.drain();
+                    // Canonicalize event paths so they align with the keys
+                    // in `graph` and the entries in `current_test_files`
+                    // (which are canonicalized below). On macOS fsevent
+                    // emits canonical paths anyway, but on Linux inotify
+                    // it doesn't — and walkdir never does. (#2765)
+                    let changes: Vec<FileChange> = debouncer
+                        .drain()
+                        .into_iter()
+                        .map(|c| FileChange {
+                            kind: c.kind,
+                            path: canonicalize_or_same(&c.path),
+                        })
+                        .collect();
 
                     // Re-discover test files (new files may have been added)
-                    let current_test_files = discover_test_files(
+                    let current_test_files: Vec<PathBuf> = discover_test_files(
                         &root_dir,
                         &paths,
                         &include,
                         &exclude,
                         DiscoveryMode::Unit,
-                    );
+                    )
+                    .into_iter()
+                    .map(|p| canonicalize_or_same(&p))
+                    .collect();
 
                     // Keep the module graph in sync with the filesystem before
                     // computing the affected set, so renamed imports and
@@ -709,6 +750,67 @@ mod tests {
                 .get_dependents(&canonical_dep)
                 .contains(&canonical_file),
             "reverse edge from dep → removed file must be cleaned"
+        );
+    }
+
+    /// Regression: `populate_graph_from_entry` and `update_graph_for_change`
+    /// used to canonicalize asymmetrically — the seed normalized paths while
+    /// the per-change update didn't — so projects under a symlinked root
+    /// (macOS `/tmp` → `/private/tmp`, symlinked deps folders, etc.) would
+    /// store canonical paths in the graph but receive non-canonical keys
+    /// from `affected_test_files`, silently regressing to full reruns.
+    ///
+    /// Both code paths now route every path through `canonicalize_or_same`.
+    /// This test proves that a test file reached through a symlink resolves
+    /// to the same graph key as one reached through its realpath, so a
+    /// change event on either path finds the seeded edges.
+    #[cfg(unix)]
+    #[test]
+    fn test_canonicalization_consistent_across_symlinked_roots() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real_root = tmp.path().join("real");
+        std::fs::create_dir(&real_root).unwrap();
+
+        let real_test_path = real_root.join("a.test.ts");
+        std::fs::write(&real_test_path, "import { x } from './dep';\n").unwrap();
+        let real_dep_path = real_root.join("dep.ts");
+        std::fs::write(&real_dep_path, "export const x = 1;\n").unwrap();
+
+        let alias_root = tmp.path().join("alias");
+        symlink(&real_root, &alias_root).unwrap();
+        let alias_test_path = alias_root.join("a.test.ts");
+        let alias_dep_path = alias_root.join("dep.ts");
+
+        // Seed via the symlinked path; the helper must normalize.
+        let mut graph = ModuleGraph::new();
+        let mut visited = HashSet::new();
+        populate_graph_from_entry(&alias_test_path, &mut graph, &mut visited);
+
+        // A Modify event arriving through the realpath must hit the same
+        // graph node the seed created, not a parallel ghost.
+        let canonical_test = canonicalize_or_same(&real_test_path);
+        let canonical_dep = canonicalize_or_same(&real_dep_path);
+        let canonical_alias_dep = canonicalize_or_same(&alias_dep_path);
+        assert_eq!(canonical_dep, canonical_alias_dep);
+        assert!(graph
+            .get_dependencies(&canonical_test)
+            .contains(&canonical_dep));
+
+        // And `affected_test_files` must return the test when the change
+        // event is expressed through either alias, once callers route it
+        // through `canonicalize_or_same` (as `run_watch_mode` does).
+        let alias_change = FileChange {
+            kind: FileChangeKind::Modify,
+            path: canonicalize_or_same(&alias_dep_path),
+        };
+        let all_tests = vec![canonicalize_or_same(&alias_test_path)];
+        let affected = affected_test_files(&[alias_change], &all_tests, &graph);
+        assert_eq!(
+            affected,
+            vec![canonical_test.clone()],
+            "change reached through the symlink must map to the same test file"
         );
     }
 }


### PR DESCRIPTION
## Summary

`native/vtz/src/test/watch.rs::run_watch_mode` built `ModuleGraph::new()` and never called `update_module` — so every file change hit the `dependents.is_empty()` fallback in `affected_test_files` and re-ran the **full** test suite, making `affected_test_files` a no-op. Deleted files would also leave ghost graph entries (the same bug #2764 fixed for the dev server).

This PR seeds the graph recursively from every discovered test file on startup and keeps it in sync with every debounced change event.

Closes #2765

## Public API Changes

None. All new symbols are `pub(crate)` inside `vtz`.

## Implementation

- **`populate_graph_from_entry`** — recursively scans a file's local imports via `crate::deps::scanner::scan_local_dependencies` and records every edge. Called once per discovered test file at startup, and again for newly discovered test files inside the watch loop.
- **`update_graph_for_change`** — on `Modify`/`Create` re-scans the file and updates its edges; on `Remove` calls `graph.remove_module` so deleted files don't leave ghost nodes.
- **`canonicalize_or_same`** — routes every path through `canonicalize()` with a fallback, so the seed, the change events, and the re-discovered `test_file_set` all use the same path shape (fsevent canonicalizes on macOS, inotify/walkdir don't on Linux — mixing them breaks `contains()` / `get_transitive_dependents()` lookups).

## Review Loop

Ran one adversarial general-purpose review agent on commit `972e65a40`. It flagged a canonicalization asymmetry (seed canonicalized, per-change update didn't) that would have silently regressed the fix back to full reruns on any project under a symlinked root. Commit `8bdb70e86` addresses it and adds a Unix-only symlink regression test.

Other review findings consciously **not** addressed in this PR:
- **S2** (seeding blocks the tokio runtime for large repos) — real, but low risk for current project sizes; worth a follow-up if it shows up in practice.
- **S3** (a newly created *intermediate* file only re-scans itself, not its parents) — documented in `update_graph_for_change`'s doc comment; a subsequent edit to the test file heals the edge.
- **S4** (silent failures during seed) — acceptable for now; would add verbose logging in a follow-up.
- **N4** (cache clearing is whole-cache, not scoped to `files_to_run`) — pre-existing, unrelated to this issue; candidate for a follow-up issue now that per-file targeting actually works.

## Test Plan

- [x] `cargo test --all` — all 3623+ Rust tests pass, incl. 4 new watch-mode tests
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hooks (build-typecheck, lint, rust-clippy, rust-fmt, rust-test, test, trojan-source) all ✅
- [x] Symlink regression test (`test_canonicalization_consistent_across_symlinked_roots`) covers the S1 asymmetry
- [ ] Manual smoke: `vtz test --watch` in a real project, edit a source file deep in the import tree, confirm only dependent test files re-run (deferred — infra/dogfooding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)