### PR TITLE
fix(changeset): use @vertz/runtime (not vtz) in #2934's field-selection changeset

### DIFF
--- a/.changeset/fix-field-selection-gaps-2782.md
+++ b/.changeset/fix-field-selection-gaps-2782.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'@vertz/runtime': patch
 ---
 
 fix(compiler): field-selection analyzer handles reduce/flatMap, loops/try/switch, and scope shadowing


### PR DESCRIPTION
## Summary

Same footgun as #2936 — the native binary is published as `@vertz/runtime`, not `vtz`. Only one file affected this time (`fix-field-selection-gaps-2782.md` from #2934).

## Current impact

The release workflow that #2902's merge triggered **failed at the version step**:

```
Found changeset fix-field-selection-gaps-2782 for package vtz
which is not in the workspace
```

Because `changesets/action` bails on the first bad changeset, the publish path **never ran** — `@vertz/runtime@0.2.77` (which contains the Phase 1 headless-screenshot feature) is NOT on npm even though:

- All `package.json` files on main are bumped to `0.2.77`
- All `CHANGELOG.md` entries are filled in
- git tags for `0.2.77` exist

Once this merges, the retriggered release workflow should succeed. It'll either publish `0.2.77` + bump to `0.2.78` simultaneously (if the action is smart), or re-open the Version Packages PR (#2937) clean and require a second merge for the actual publish.

## Fix

Mechanical: `'vtz': patch` → `'@vertz/runtime': patch` in the one file.

Also verified the other remaining changeset (`route-splitting-non-bare-identifier-2787.md` from #2933) already uses the correct `'@vertz/runtime': patch` name.

## Follow-up

This is the third PR in a month fixing the same bad package name in a changeset. A CI check that validates changeset package names against the workspace would prevent it. Tracked as a follow-up (not bundled here to keep the fix minimal).

## Test plan

- [x] `.changeset/fix-field-selection-gaps-2782.md` now uses `'@vertz/runtime': patch`
- [x] No other `.changeset/*.md` files reference `'vtz':` (grepped)
- [ ] Release workflow on merge succeeds at the version step

🤖 Generated with [Claude Code](https://claude.com/claude-code)