### PR TITLE
fix(compiler): disambiguate context stable ids on same-name collisions [#2786]

### DIFF
--- a/.changeset/fix-context-stable-id-collision-2786.md
+++ b/.changeset/fix-context-stable-id-collision-2786.md
@@ -1,7 +1,7 @@
 ---
 '@vertz/ui-server': patch
 '@vertz/native-compiler': patch
-'vtz': patch
+'vertz': patch
 ---
 
 fix(compiler): disambiguate context stable ids when two `createContext` calls share a variable name in the same file

--- a/.changeset/fix-context-stable-id-collision-2786.md
+++ b/.changeset/fix-context-stable-id-collision-2786.md
@@ -1,0 +1,15 @@
+---
+'@vertz/ui-server': patch
+'@vertz/native-compiler': patch
+'vtz': patch
+---
+
+fix(compiler): disambiguate context stable ids when two `createContext` calls share a variable name in the same file
+
+Closes [#2786](https://github.com/vertz-dev/vertz/issues/2786).
+
+`injectContextStableIds` generated the id as `{filePath}::{varName}`. Two `createContext()` calls in the same file with the same variable name (e.g. an inlined/formatted pair on one line, or a code-generated module) produced the same id, so the runtime context registry silently returned the same object for both — breaking Provider/useContext pairing.
+
+Both the Rust transform (`native/vertz-compiler-core/src/context_stable_ids.rs`) and the TypeScript sibling (`packages/ui-server/src/build-plugin/context-stable-ids.ts`) now track a per-name occurrence counter and suffix `@N` on repeats. The first occurrence of a name keeps the original `{filePath}::{varName}` id (so existing single-context files are unchanged); the second becomes `{filePath}::{varName}@1`, the third `@2`, and so on.
+
+A per-name counter is used rather than a source span because counters only shift when contexts are added or removed, whereas spans shift on any edit to earlier code — counters are more HMR-stable.

--- a/native/vertz-compiler-core/src/context_stable_ids.rs
+++ b/native/vertz-compiler-core/src/context_stable_ids.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use oxc_ast::ast::{
     BindingPattern, Declaration, Expression, Program, Statement, VariableDeclaration,
 };
@@ -9,8 +11,15 @@ use crate::magic_string::MagicString;
 ///
 /// Detects `const X = createContext(...)` patterns at module level and injects
 /// a `__stableId` argument so the context registry survives bundle re-evaluation.
-/// The ID format is `filePath::varName`.
+/// The ID format is `filePath::varName` for the first occurrence of a given name
+/// in the file, and `filePath::varName@N` for subsequent occurrences (N is the
+/// 0-based occurrence index, starting from 1 for the second occurrence).
+///
+/// The per-name counter is preferred over source spans: counters only shift when
+/// contexts are added or removed, whereas spans shift on any edit to earlier
+/// code — making counters more HMR-stable.
 pub fn inject_context_stable_ids(ms: &mut MagicString, program: &Program, rel_file_path: &str) {
+    let mut name_counts: HashMap<String, u32> = HashMap::new();
     for stmt in &program.body {
         // Unwrap export declarations to get the inner variable declaration
         let var_decl: &VariableDeclaration = match stmt {
@@ -48,8 +57,15 @@ pub fn inject_context_stable_ids(ms: &mut MagicString, program: &Program, rel_fi
             };
 
             let var_name = binding.name.as_str();
+            let count = name_counts.entry(var_name.to_string()).or_insert(0);
+            let suffix = if *count == 0 {
+                String::new()
+            } else {
+                format!("@{count}")
+            };
+            *count += 1;
             let escaped_path = rel_file_path.replace('\\', "\\\\").replace('\'', "\\'");
-            let stable_id = format!("{escaped_path}::{var_name}");
+            let stable_id = format!("{escaped_path}::{var_name}{suffix}");
 
             let args = &call_expr.arguments;
             if args.is_empty() {
@@ -180,6 +196,38 @@ mod tests {
         assert_eq!(
             result,
             "let Ctx;\nconst Other = createContext(undefined, 'test.tsx::Other');"
+        );
+    }
+
+    #[test]
+    fn same_name_contexts_get_unique_ids() {
+        let source = "const Ctx = createContext();\nconst Ctx = createContext(0);";
+        let result = transform(source, "test.tsx");
+        assert_eq!(
+            result,
+            "const Ctx = createContext(undefined, 'test.tsx::Ctx');\nconst Ctx = createContext(0, 'test.tsx::Ctx@1');"
+        );
+    }
+
+    #[test]
+    fn three_same_name_contexts_get_sequential_ids() {
+        let source =
+            "const A = createContext();\nconst A = createContext();\nconst A = createContext();";
+        let result = transform(source, "test.tsx");
+        assert_eq!(
+            result,
+            "const A = createContext(undefined, 'test.tsx::A');\nconst A = createContext(undefined, 'test.tsx::A@1');\nconst A = createContext(undefined, 'test.tsx::A@2');"
+        );
+    }
+
+    #[test]
+    fn per_name_counter_is_independent() {
+        let source =
+            "const A = createContext();\nconst B = createContext();\nconst A = createContext();";
+        let result = transform(source, "test.tsx");
+        assert_eq!(
+            result,
+            "const A = createContext(undefined, 'test.tsx::A');\nconst B = createContext(undefined, 'test.tsx::B');\nconst A = createContext(undefined, 'test.tsx::A@1');"
         );
     }
 }

--- a/native/vertz-compiler-core/src/context_stable_ids.rs
+++ b/native/vertz-compiler-core/src/context_stable_ids.rs
@@ -15,9 +15,9 @@ use crate::magic_string::MagicString;
 /// in the file, and `filePath::varName@N` for subsequent occurrences (N is the
 /// 0-based occurrence index, starting from 1 for the second occurrence).
 ///
-/// The per-name counter is preferred over source spans: counters only shift when
-/// contexts are added or removed, whereas spans shift on any edit to earlier
-/// code — making counters more HMR-stable.
+/// The per-name counter is preferred over source spans: counters only shift
+/// when same-name contexts are added, removed, or reordered, whereas spans
+/// shift on any edit to earlier code — making counters more HMR-stable.
 pub fn inject_context_stable_ids(ms: &mut MagicString, program: &Program, rel_file_path: &str) {
     let mut name_counts: HashMap<String, u32> = HashMap::new();
     for stmt in &program.body {

--- a/packages/ui-server/src/build-plugin/__tests__/context-stable-ids.test.ts
+++ b/packages/ui-server/src/build-plugin/__tests__/context-stable-ids.test.ts
@@ -116,4 +116,32 @@ const Ctx = createContext();`;
       });
     });
   });
+
+  describe('Given two createContext calls sharing the same variable name', () => {
+    describe('When the transform runs', () => {
+      it('Then suffixes @N on repeats so the ids are unique', () => {
+        const source = `import { createContext } from '@vertz/ui';
+const Ctx = createContext();
+const Ctx = createContext(0);`;
+        const result = transform(source);
+        expect(result).toContain("undefined, 'src/contexts/settings.tsx::Ctx'");
+        expect(result).toContain("0, 'src/contexts/settings.tsx::Ctx@1'");
+      });
+    });
+  });
+
+  describe('Given three createContext calls sharing the same variable name', () => {
+    describe('When the transform runs', () => {
+      it('Then increments the suffix for each repeat independently', () => {
+        const source = `import { createContext } from '@vertz/ui';
+const A = createContext();
+const B = createContext();
+const A = createContext();`;
+        const result = transform(source);
+        expect(result).toContain("undefined, 'src/contexts/settings.tsx::A'");
+        expect(result).toContain("undefined, 'src/contexts/settings.tsx::B'");
+        expect(result).toContain("undefined, 'src/contexts/settings.tsx::A@1'");
+      });
+    });
+  });
 });

--- a/packages/ui-server/src/build-plugin/context-stable-ids.ts
+++ b/packages/ui-server/src/build-plugin/context-stable-ids.ts
@@ -10,8 +10,8 @@ import ts from 'typescript';
  * variable name in the file, and `filePath::varName@N` for subsequent
  * occurrences (N is the 0-based occurrence index, starting at 1 for the
  * second occurrence). A per-name counter is used rather than a source span
- * because counters only shift when contexts are added/removed, while spans
- * shift on any edit to earlier code.
+ * because counters only shift when same-name contexts are added, removed,
+ * or reordered, while spans shift on any edit to earlier code.
  */
 export function injectContextStableIds(
   source: MagicString,

--- a/packages/ui-server/src/build-plugin/context-stable-ids.ts
+++ b/packages/ui-server/src/build-plugin/context-stable-ids.ts
@@ -6,14 +6,19 @@ import ts from 'typescript';
  *
  * Detects `const X = createContext(...)` patterns and injects a `__stableId`
  * argument so the context registry survives bundle re-evaluation.
- * The ID format is `filePath::varName` — unique because file paths are unique
- * and variable names are unique within a file.
+ * The ID format is `filePath::varName` for the first occurrence of a given
+ * variable name in the file, and `filePath::varName@N` for subsequent
+ * occurrences (N is the 0-based occurrence index, starting at 1 for the
+ * second occurrence). A per-name counter is used rather than a source span
+ * because counters only shift when contexts are added/removed, while spans
+ * shift on any edit to earlier code.
  */
 export function injectContextStableIds(
   source: MagicString,
   sourceFile: ts.SourceFile,
   relFilePath: string,
 ): void {
+  const nameCounts = new Map<string, number>();
   for (const stmt of sourceFile.statements) {
     if (!ts.isVariableStatement(stmt)) continue;
     for (const decl of stmt.declarationList.declarations) {
@@ -23,8 +28,11 @@ export function injectContextStableIds(
       if (!ts.isIdentifier(decl.name)) continue;
 
       const varName = decl.name.text;
+      const count = nameCounts.get(varName) ?? 0;
+      nameCounts.set(varName, count + 1);
+      const suffix = count === 0 ? '' : `@${count}`;
       const escapedPath = relFilePath.replace(/['\\]/g, '\\$&');
-      const stableId = `${escapedPath}::${varName}`;
+      const stableId = `${escapedPath}::${varName}${suffix}`;
       const callExpr = decl.initializer;
 
       // Insert the stable ID as the last argument


### PR DESCRIPTION
## Summary

- `injectContextStableIds` built the stable id as `{filePath}::{varName}`. Two `createContext()` calls in the same file with the same variable name (an inlined/formatted pair on one line, or a code-generated context module) collided, and the runtime context registry silently returned the same object for both — breaking Provider/useContext pairing with no diagnostic.
- Both the Rust transform (`native/vertz-compiler-core/src/context_stable_ids.rs`) and the TypeScript sibling (`packages/ui-server/src/build-plugin/context-stable-ids.ts`) now track a per-variable-name occurrence counter. First occurrence keeps `{filePath}::{varName}` (unchanged); repeats get `{filePath}::{varName}@N` where `N` is the 0-based index (starting at 1 for the second occurrence).
- Per-name counter is preferred over a source span: counters only shift when same-name contexts are added, removed, or reordered, whereas spans shift on any edit to earlier code — so counters are more HMR-stable.

Closes #2786.

## Public API Changes

None. `__stableId` is an internal registry key, not a user-facing API. First-occurrence ids are unchanged, so existing single-context files produce identical output.

## Adversarial Review

`reviews/context-stable-ids-2786/phase-01-adversarial-review.md` — one blocker caught (changeset listed `'vtz'` instead of `'vertz'`; fixed in follow-up commit) plus one nice-to-have doc comment refinement (applied). Pre-existing `'vtz'` typo in #2784's already-merged changeset was spun out to #2964.

## Test Plan

- [x] Regression test (Rust + TS): two same-named `createContext` calls produce different ids.
- [x] Regression test: three same-name `createContext` calls get sequential `@1`, `@2` suffixes.
- [x] Regression test: independent per-name counters (mixed A/B/A stays correctly suffixed).
- [x] All existing tests continue to pass (first-occurrence id is unchanged).
- [x] `cargo test --all` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `vtz test` green in `@vertz/ui-server`.
- [x] `vtz run typecheck` green in `@vertz/ui-server`.
- [x] Lint + format clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)