### PR TITLE
fix(changeset): use @vertz/runtime (not vtz) so release workflow parses

### DIFF
--- a/.changeset/fix-install-dedup-2894.md
+++ b/.changeset/fix-install-dedup-2894.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(vtz): dedup redundant package versions when a single version satisfies every declared range

--- a/.changeset/fix-install-dedup-orphans-2912.md
+++ b/.changeset/fix-install-dedup-orphans-2912.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(vtz): iterate install dedup until fixpoint so orphan optional binaries collapse with their parent


### PR DESCRIPTION
## Summary

The changeset files added in #2909 and #2914 use `'vtz': patch` as the package name. `vtz` is the CLI binary — the actual workspace package that ships it is `@vertz/runtime` (see `packages/runtime/package.json`).

Result: the release workflow has been failing on every push to main since #2909 merged:

```
Found changeset fix-install-dedup-2894 for package vtz which is not in the workspace
```

Because `changesets/action` bails on the first bad changeset, **no entry** has been added to #2902 (the Version Packages PR) for #2909, #2914, or anything merged afterwards — including my #2935 changeset for the #2865 Phase 1 feature.

## Fix

Mechanical: replace `'vtz': patch` with `'@vertz/runtime': patch` in both frontmatters. Everything else in the two changeset files is unchanged.

Files:
- `.changeset/fix-install-dedup-2894.md`
- `.changeset/fix-install-dedup-orphans-2912.md`

## Test plan

- [x] Verified `@vertz/runtime` is the correct package name (matches `packages/runtime/package.json`)
- [x] No other `.changeset/*.md` files reference `'vtz':` (grepped)
- [ ] Release workflow succeeds on merge → #2902 updates with the backlog of entries

Once this merges, the next release workflow run should append entries for #2909, #2914, and my Phase 1 changeset (#2935) to #2902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)