### PR TITLE
fix(vtz): invalidate dependents' cache when a file fails to compile [#2766]

### DIFF
--- a/.changeset/fix-hmr-on-compile-error-2766.md
+++ b/.changeset/fix-hmr-on-compile-error-2766.md
@@ -1,0 +1,13 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): invalidate dependents' cache when a source file fails to compile
+
+Closes [#2766](https://github.com/vertz-dev/vertz/issues/2766).
+
+The dev-server file-watcher loop `continue`d inside the compile-error branch, bypassing `process_file_change`. Consequence: if a user introduced a syntax error in `utils.ts`, transitive dependents of `utils.ts` kept their stale compiled cache entries until they were individually re-touched. After the error was fixed, those dependents could still serve stale code.
+
+Same shape as the delete-event bug fixed in [#2764](https://github.com/vertz-dev/vertz/pull/2768). The compile-error branch now falls through to `process_file_change` so the changed file and its transitive dependents are invalidated. The module-graph update is still skipped on error — we don't want to commit import edges scanned from broken source.
+
+As part of this fix, the per-change handler body was moved out of the file-watcher closure in `server::http` into `server::file_change_handler::handle_file_change` so the pipeline is directly reachable from tests without spinning up `start_server_with_lifecycle`.

--- a/native/vtz/src/server/file_change_handler.rs
+++ b/native/vtz/src/server/file_change_handler.rs
@@ -1,0 +1,182 @@
+//! Per-event handling inside the dev server's file-watcher loop.
+//!
+//! Extracted from `server::http` so the change pipeline — MCP event emission,
+//! error clearing, optional recompilation, module-graph maintenance, and the
+//! downstream HMR broadcast — is reachable from tests without spinning up the
+//! full `start_server_with_lifecycle` stack.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::deps::scanner::scan_local_dependencies;
+use crate::errors::categories::{build_compile_error, ErrorCategory};
+use crate::hmr::protocol::HmrMessage;
+use crate::hmr::recovery::RestartTriggers;
+use crate::plugin::{hmr_action_to_message, HmrAction};
+use crate::server::audit_log::AuditEvent;
+use crate::server::mcp_events::{self, McpEvent};
+use crate::server::module_server::DevServerState;
+use crate::watcher::file_watcher::{FileChange, FileChangeKind};
+use crate::watcher::process_file_change;
+
+/// Handle a single debounced file change. This runs once per unique path in a
+/// batch; the outer loop already handles per-batch work (isolate restart, SSR
+/// pool reload).
+///
+/// On compile errors for `Modify`/`Create`: the structured diagnostic is
+/// broadcast, the module-graph update is skipped (don't commit edges scanned
+/// from broken source), but `process_file_change` still runs so transitive
+/// dependents are invalidated. Without that, dependents of a file that failed
+/// to compile would keep serving stale compiled output until individually
+/// re-touched (#2766).
+pub async fn handle_file_change(
+    change: &FileChange,
+    state: &Arc<DevServerState>,
+    entry_file: &Path,
+    root_dir: &Path,
+    restart_triggers: &RestartTriggers,
+) {
+    eprintln!("[Server] File changed: {}", change.path.display());
+
+    // Emit file_change event to MCP LLM clients. Never leak absolute paths —
+    // use file_name() as last resort.
+    let relative_path = change
+        .path
+        .strip_prefix(root_dir)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| {
+            change
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string())
+        });
+    let kind_str = match change.kind {
+        FileChangeKind::Create => "create",
+        FileChangeKind::Modify => "modify",
+        FileChangeKind::Remove => "delete",
+    };
+    state
+        .audit_log
+        .record(AuditEvent::file_change(&relative_path, kind_str));
+    state.mcp_event_hub.broadcast(McpEvent::FileChange {
+        timestamp: mcp_events::iso_timestamp(),
+        data: mcp_events::FileChangeData {
+            path: relative_path,
+            kind: kind_str.to_string(),
+        },
+    });
+
+    // Config/dependency file → full reload, clear cache, skip the rest.
+    if restart_triggers.is_restart_trigger(&change.path) {
+        eprintln!(
+            "[Server] Config/dependency change detected: {}",
+            change.path.display()
+        );
+        state
+            .hmr_hub
+            .broadcast(HmrMessage::FullReload {
+                reason: format!(
+                    "Config file changed: {}",
+                    change
+                        .path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                ),
+            })
+            .await;
+        state.pipeline.cache().clear();
+        return;
+    }
+
+    // Record the file change timestamp so the client error handler can reject
+    // stale reports.
+    if let Ok(mut ts) = state.last_file_change.lock() {
+        *ts = Some(std::time::Instant::now());
+    }
+
+    // Clear any previous errors for this file.
+    let file_str = change.path.to_string_lossy().to_string();
+    state
+        .error_broadcaster
+        .clear_file(ErrorCategory::Build, &file_str)
+        .await;
+    // A changed import may now point to a valid module.
+    state
+        .error_broadcaster
+        .clear_category(ErrorCategory::Resolve)
+        .await;
+    // A fixed source file means SSR will succeed on next render.
+    state
+        .error_broadcaster
+        .clear_category(ErrorCategory::Ssr)
+        .await;
+    // Previous client-side errors may no longer apply after a code change.
+    state
+        .error_broadcaster
+        .clear_category(ErrorCategory::Runtime)
+        .await;
+
+    // Delete events: skip compilation and import-graph rewriting — the file is
+    // gone. `process_file_change` still cleans up the graph entry and
+    // invalidates dependents.
+    let is_remove = matches!(change.kind, FileChangeKind::Remove);
+
+    let mut had_compile_error = false;
+    if !is_remove {
+        // Attempt recompilation for error recovery.
+        let compile_result = state.pipeline.compile_for_browser(&change.path);
+
+        if !compile_result.errors.is_empty() {
+            had_compile_error = true;
+            // Report structured compilation diagnostics. Fall through to
+            // `process_file_change` below so the cache for this file and its
+            // transitive dependents is invalidated — otherwise dependents keep
+            // serving stale compiled output after the error is fixed (#2766).
+            // Skip the graph update: we don't want to commit import edges
+            // scanned from broken source. Side effect: the last-successful
+            // graph edges for this module persist until the next successful
+            // compile — that only ever causes over-invalidation of unrelated
+            // edits (safe), never missed invalidation.
+            let source = std::fs::read_to_string(&change.path).unwrap_or_default();
+            if let Some(error) = build_compile_error(&compile_result.errors, &file_str, &source) {
+                state.error_broadcaster.report_error(error).await;
+            }
+        } else {
+            // Update module graph with this file's imports so transitive
+            // dependents are invalidated correctly.
+            let source = std::fs::read_to_string(&change.path).unwrap_or_default();
+            if !source.is_empty() {
+                let deps = scan_local_dependencies(&source, &change.path);
+                if let Ok(mut graph) = state.module_graph.write() {
+                    graph.update_module(&change.path, deps);
+                }
+            }
+        }
+    }
+
+    // Process the change — invalidates cache, computes dependents, and for
+    // Remove events also cleans the graph.
+    let result = process_file_change(
+        change,
+        state.pipeline.cache(),
+        &state.module_graph,
+        entry_file,
+    );
+
+    // Use plugin's HMR strategy to decide what action to take. Skip the
+    // broadcast when the file failed to compile: the error overlay is the
+    // user-visible state, and firing Update/FullReload on every broken
+    // keystroke either makes the client re-fetch a module that will error
+    // out or (for entry-file edits) reloads the page mid-error and loses
+    // in-memory state. Cache was invalidated above; the next successful
+    // compile will drive the refetch.
+    if !had_compile_error {
+        let action = state.plugin.hmr_strategy(&result);
+        if !matches!(action, HmrAction::Handled) {
+            let message = hmr_action_to_message(&action, root_dir);
+            state.hmr_hub.broadcast(message).await;
+        }
+    }
+}

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -3,9 +3,7 @@ use crate::compiler::pipeline::CompilationPipeline;
 use crate::config::ServerConfig;
 use crate::deps::linked::{discover_linked_packages, WatchTarget};
 use crate::errors::broadcaster::ErrorBroadcaster;
-use crate::errors::categories::{
-    build_compile_error, extract_snippet, refine_error_line, DevError, ErrorCategory,
-};
+use crate::errors::categories::{extract_snippet, refine_error_line, DevError};
 use crate::hmr::recovery::RestartTriggers;
 use crate::hmr::websocket::HmrHub;
 use crate::runtime::persistent_isolate::{
@@ -1697,151 +1695,14 @@ pub async fn start_server_with_lifecycle(
                                 }
 
                                 for change in &changes {
-                                    let change_msg = format!("File changed: {}", change.path.display());
-                                    eprintln!("[Server] {}", change_msg);
-                                    // Emit file_change event to MCP LLM clients
-                                    // Never leak absolute paths — use file_name() as last resort
-                                    let relative_path = change.path
-                                        .strip_prefix(&root_dir)
-                                        .map(|p| p.to_string_lossy().to_string())
-                                        .unwrap_or_else(|_| {
-                                            change.path.file_name()
-                                                .map(|n| n.to_string_lossy().to_string())
-                                                .unwrap_or_else(|| "<unknown>".to_string())
-                                        });
-                                    let kind_str = match change.kind {
-                                        crate::watcher::file_watcher::FileChangeKind::Create => "create",
-                                        crate::watcher::file_watcher::FileChangeKind::Modify => "modify",
-                                        crate::watcher::file_watcher::FileChangeKind::Remove => "delete",
-                                    };
-                                    watcher_state.audit_log.record(
-                                        crate::server::audit_log::AuditEvent::file_change(
-                                            &relative_path,
-                                            kind_str,
-                                        ),
-                                    );
-                                    watcher_state.mcp_event_hub.broadcast(
-                                        mcp_events::McpEvent::FileChange {
-                                            timestamp: mcp_events::iso_timestamp(),
-                                            data: mcp_events::FileChangeData {
-                                                path: relative_path,
-                                                kind: kind_str.to_string(),
-                                            },
-                                        },
-                                    );
-
-                                    // Check for config/dependency changes
-                                    if restart_triggers.is_restart_trigger(&change.path) {
-                                        eprintln!(
-                                            "[Server] Config/dependency change detected: {}",
-                                            change.path.display()
-                                        );
-                                        // Broadcast full reload to clients
-                                        watcher_state.hmr_hub.broadcast(
-                                            crate::hmr::protocol::HmrMessage::FullReload {
-                                                reason: format!(
-                                                    "Config file changed: {}",
-                                                    change.path.file_name()
-                                                        .unwrap_or_default()
-                                                        .to_string_lossy()
-                                                ),
-                                            },
-                                        ).await;
-                                        // Clear compilation cache for full rebuild
-                                        watcher_state.pipeline.cache().clear();
-                                        continue;
-                                    }
-
-                                    // Record the file change timestamp so the client
-                                    // error handler can reject stale reports.
-                                    if let Ok(mut ts) = watcher_state.last_file_change.lock() {
-                                        *ts = Some(std::time::Instant::now());
-                                    }
-
-                                    // Clear any previous errors for this file
-                                    let file_str = change.path.to_string_lossy().to_string();
-                                    watcher_state.error_broadcaster
-                                        .clear_file(ErrorCategory::Build, &file_str)
-                                        .await;
-                                    // Also clear resolve errors — a changed import may
-                                    // now point to a valid module.
-                                    watcher_state.error_broadcaster
-                                        .clear_category(ErrorCategory::Resolve)
-                                        .await;
-                                    // Also clear SSR errors — a fixed source file means SSR
-                                    // will succeed on next render.
-                                    watcher_state.error_broadcaster
-                                        .clear_category(ErrorCategory::Ssr)
-                                        .await;
-                                    // Also clear runtime errors — the previous client-side
-                                    // errors may no longer apply after a code change.
-                                    watcher_state.error_broadcaster
-                                        .clear_category(ErrorCategory::Runtime)
-                                        .await;
-
-                                    // For delete events: skip compilation and import-graph
-                                    // rewriting — the file is gone. process_file_change still
-                                    // cleans up the graph entry and invalidates dependents.
-                                    let is_remove = matches!(
-                                        change.kind,
-                                        crate::watcher::file_watcher::FileChangeKind::Remove,
-                                    );
-
-                                    if !is_remove {
-                                        // Attempt recompilation for error recovery
-                                        let compile_result = watcher_state.pipeline
-                                            .compile_for_browser(&change.path);
-
-                                        // Report any structured compilation diagnostics
-                                        if !compile_result.errors.is_empty() {
-                                            let source = std::fs::read_to_string(&change.path)
-                                                .unwrap_or_default();
-                                            if let Some(error) = build_compile_error(
-                                                &compile_result.errors,
-                                                &file_str,
-                                                &source,
-                                            ) {
-                                                watcher_state.error_broadcaster
-                                                    .report_error(error)
-                                                    .await;
-                                            }
-
-                                            continue;
-                                        }
-
-                                        // Update module graph with this file's imports
-                                        // so transitive dependents are invalidated correctly.
-                                        let source = std::fs::read_to_string(&change.path)
-                                            .unwrap_or_default();
-                                        if !source.is_empty() {
-                                            let deps = crate::deps::scanner::scan_local_dependencies(
-                                                &source,
-                                                &change.path,
-                                            );
-                                            if let Ok(mut graph) = watcher_state.module_graph.write() {
-                                                graph.update_module(&change.path, deps);
-                                            }
-                                        }
-                                    }
-
-                                    // Process the change — invalidates cache, computes dependents,
-                                    // and for Remove events also cleans the graph.
-                                    let result = watcher::process_file_change(
+                                    crate::server::file_change_handler::handle_file_change(
                                         change,
-                                        watcher_state.pipeline.cache(),
-                                        &watcher_state.module_graph,
+                                        &watcher_state,
                                         &entry_file,
-                                    );
-
-                                    // Use plugin's HMR strategy to decide what action to take
-                                    let action = watcher_state.plugin.hmr_strategy(&result);
-                                    if !matches!(action, crate::plugin::HmrAction::Handled) {
-                                        let message = crate::plugin::hmr_action_to_message(
-                                            &action,
-                                            &root_dir,
-                                        );
-                                        watcher_state.hmr_hub.broadcast(message).await;
-                                    }
+                                        &root_dir,
+                                        &restart_triggers,
+                                    )
+                                    .await;
                                 }
                             }
                             // Channel closed (shutdown) and no pending changes — exit.

--- a/native/vtz/src/server/mod.rs
+++ b/native/vtz/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod binary_fs;
 pub mod browser_hub;
 pub mod css_server;
 pub mod diagnostics;
+pub mod file_change_handler;
 pub mod html_shell;
 pub mod http;
 pub mod image_cache;

--- a/native/vtz/tests/parity/common.rs
+++ b/native/vtz/tests/parity/common.rs
@@ -66,6 +66,63 @@ pub async fn start_dev_server(fixture: &str) -> (String, ShutdownHandle) {
     start_dev_server_with(fixture, TestConfig::default()).await
 }
 
+/// Start a dev server rooted at an arbitrary path (e.g., a tempdir). Used by
+/// tests that need to mutate source files during the run.
+#[allow(dead_code)]
+pub async fn start_dev_server_at_root(root: PathBuf) -> (String, ShutdownHandle) {
+    start_dev_server_at_root_with(root, TestConfig::default()).await
+}
+
+/// Start a dev server at an arbitrary root with custom config overrides.
+#[allow(dead_code)]
+pub async fn start_dev_server_at_root_with(
+    root: PathBuf,
+    test_config: TestConfig,
+) -> (String, ShutdownHandle) {
+    let port = free_port();
+    let addr = format!("127.0.0.1:{}", port);
+    let base_url = format!("http://127.0.0.1:{}", port);
+
+    let mut config = ServerConfig::with_root(
+        port,
+        "127.0.0.1".to_string(),
+        root.join("public"),
+        root.clone(),
+    );
+    config.enable_ssr = test_config.enable_ssr;
+    config.auto_install = test_config.auto_install;
+    if let Some(entry) = test_config.server_entry {
+        config.server_entry = Some(entry);
+    }
+    let (router, state, _inspector_rx) = build_router(&config, test_plugin());
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    wait_for_ready(
+        &base_url,
+        &root.display().to_string(),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    (
+        base_url,
+        ShutdownHandle {
+            shutdown_tx: Some(shutdown_tx),
+            state,
+        },
+    )
+}
+
 /// Start a dev server with custom config overrides.
 #[allow(dead_code)]
 pub async fn start_dev_server_with(

--- a/native/vtz/tests/parity/hmr.rs
+++ b/native/vtz/tests/parity/hmr.rs
@@ -1,9 +1,9 @@
 use crate::common::*;
 use futures_util::StreamExt;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
-use vertz_runtime::compiler::cache::CompilationCache;
+use vertz_runtime::compiler::cache::{CachedModule, CompilationCache};
 use vertz_runtime::hmr::protocol::HmrMessage;
 use vertz_runtime::plugin::vertz::VertzPlugin;
 use vertz_runtime::plugin::{hmr_action_to_message, HmrAction, VtzPlugin};
@@ -257,5 +257,93 @@ async fn dependency_change_invalidates_transitive_dependents() {
     assert!(
         transitive.contains(&c),
         "C should include itself in transitive set"
+    );
+}
+
+/// Regression for #2766: a Modify event that fails to compile must still
+/// invalidate the cache for **transitive** dependents. The old code `continue`d
+/// inside the compile-error branch, skipping `process_file_change`, so
+/// dependents of a broken file kept serving stale compiled output until they
+/// were individually re-touched.
+#[tokio::test]
+async fn file_modify_with_compile_error_still_invalidates_dependents_cache() {
+    use vertz_runtime::hmr::recovery::RestartTriggers;
+    use vertz_runtime::server::file_change_handler::handle_file_change;
+
+    let tmp = tempfile::tempdir().unwrap();
+    copy_fixture("minimal-app", tmp.path());
+    // Canonicalize so graph paths and the path we pass through the handler
+    // match (macOS tempdirs canonicalize through /private).
+    let root = tmp.path().canonicalize().unwrap();
+    let src_dir = root.join("src");
+    let app = src_dir.join("app.tsx");
+    let hello = src_dir.join("components").join("Hello.tsx");
+    // Synthetic transitive dependent: page.tsx importing app.tsx. The file
+    // doesn't need to exist on disk; we only care about the cache entry and
+    // the graph edge.
+    let page = src_dir.join("page.tsx");
+
+    let (_base_url, handle) = start_dev_server_at_root(root.clone()).await;
+
+    // Model `page → app → hello` so the fix has to BFS through the chain.
+    {
+        let mut g = handle.state.module_graph.write().unwrap();
+        g.update_module(&app, vec![hello.clone()]);
+        g.update_module(&page, vec![app.clone()]);
+    }
+
+    // Prime the compilation cache with stale entries for the chain.
+    let make_cached = |code: &str| CachedModule {
+        code: code.to_string(),
+        source_map: None,
+        css: None,
+        mtime: SystemTime::UNIX_EPOCH,
+    };
+    let cache = handle.state.pipeline.cache();
+    cache.insert(page.clone(), make_cached("stale page"));
+    cache.insert(app.clone(), make_cached("stale app"));
+    cache.insert(hello.clone(), make_cached("stale hello"));
+
+    // Overwrite Hello.tsx with source the compiler is guaranteed to reject
+    // (unclosed string literal + bare stray tokens — neither can be recovered
+    // into a valid TS AST).
+    let broken = "export const x = \"unterminated;\n@@ !!! *** ;\n";
+    std::fs::write(&hello, broken).unwrap();
+
+    // Sanity-check the premise: the compiler really does reject this input.
+    // Without a compile error there's no #2766 regression path to exercise.
+    let compile_result = handle.state.pipeline.compile_for_browser(&hello);
+    assert!(
+        !compile_result.errors.is_empty(),
+        "test premise: broken Hello.tsx must fail to compile; if the compiler \
+         ever accepts this input, pick a new broken sample"
+    );
+
+    // Drive the real handler as the file-watcher loop would.
+    handle_file_change(
+        &FileChange {
+            kind: FileChangeKind::Modify,
+            path: hello.clone(),
+        },
+        &handle.state,
+        &app,
+        &root,
+        &RestartTriggers::default(),
+    )
+    .await;
+
+    assert!(
+        cache.get_unchecked(&app).is_none(),
+        "direct dependent (app.tsx) cache entry must be invalidated after \
+         Hello.tsx fails to compile (#2766)"
+    );
+    assert!(
+        cache.get_unchecked(&page).is_none(),
+        "transitive dependent (page.tsx) cache entry must be invalidated — \
+         the bug specifically called out transitive-dependent staleness"
+    );
+    assert!(
+        cache.get_unchecked(&hello).is_none(),
+        "changed file's own cache entry must be invalidated on compile error"
     );
 }


### PR DESCRIPTION
## Summary

The dev-server file-watcher loop `continue`d inside the compile-error branch, bypassing `process_file_change`. If a user introduced a syntax error in `utils.ts`, transitive dependents kept their stale compiled-cache entries — so even after the error was fixed, dependents could still serve stale compiled code until individually re-touched. Same shape as #2764 (delete events), different trigger.

- Compile-error branch now falls through to `process_file_change` so the changed file and its transitive dependents are invalidated.
- The module-graph update is still skipped on error — don't commit edges scanned from broken source; last-successful edges persist until the next successful compile, which can only over-invalidate (safe).
- HMR broadcast is suppressed while `compile_result.errors` is non-empty: the overlay is the user-visible state, and firing `Update`/`FullReload` on every broken keystroke would make the client re-fetch a broken module, or (for entry-file edits) reload mid-error and lose in-memory state. The next successful compile drives the refetch.
- The per-change handler body was moved out of `server::http`'s file-watcher closure into a new `server::file_change_handler::handle_file_change` so it's reachable from tests without spinning up `start_server_with_lifecycle`.

## Public API Changes

None. `@vertz/runtime` is documented as internal; the newly-exposed `pub fn handle_file_change` is used by the in-tree regression test only and is not surfaced anywhere a user would reach.

## Test Plan

- [x] `cargo test --all` green (incl. new regression test that models `page → app → hello` and verifies all three cache entries are invalidated when `hello.tsx` is modified with a syntax error)
- [x] Regression test has been manually verified to fail when a `return;` is re-introduced in the compile-error branch
- [x] `cargo clippy --all-targets --release -- -D warnings` clean (pre-push hook)
- [x] `cargo fmt --all -- --check` clean
- [x] TS build-typecheck / lint / tests green (pre-push hook)
- [x] Trojan-source check green

## Review

Ran one adversarial review; all three should-fix findings (HMR broadcast on compile error, stale graph-edge comment, single-level dependent test coverage) and the brittle broken-source string nit were addressed. Review notes and resolution: `reviews/fix-2766/phase-01-hmr-compile-error.md` (not committed to main).

Closes #2766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)