### PR TITLE
fix(ui): prevent concurrent form submissions on double-click [#2982]

### DIFF
--- a/.changeset/fix-form-concurrent-submission-2982.md
+++ b/.changeset/fix-form-concurrent-submission-2982.md
@@ -1,0 +1,11 @@
+---
+'@vertz/ui': patch
+---
+
+fix(ui): prevent concurrent form submissions (double-click creates duplicates)
+
+Closes [#2982](https://github.com/vertz-dev/vertz/issues/2982).
+
+`form()` did not lock against re-entrant submissions. A double-clicked submit button fired two `submit` events back-to-back; both entered `submitPipeline`, passed validation, and called the SDK — creating duplicate records.
+
+`submitPipeline` now checks `submitting.peek()` synchronously at entry and returns early if a submission is already in flight. `submitting.value = true` is set before any work (so the second synchronous call sees the guard), and a `try/finally` ensures it is reset on every exit path. The pipeline returns a boolean so the `onSubmit` / `submit` wrappers skip their post-processing (form reset) when a call was rejected.

--- a/packages/ui/src/form/__tests__/form-concurrent.test.ts
+++ b/packages/ui/src/form/__tests__/form-concurrent.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, mock } from '@vertz/test';
+import { ok } from '@vertz/fetch';
+import { form } from '../form';
+import type { FormSchema } from '../validation';
+
+function mockSdkMethod<TBody, TResult>(config: {
+  url: string;
+  method: string;
+  handler: (body: TBody) => Promise<TResult>;
+}) {
+  const wrappedHandler = async (body: TBody) => ok(await config.handler(body));
+  const fn = wrappedHandler as ((body: TBody) => Promise<{ ok: true; data: TResult }>) & {
+    url: string;
+    method: string;
+  };
+  fn.url = config.url;
+  fn.method = config.method;
+  return fn;
+}
+
+function passingSchema<T>(): FormSchema<T> {
+  return {
+    parse(data: unknown) {
+      return { ok: true as const, data: data as T };
+    },
+  };
+}
+
+describe('form concurrent submission', () => {
+  it('ignores reentrant submit() calls while one is in flight', async () => {
+    const handler = mock().mockResolvedValue({ id: 1 });
+    const sdk = mockSdkMethod({ url: '/api/users', method: 'POST', handler });
+
+    const f = form(sdk, { schema: passingSchema() });
+    const fd = new FormData();
+    fd.append('name', 'Alice');
+
+    const first = f.submit(fd);
+    const second = f.submit(fd);
+
+    expect(f.submitting.peek()).toBe(true);
+
+    await Promise.all([first, second]);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(f.submitting.peek()).toBe(false);
+  });
+
+  it('allows a new submission after the previous one settles', async () => {
+    const handler = mock().mockResolvedValue({ id: 1 });
+    const sdk = mockSdkMethod({ url: '/api/users', method: 'POST', handler });
+
+    const f = form(sdk, { schema: passingSchema() });
+    const fd = new FormData();
+    fd.append('name', 'Alice');
+
+    await f.submit(fd);
+    await f.submit(fd);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores reentrant onSubmit calls (double-clicked submit button)', async () => {
+    const handler = mock().mockResolvedValue({ id: 1 });
+    const onSuccess = mock();
+    const sdk = mockSdkMethod({ url: '/api/users', method: 'POST', handler });
+
+    const f = form(sdk, { schema: passingSchema(), resetOnSuccess: true, onSuccess });
+
+    const fd = new FormData();
+    fd.append('name', 'Alice');
+
+    const OriginalFormData = globalThis.FormData;
+    globalThis.FormData = class extends OriginalFormData {
+      constructor(_formElement?: HTMLFormElement) {
+        super();
+        for (const [k, v] of fd.entries()) this.append(k, v);
+      }
+    };
+
+    try {
+      const firstReset = mock();
+      const secondReset = mock();
+      const event1 = new Event('submit', { cancelable: true });
+      Object.defineProperty(event1, 'target', { value: { reset: firstReset } });
+      const event2 = new Event('submit', { cancelable: true });
+      Object.defineProperty(event2, 'target', { value: { reset: secondReset } });
+
+      const first = f.onSubmit(event1);
+      const second = f.onSubmit(event2);
+      await Promise.all([first, second]);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      // Only the winning call triggers reset; the rejected one must not.
+      expect(firstReset).toHaveBeenCalledTimes(1);
+      expect(secondReset).not.toHaveBeenCalled();
+    } finally {
+      globalThis.FormData = OriginalFormData;
+    }
+  });
+
+  it('releases the lock after a validation failure — same form can submit again', async () => {
+    const handler = mock().mockResolvedValue({ id: 1 });
+    const sdk = mockSdkMethod({ url: '/api/users', method: 'POST', handler });
+
+    let shouldFail = true;
+    const schema: FormSchema<{ name: string }> = {
+      parse(data: unknown) {
+        if (shouldFail) {
+          const error = new Error('Validation failed');
+          (error as Error & { fieldErrors: Record<string, string> }).fieldErrors = {
+            name: 'Required',
+          };
+          return { ok: false as const, error };
+        }
+        return { ok: true as const, data: data as { name: string } };
+      },
+    };
+    const f = form(sdk, { schema });
+
+    const fd1 = new FormData();
+    fd1.append('name', '');
+    await f.submit(fd1);
+    expect(handler).not.toHaveBeenCalled();
+    expect(f.submitting.peek()).toBe(false);
+
+    shouldFail = false;
+    const fd2 = new FormData();
+    fd2.append('name', 'Alice');
+    await f.submit(fd2);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -256,43 +256,50 @@ export function form<TBody, TResult>(
 
   const resolvedSchema = options?.schema ?? sdkMethod.meta?.bodySchema;
 
-  async function submitPipeline(formData: FormData): Promise<void> {
-    hasSubmitted = true;
-    const data = resolvedSchema
-      ? coerceFormDataToSchema(formData, resolvedSchema)
-      : formDataToObject(formData, { nested: true });
-
-    if (resolvedSchema) {
-      const result = validate(resolvedSchema, data);
-      if (!result.success) {
-        for (const [fieldName, message] of Object.entries(result.errors)) {
-          getOrCreateField(fieldName).error.value = message;
-        }
-        options?.onError?.(result.errors);
-        return;
-      }
-    }
-
-    // Clear previous errors
-    for (const field of fieldCache.values()) {
-      field.error.value = undefined;
-    }
-
+  async function submitPipeline(formData: FormData): Promise<boolean> {
+    // Lock against reentrant submissions (e.g. double-clicked submit button).
+    // Set synchronously before any other work so a second sync call sees the guard.
+    // Returns false when locked out so wrappers can skip post-processing.
+    if (submitting.peek()) return false;
     submitting.value = true;
-    const result = await sdkMethod(data as TBody);
-    if (!result.ok) {
-      submitting.value = false;
-      const message = result.error.message;
-      getOrCreateField('_form').error.value = message;
-      options?.onError?.({ _form: message });
-      return;
-    }
-    submitting.value = false;
-    options?.onSuccess?.(result.data);
+    try {
+      hasSubmitted = true;
+      const data = resolvedSchema
+        ? coerceFormDataToSchema(formData, resolvedSchema)
+        : formDataToObject(formData, { nested: true });
 
-    if (options?.resetOnSuccess) {
-      resetForm();
+      if (resolvedSchema) {
+        const result = validate(resolvedSchema, data);
+        if (!result.success) {
+          for (const [fieldName, message] of Object.entries(result.errors)) {
+            getOrCreateField(fieldName).error.value = message;
+          }
+          options?.onError?.(result.errors);
+          return true;
+        }
+      }
+
+      // Clear previous errors
+      for (const field of fieldCache.values()) {
+        field.error.value = undefined;
+      }
+
+      const result = await sdkMethod(data as TBody);
+      if (!result.ok) {
+        const message = result.error.message;
+        getOrCreateField('_form').error.value = message;
+        options?.onError?.({ _form: message });
+        return true;
+      }
+      options?.onSuccess?.(result.data);
+
+      if (options?.resetOnSuccess) {
+        resetForm();
+      }
+    } finally {
+      submitting.value = false;
     }
+    return true;
   }
 
   let boundElement: HTMLFormElement | undefined;
@@ -341,10 +348,10 @@ export function form<TBody, TResult>(
   }
 
   async function submitPipelineWithReset(formData: FormData): Promise<void> {
-    await submitPipeline(formData);
-    if (options?.resetOnSuccess && !submitting.peek() && boundElement) {
-      // Only call reset on the element if submission succeeded (submitting is already false
-      // and no error was set). Check that there are no errors as a proxy for success.
+    const ran = await submitPipeline(formData);
+    if (ran && options?.resetOnSuccess && boundElement) {
+      // Only call reset on the element if submission succeeded (no error was set).
+      // Check that there are no errors as a proxy for success.
       const hasErrors = [...fieldCache.values()].some((f) => f.error.peek() !== undefined);
       if (!hasErrors) {
         boundElement.reset();
@@ -379,8 +386,8 @@ export function form<TBody, TResult>(
       e.preventDefault();
       const formElement = e.target as HTMLFormElement;
       const formData = new FormData(formElement);
-      await submitPipeline(formData);
-      if (options?.resetOnSuccess && !submitting.peek()) {
+      const ran = await submitPipeline(formData);
+      if (ran && options?.resetOnSuccess) {
         const hasErrors = [...fieldCache.values()].some((f) => f.error.peek() !== undefined);
         if (!hasErrors) {
           formElement.reset();
@@ -393,16 +400,15 @@ export function form<TBody, TResult>(
     },
     submit: async (formData?: FormData) => {
       if (formData) {
-        await submitPipeline(formData);
+        const ran = await submitPipeline(formData);
+        if (ran && options?.resetOnSuccess && boundElement) {
+          const hasErrors = [...fieldCache.values()].some((f) => f.error.peek() !== undefined);
+          if (!hasErrors) {
+            boundElement.reset();
+          }
+        }
       } else if (boundElement) {
         await submitPipelineWithReset(new FormData(boundElement));
-        return;
-      }
-      if (options?.resetOnSuccess && formData && !submitting.peek()) {
-        const hasErrors = [...fieldCache.values()].some((f) => f.error.peek() !== undefined);
-        if (!hasErrors && boundElement) {
-          boundElement.reset();
-        }
       }
     },
     submitting,


### PR DESCRIPTION
## Summary

- `form()` didn't lock against re-entrant submissions — double-clicking submit fired two `submit` events, both entered `submitPipeline`, passed validation, and called the SDK, creating duplicate records.
- `submitPipeline` now checks `submitting.peek()` synchronously at entry and bails if already in flight; `submitting.value = true` is set before any work; a `try/finally` resets it on every exit path.
- Pipeline returns a `boolean` so `onSubmit` / `submit` wrappers skip their post-processing (form reset) when their call was rejected — prevents a stale double `formElement.reset()` on the losing click.

Closes #2982

## Public API Changes

None. Internal refactor of `submitPipeline`. User-facing contract is unchanged — just fewer bugs.

## Test plan

- [x] `packages/ui/src/form/__tests__/form-concurrent.test.ts` — 4 new tests:
  - Re-entrant `submit()` calls — SDK called once, `submitting` settles back to false.
  - Sequential submits still work (lock releases).
  - Double-clicked `onSubmit` — SDK called once, `onSuccess` fired once, only the winning event's `target.reset()` is invoked.
  - Validation failure on the same form releases the lock so the next submission can proceed.
- [x] All 2468 `@vertz/ui` tests pass.
- [x] `vtz run typecheck` green.
- [x] `vtzx oxlint` / `vtzx oxfmt` clean on changed files.

## Review

Adversarial self-review at `reviews/fix-2982/review.md` (not committed — working artifact). Two blockers found and addressed: (1) outer wrappers would still reset the form on rejected calls, fixed by returning a boolean from the pipeline and gating post-processing; (2) validation-failure test used two different form instances so it didn't exercise the same-form lock release — rewrote to use a single form with a schema that flips between fail/pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)