### PR TITLE
fix(client): type import.meta.main for run-if-main idioms (#2811)

### DIFF
--- a/.changeset/import-meta-main-type-2811.md
+++ b/.changeset/import-meta-main-type-2811.md
@@ -1,0 +1,22 @@
+---
+'@vertz/ui': patch
+'vertz': patch
+---
+
+feat(client): type `import.meta.main` in `vertz/client` and `@vertz/ui/client`
+
+Closes [#2811](https://github.com/vertz-dev/vertz/issues/2811).
+
+Follow-up to #2777. The vtz runtime (via deno_core) already sets `import.meta.main` on every module — `true` for the entry module, `false` for imported modules — so the standard "run if main" idiom works without any polyfill:
+
+```ts
+// src/api/server.ts
+const app = createServer({ /* ... */ });
+export default app;
+
+if (import.meta.main) app.listen(env.PORT);
+```
+
+Previously the type was only available to projects that pulled in `bun-types`. The client augmentation (`packages/ui/client.d.ts`) now declares `readonly main: boolean` alongside `hot`, so any tsconfig that includes `"types": ["vertz/client"]` (or `"@vertz/ui/client"`) gets it automatically. Scaffolded apps already have this entry.
+
+`bun-types` removed from `sites/dev-orchestrator` where it was only kept for this type.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6579,7 +6579,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.76"
+version = "0.2.78"
 dependencies = [
  "napi",
  "napi-build",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.76"
+version = "0.2.78"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6611,7 +6611,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.76"
+version = "0.2.78"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/tests/v8_integration.rs
+++ b/native/vtz/tests/v8_integration.rs
@@ -2114,3 +2114,67 @@ async fn test_child_process_spawn_kill() {
         elapsed.as_secs()
     );
 }
+
+// --- #2811: import.meta.main for "run if main" idioms ---
+
+#[tokio::test]
+async fn test_import_meta_main_true_for_entry_module() {
+    let tmp = tempfile::tempdir().unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(&entry, r#"console.log("main: " + import.meta.main);"#).unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "main: true",
+        "import.meta.main should be true when module is loaded as main. Got: {:?}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+async fn test_import_meta_main_false_for_imported_module() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lib = tmp.path().join("lib.js");
+    std::fs::write(&lib, r#"console.log("lib main: " + import.meta.main);"#).unwrap();
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(
+        &entry,
+        r#"
+        import "./lib.js";
+        console.log("entry main: " + import.meta.main);
+        "#,
+    )
+    .unwrap();
+
+    let mut rt = VertzJsRuntime::new(VertzRuntimeOptions {
+        root_dir: Some(tmp.path().to_string_lossy().to_string()),
+        capture_output: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let specifier = deno_core::ModuleSpecifier::from_file_path(&entry).unwrap();
+    rt.load_main_module(&specifier).await.unwrap();
+
+    let output = rt.captured_output();
+    assert_eq!(
+        output.stdout[0], "lib main: false",
+        "import.meta.main should be false inside imported modules. Got: {:?}",
+        output.stdout
+    );
+    assert_eq!(
+        output.stdout[1], "entry main: true",
+        "import.meta.main should be true in the entry module. Got: {:?}",
+        output.stdout
+    );
+}

--- a/packages/mint-docs/guides/env.mdx
+++ b/packages/mint-docs/guides/env.mdx
@@ -65,6 +65,8 @@ if (import.meta.main) {
 }
 ```
 
+`import.meta.main` is `true` when the file is executed directly (`vtz src/api/server.ts`) and `false` when it's imported by another module — for example, a test that imports `app` to make in-process requests. This is the standard "run if main" idiom. The vtz runtime sets it natively; the `boolean` type comes from `vertz/client`, which is already in the scaffolded `tsconfig.json`.
+
 ## Loading `.env` files
 
 Use the `load` property to read variables from dotenv files:

--- a/packages/site/pages/guides/env.mdx
+++ b/packages/site/pages/guides/env.mdx
@@ -65,6 +65,8 @@ if (import.meta.main) {
 }
 ```
 
+`import.meta.main` is `true` when the file is executed directly (`vtz src/api/server.ts`) and `false` when it's imported by another module — for example, a test that imports `app` to make in-process requests. This is the standard "run if main" idiom. The vtz runtime sets it natively; the `boolean` type comes from `vertz/client`, which is already in the scaffolded `tsconfig.json`.
+
 ## Loading `.env` files
 
 Use the `load` property to read variables from dotenv files:

--- a/packages/ui/client.d.ts
+++ b/packages/ui/client.d.ts
@@ -81,8 +81,13 @@ declare global {
      * ```
      *
      * Set natively by the vtz runtime on every module, so no polyfill is required.
+     *
+     * Declared as mutable (not `readonly`) to match `bun-types`' `ImportMeta.main`
+     * shape — declaration merging requires identical modifiers, so projects that
+     * keep both `bun-types` and `vertz/client` in their tsconfig `types` avoid
+     * a `TS2687: All declarations must have identical modifiers` error.
      */
-    readonly main: boolean;
+    main: boolean;
   }
 }
 

--- a/packages/ui/client.d.ts
+++ b/packages/ui/client.d.ts
@@ -69,6 +69,20 @@ declare global {
   interface ImportMeta {
     /** Hot Module Replacement API. Only available in dev mode; undefined in production and SSR. */
     readonly hot: ImportMetaHot | undefined;
+    /**
+     * `true` when the current module is the entry point (`vtz <file>`, dev server entry,
+     * or `vtz test` runner target). `false` when imported from another module.
+     *
+     * Use for "run if main" idioms — e.g. starting an HTTP server only when the file
+     * is executed directly, not when imported by a test:
+     *
+     * ```ts
+     * if (import.meta.main) app.listen(env.PORT);
+     * ```
+     *
+     * Set natively by the vtz runtime on every module, so no polyfill is required.
+     */
+    readonly main: boolean;
   }
 }
 

--- a/packages/ui/src/__tests__/import-meta-hot.test-d.ts
+++ b/packages/ui/src/__tests__/import-meta-hot.test-d.ts
@@ -103,9 +103,8 @@ describe('Feature: on / off event subscription', () => {
   });
 });
 
-describe('Feature: removed augmentations', () => {
-  it('ImportMeta.main is not declared by @vertz/ui/client', () => {
-    // @ts-expect-error — main is a Bun-ism, not provided by the vtz runtime.
-    const _main: boolean = import.meta.main;
+describe('Feature: ImportMeta.main (run-if-main)', () => {
+  it('Typed as boolean — set by the vtz runtime', () => {
+    expectTypeOf(import.meta.main).toEqualTypeOf<boolean>();
   });
 });

--- a/packages/vertz/src/__tests__/import-meta-hot.test-d.ts
+++ b/packages/vertz/src/__tests__/import-meta-hot.test-d.ts
@@ -101,9 +101,8 @@ describe('Feature: on / off event subscription', () => {
   });
 });
 
-describe('Feature: removed augmentations', () => {
-  it('ImportMeta.main is not declared by vertz/client', () => {
-    // @ts-expect-error — main is a Bun-ism, not provided by the vtz runtime.
-    const _main: boolean = import.meta.main;
+describe('Feature: ImportMeta.main (run-if-main)', () => {
+  it('Typed as boolean — set by the vtz runtime', () => {
+    expectTypeOf(import.meta.main).toEqualTypeOf<boolean>();
   });
 });

--- a/sites/dev-orchestrator/package.json
+++ b/sites/dev-orchestrator/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@oxlint/binding-darwin-arm64": "^1.58.0",
     "@types/node": "^25.5.0",
-    "bun-types": "^1.3.9",
     "oxfmt": "^0.42.0",
     "oxlint": "^1.58.0",
     "typescript": "^5.9.3"

--- a/sites/dev-orchestrator/tsconfig.json
+++ b/sites/dev-orchestrator/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
-    "types": ["bun-types", "node"],
+    "types": ["node", "vertz/client"],
     "jsx": "react-jsx",
     "jsxImportSource": "@vertz/ui",
     "strict": true,


### PR DESCRIPTION
Closes #2811.

## Summary

Follow-up to #2777. The vtz runtime (via `deno_core`) already sets `import.meta.main` on every module — `true` for the entry module, `false` for imports — so the standard "run if main" guard works without any polyfill. This PR types it in `vertz/client` so apps don't need `bun-types` just to satisfy TypeScript.

```ts
// src/api/server.ts
const app = createServer({ /* ... */ });
export default app;

if (import.meta.main) app.listen(env.PORT);  // ✅ typed as boolean
```

## Public API Changes

**Addition:** `ImportMeta.main: boolean` declared in [`packages/ui/client.d.ts`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/ui/client.d.ts). Projects with `"types": ["vertz/client"]` (or `"@vertz/ui/client"`) get it automatically. Scaffolded apps already have this tsconfig entry.

Declared as **mutable** (not `readonly`) on purpose — `bun-types` declares the same property as `main: boolean`. Declaration merging requires identical modifiers (TS2687), so matching bun-types avoids a conflict for anyone who keeps both in their tsconfig `types`.

**Breaking / deferred:** None.

## Changes

- [`packages/ui/client.d.ts`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/ui/client.d.ts) — add `main: boolean` to `ImportMeta`.
- [`packages/ui/src/__tests__/import-meta-hot.test-d.ts`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/ui/src/__tests__/import-meta-hot.test-d.ts), [`packages/vertz/src/__tests__/import-meta-hot.test-d.ts`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/vertz/src/__tests__/import-meta-hot.test-d.ts) — flip `@ts-expect-error` assertions from "not declared" to `expectTypeOf<boolean>()`.
- [`native/vtz/tests/v8_integration.rs`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/native/vtz/tests/v8_integration.rs) — add `test_import_meta_main_true_for_entry_module` and `test_import_meta_main_false_for_imported_module`.
- [`sites/dev-orchestrator/tsconfig.json`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/sites/dev-orchestrator/tsconfig.json) + `package.json` — drop `bun-types` (only kept for this type; no `Bun.*` API usage anywhere else). `examples/entity-todo` keeps `bun-types` because its test compiler plugin still uses `Bun.Transpiler`.
- [`packages/mint-docs/guides/env.mdx`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/mint-docs/guides/env.mdx), [`packages/site/pages/guides/env.mdx`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/packages/site/pages/guides/env.mdx) — document the idiom and tie the type to `vertz/client`.
- [`.changeset/import-meta-main-type-2811.md`](https://github.com/vertz-dev/vertz/blob/fix/bun-types-import-meta-main-2811/.changeset/import-meta-main-type-2811.md) — patch bump for `@vertz/ui` and `vertz`.

## Acceptance criteria (from #2811)

- [x] **Framework stance:** Endorse `import.meta.main` — it's already a runtime guarantee via deno_core; now a typed framework-standard idiom.
- [x] **Type augmentation:** Added to `vertz/client` / `@vertz/ui/client` with JSDoc.
- [x] **Migration:** Not applicable — call sites continue to use `import.meta.main`.
- [x] **Docs updated:** `guides/env.mdx` (both mint-docs and site) reflect the decision.

## Test plan

- [x] `cargo test --test v8_integration test_import_meta_main` — 2 new Rust integration tests pass (main/side modules).
- [x] `vtz test` in `packages/ui`, `packages/vertz`, `packages/create-vertz-app`, `packages/icons` — all green.
- [x] `tsc --noEmit` in `packages/ui`, `packages/vertz`, `sites/dev-orchestrator` — clean (dev-orchestrator has one pre-existing unrelated error in `agent-detail.tsx`).
- [x] `vtz run format` + `vtz run lint` — clean.
- [x] `cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings` — clean.
- [x] Pre-push hooks (build-typecheck, lint, rust-clippy, rust-fmt, rust-test, test, trojan-source) — all green.

## Reviews

Adversarial self-review surfaced a latent declaration-merge conflict between `readonly main` and bun-types' mutable `main`. Fixed in commit 6117fd9e1.