### PR TITLE
fix(query): refetch on remount after mutation while unmounted [#2986]

### DIFF
--- a/.changeset/fix-query-stale-cache-on-remount.md
+++ b/.changeset/fix-query-stale-cache-on-remount.md
@@ -1,0 +1,11 @@
+---
+'@vertz/ui': patch
+---
+
+fix(query): refetch on remount when a mutation occurred while the query was unmounted [#2986]
+
+When a user navigated from a list page to a form, created an entity, and navigated back via `router.navigate()`, the list kept showing the old cached data until a full page reload. Between unmount and remount, the list query had unsubscribed from the `MutationEventBus`, so the `emit()` fired by the form's create mutation had no live listener — yet the cached entry (and its query indices) remained, and was served on remount.
+
+`MutationEventBus` now tracks a monotonic per-entity-type version that increments on every `emit()`. `MemoryCache.set()` accepts an optional `version` argument and records it alongside the value; `CacheStore<T>` gained an optional `getVersion(key)` accessor. When `query()` gets a cache hit for an entity-backed query on mount, it compares the cached entry's version with the current bus version for the same entity type and treats the entry as stale when the bus version is newer, falling through to a fresh fetch.
+
+This is additive — custom `CacheStore` implementations that don't implement `getVersion` continue to work and simply keep the previous (cached) behavior.

--- a/packages/ui/src/query/__tests__/cache.test.ts
+++ b/packages/ui/src/query/__tests__/cache.test.ts
@@ -387,4 +387,64 @@ describe('MemoryCache orphan-aware eviction', () => {
     expect(cache.get('c')).toBe('3');
     expect(cache.get('d')).toBe('4');
   });
+
+  describe('version stamp', () => {
+    test('getVersion returns undefined when no version was passed', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'value');
+      expect(cache.getVersion('key')).toBeUndefined();
+    });
+
+    test('getVersion returns the value supplied to set', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'value', 7);
+      expect(cache.getVersion('key')).toBe(7);
+    });
+
+    test('re-setting a key without a version clears the stamp', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'a', 3);
+      cache.set('key', 'b');
+      expect(cache.getVersion('key')).toBeUndefined();
+    });
+
+    test('re-setting a key with a new version replaces the stamp', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'a', 1);
+      cache.set('key', 'b', 2);
+      expect(cache.getVersion('key')).toBe(2);
+    });
+
+    test('delete also removes the version stamp', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'value', 5);
+      cache.delete('key');
+      expect(cache.getVersion('key')).toBeUndefined();
+    });
+
+    test('clear wipes version stamps', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('a', 'x', 1);
+      cache.set('b', 'y', 2);
+      cache.clear();
+      expect(cache.getVersion('a')).toBeUndefined();
+      expect(cache.getVersion('b')).toBeUndefined();
+    });
+
+    test('LRU eviction removes the evicted entry version stamp', () => {
+      const cache = new MemoryCache<string>({ maxSize: 2 });
+      cache.set('a', '1', 10);
+      cache.set('b', '2', 20);
+      cache.set('c', '3', 30); // evicts 'a'
+      expect(cache.getVersion('a')).toBeUndefined();
+      expect(cache.getVersion('b')).toBe(20);
+      expect(cache.getVersion('c')).toBe(30);
+    });
+
+    test('version 0 is a valid stamp', () => {
+      const cache = new MemoryCache<string>();
+      cache.set('key', 'value', 0);
+      expect(cache.getVersion('key')).toBe(0);
+    });
+  });
 });

--- a/packages/ui/src/query/__tests__/query.test.ts
+++ b/packages/ui/src/query/__tests__/query.test.ts
@@ -1842,6 +1842,207 @@ describe('query()', () => {
       expect(fetchCount).toBe(1);
     });
 
+    // Regression: user navigates list → form → back to list after creating an
+    // entity. Without this, the remounted list serves stale cached data
+    // because the mutation event fired while the query was unsubscribed.
+    test('refetches on remount when mutation occurred while disposed', async () => {
+      resetMutationEventBus();
+      resetDefaultQueryCache();
+      resetEntityStore();
+      let fetchCount = 0;
+      const makeDescriptor = () => ({
+        _tag: 'QueryDescriptor' as const,
+        _key: 'GET:/remount-todos',
+        _entity: { entityType: 'remount-todos', kind: 'list' as const },
+        _fetch: () => {
+          fetchCount++;
+          const n = fetchCount;
+          return Promise.resolve(
+            ok({
+              items: [{ id: String(n), title: `Fetch ${n}`, completed: false }],
+              total: n,
+            }),
+          );
+        },
+        then(onFulfilled: any, onRejected: any) {
+          return this._fetch().then(onFulfilled, onRejected);
+        },
+      });
+
+      // Initial mount — query fetches and caches.
+      const first = query(makeDescriptor());
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fetchCount).toBe(1);
+
+      // Dispose simulates navigating away.
+      first.dispose();
+
+      // Mutation event fires while unmounted (e.g. form.submit on another page).
+      getMutationEventBus().emit('remount-todos');
+
+      // Remount — same descriptor/key. Must refetch, not serve stale cache.
+      const second = query(makeDescriptor());
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchCount).toBe(2);
+      const data = second.data.value as { items: { id: string; title: string }[]; total: number };
+      expect(data.items[0].title).toBe('Fetch 2');
+      expect(data.total).toBe(2);
+
+      second.dispose();
+    });
+
+    // Same remount-after-mutation scenario, but the query is built with the
+    // descriptor-in-thunk pattern. Entity metadata is discovered lazily on
+    // the first effect run, so the cache.set() call during the first fetch
+    // must still stamp the entry with a version the next mount can compare.
+    test('refetches on remount for descriptor-in-thunk when mutation occurred while disposed', async () => {
+      resetMutationEventBus();
+      resetDefaultQueryCache();
+      resetEntityStore();
+      let fetchCount = 0;
+      const makeDescriptor = () => ({
+        _tag: 'QueryDescriptor' as const,
+        _key: 'GET:/remount-thunk-todos',
+        _entity: { entityType: 'remount-thunk-todos', kind: 'list' as const },
+        _fetch: () => {
+          fetchCount++;
+          const n = fetchCount;
+          return Promise.resolve(
+            ok({
+              items: [{ id: String(n), title: `Fetch ${n}`, completed: false }],
+              total: n,
+            }),
+          );
+        },
+        then(onFulfilled: any, onRejected: any) {
+          return this._fetch().then(onFulfilled, onRejected);
+        },
+      });
+
+      const first = query(() => makeDescriptor());
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fetchCount).toBe(1);
+
+      first.dispose();
+      getMutationEventBus().emit('remount-thunk-todos');
+
+      const second = query(() => makeDescriptor());
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchCount).toBe(2);
+      second.dispose();
+    });
+
+    // Same remount-after-mutation scenario with a custom cache key. Custom
+    // keys hit a different cache-lookup code path than descriptor keys, so
+    // the freshness check must apply there too.
+    test('refetches on remount with customKey when mutation occurred while disposed', async () => {
+      resetMutationEventBus();
+      resetDefaultQueryCache();
+      resetEntityStore();
+      let fetchCount = 0;
+      const descriptor = {
+        _tag: 'QueryDescriptor' as const,
+        _key: 'GET:/remount-customkey-todos',
+        _entity: { entityType: 'remount-customkey-todos', kind: 'list' as const },
+        _fetch: () => {
+          fetchCount++;
+          const n = fetchCount;
+          return Promise.resolve(
+            ok({
+              items: [{ id: String(n), title: `Fetch ${n}`, completed: false }],
+              total: n,
+            }),
+          );
+        },
+        then(onFulfilled: any, onRejected: any) {
+          return this._fetch().then(onFulfilled, onRejected);
+        },
+      };
+
+      const first = query(descriptor, { key: 'custom-todos-key' });
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fetchCount).toBe(1);
+
+      first.dispose();
+      getMutationEventBus().emit('remount-customkey-todos');
+
+      const second = query(descriptor, { key: 'custom-todos-key' });
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchCount).toBe(2);
+      second.dispose();
+    });
+
+    // Ensures entries for entity type A are not invalidated by emits for
+    // entity type B. Asserts on the served data rather than the fetch
+    // counter, because the descriptor's _fetch() is always invoked once per
+    // effect run — the cache-hit path suppresses the resulting promise, but
+    // the call itself bumps the counter. The served data is what we actually
+    // care about: a cache hit returns the first fetch's payload unchanged.
+    test('remount after emit for different entity type serves cached data', async () => {
+      resetMutationEventBus();
+      resetEntityStore();
+      const cache = new MemoryCache();
+      let fetchCount = 0;
+      const descriptor = {
+        _tag: 'QueryDescriptor' as const,
+        _key: 'GET:/isolate-todos',
+        _entity: { entityType: 'isolate-todos', kind: 'list' as const },
+        _fetch: () => {
+          fetchCount++;
+          const n = fetchCount;
+          return Promise.resolve(
+            ok({
+              items: [{ id: String(n), title: `Fetch ${n}`, completed: false }],
+              total: n,
+            }),
+          );
+        },
+        then(onFulfilled: any, onRejected: any) {
+          return this._fetch().then(onFulfilled, onRejected);
+        },
+      };
+
+      const first = query(descriptor, { cache });
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      const firstData = first.data.value as { items: { title: string }[]; total: number };
+      expect(firstData.total).toBe(1);
+      expect(firstData.items[0].title).toBe('Fetch 1');
+
+      first.dispose();
+      // Unrelated entity type — must not bust this cache entry.
+      getMutationEventBus().emit('unrelated-entity');
+
+      const second = query(descriptor, { cache });
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Cache-hit serves the first fetch's data, not whatever _fetch() returns
+      // on its eager effect-run call (total would be 2 if the new fetch won).
+      const secondData = second.data.value as { items: { title: string }[]; total: number };
+      expect(secondData.total).toBe(1);
+      expect(secondData.items[0].title).toBe('Fetch 1');
+
+      second.dispose();
+    });
+
     test('non-entity query does not subscribe to mutation event bus', async () => {
       resetMutationEventBus();
       let fetchCount = 0;

--- a/packages/ui/src/query/cache.ts
+++ b/packages/ui/src/query/cache.ts
@@ -4,9 +4,19 @@
  */
 export interface CacheStore<T = unknown> {
   get(key: string): T | undefined;
-  set(key: string, value: T): void;
+  /**
+   * Store a value under `key`. An optional `version` stamp is recorded for
+   * entity-backed queries so `query()` can detect cache staleness on
+   * remount after a mutation has invalidated the entity type.
+   */
+  set(key: string, value: T, version?: number): void;
   delete(key: string): void;
   clear?(): void;
+  /**
+   * Version stamp recorded at the last `set(key, value, version)` call.
+   * Returns undefined when no version was stamped (non-entity queries).
+   */
+  getVersion?(key: string): number | undefined;
 }
 
 /**
@@ -21,6 +31,8 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
   private _refs = new Map<string, number>();
   // Insertion order = orphan order (longest-orphaned first)
   private _orphans = new Map<string, true>();
+  // Per-key version stamps captured at set-time (entity-backed queries only).
+  private _versions = new Map<string, number>();
 
   constructor(options?: { maxSize?: number }) {
     const raw = options?.maxSize ?? 1000;
@@ -36,10 +48,15 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
     return value;
   }
 
-  set(key: string, value: T): void {
+  set(key: string, value: T, version?: number): void {
     // Remove first so re-insert goes to end (most-recently-used position)
     if (this._store.has(key)) this._store.delete(key);
     this._store.set(key, value);
+    if (version !== undefined) {
+      this._versions.set(key, version);
+    } else {
+      this._versions.delete(key);
+    }
     // Evict entries if over capacity.
     // Priority: 1) orphaned (explicitly released), 2) unclaimed (never retained), 3) retained
     while (this._store.size > this._maxSize) {
@@ -50,11 +67,13 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
           this._store.delete(orphan.value);
           this._orphans.delete(orphan.value);
           this._refs.delete(orphan.value);
+          this._versions.delete(orphan.value);
           continue;
         }
         // Stale orphan — clean up metadata and re-check tier 1
         this._orphans.delete(orphan.value);
         this._refs.delete(orphan.value);
+        this._versions.delete(orphan.value);
         continue;
       }
       // 2. Unclaimed entries (oldest in _store with no ref count, excluding current key)
@@ -62,6 +81,7 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
       for (const k of this._store.keys()) {
         if (k !== key && !this._refs.has(k)) {
           this._store.delete(k);
+          this._versions.delete(k);
           evicted = true;
           break;
         }
@@ -73,6 +93,7 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
       this._store.delete(oldest.value);
       this._refs.delete(oldest.value);
       this._orphans.delete(oldest.value);
+      this._versions.delete(oldest.value);
     }
   }
 
@@ -80,12 +101,18 @@ export class MemoryCache<T = unknown> implements CacheStore<T> {
     this._store.delete(key);
     this._refs.delete(key);
     this._orphans.delete(key);
+    this._versions.delete(key);
   }
 
   clear(): void {
     this._store.clear();
     this._refs.clear();
     this._orphans.clear();
+    this._versions.clear();
+  }
+
+  getVersion(key: string): number | undefined {
+    return this._versions.get(key);
   }
 
   /** Mark a cache key as actively used by a query instance. */

--- a/packages/ui/src/query/query.ts
+++ b/packages/ui/src/query/query.ts
@@ -357,6 +357,43 @@ export function query<T, E = unknown>(
   }
 
   /**
+   * Current mutation-bus version stamp for this query's entity type.
+   *
+   * Returns 0 when the query isn't entity-backed, during SSR (the server
+   * bus never emits against this instance), or when `entityMeta` hasn't
+   * been resolved yet (descriptor-in-thunk before the first effect run).
+   * Stamping with 0 in the last case is load-bearing: later mutations will
+   * bump the bus version above 0 so `isCachedEntryStale()` correctly flags
+   * the entry as stale on remount.
+   */
+  function currentEntityVersion(): number {
+    if (!entityMeta || isSSR()) return 0;
+    return getMutationEventBus().getVersion(entityMeta.entityType);
+  }
+
+  /**
+   * Returns true when the cached entry for `key` was written before a
+   * mutation event for this query's entity type. Such entries must be
+   * refetched rather than served, otherwise a user who navigates away,
+   * mutates the entity, and returns will see stale data until a full reload.
+   *
+   * Entries without a stamp (`cache.getVersion` returns undefined) are
+   * treated as version 0, so any emit for the entity type supersedes them.
+   *
+   * The optional `meta` override is used by nav-prefetch cache-hit paths
+   * that discover the descriptor's entity metadata before the main effect
+   * has assigned `entityMeta`.
+   */
+  function isCachedEntryStale(
+    key: string,
+    meta: EntityQueryMeta | undefined = entityMeta,
+  ): boolean {
+    if (!meta || isSSR()) return false;
+    const cacheVersion = cache.getVersion?.(key) ?? 0;
+    return getMutationEventBus().getVersion(meta.entityType) > cacheVersion;
+  }
+
+  /**
    * Call the thunk while capturing the values of all signals it reads.
    * Returns the raw thunk result and updates `depHashSignal` with a
    * deterministic hash of the captured values.
@@ -547,7 +584,7 @@ export function query<T, E = unknown>(
   // If initialData was provided, seed the cache.
   if (initialData !== undefined) {
     const initKey = getCacheKey();
-    cache.set(initKey, initialData);
+    cache.set(initKey, initialData, currentEntityVersion());
     retainKey(initKey);
   }
 
@@ -606,7 +643,7 @@ export function query<T, E = unknown>(
               rawData.value = result as T;
               loading.value = false;
               idle.value = false;
-              cache.set(key, result as T);
+              cache.set(key, result as T, currentEntityVersion());
             },
             key,
           });
@@ -675,7 +712,11 @@ export function query<T, E = unknown>(
         rawData.value = result as T;
         loading.value = false;
         idle.value = false;
-        cache.set(hydrationKey, result as T);
+        // SSR-sourced data predates any client-side mutation, so stamp with
+        // version 0. If a client emit has already bumped the bus version
+        // before hydration lands, stamping the current version would make
+        // the stale SSR payload look fresh on the next remount.
+        cache.set(hydrationKey, result as T, 0);
         ssrHydrated = true;
       },
       { persistent: isNavigation },
@@ -690,7 +731,7 @@ export function query<T, E = unknown>(
     if (!ssrHydrated && ssrHydrationCleanup !== null && isNavPrefetchActive()) {
       if (customKey) {
         const cached = cache.get(customKey);
-        if (cached !== undefined) {
+        if (cached !== undefined && !isCachedEntryStale(customKey)) {
           retainKey(customKey);
           normalizeToEntityStore(cached);
           rawData.value = cached;
@@ -700,7 +741,7 @@ export function query<T, E = unknown>(
       } else {
         // Derived key: try exact hydrationKey match first.
         const cached = cache.get(hydrationKey);
-        if (cached !== undefined) {
+        if (cached !== undefined && !isCachedEntryStale(hydrationKey)) {
           retainKey(hydrationKey);
           normalizeToEntityStore(cached);
           rawData.value = cached;
@@ -716,7 +757,7 @@ export function query<T, E = unknown>(
           const mc = cache as MemoryCache<T>;
           const found =
             mc.findByPrefix(initDescriptorKey + '&') ?? mc.findByPrefix(initDescriptorKey + ':');
-          if (found) {
+          if (found && !isCachedEntryStale(found.key)) {
             retainKey(found.key);
             normalizeToEntityStore(found.value);
             rawData.value = found.value;
@@ -818,7 +859,7 @@ export function query<T, E = unknown>(
         getInflight().delete(key);
         inflightKeys.delete(key);
         if (id !== fetchId) return; // stale
-        cache.set(key, result);
+        cache.set(key, result, currentEntityVersion());
         retainKey(key);
         normalizeToEntityStore(result);
         rawData.value = result;
@@ -1075,7 +1116,7 @@ export function query<T, E = unknown>(
     if (isFirst && navPrefetchDeferred) {
       if (customKey) {
         const cached = untrack(() => cache.get(customKey));
-        if (cached !== undefined) {
+        if (cached !== undefined && !isCachedEntryStale(customKey)) {
           retainKey(customKey);
           untrack(() => {
             rawData.value = cached;
@@ -1097,6 +1138,7 @@ export function query<T, E = unknown>(
         // `baseKey:depHash`. Use the same key format here so nav-prefetch
         // finds data cached by a previous visit.
         const descriptorKey = isQueryDescriptor(trackRaw) ? trackRaw._key : undefined;
+        const descriptorEntity = isQueryDescriptor(trackRaw) ? trackRaw._entity : undefined;
         if (!descriptorKey) {
           (trackRaw as Promise<T>).catch(() => {});
         }
@@ -1107,7 +1149,7 @@ export function query<T, E = unknown>(
             : descriptorKey
           : untrack(() => getCacheKey());
         const cached = untrack(() => cache.get(derivedKey));
-        if (cached !== undefined) {
+        if (cached !== undefined && !isCachedEntryStale(derivedKey, descriptorEntity)) {
           retainKey(derivedKey);
           untrack(() => {
             rawData.value = cached;
@@ -1123,7 +1165,7 @@ export function query<T, E = unknown>(
           const found = untrack(
             () => mc.findByPrefix(descriptorKey + '&') ?? mc.findByPrefix(descriptorKey + ':'),
           );
-          if (found) {
+          if (found && !isCachedEntryStale(found.key, descriptorEntity)) {
             retainKey(found.key);
             untrack(() => {
               normalizeToEntityStore(found.value);
@@ -1347,7 +1389,7 @@ export function query<T, E = unknown>(
     const shouldCheckCache = effectKey || isNavigation || (isFirst ? !!customKey : !customKey);
     if (shouldCheckCache) {
       const cached = untrack(() => cache.get(key));
-      if (cached !== undefined) {
+      if (cached !== undefined && !isCachedEntryStale(key)) {
         retainKey(key);
         promise.catch(() => {});
         untrack(() => {

--- a/packages/ui/src/store/__tests__/mutation-event-bus.test.ts
+++ b/packages/ui/src/store/__tests__/mutation-event-bus.test.ts
@@ -59,4 +59,44 @@ describe('MutationEventBus', () => {
     bus.emit('projects');
     expect(calls).toEqual([]);
   });
+
+  describe('getVersion', () => {
+    it('returns 0 for entity types that have never been emitted', () => {
+      const bus = createMutationEventBus();
+      expect(bus.getVersion('tasks')).toBe(0);
+    });
+
+    it('increments on every emit for the same entity type', () => {
+      const bus = createMutationEventBus();
+      bus.emit('tasks');
+      expect(bus.getVersion('tasks')).toBe(1);
+      bus.emit('tasks');
+      expect(bus.getVersion('tasks')).toBe(2);
+    });
+
+    it('tracks versions per entity type independently', () => {
+      const bus = createMutationEventBus();
+      bus.emit('tasks');
+      bus.emit('tasks');
+      bus.emit('projects');
+      expect(bus.getVersion('tasks')).toBe(2);
+      expect(bus.getVersion('projects')).toBe(1);
+      expect(bus.getVersion('other')).toBe(0);
+    });
+
+    it('increments even when no subscribers are registered', () => {
+      const bus = createMutationEventBus();
+      bus.emit('tasks');
+      expect(bus.getVersion('tasks')).toBe(1);
+    });
+
+    it('clear resets versions alongside listeners', () => {
+      const bus = createMutationEventBus();
+      bus.emit('tasks');
+      bus.emit('projects');
+      bus.clear();
+      expect(bus.getVersion('tasks')).toBe(0);
+      expect(bus.getVersion('projects')).toBe(0);
+    });
+  });
 });

--- a/packages/ui/src/store/mutation-event-bus.ts
+++ b/packages/ui/src/store/mutation-event-bus.ts
@@ -9,6 +9,16 @@ export interface MutationEventBus {
   subscribe(entityType: string, callback: () => void): () => void;
   /** Emit a mutation event for an entity type. All subscribers for that type are notified. */
   emit(entityType: string): void;
+  /**
+   * Monotonic per-entity-type version that increments on every `emit()`.
+   * Starts at 0 and never resets for a given bus instance.
+   *
+   * Used by `query()` to detect mutations that occurred while the query was
+   * unsubscribed (e.g. the user navigated away and then came back). On
+   * remount, cached data whose version snapshot predates the current
+   * version must be considered stale and refetched.
+   */
+  getVersion(entityType: string): number;
   /** Remove all subscriptions. Used for SSR per-request isolation. */
   clear(): void;
 }
@@ -16,6 +26,7 @@ export interface MutationEventBus {
 /** Create a new MutationEventBus instance. */
 export function createMutationEventBus(): MutationEventBus {
   const listeners = new Map<string, Set<() => void>>();
+  const versions = new Map<string, number>();
 
   return {
     subscribe(entityType: string, callback: () => void): () => void {
@@ -28,14 +39,19 @@ export function createMutationEventBus(): MutationEventBus {
       return () => set?.delete(callback);
     },
     emit(entityType: string): void {
+      versions.set(entityType, (versions.get(entityType) ?? 0) + 1);
       const set = listeners.get(entityType);
       if (set) {
         // Snapshot to avoid re-entrancy issues if a callback unsubscribes during iteration.
         for (const cb of [...set]) cb();
       }
     },
+    getVersion(entityType: string): number {
+      return versions.get(entityType) ?? 0;
+    },
     clear(): void {
       listeners.clear();
+      versions.clear();
     },
   };
 }


### PR DESCRIPTION
Closes #2986.

## Summary

- `MutationEventBus` now tracks a monotonic per-entity-type version that increments on every `emit()`; `getVersion(entityType)` exposes it.
- `MemoryCache.set(key, value, version?)` records the stamp; `CacheStore<T>` gained an optional `getVersion(key)`.
- `query()` stamps every cache write with the bus version for its entity type and skips cache hits whose stamp is older than the current bus version. SSR-hydrated entries are explicitly stamped `0` so a client emit that lands before hydration completes correctly marks the SSR payload stale on remount. Nav-prefetch cache-hit paths (init-time and effect-time) honor the same check, using the descriptor's `_entity` when the query's `entityMeta` hasn't been assigned yet.

## Why

Navigating list → form → back via `router.navigate()` left the list showing pre-mutation data until a full page reload. The list query had unsubscribed from the bus on navigate-away, so the `emit()` fired by the form's mutation reached no live listener — yet the cached entry and its query indices remained and were served on remount. `emit()` only notified live subscribers; it didn't touch the cache.

## Public API Changes

- `MutationEventBus.getVersion(entityType: string): number` — **new**.
- `CacheStore<T>.set(key, value, version?)` — **added optional `version` parameter** (backward compatible).
- `CacheStore<T>.getVersion(key): number | undefined` — **new optional method**. Custom cache implementations without it keep the previous behavior.

No breaking changes. Entity-backed queries automatically participate. Non-entity queries are unaffected.

## Test plan

- [x] `vtz test` — 2481 tests pass in `@vertz/ui`
- [x] `vtz test` — 1285 tests pass in `@vertz/ui-server`
- [x] `vtz run typecheck` — clean
- [x] `vtzx oxlint` — no new warnings (16 pre-existing, 16 after)
- [x] `vtzx oxfmt --check` — clean
- [x] New regression tests in `packages/ui/src/query/__tests__/query.test.ts`:
  - Direct descriptor: mount → dispose → emit same type → remount → fresh fetch
  - Descriptor-in-thunk: same flow, with lazy entity metadata
  - Custom key: same flow
  - Cross-entity isolation: emit on unrelated type → cache still served
- [x] New unit tests in `packages/ui/src/query/__tests__/cache.test.ts` (version stamp: set/get/delete/clear/LRU/v0)
- [x] New unit tests in `packages/ui/src/store/__tests__/mutation-event-bus.test.ts` (getVersion: initial state, increments per type, reset on clear)

## Pre-existing out-of-scope note

The effect calls `raw._fetch()` eagerly on every run before the cache-hit check is evaluated. On a cache hit the resulting promise is suppressed via `.catch`, but the fetch call itself has already started. Worth revisiting separately — unrelated to this fix.