### PR TITLE
feat(agents): bridge AgentStore to Vertz entities (RLS-aware sessions/messages) [#2847]

### DIFF
--- a/.changeset/agent-store-entity-bridge.md
+++ b/.changeset/agent-store-entity-bridge.md
@@ -1,0 +1,31 @@
+---
+'@vertz/agents': patch
+---
+
+feat(agents): bridge `AgentStore` with Vertz entities for RLS-aware queries [#2847]
+
+Adds `@vertz/agents/entities` subpath exporting column packs
+(`agentSessionColumns`, `agentMessageColumns`, `agentSessionIndexes`,
+`agentMessageIndexes`) and a `defineAgentEntities(db)` factory that turns the
+store's tables into first-class Vertz entities. App-side reads via
+`/api/agent-session` routes or `ctx.entities.agentSession.list()` now flow
+through the CRUD pipeline with full `rules.*` enforcement (auth, tenant
+scoping, row-level `where`). Writes from the agent loop keep going through
+`sqliteStore`/`d1Store` — same atomic paths, unchanged hot path.
+
+**Breaking:** `AgentStore.appendMessages(sessionId, messages)` gains a third
+`session: AgentSession` parameter — matches the existing
+`appendMessagesAtomic` shape. `run.ts` already has the session in scope at the
+call site; external `AgentStore` implementers need to update their method
+signature (and, if they back entity reads, denormalize `userId`/`tenantId`
+onto message rows as the shipped implementations now do).
+
+**Breaking:** `agent_messages` gains `user_id` and `tenant_id` columns.
+Fresh installs get them automatically; existing databases must run
+`packages/agents/migrations/001-add-rls-columns.sql` once on upgrade.
+
+Follow-ups tracked: #2957 (reject entity hook registration on factory
+entities), #2958 (migrate `state`/`toolCalls` to `d.jsonb<T>()`).
+
+See `plans/agent-store-entity-bridge.md` (merged as #2959) for the full
+design and `guides/agents/entity-bridge` in mint-docs for usage.

--- a/packages/agents/build.config.ts
+++ b/packages/agents/build.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@vertz/build';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cloudflare.ts', 'src/testing/index.ts'],
+  entry: ['src/index.ts', 'src/cloudflare.ts', 'src/entities/index.ts', 'src/testing/index.ts'],
   dts: true,
-  external: ['bun:sqlite'],
+  external: ['bun:sqlite', '@vertz/db', '@vertz/server'],
   clean: true,
 });

--- a/packages/agents/migrations/001-add-rls-columns.sql
+++ b/packages/agents/migrations/001-add-rls-columns.sql
@@ -1,0 +1,29 @@
+-- Migration 001: add RLS columns (user_id, tenant_id) to agent_messages.
+--
+-- Applies to existing databases created by earlier versions of sqliteStore / d1Store.
+-- Fresh installs already include these columns via the updated DDL in the stores'
+-- CREATE TABLE IF NOT EXISTS statements.
+--
+-- Rationale: #2847 bridges agent persistence with Vertz entity RLS. Entity access rules
+-- are evaluated as flat equality against row data (access-enforcer.ts:64-72), so
+-- enforcing `rules.where({ userId: rules.user.id })` on the Message entity requires
+-- the userId column directly on the message row — a relation traversal is not
+-- supported today.
+--
+-- RUN ONCE. The ALTER TABLE statements below will fail with "duplicate column name"
+-- on a second run — SQLite/D1 don't support `ADD COLUMN IF NOT EXISTS`. Wire this
+-- through a migration runner that tracks applied migrations (e.g. @vertz/db's
+-- migrate commands, or Wrangler's `wrangler d1 migrations` for D1).
+
+ALTER TABLE agent_messages ADD COLUMN user_id TEXT;
+ALTER TABLE agent_messages ADD COLUMN tenant_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_messages_user ON agent_messages(user_id);
+
+-- Backfill userId / tenantId onto historical messages by joining through agent_sessions.
+-- After this runs, existing message rows are visible to the Message entity's RLS reads.
+UPDATE agent_messages
+SET
+  user_id = (SELECT user_id FROM agent_sessions WHERE agent_sessions.id = agent_messages.session_id),
+  tenant_id = (SELECT tenant_id FROM agent_sessions WHERE agent_sessions.id = agent_messages.session_id)
+WHERE user_id IS NULL;

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -9,7 +9,8 @@
     "directory": "packages/agents"
   },
   "files": [
-    "dist"
+    "dist",
+    "migrations"
   ],
   "type": "module",
   "sideEffects": false,
@@ -23,6 +24,10 @@
     "./cloudflare": {
       "import": "./dist/cloudflare.js",
       "types": "./dist/cloudflare.d.ts"
+    },
+    "./entities": {
+      "import": "./dist/entities/index.js",
+      "types": "./dist/entities/index.d.ts"
     },
     "./testing": {
       "import": "./dist/testing/index.js",
@@ -47,15 +52,20 @@
   "devDependencies": {
     "@types/node": "^25.3.1",
     "@vertz/build": "workspace:^",
+    "@vertz/db": "workspace:^",
     "@vertz/server": "workspace:^",
     "@vertz/test": "workspace:*",
     "bun-types": "^1.3.10",
     "typescript": "^5.7.0"
   },
   "peerDependencies": {
+    "@vertz/db": "workspace:^",
     "@vertz/server": "workspace:^"
   },
   "peerDependenciesMeta": {
+    "@vertz/db": {
+      "optional": true
+    },
     "@vertz/server": {
       "optional": true
     }

--- a/packages/agents/src/entities/__tests__/bridge.integration.test.ts
+++ b/packages/agents/src/entities/__tests__/bridge.integration.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, afterEach, beforeEach } from '@vertz/test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { unlinkSync } from 'node:fs';
+import { d, createDb, createDatabaseBridgeAdapter } from '@vertz/db';
+import {
+  createServer,
+  createCrudHandlers,
+  createEntityContext,
+  EntityRegistry,
+  type EntityOperations,
+} from '@vertz/server';
+import { sqliteStore } from '../../stores/sqlite-store';
+import type { AgentSession } from '../../stores/types';
+import {
+  agentSessionColumns,
+  agentSessionIndexes,
+  agentMessageColumns,
+  agentMessageIndexes,
+} from '../columns';
+import { defineAgentEntities } from '../define';
+
+// Stub EntityOperations — the handlers path uses its own EntityDbAdapter; these stubs
+// are only referenced by ctx.entities.* cross-entity traversal, which this test
+// doesn't exercise. Shape matches the interface at entity-operations.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ops are unused in this test; shape erasure is deliberate
+const stubOps: EntityOperations<any> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub — return any empty row
+  get: async () => ({}) as any,
+  list: async () =>
+    ({
+      items: [],
+      total: 0,
+      limit: 0,
+      nextCursor: null,
+      hasNextPage: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub
+    }) as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub
+  create: async () => ({}) as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub
+  update: async () => ({}) as any,
+  delete: async () => undefined,
+};
+
+function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
+  const now = '2026-04-22T00:00:00.000Z';
+  return {
+    id: 'sess_default',
+    agentName: 'coder',
+    userId: null,
+    tenantId: null,
+    state: '{}',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('Feature: Agent store ↔ entity bridge (#2847)', () => {
+  let dbPath: string;
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `agent-bridge-${Date.now()}-${Math.random()}.db`);
+  });
+  afterEach(() => {
+    try {
+      unlinkSync(dbPath);
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  describe('Given run() persisted a session + messages via sqliteStore, and entities are registered on the same DB', () => {
+    it('Then entity RLS isolates the session from a different user in a different tenant', async () => {
+      // Schema: shared DB file used by BOTH the store and the entity-side createDb.
+      const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+        indexes: agentSessionIndexes,
+      });
+      const messagesTable = d.table('agent_messages', agentMessageColumns, {
+        indexes: agentMessageIndexes,
+      });
+      const db = createDb({
+        dialect: 'sqlite',
+        path: dbPath,
+        migrations: { autoApply: true },
+        models: {
+          agentSessions: d.model(sessionsTable),
+          agentMessages: d.model(messagesTable, {
+            session: d.ref.one(() => sessionsTable, 'sessionId'),
+          }),
+        },
+      });
+
+      const { session: Session, message: Message } = defineAgentEntities(db);
+      // Registration side-effect runs tenant-chain resolution inside createServer.
+      createServer({ db, entities: [Session, Message] });
+
+      // Simulate run()-driven writes by calling the store directly.
+      const store = sqliteStore({ path: dbPath });
+      const userASession = makeSession({
+        id: 'sess_user-a',
+        userId: 'user-a',
+        tenantId: 'ws-1',
+      });
+      await store.saveSession(userASession);
+      await store.appendMessages(
+        userASession.id,
+        [
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello' },
+        ],
+        userASession,
+      );
+
+      // --- Entity-side reads with an EntityContext per user ---
+      const registry = new EntityRegistry();
+      registry.register(Session.name, stubOps);
+      registry.register(Message.name, stubOps);
+      const asCtx = (userId: string | null, tenantId: string | null) =>
+        createEntityContext({ userId, tenantId, roles: [] }, stubOps, registry.createProxy());
+
+      const sessionAdapter = createDatabaseBridgeAdapter(db, 'agentSessions');
+      const messageAdapter = createDatabaseBridgeAdapter(db, 'agentMessages');
+      const sessionHandlers = createCrudHandlers(Session, sessionAdapter);
+      const messageHandlers = createCrudHandlers(Message, messageAdapter);
+
+      // User B (different tenant) → no rows via RLS.
+      const listB = await sessionHandlers.list!(asCtx('user-b', 'ws-2'));
+      expect(listB.ok).toBe(true);
+      if (!listB.ok) throw listB.error;
+      expect(listB.data.body.items).toEqual([]);
+
+      // User C (same tenant, different user) → no rows either.
+      const listC = await sessionHandlers.list!(asCtx('user-c', 'ws-1'));
+      expect(listC.ok).toBe(true);
+      if (!listC.ok) throw listC.error;
+      expect(listC.data.body.items).toEqual([]);
+
+      // User A → sees exactly their session.
+      const listA = await sessionHandlers.list!(asCtx('user-a', 'ws-1'));
+      expect(listA.ok).toBe(true);
+      if (!listA.ok) throw listA.error;
+      expect(listA.data.body.items).toHaveLength(1);
+      expect((listA.data.body.items[0] as { id: string; userId: string | null }).id).toBe(
+        'sess_user-a',
+      );
+
+      // Messages are filterable + ordered by seq, and RLS-scoped via denormalized userId.
+      const msgsA = await messageHandlers.list!(asCtx('user-a', 'ws-1'), {
+        where: { sessionId: 'sess_user-a' },
+      });
+      expect(msgsA.ok).toBe(true);
+      if (!msgsA.ok) throw msgsA.error;
+      const items = msgsA.data.body.items as {
+        role: string;
+        seq: number;
+        content: string;
+      }[];
+      expect(items.map((m) => m.role)).toEqual(['user', 'assistant']);
+      expect(items.map((m) => m.seq)).toEqual([1, 2]);
+
+      // User C in same tenant can't read user A's messages.
+      const msgsC = await messageHandlers.list!(asCtx('user-c', 'ws-1'), {
+        where: { sessionId: 'sess_user-a' },
+      });
+      expect(msgsC.ok).toBe(true);
+      if (!msgsC.ok) throw msgsC.error;
+      expect(msgsC.data.body.items).toEqual([]);
+    });
+  });
+
+  describe('Given an extended sessions table with a custom workspaceId column', () => {
+    it('Then Session.create via the entity API runs before.create, injects userId, and the custom field round-trips', async () => {
+      const sessionsTable = d.table(
+        'agent_sessions',
+        {
+          ...agentSessionColumns,
+          workspaceId: d.text(),
+        },
+        { indexes: [...agentSessionIndexes, d.index('workspaceId')] },
+      );
+      const messagesTable = d.table('agent_messages', agentMessageColumns, {
+        indexes: agentMessageIndexes,
+      });
+      const db = createDb({
+        dialect: 'sqlite',
+        path: dbPath,
+        migrations: { autoApply: true },
+        models: {
+          agentSessions: d.model(sessionsTable),
+          agentMessages: d.model(messagesTable, {
+            session: d.ref.one(() => sessionsTable, 'sessionId'),
+          }),
+        },
+      });
+
+      const { session: Session } = defineAgentEntities(db);
+      createServer({ db, entities: [Session] });
+
+      const registry = new EntityRegistry();
+      registry.register(Session.name, stubOps);
+      const asCtx = (userId: string | null, tenantId: string | null) =>
+        createEntityContext({ userId, tenantId, roles: [] }, stubOps, registry.createProxy());
+
+      const adapter = createDatabaseBridgeAdapter(db, 'agentSessions');
+      const handlers = createCrudHandlers(Session, adapter);
+
+      // Caller passes only agentName + workspaceId. The hook injects userId/tenantId from ctx.
+      const created = await handlers.create!(asCtx('user-a', 'ws-1'), {
+        agentName: 'coder',
+        workspaceId: 'ws-1',
+        state: '{}',
+        createdAt: '2026-04-22T00:00:00.000Z',
+        updatedAt: '2026-04-22T00:00:00.000Z',
+      });
+      if (!created.ok) {
+        // Surface detail so failures are diagnosable.
+        throw new Error(`create failed: ${JSON.stringify(created.error, null, 2)}`);
+      }
+      expect(created.ok).toBe(true);
+      if (!created.ok) throw created.error;
+      const body = created.data.body as {
+        id: string;
+        userId: string | null;
+        tenantId: string | null;
+        workspaceId: string;
+      };
+      expect(body.userId).toBe('user-a');
+      expect(body.tenantId).toBe('ws-1');
+      expect(body.workspaceId).toBe('ws-1');
+
+      // The CRUD pipeline excludes `userId` / `tenantId` from the create input schema
+      // (tenant-scoping auto-sets them; our before.create hook fills in userId), so the
+      // "ctx wins over explicit input" semantic is verified as a unit test in
+      // define.test.ts rather than end-to-end here — there is no way to smuggle an
+      // `attacker` userId through the entity API in the first place.
+
+      // Custom-column query via the entity pipeline (RLS + user-defined filter).
+      const inWs1 = await handlers.list!(asCtx('user-a', 'ws-1'), {
+        where: { workspaceId: 'ws-1' },
+      });
+      expect(inWs1.ok).toBe(true);
+      if (!inWs1.ok) throw inWs1.error;
+      expect(inWs1.data.body.items).toHaveLength(1);
+    });
+  });
+});

--- a/packages/agents/src/entities/__tests__/define.test-d.ts
+++ b/packages/agents/src/entities/__tests__/define.test-d.ts
@@ -1,0 +1,50 @@
+import { describe, it } from '@vertz/test';
+import { d, createDb } from '@vertz/db';
+import {
+  agentSessionColumns,
+  agentSessionIndexes,
+  agentMessageColumns,
+  agentMessageIndexes,
+} from '../columns';
+import { defineAgentEntities } from '../define';
+
+// Build a real createDb to drive the generic. Never executed — types only.
+const _sessions = d.table('agent_sessions', agentSessionColumns, { indexes: agentSessionIndexes });
+const _messages = d.table('agent_messages', agentMessageColumns, { indexes: agentMessageIndexes });
+
+// Don't bother plumbing the full generic here — the factory accepts DatabaseClient<any>
+// by design; the runtime check is the real contract.
+declare const db: ReturnType<typeof createDb>;
+
+describe('defineAgentEntities() — type-level', () => {
+  it('returns { session, message } as EntityDefinitions', () => {
+    const { session, message } = defineAgentEntities(db);
+    session satisfies { kind: 'entity'; name: string };
+    message satisfies { kind: 'entity'; name: string };
+  });
+
+  it('rejects a non-string sessionName', () => {
+    // @ts-expect-error — sessionName must be string
+    defineAgentEntities(db, { sessionName: 42 });
+  });
+
+  it('rejects a non-string messageName', () => {
+    // @ts-expect-error — messageName must be string
+    defineAgentEntities(db, { messageName: true });
+  });
+
+  it('rejects a non-object sessionAccess', () => {
+    // @ts-expect-error — sessionAccess must be an object of AccessRule values
+    defineAgentEntities(db, { sessionAccess: 'authenticated' });
+  });
+
+  it('rejects a string value inside sessionAccess', () => {
+    // @ts-expect-error — each value in sessionAccess must be an AccessRule, not a string
+    defineAgentEntities(db, { sessionAccess: { list: 'not-a-rule' } });
+  });
+
+  it('requires a db argument', () => {
+    // @ts-expect-error — db is required
+    defineAgentEntities();
+  });
+});

--- a/packages/agents/src/entities/__tests__/define.test.ts
+++ b/packages/agents/src/entities/__tests__/define.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from '@vertz/test';
+import { d, createDb } from '@vertz/db';
+import { rules } from '@vertz/server';
+import {
+  agentSessionColumns,
+  agentSessionIndexes,
+  agentMessageColumns,
+  agentMessageIndexes,
+} from '../columns';
+import { AgentBridgeMissingTableError, defineAgentEntities } from '../define';
+
+function makeDb() {
+  const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+    indexes: agentSessionIndexes,
+  });
+  const messagesTable = d.table('agent_messages', agentMessageColumns, {
+    indexes: agentMessageIndexes,
+  });
+  return createDb({
+    dialect: 'sqlite',
+    path: ':memory:',
+    migrations: { autoApply: true },
+    models: {
+      agentSessions: d.model(sessionsTable),
+      agentMessages: d.model(messagesTable, {
+        session: d.ref.one(() => sessionsTable, 'sessionId'),
+      }),
+    },
+  });
+}
+
+describe('defineAgentEntities()', () => {
+  describe('Given a db with registered agent tables', () => {
+    describe('When called without options', () => {
+      it('Then returns entities with default names', () => {
+        const db = makeDb();
+        const { session, message } = defineAgentEntities(db);
+        expect(session.name).toBe('agent-session');
+        expect(message.name).toBe('agent-message');
+        expect(session.kind).toBe('entity');
+        expect(message.kind).toBe('entity');
+      });
+
+      it('Then applies default access rules (user-scoped where rule)', () => {
+        const db = makeDb();
+        const { session, message } = defineAgentEntities(db);
+        // Spot-check: every op on session has a rule; message reads are user-scoped, writes disabled.
+        expect(session.access.list).toBeDefined();
+        expect(session.access.get).toBeDefined();
+        expect(session.access.create).toBeDefined();
+        expect(message.access.list).toBeDefined();
+        expect(message.access.get).toBeDefined();
+        // Message writes default to undefined (factory leaves them off so entity pipeline denies).
+        expect(message.access.create).toBeUndefined();
+      });
+
+      it('Then installs a before.create hook on session that injects userId/tenantId from ctx', async () => {
+        const db = makeDb();
+        const { session } = defineAgentEntities(db);
+        const hook = session.before.create;
+        expect(hook).toBeDefined();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- hook ctx stubbed for unit test
+        const ctx = { userId: 'user-1', tenantId: 'tenant-1' } as any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- hook is type-erased at runtime
+        const result = (await (hook as any)({ agentName: 'coder' }, ctx)) as {
+          userId: string | null;
+          tenantId: string | null;
+        };
+        expect(result.userId).toBe('user-1');
+        expect(result.tenantId).toBe('tenant-1');
+      });
+
+      it('Then ctx.userId wins over explicit input.userId (prevents impersonation)', async () => {
+        const db = makeDb();
+        const { session } = defineAgentEntities(db);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ctx/hook stubbed for unit test
+        const ctx = { userId: 'actual-user', tenantId: 'actual-tenant' } as any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- hook is type-erased at runtime
+        const result = (await (session.before.create as any)(
+          { agentName: 'coder', userId: 'attacker', tenantId: 'other-tenant' },
+          ctx,
+        )) as { userId: string | null; tenantId: string | null };
+        expect(result.userId).toBe('actual-user');
+        expect(result.tenantId).toBe('actual-tenant');
+      });
+    });
+
+    describe('When called with custom sessionName / messageName', () => {
+      it('Then uses the overridden names', () => {
+        const db = makeDb();
+        const { session, message } = defineAgentEntities(db, {
+          sessionName: 'coder-session',
+          messageName: 'coder-message',
+        });
+        expect(session.name).toBe('coder-session');
+        expect(message.name).toBe('coder-message');
+      });
+    });
+
+    describe('When called with custom sessionAccess', () => {
+      it('Then the override replaces defaults', () => {
+        const db = makeDb();
+        const { session } = defineAgentEntities(db, {
+          sessionAccess: {
+            list: rules.authenticated(),
+          },
+        });
+        expect(session.access.list).toEqual(rules.authenticated());
+      });
+    });
+  });
+
+  describe('Given a db without the required tables', () => {
+    it('Then throws AgentBridgeMissingTableError with actionable message', () => {
+      const unrelatedTable = d.table('users', { id: d.text().primary() });
+      const db = createDb({
+        dialect: 'sqlite',
+        path: ':memory:',
+        migrations: { autoApply: true },
+        models: { users: d.model(unrelatedTable) },
+      });
+      expect(() => defineAgentEntities(db)).toThrow(AgentBridgeMissingTableError);
+    });
+  });
+});

--- a/packages/agents/src/entities/columns.ts
+++ b/packages/agents/src/entities/columns.ts
@@ -1,0 +1,59 @@
+import { d } from '@vertz/db';
+import type { ColumnRecord, IndexDef } from '@vertz/db';
+
+/**
+ * Column pack for `agent_sessions`. Matches the legacy DDL in
+ * `sqlite-store.ts` / `d1-store.ts` on every column.
+ *
+ * Spread into your own `d.table()` call. See `plans/agent-store-entity-bridge.md`
+ * for the full usage pattern and the rationale for the ctx-wins `before.create`
+ * hook that `defineAgentEntities()` installs.
+ */
+export const agentSessionColumns = {
+  // `generate: 'uuid'` auto-generates an id when the entity CRUD pipeline creates a row
+  // (the pipeline excludes PK columns from $create_input unless they have a default).
+  // The `AgentStore` path (sqliteStore/d1Store) still provides its own id — `run()` mints
+  // `sess_<uuid>` via `generateSessionId()`. Both paths write to the same TEXT column;
+  // the DB doesn't care about the id format.
+  id: d.text().primary({ generate: 'uuid' }),
+  agentName: d.text(),
+  userId: d.text().nullable(),
+  tenantId: d.text().nullable(),
+  state: d.text(),
+  createdAt: d.text(),
+  updatedAt: d.text(),
+} satisfies ColumnRecord;
+
+/**
+ * Column pack for `agent_messages`. Existing legacy columns + two new denormalized
+ * columns (`userId`, `tenantId`) that enable flat `rules.where({ userId: rules.user.id })`
+ * on the `Message` entity without relation-traversing access rules.
+ *
+ * The agent store writes `userId` / `tenantId` from the session on every append —
+ * which is why `AgentStore.appendMessages` gained a `session` parameter in the
+ * same PR. See `plans/agent-store-entity-bridge.md`.
+ */
+export const agentMessageColumns = {
+  id: d.integer().primary(),
+  sessionId: d.text(),
+  seq: d.integer(),
+  role: d.text(),
+  content: d.text(),
+  toolCallId: d.text().nullable(),
+  toolName: d.text().nullable(),
+  toolCalls: d.text().nullable(),
+  userId: d.text().nullable(),
+  tenantId: d.text().nullable(),
+  createdAt: d.text(),
+} satisfies ColumnRecord;
+
+export const agentSessionIndexes: IndexDef[] = [
+  d.index('agentName'),
+  d.index('userId'),
+  d.index('updatedAt'),
+];
+
+export const agentMessageIndexes: IndexDef[] = [
+  d.index(['sessionId', 'seq'], { unique: true }),
+  d.index('userId'),
+];

--- a/packages/agents/src/entities/define.ts
+++ b/packages/agents/src/entities/define.ts
@@ -1,0 +1,149 @@
+import { AppError } from '@vertz/errors';
+import type { DatabaseClient, ModelDef, TableDef } from '@vertz/db';
+import { d } from '@vertz/db';
+// `@vertz/server` is an optional peer dep on `@vertz/agents` (see package.json).
+// This subpath is only loaded when the consumer has `@vertz/server` installed,
+// same as `@vertz/agents/cloudflare`.
+import type { AccessRule, EntityDefinition } from '@vertz/server';
+import { entity, rules } from '@vertz/server';
+
+// Agent sessions / messages table names — stable contract with the store DDL.
+const SESSION_TABLE = 'agent_sessions';
+const MESSAGE_TABLE = 'agent_messages';
+
+// `Partial<Record<op, AccessRule>>` is the shape `EntityConfig.access` accepts.
+// Re-exported as `EntityAccess` for the public option types — keeps the surface
+// at `@vertz/agents/entities` self-contained without forcing a new type through
+// `@vertz/server`.
+export type EntityAccess = Partial<
+  Record<'list' | 'get' | 'create' | 'update' | 'delete', AccessRule>
+>;
+
+export interface DefineAgentEntitiesOptions {
+  /** Override entity names if 'agent-session' / 'agent-message' collides with existing entities. */
+  readonly sessionName?: string;
+  readonly messageName?: string;
+  /**
+   * Override access rules. Defaults scope every op to `rules.where({ userId: rules.user.id })`,
+   * with a `before.create` hook that injects `userId`/`tenantId` from the request context.
+   * See `plans/agent-store-entity-bridge.md` (Rev 6) for the rationale behind `ctx.userId`
+   * winning over any caller-supplied `userId` (prevents silent impersonation).
+   */
+  readonly sessionAccess?: EntityAccess;
+  readonly messageAccess?: EntityAccess;
+}
+
+const defaultSessionAccess: EntityAccess = {
+  list: rules.where({ userId: rules.user.id }),
+  get: rules.where({ userId: rules.user.id }),
+  create: rules.authenticated(),
+  update: rules.where({ userId: rules.user.id }),
+  delete: rules.where({ userId: rules.user.id }),
+};
+
+const defaultMessageAccess: EntityAccess = {
+  list: rules.where({ userId: rules.user.id }),
+  get: rules.where({ userId: rules.user.id }),
+  // Writes default to denied — only the AgentStore writes messages, via the store path
+  // which bypasses the entity CRUD pipeline entirely.
+};
+
+interface ModelEntryShape {
+  readonly table: TableDef;
+  readonly relations: Record<string, unknown>;
+}
+
+function findModelByTableName(
+  models: Record<string, ModelEntryShape>,
+  tableName: string,
+): ModelEntryShape | null {
+  for (const entry of Object.values(models)) {
+    if (entry.table._name === tableName) return entry;
+  }
+  return null;
+}
+
+export class AgentBridgeMissingTableError extends AppError<'AGENT_BRIDGE_MISSING_TABLE'> {
+  constructor(tableName: string) {
+    super(
+      'AGENT_BRIDGE_MISSING_TABLE',
+      `defineAgentEntities: no model registered for table '${tableName}'. Spread the appropriate column pack into your own d.table('${tableName}', {...}) call and register it in createDb({ models: { ... } }).`,
+    );
+  }
+}
+
+/**
+ * Build Vertz entities from tables registered in your `createDb({ models })` call.
+ *
+ * Requires the consumer to have registered two tables named `agent_sessions` and
+ * `agent_messages` (or the names passed via `sessionName` / `messageName`) using the
+ * column packs from this package. The factory:
+ *
+ *   1. Looks up the registered models via `db._internals.models`.
+ *   2. Builds `entity()` definitions wired to those models.
+ *   3. Installs a `before.create` hook on the session that auto-populates
+ *      `userId` / `tenantId` from the request context.
+ *
+ * See `plans/agent-store-entity-bridge.md` and the mint-docs page at
+ * `guides/agents/entity-bridge` for full usage.
+ */
+export function defineAgentEntities(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- DatabaseClient's generic would force callers through cumbersome type gymnastics; the factory validates the two required tables at runtime via _internals.models
+  db: DatabaseClient<any>,
+  opts: DefineAgentEntitiesOptions = {},
+): { session: EntityDefinition; message: EntityDefinition } {
+  const sessionName = opts.sessionName ?? 'agent-session';
+  const messageName = opts.messageName ?? 'agent-message';
+
+  const models = db._internals.models as unknown as Record<string, ModelEntryShape>;
+
+  const sessionEntry = findModelByTableName(models, SESSION_TABLE);
+  if (!sessionEntry) throw new AgentBridgeMissingTableError(SESSION_TABLE);
+
+  const messageEntry = findModelByTableName(models, MESSAGE_TABLE);
+  if (!messageEntry) throw new AgentBridgeMissingTableError(MESSAGE_TABLE);
+
+  // Reconstruct ModelDef from the registry entry (which only carries table+relations,
+  // not the derived schemas). d.model() adds the schemas.
+  const sessionModel = d.model(
+    sessionEntry.table,
+    sessionEntry.relations as Record<string, never>,
+  ) as ModelDef;
+  const messageModel = d.model(
+    messageEntry.table,
+    messageEntry.relations as Record<string, never>,
+  ) as ModelDef;
+
+  // Only inject columns that actually exist on the session table. An extended schema
+  // may drop `tenantId` (docs recommend this when adding a `.tenant()` relation) — in
+  // that case the CRUD pipeline's tenant auto-set handles scoping, and this hook must
+  // not fight it. `userId` is always handled here because no other layer populates it.
+  const sessionColumns = sessionEntry.table._columns as Record<string, unknown>;
+  const hasUserIdColumn = 'userId' in sessionColumns;
+  const hasTenantIdColumn = 'tenantId' in sessionColumns;
+
+  const session = entity(sessionName, {
+    model: sessionModel,
+    access: opts.sessionAccess ?? defaultSessionAccess,
+    before: {
+      create: (data, ctx) => {
+        const patch: Record<string, unknown> = {};
+        if (hasUserIdColumn) {
+          // ctx.userId wins over input — prevents impersonation. See design doc Rev 6.
+          patch.userId = ctx.userId ?? (data as { userId?: string | null }).userId ?? null;
+        }
+        if (hasTenantIdColumn) {
+          patch.tenantId = ctx.tenantId ?? (data as { tenantId?: string | null }).tenantId ?? null;
+        }
+        return { ...data, ...patch };
+      },
+    },
+  });
+
+  const message = entity(messageName, {
+    model: messageModel,
+    access: opts.messageAccess ?? defaultMessageAccess,
+  });
+
+  return { session, message };
+}

--- a/packages/agents/src/entities/index.ts
+++ b/packages/agents/src/entities/index.ts
@@ -1,0 +1,8 @@
+export {
+  agentSessionColumns,
+  agentMessageColumns,
+  agentSessionIndexes,
+  agentMessageIndexes,
+} from './columns';
+export { defineAgentEntities, AgentBridgeMissingTableError } from './define';
+export type { DefineAgentEntitiesOptions, EntityAccess } from './define';

--- a/packages/agents/src/run.ts
+++ b/packages/agents/src/run.ts
@@ -492,7 +492,7 @@ export async function run(
           : newMessages;
 
         if (messagesToPersist.length > 0) {
-          await store.appendMessages(sessionId, [...messagesToPersist]);
+          await store.appendMessages(sessionId, [...messagesToPersist], session);
         }
 
         // Prune messages if maxStoredMessages is set

--- a/packages/agents/src/stores/d1-store.test.ts
+++ b/packages/agents/src/stores/d1-store.test.ts
@@ -166,7 +166,7 @@ describe('d1Store()', () => {
           { role: 'assistant', content: 'Hi there!' },
         ];
 
-        await store.appendMessages('sess_test-1', messages);
+        await store.appendMessages('sess_test-1', messages, makeSession());
         const loaded = await store.loadMessages('sess_test-1');
 
         expect(loaded).toHaveLength(2);
@@ -193,7 +193,7 @@ describe('d1Store()', () => {
           { role: 'tool', content: '{"result": 42}', toolCallId: 'call_1', toolName: 'myTool' },
         ];
 
-        await store.appendMessages('sess_test-1', messages);
+        await store.appendMessages('sess_test-1', messages, makeSession());
         const loaded = await store.loadMessages('sess_test-1');
 
         expect(loaded).toHaveLength(3);
@@ -211,14 +211,18 @@ describe('d1Store()', () => {
       it('Then returns only the 4 most recent messages', async () => {
         const store = d1Store({ binding: mockD1Binding() });
         await store.saveSession(makeSession());
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'M1' },
-          { role: 'assistant', content: 'M2' },
-          { role: 'user', content: 'M3' },
-          { role: 'assistant', content: 'M4' },
-          { role: 'user', content: 'M5' },
-          { role: 'assistant', content: 'M6' },
-        ]);
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'M1' },
+            { role: 'assistant', content: 'M2' },
+            { role: 'user', content: 'M3' },
+            { role: 'assistant', content: 'M4' },
+            { role: 'user', content: 'M5' },
+            { role: 'assistant', content: 'M6' },
+          ],
+          makeSession(),
+        );
 
         await store.pruneMessages('sess_test-1', 4);
         const messages = await store.loadMessages('sess_test-1');
@@ -235,7 +239,11 @@ describe('d1Store()', () => {
       it('Then returns null for session and empty array for messages', async () => {
         const store = d1Store({ binding: mockD1Binding() });
         await store.saveSession(makeSession());
-        await store.appendMessages('sess_test-1', [{ role: 'user', content: 'Hello' }]);
+        await store.appendMessages(
+          'sess_test-1',
+          [{ role: 'user', content: 'Hello' }],
+          makeSession(),
+        );
 
         await store.deleteSession('sess_test-1');
 

--- a/packages/agents/src/stores/d1-store.ts
+++ b/packages/agents/src/stores/d1-store.ts
@@ -54,11 +54,14 @@ CREATE TABLE IF NOT EXISTS agent_messages (
   tool_call_id TEXT,
   tool_name TEXT,
   tool_calls TEXT,
+  user_id TEXT,
+  tenant_id TEXT,
   created_at TEXT NOT NULL,
   UNIQUE(session_id, seq)
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session ON agent_messages(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_user ON agent_messages(user_id);
 `;
 
 // ---------------------------------------------------------------------------
@@ -189,7 +192,7 @@ export function d1Store(options: D1StoreOptions): AgentStore {
       return result.results.map(rowToMessage);
     },
 
-    async appendMessages(sessionId, messages) {
+    async appendMessages(sessionId, messages, session) {
       await ensureTables();
       const seqResult = await db
         .prepare('SELECT MAX(seq) as max_seq FROM agent_messages WHERE session_id = ?')
@@ -203,8 +206,9 @@ export function d1Store(options: D1StoreOptions): AgentStore {
         statements.push(
           db
             .prepare(
-              `INSERT INTO agent_messages (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+              `INSERT INTO agent_messages
+                 (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, user_id, tenant_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             )
             .bind(
               sessionId,
@@ -214,6 +218,8 @@ export function d1Store(options: D1StoreOptions): AgentStore {
               msg.toolCallId ?? null,
               msg.toolName ?? null,
               msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+              session.userId,
+              session.tenantId,
               now,
             ),
         );
@@ -312,11 +318,12 @@ export function d1Store(options: D1StoreOptions): AgentStore {
         statements.push(
           db
             .prepare(
-              `INSERT INTO agent_messages (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, created_at)
+              `INSERT INTO agent_messages
+                 (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, user_id, tenant_id, created_at)
                VALUES (
                  ?,
                  COALESCE((SELECT MAX(seq) FROM agent_messages WHERE session_id = ?), 0) + 1,
-                 ?, ?, ?, ?, ?, ?
+                 ?, ?, ?, ?, ?, ?, ?, ?
                )`,
             )
             .bind(
@@ -327,6 +334,8 @@ export function d1Store(options: D1StoreOptions): AgentStore {
               msg.toolCallId ?? null,
               msg.toolName ?? null,
               msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+              session.userId,
+              session.tenantId,
               now,
             ),
         );

--- a/packages/agents/src/stores/memory-store.test.ts
+++ b/packages/agents/src/stores/memory-store.test.ts
@@ -74,7 +74,7 @@ describe('memoryStore()', () => {
           { role: 'assistant', content: 'Hi there!' },
         ];
 
-        await store.appendMessages('sess_test-1', messages);
+        await store.appendMessages('sess_test-1', messages, makeSession());
         const loaded = await store.loadMessages('sess_test-1');
 
         expect(loaded).toHaveLength(2);
@@ -91,14 +91,22 @@ describe('memoryStore()', () => {
       it('Then returns all messages in append order', async () => {
         const store = memoryStore();
 
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'First' },
-          { role: 'assistant', content: 'Response 1' },
-        ]);
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'Second' },
-          { role: 'assistant', content: 'Response 2' },
-        ]);
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'First' },
+            { role: 'assistant', content: 'Response 1' },
+          ],
+          makeSession(),
+        );
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'Second' },
+            { role: 'assistant', content: 'Response 2' },
+          ],
+          makeSession(),
+        );
 
         const loaded = await store.loadMessages('sess_test-1');
         expect(loaded).toHaveLength(4);
@@ -113,7 +121,11 @@ describe('memoryStore()', () => {
       it('Then returns null for session and empty array for messages', async () => {
         const store = memoryStore();
         await store.saveSession(makeSession());
-        await store.appendMessages('sess_test-1', [{ role: 'user', content: 'Hello' }]);
+        await store.appendMessages(
+          'sess_test-1',
+          [{ role: 'user', content: 'Hello' }],
+          makeSession(),
+        );
 
         await store.deleteSession('sess_test-1');
 
@@ -205,14 +217,18 @@ describe('memoryStore()', () => {
     describe('When loadMessages is called', () => {
       it('Then returns only the 4 most recent messages', async () => {
         const store = memoryStore();
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'M1' },
-          { role: 'assistant', content: 'M2' },
-          { role: 'user', content: 'M3' },
-          { role: 'assistant', content: 'M4' },
-          { role: 'user', content: 'M5' },
-          { role: 'assistant', content: 'M6' },
-        ]);
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'M1' },
+            { role: 'assistant', content: 'M2' },
+            { role: 'user', content: 'M3' },
+            { role: 'assistant', content: 'M4' },
+            { role: 'user', content: 'M5' },
+            { role: 'assistant', content: 'M6' },
+          ],
+          makeSession(),
+        );
 
         await store.pruneMessages('sess_test-1', 4);
         const messages = await store.loadMessages('sess_test-1');

--- a/packages/agents/src/stores/memory-store.ts
+++ b/packages/agents/src/stores/memory-store.ts
@@ -36,7 +36,9 @@ export function memoryStore(): AgentStore {
       return [...(messages.get(sessionId) ?? [])];
     },
 
-    async appendMessages(sessionId, newMessages) {
+    async appendMessages(sessionId, newMessages, _session) {
+      // `_session` is unused — memoryStore doesn't back entity reads, so there's no
+      // denormalized userId/tenantId to persist.
       const existing = messages.get(sessionId) ?? [];
       existing.push(...newMessages);
       messages.set(sessionId, existing);

--- a/packages/agents/src/stores/sqlite-store.test.ts
+++ b/packages/agents/src/stores/sqlite-store.test.ts
@@ -75,7 +75,7 @@ describe('sqliteStore()', () => {
           { role: 'assistant', content: 'Hi there!' },
         ];
 
-        await store.appendMessages('sess_test-1', messages);
+        await store.appendMessages('sess_test-1', messages, makeSession());
         const loaded = await store.loadMessages('sess_test-1');
 
         expect(loaded).toHaveLength(2);
@@ -93,14 +93,22 @@ describe('sqliteStore()', () => {
         const store = sqliteStore({ path: ':memory:' });
         await store.saveSession(makeSession());
 
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'First' },
-          { role: 'assistant', content: 'Response 1' },
-        ]);
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'Second' },
-          { role: 'assistant', content: 'Response 2' },
-        ]);
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'First' },
+            { role: 'assistant', content: 'Response 1' },
+          ],
+          makeSession(),
+        );
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'Second' },
+            { role: 'assistant', content: 'Response 2' },
+          ],
+          makeSession(),
+        );
 
         const loaded = await store.loadMessages('sess_test-1');
         expect(loaded).toHaveLength(4);
@@ -126,7 +134,7 @@ describe('sqliteStore()', () => {
           { role: 'assistant', content: 'The result is 42.' },
         ];
 
-        await store.appendMessages('sess_test-1', messages);
+        await store.appendMessages('sess_test-1', messages, makeSession());
         const loaded = await store.loadMessages('sess_test-1');
 
         expect(loaded).toHaveLength(4);
@@ -144,7 +152,11 @@ describe('sqliteStore()', () => {
       it('Then returns null for session and empty array for messages', async () => {
         const store = sqliteStore({ path: ':memory:' });
         await store.saveSession(makeSession());
-        await store.appendMessages('sess_test-1', [{ role: 'user', content: 'Hello' }]);
+        await store.appendMessages(
+          'sess_test-1',
+          [{ role: 'user', content: 'Hello' }],
+          makeSession(),
+        );
 
         await store.deleteSession('sess_test-1');
 
@@ -274,14 +286,18 @@ describe('sqliteStore()', () => {
       it('Then returns only the 4 most recent messages', async () => {
         const store = sqliteStore({ path: ':memory:' });
         await store.saveSession(makeSession());
-        await store.appendMessages('sess_test-1', [
-          { role: 'user', content: 'M1' },
-          { role: 'assistant', content: 'M2' },
-          { role: 'user', content: 'M3' },
-          { role: 'assistant', content: 'M4' },
-          { role: 'user', content: 'M5' },
-          { role: 'assistant', content: 'M6' },
-        ]);
+        await store.appendMessages(
+          'sess_test-1',
+          [
+            { role: 'user', content: 'M1' },
+            { role: 'assistant', content: 'M2' },
+            { role: 'user', content: 'M3' },
+            { role: 'assistant', content: 'M4' },
+            { role: 'user', content: 'M5' },
+            { role: 'assistant', content: 'M6' },
+          ],
+          makeSession(),
+        );
 
         await store.pruneMessages('sess_test-1', 4);
         const messages = await store.loadMessages('sess_test-1');
@@ -444,6 +460,45 @@ describe('sqliteStore()', () => {
 
         const loaded = await store.loadMessages(session.id);
         expect(loaded.map((m) => m.content)).toEqual(['a', 'b', 'c', 'd']);
+      });
+    });
+  });
+
+  describe('Given appendMessages is called with a session carrying userId/tenantId', () => {
+    describe('When we read the raw agent_messages rows', () => {
+      it('Then user_id and tenant_id are denormalized onto every row (#2847 bridge)', async () => {
+        const { Database } = await import('@vertz/sqlite');
+        const path = `/tmp/agent-bridge-denorm-${Date.now()}-${Math.random()}.db`;
+        const store = sqliteStore({ path });
+        const session = makeSession({
+          id: 'sess_denorm',
+          userId: 'user-a',
+          tenantId: 'tenant-a',
+        });
+        await store.saveSession(session);
+        await store.appendMessages(
+          session.id,
+          [
+            { role: 'user', content: 'u' },
+            { role: 'assistant', content: 'a' },
+          ],
+          session,
+        );
+
+        // Open the same file via the raw sqlite driver; inspect the rows directly.
+        const raw = new Database(path);
+        const rows = raw
+          .prepare<{ user_id: string | null; tenant_id: string | null }, [string]>(
+            'SELECT user_id, tenant_id FROM agent_messages WHERE session_id = ? ORDER BY seq',
+          )
+          .all(session.id);
+        raw.close();
+
+        expect(rows).toHaveLength(2);
+        for (const row of rows) {
+          expect(row.user_id).toBe('user-a');
+          expect(row.tenant_id).toBe('tenant-a');
+        }
       });
     });
   });

--- a/packages/agents/src/stores/sqlite-store.ts
+++ b/packages/agents/src/stores/sqlite-store.ts
@@ -30,11 +30,14 @@ CREATE TABLE IF NOT EXISTS agent_messages (
   tool_call_id TEXT,
   tool_name TEXT,
   tool_calls TEXT,
+  user_id TEXT,
+  tenant_id TEXT,
   created_at TEXT NOT NULL,
   UNIQUE(session_id, seq)
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session ON agent_messages(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_user ON agent_messages(user_id);
 `;
 
 // ---------------------------------------------------------------------------
@@ -137,10 +140,22 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
 
   const insertMessageStmt = db.prepare<
     void,
-    [string, number, string, string, string | null, string | null, string | null, string]
+    [
+      string,
+      number,
+      string,
+      string,
+      string | null,
+      string | null,
+      string | null,
+      string | null,
+      string | null,
+      string,
+    ]
   >(
-    `INSERT INTO agent_messages (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO agent_messages
+       (session_id, seq, role, content, tool_call_id, tool_name, tool_calls, user_id, tenant_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
 
   return {
@@ -166,7 +181,7 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
       return rows.map(rowToMessage);
     },
 
-    async appendMessages(sessionId, messages) {
+    async appendMessages(sessionId, messages, session) {
       const result = maxSeqStmt.get(sessionId);
       let seq = (result?.max_seq ?? 0) + 1;
       const now = new Date().toISOString();
@@ -181,6 +196,8 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
             msg.toolCallId ?? null,
             msg.toolName ?? null,
             msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+            session.userId,
+            session.tenantId,
             now,
           );
           seq++;
@@ -257,6 +274,8 @@ export function sqliteStore(options: SqliteStoreOptions): AgentStore {
             msg.toolCallId ?? null,
             msg.toolName ?? null,
             msg.toolCalls ? JSON.stringify(msg.toolCalls) : null,
+            session.userId,
+            session.tenantId,
             now,
           );
           seq++;

--- a/packages/agents/src/stores/types.ts
+++ b/packages/agents/src/stores/types.ts
@@ -37,8 +37,15 @@ export interface AgentStore {
   /** Load all messages for a session, ordered by sequence. */
   loadMessages(sessionId: string): Promise<Message[]>;
 
-  /** Append messages to a session. Assigns seq values starting from the current max + 1. */
-  appendMessages(sessionId: string, messages: Message[]): Promise<void>;
+  /**
+   * Append messages to a session. Assigns seq values starting from the current max + 1.
+   *
+   * `session` is passed so stores can denormalize `userId`/`tenantId` onto the message rows,
+   * which is what makes `rules.where({ userId: rules.user.id })` work on the `Message` entity
+   * in the entity-bridge integration (#2847). Callers already have a session in scope here
+   * (the atomic variant `appendMessagesAtomic` has always had this parameter).
+   */
+  appendMessages(sessionId: string, messages: Message[], session: AgentSession): Promise<void>;
 
   /** Delete the oldest messages for a session, keeping only the most recent `keepCount`. */
   pruneMessages(sessionId: string, keepCount: number): Promise<void>;

--- a/packages/agents/src/testing/crash-harness.test.ts
+++ b/packages/agents/src/testing/crash-harness.test.ts
@@ -70,7 +70,7 @@ describe('crashAfterToolResults()', () => {
       const loaded = await harness.loadSession(session.id);
       expect(loaded).toEqual(session);
 
-      await harness.appendMessages(session.id, [{ role: 'user', content: 'pt' }]);
+      await harness.appendMessages(session.id, [{ role: 'user', content: 'pt' }], session);
       const msgs = await harness.loadMessages(session.id);
       expect(msgs).toEqual([{ role: 'user', content: 'pt' }]);
 

--- a/packages/agents/src/testing/crash-harness.ts
+++ b/packages/agents/src/testing/crash-harness.ts
@@ -19,7 +19,7 @@ export function crashAfterToolResults(store: AgentStore, failOnCallNumber: numbe
     loadSession: (id) => store.loadSession(id),
     saveSession: (s) => store.saveSession(s),
     loadMessages: (id) => store.loadMessages(id),
-    appendMessages: (id, msgs) => store.appendMessages(id, msgs),
+    appendMessages: (id, msgs, session) => store.appendMessages(id, msgs, session),
     pruneMessages: (id, keep) => store.pruneMessages(id, keep),
     deleteSession: (id) => store.deleteSession(id),
     listSessions: (f) => store.listSessions(f),

--- a/packages/mint-docs/docs.json
+++ b/packages/mint-docs/docs.json
@@ -110,7 +110,8 @@
             "pages": [
               "guides/agents/overview",
               "guides/agents/workflows",
-              "guides/agents/durable-resume"
+              "guides/agents/durable-resume",
+              "guides/agents/entity-bridge"
             ]
           },
           {

--- a/packages/mint-docs/guides/agents/entity-bridge.mdx
+++ b/packages/mint-docs/guides/agents/entity-bridge.mdx
@@ -1,0 +1,238 @@
+---
+title: Entity bridge (RLS for agent data)
+description: 'Expose agent sessions and messages as Vertz entities so they respect rules.*, tenant scoping, and can be queried alongside app data.'
+---
+
+By default, `sqliteStore` / `d1Store` write agent sessions and messages to their own
+tables invisible to `@vertz/server`. Good for single-tenant apps, wrong for anything
+with users and tenants — `Session.list({ where })` can't be called from app code
+and `rules.*` (authenticated, tenant-scoped, row-level `where`) never fires on
+agent reads.
+
+The **entity bridge** fixes this: one factory call turns the store's tables into
+first-class Vertz entities registered with `createServer`, so app-side reads flow
+through the CRUD pipeline with full RLS.
+
+- Same tables, same writes — `sqliteStore`/`d1Store` are unchanged on the hot path.
+- Reads from app code (`/api/agent-session` routes, `ctx.entities['agent-session'].list()`)
+  enforce access rules.
+- Tenant auto-detection picks up `tenantId` on the session row; extended schemas
+  with a `.tenant()` relation inherit the chain.
+
+## Setup
+
+Three pieces: define tables with the exported column packs, call the factory,
+register the entities.
+
+```ts
+// src/db.ts
+import { d, createDb } from '@vertz/db';
+import {
+  agentSessionColumns,
+  agentSessionIndexes,
+  agentMessageColumns,
+  agentMessageIndexes,
+} from '@vertz/agents/entities';
+
+const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+  indexes: agentSessionIndexes,
+});
+const messagesTable = d.table('agent_messages', agentMessageColumns, {
+  indexes: agentMessageIndexes,
+});
+
+export const db = createDb({
+  dialect: 'sqlite',
+  path: 'app.db',
+  migrations: { autoApply: true },
+  models: {
+    agentSessions: d.model(sessionsTable),
+    agentMessages: d.model(messagesTable, {
+      session: d.ref.one(() => sessionsTable, 'sessionId'),
+    }),
+  },
+});
+```
+
+```ts
+// src/entities.ts
+import { defineAgentEntities } from '@vertz/agents/entities';
+import { db } from './db';
+
+export const { session: Session, message: Message } = defineAgentEntities(db);
+```
+
+```ts
+// src/server.ts
+import { createServer } from '@vertz/server';
+import { db } from './db';
+import { Session, Message } from './entities';
+
+const server = createServer({ db, entities: [Session, Message] });
+```
+
+```ts
+// src/agent.ts — agent loop unchanged
+import { sqliteStore } from '@vertz/agents';
+const store = sqliteStore({ path: 'app.db' }); // same file as `db` above
+const result = await run(coderAgent, {
+  message: 'Fix bug',
+  llm,
+  store,
+  userId: ctx.userId,
+  tenantId: ctx.tenantId,
+});
+```
+
+## Default access rules
+
+`defineAgentEntities()` applies user-scoped row-level rules on every op so the
+happy path is safe. `ctx.userId` / `ctx.tenantId` are injected by a
+`before.create` hook — callers never need to pass them explicitly, and if they
+do, `ctx.userId` wins (prevents impersonation).
+
+| Op       | Session                                  | Message                                  |
+| -------- | ---------------------------------------- | ---------------------------------------- |
+| `list`   | `rules.where({ userId: rules.user.id })` | `rules.where({ userId: rules.user.id })` |
+| `get`    | `rules.where({ userId: rules.user.id })` | `rules.where({ userId: rules.user.id })` |
+| `create` | `rules.authenticated()` (+ hook)         | denied (store writes)                    |
+| `update` | `rules.where({ userId: rules.user.id })` | denied                                   |
+| `delete` | `rules.where({ userId: rules.user.id })` | denied                                   |
+
+Override with the factory options:
+
+```ts
+import { rules } from '@vertz/server';
+const { session, message } = defineAgentEntities(db, {
+  sessionAccess: {
+    list: rules.all(rules.authenticated(), rules.where({ userId: rules.user.id })),
+    // ...
+  },
+});
+```
+
+## Reading agent data
+
+Flow from the client goes through the auto-generated route:
+
+```ts
+// Client-side — RLS applied by the route handler
+const res = await fetch('/api/agent-session?agentName=coder');
+const { items } = await res.json();
+```
+
+From server-side code inside a route or service that has an `EntityContext`:
+
+```ts
+// Default entity names are kebab-case, so use bracket access on ctx.entities:
+const sessions = await ctx.entities['agent-session'].list({
+  where: { agentName: 'coder' },
+});
+```
+
+If you want dot-access, override the names (lowercase, no hyphen) at factory time:
+
+```ts
+const { session, message } = defineAgentEntities(db, {
+  sessionName: 'agentsession',
+  messageName: 'agentmessage',
+});
+// Then: ctx.entities.agentsession.list(...)
+```
+
+**Do not use `db.agentSessions.list(...)`** from handler code and expect RLS —
+that path is the raw `DatabaseClient` delegate and bypasses the entity
+pipeline. It's fine for internal/trusted code (migrations, admin tasks) but
+user-facing queries must go through the routes or `ctx.entities.*`.
+
+## Extending the schema
+
+Add your own columns and relations by spreading the column packs and building
+your own `d.table()` — no special helper:
+
+```ts
+const sessionsTable = d.table(
+  'agent_sessions',
+  {
+    ...agentSessionColumns,
+    projectId: d.uuid().nullable(),
+  },
+  { indexes: [...agentSessionIndexes, d.index('projectId')] },
+);
+
+const db = createDb({
+  dialect: 'sqlite',
+  path: 'app.db',
+  migrations: { autoApply: true },
+  models: {
+    agentSessions: d.model(sessionsTable, {
+      project: d.ref.one(() => projectsTable, 'projectId'),
+    }),
+    // ...
+  },
+});
+```
+
+## Tenant scoping
+
+`defineAgentEntities` opts each entity into tenant scoping automatically when
+the `tenantId` column (from the pack) or a `ref.one()` to a `.tenant()` table
+is present. Priority: relation wins over column. If you add a `.tenant()`
+relation on your extended session, drop `tenantId` from the spread to avoid
+a dead column:
+
+```ts
+const { tenantId: _drop, ...sessionColsMinusTenant } = agentSessionColumns;
+const sessionsTable = d.table(
+  'agent_sessions',
+  {
+    ...sessionColsMinusTenant,
+    tenantId: d.uuid(), // your own — will be picked up by the .tenant() relation
+  },
+  {
+    /* ... */
+  },
+);
+```
+
+## Upgrade migration
+
+Existing databases from earlier `@vertz/agents` versions must add two columns
+to `agent_messages`. A migration SQL file ships with the package at
+`packages/agents/migrations/001-add-rls-columns.sql`:
+
+```sql
+ALTER TABLE agent_messages ADD COLUMN user_id TEXT;
+ALTER TABLE agent_messages ADD COLUMN tenant_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_messages_user ON agent_messages(user_id);
+
+-- Backfill so historical messages are visible to entity RLS reads
+UPDATE agent_messages
+SET
+  user_id = (SELECT user_id FROM agent_sessions WHERE agent_sessions.id = agent_messages.session_id),
+  tenant_id = (SELECT tenant_id FROM agent_sessions WHERE agent_sessions.id = agent_messages.session_id)
+WHERE user_id IS NULL;
+```
+
+Fresh installs get the columns automatically — the stores' built-in DDL was updated.
+
+## What the bridge does not cover
+
+- **Entity hooks on agent-loop writes.** `before.create` / `after.create` on
+  the `Message` entity do **not** fire for messages inserted by `run()` —
+  writes go through the `AgentStore`, not the entity pipeline. Reads and
+  app-side writes via entity handlers do fire hooks normally. Tracked as
+  [#2957](https://github.com/vertz-dev/vertz/issues/2957) (registration-time
+  rejection of hooks on factory-produced entities).
+- **Typed `state` / `toolCalls` columns.** Stored as `TEXT` (JSON string) for
+  byte-compat with the legacy DDL. Tracked as
+  [#2958](https://github.com/vertz-dev/vertz/issues/2958).
+- **RLS on in-loop reads.** `store.loadSession()` inside `run()` bypasses
+  entity rules — identity is checked by `run()` directly against
+  `session.userId` / `session.tenantId`. Same ownership story as before the
+  bridge; app-side reads get the full RLS.
+
+## See also
+
+- Design doc: [`plans/agent-store-entity-bridge.md`](https://github.com/vertz-dev/vertz/blob/main/plans/agent-store-entity-bridge.md)
+- Issue: [#2847](https://github.com/vertz-dev/vertz/issues/2847)


### PR DESCRIPTION
## Summary

Implements the agent-store ↔ entity bridge designed in #2959 (merged). Agent sessions and messages become first-class Vertz entities, queryable from app code with full `rules.*` enforcement. Writes still flow through `sqliteStore` / `d1Store` / `memoryStore` — atomic paths unchanged.

Closes #2847.

## What ships

**New `@vertz/agents/entities` subpath:**
- `agentSessionColumns`, `agentMessageColumns`, `agentSessionIndexes`, `agentMessageIndexes` — plain constants that developers spread into their own `d.table()`.
- `defineAgentEntities(db)` factory — looks up the registered tables via `db._internals.models`, wires `entity()` definitions with user-scoped defaults, installs a column-aware `before.create` hook that injects `userId` / `tenantId` from the request context (ctx wins — prevents silent impersonation).

**Breaking changes** (pre-v1, `.claude/rules/policies.md`):
- `AgentStore.appendMessages` gains a `session: AgentSession` parameter — matches `appendMessagesAtomic`. All three in-repo store impls, `run.ts`, `crash-harness.ts` updated.
- `agent_messages` gains `user_id` / `tenant_id` columns (denormalized on every append — required for flat `rules.where({ userId })`). Fresh installs get them via the stores' updated DDL; existing DBs run the one-shot migration at `packages/agents/migrations/001-add-rls-columns.sql`.

## Adversarial review

Spawned a review agent post-implementation. Three blockers surfaced and all fixed before push:

1. **Migration SQL not idempotent** — the header comment claimed "safe to run more than once" while the body crashes on a second run. Removed the false claim; documented the need for a migration runner.
2. **Docs showed `ctx.entities.agentSession.list()`** — default entity names are kebab (`agent-session`), `ctx.entities` does exact-key lookup. Updated docs to use bracket access + documented the lowercase `sessionName: 'agentsession'` escape hatch for dot-access.
3. **`before.create` hook unconditionally injected `tenantId`** — broke extended schemas that drop the column (the docs themselves recommend this) and could conflict with the CRUD pipeline's multi-level tenancy auto-set. Hook now inspects `table._columns` and only injects fields the table actually declares.

Two should-fixes also landed:

- Added the missing negative type tests (string-value inside `sessionAccess`, missing `db` arg).
- Beefed up the integration test with an extended-schema path (`workspaceId` custom column, hook-through-entity verification, custom-field query via `handlers.list`).
- Added a direct store-level assertion that `user_id` / `tenant_id` are denormalized onto rows.

## Test plan

- [x] `vtz run ci:affected` — all 254 tests pass, 0 failures. Build + typecheck + lint green.
- [x] `vtz run format` + `format:fix` — clean.
- [x] `vtz run lint` — 0 errors (pre-existing warnings only).
- [x] Integration test in `packages/agents/src/entities/__tests__/bridge.integration.test.ts` exercises the full path end-to-end: `sqliteStore.saveSession` + `store.appendMessages` → entity-side `sessionHandlers.list(ctx)` → RLS rejects cross-tenant and cross-user-same-tenant reads; extended `workspaceId` column round-trips through `handlers.create` + `before.create` hook.

## Design

Merged at #2959 (`plans/agent-store-entity-bridge.md`). Six review rounds (DX, Product, Technical × 2) settled the architecture, API surface, breaking-change scope, and all API references against real code.

## Follow-ups

- #2957 — reject entity hook registration on factory-produced entities (boot-time enforcement of the write-path-bypasses-hooks contract).
- #2958 — migrate `state` / `toolCalls` columns to `d.jsonb<T>()` with an opt-in flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)