### PR TITLE
fix(ui): form() initial option re-evaluates reactively [#2984]

### DIFF
--- a/packages/ui/src/form/__tests__/field-state.test.ts
+++ b/packages/ui/src/form/__tests__/field-state.test.ts
@@ -83,4 +83,53 @@ describe('createFieldState', () => {
       expect(field.dirty.peek()).toBe(false);
     });
   });
+
+  describe('setInitial', () => {
+    it('updates value when field is not dirty', () => {
+      const field = createFieldState<string>('title', 'Old');
+
+      field.setInitial('New');
+
+      expect(field.value.peek()).toBe('New');
+      expect(field.dirty.peek()).toBe(false);
+    });
+
+    it('preserves user input when field is dirty', () => {
+      const field = createFieldState<string>('title', 'Old');
+
+      field.setValue('User Input');
+      expect(field.dirty.peek()).toBe(true);
+
+      field.setInitial('New');
+
+      expect(field.value.peek()).toBe('User Input');
+      expect(field.dirty.peek()).toBe(true);
+    });
+
+    it('clears dirty when user input already matches new initial', () => {
+      const field = createFieldState<string>('title', 'Old');
+
+      field.setValue('Match');
+      expect(field.dirty.peek()).toBe(true);
+
+      field.setInitial('Match');
+
+      expect(field.value.peek()).toBe('Match');
+      expect(field.dirty.peek()).toBe(false);
+    });
+
+    it('updates the baseline for subsequent setValue/reset calls', () => {
+      const field = createFieldState<string>('title', 'Old');
+
+      field.setInitial('New');
+      field.setValue('New');
+      expect(field.dirty.peek()).toBe(false);
+
+      field.setValue('Changed');
+      expect(field.dirty.peek()).toBe(true);
+
+      field.reset();
+      expect(field.value.peek()).toBe('New');
+    });
+  });
 });

--- a/packages/ui/src/form/__tests__/form.test.ts
+++ b/packages/ui/src/form/__tests__/form.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from '@vertz/test';
 import { err, ok } from '@vertz/fetch';
 import { s } from '@vertz/schema';
+import { signal } from '../../runtime/signal';
 import type { SdkMethodWithMeta } from '../form';
 import { form } from '../form';
 import type { FormSchema } from '../validation';
@@ -748,6 +749,145 @@ describe('form', () => {
       await f.submit(fd);
 
       expect(f.address.street.error.peek()).toBe('Required');
+    });
+  });
+
+  describe('reactive initial', () => {
+    it('updates field values when initial() function dependency changes', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ title: string } | undefined>(undefined);
+      const f = form(sdk, {
+        schema: passingSchema<{ title: string }>(),
+        initial: () => data.value,
+      });
+
+      expect(f.title.value.peek()).toBeUndefined();
+
+      data.value = { title: 'Loaded' };
+
+      expect(f.title.value.peek()).toBe('Loaded');
+    });
+
+    it('does not overwrite dirty fields when initial changes', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ title: string }>({ title: 'Original' });
+      const f = form(sdk, {
+        schema: passingSchema<{ title: string }>(),
+        initial: () => data.value,
+      });
+
+      f.title.setValue('User Input');
+      expect(f.title.dirty.peek()).toBe(true);
+
+      data.value = { title: 'Updated' };
+
+      expect(f.title.value.peek()).toBe('User Input');
+      expect(f.title.dirty.peek()).toBe(true);
+    });
+
+    it('reset() uses the latest initial after reactive update', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ title: string }>({ title: 'Old' });
+      const f = form(sdk, {
+        schema: passingSchema<{ title: string }>(),
+        initial: () => data.value,
+      });
+
+      f.title.setValue('User Input');
+      data.value = { title: 'New' };
+
+      f.reset();
+
+      expect(f.title.value.peek()).toBe('New');
+      expect(f.title.dirty.peek()).toBe(false);
+    });
+
+    it('fields accessed after initial resolves see the resolved value', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ title: string } | undefined>(undefined);
+      const f = form(sdk, {
+        schema: passingSchema<{ title: string }>(),
+        initial: () => data.value,
+      });
+
+      data.value = { title: 'Loaded' };
+
+      // First access to f.title happens after data loads.
+      expect(f.title.value.peek()).toBe('Loaded');
+    });
+
+    it('dirty-comparison baseline follows latest initial', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ title: string }>({ title: 'Original' });
+      const f = form(sdk, {
+        schema: passingSchema<{ title: string }>(),
+        initial: () => data.value,
+      });
+      const { el } = createMockFormElement();
+      f.__bindElement(el);
+
+      data.value = { title: 'Updated' };
+
+      // Typing the new initial value should not mark dirty.
+      el.dispatchEvent(createInputEvent('title', 'Updated'));
+      expect(f.title.dirty.peek()).toBe(false);
+
+      // Typing anything else should mark dirty.
+      el.dispatchEvent(createInputEvent('title', 'Something else'));
+      expect(f.title.dirty.peek()).toBe(true);
+    });
+
+    it('field.setInitial is accessible via the form proxy', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const f = form(sdk, { schema: passingSchema<{ title: string }>() });
+
+      f.title.setInitial('Preloaded');
+
+      expect(f.title.value.peek()).toBe('Preloaded');
+      expect(f.title.dirty.peek()).toBe(false);
+    });
+
+    it('updates nested field values when initial() returns new nested data', () => {
+      const sdk = mockSdkMethod({
+        url: '/api/users',
+        method: 'POST',
+        handler: async () => ({ id: 1 }),
+      });
+      const data = signal<{ address: { city: string } } | undefined>(undefined);
+      const f = form(sdk, {
+        schema: passingSchema<{ address: { city: string } }>(),
+        initial: () => data.value,
+      });
+
+      expect(f.address.city.value.peek()).toBeUndefined();
+
+      data.value = { address: { city: 'Springfield' } };
+
+      expect(f.address.city.value.peek()).toBe('Springfield');
     });
   });
 

--- a/packages/ui/src/form/field-state.ts
+++ b/packages/ui/src/form/field-state.ts
@@ -8,6 +8,12 @@ export interface FieldState<T = unknown> {
   value: Signal<T>;
   setValue: (value: T) => void;
   reset: () => void;
+  /**
+   * Replace the baseline value used for dirty comparison and reset().
+   * If the field is not dirty, its current value is updated to `newInitial`
+   * so async-loaded data flows into the UI. Dirty fields keep their user input.
+   */
+  setInitial: (newInitial: T) => void;
 }
 
 export function createFieldState<T>(_name: string, initialValue?: T): FieldState<T> {
@@ -15,6 +21,7 @@ export function createFieldState<T>(_name: string, initialValue?: T): FieldState
   const dirty = signal(false);
   const touched = signal(false);
   const value = signal(initialValue as T);
+  let currentInitial = initialValue as T;
 
   return {
     error,
@@ -23,13 +30,21 @@ export function createFieldState<T>(_name: string, initialValue?: T): FieldState
     value,
     setValue(newValue: T) {
       value.value = newValue;
-      dirty.value = newValue !== initialValue;
+      dirty.value = newValue !== currentInitial;
     },
     reset() {
-      value.value = initialValue as T;
+      value.value = currentInitial;
       error.value = undefined;
       dirty.value = false;
       touched.value = false;
+    },
+    setInitial(newInitial: T) {
+      currentInitial = newInitial;
+      if (!dirty.peek()) {
+        value.value = newInitial;
+      } else if (value.peek() === newInitial) {
+        dirty.value = false;
+      }
     },
   };
 }

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -1,6 +1,6 @@
 import type { Result } from '@vertz/fetch';
 import { coerceFormDataToSchema, coerceLeaf } from '@vertz/schema';
-import { computed, signal } from '../runtime/signal';
+import { computed, lifecycleEffect, signal } from '../runtime/signal';
 import type { ReadonlySignal, Signal } from '../runtime/signal-types';
 import { createFieldState, type FieldState } from './field-state';
 import { formDataToObject } from './form-data';
@@ -8,7 +8,7 @@ import type { FormSchema } from './validation';
 import { resolveFieldSchema, validate, validateField } from './validation';
 
 const FIELD_STATE_SIGNALS = new Set(['error', 'dirty', 'touched', 'value']);
-const FIELD_STATE_METHODS = new Set(['setValue', 'reset']);
+const FIELD_STATE_METHODS = new Set(['setValue', 'reset', 'setInitial']);
 
 /**
  * An SDK method with endpoint metadata attached.
@@ -200,12 +200,17 @@ export function form<TBody, TResult>(
     return true;
   });
 
-  function resolveNestedInitial(dotPath: string): unknown {
-    const initialObj =
-      typeof options?.initial === 'function' ? options.initial() : options?.initial;
-    if (!initialObj) return undefined;
-    const segments = dotPath.split('.');
-    let current: unknown = initialObj;
+  // When `initial` is a function, track its reactive dependencies so async
+  // data (e.g. `() => query.data`) flows into the fields as it resolves.
+  // A static value is used directly.
+  const initialFn = typeof options?.initial === 'function' ? options.initial : undefined;
+  let latestInitial: DeepPartial<TBody> | undefined =
+    initialFn !== undefined ? initialFn() : (options?.initial as DeepPartial<TBody> | undefined);
+
+  function resolveInitialFor(name: string): unknown {
+    if (latestInitial == null) return undefined;
+    const segments = name.includes('.') ? name.split('.') : [name];
+    let current: unknown = latestInitial;
     for (const segment of segments) {
       if (current == null || typeof current !== 'object') return undefined;
       current = (current as Record<string, unknown>)[segment];
@@ -216,18 +221,20 @@ export function form<TBody, TResult>(
   function getOrCreateField(name: string): FieldState {
     let field = fieldCache.get(name);
     if (!field) {
-      const initialValue = name.includes('.')
-        ? resolveNestedInitial(name)
-        : (() => {
-            const initialObj =
-              typeof options?.initial === 'function' ? options.initial() : options?.initial;
-            return (initialObj as Record<string, unknown> | undefined)?.[name];
-          })();
-      field = createFieldState(name, initialValue);
+      field = createFieldState(name, resolveInitialFor(name));
       fieldCache.set(name, field);
       fieldGeneration.value++;
     }
     return field;
+  }
+
+  if (initialFn !== undefined) {
+    lifecycleEffect(() => {
+      latestInitial = initialFn();
+      for (const [name, field] of fieldCache) {
+        field.setInitial(resolveInitialFor(name));
+      }
+    });
   }
 
   function getOrCreateChainProxy(dotPath: string): object {


### PR DESCRIPTION
## Summary

- `form({ initial: () => query.data })` evaluated `initial` once at creation. Since components run once in Vertz, async-loaded data never reached the fields — inputs stayed empty after `query` resolved.
- When `initial` is a function, we now wrap it in `lifecycleEffect` so it re-runs whenever its reactive dependencies change. Each run updates `latestInitial` and calls `field.setInitial(newValue)` on every existing field.
- `FieldState.setInitial(v)` replaces the dirty-comparison baseline and `reset()` target. Non-dirty fields also update their current value; dirty fields keep user input.

## Public API Changes

**Additions:**
- `FieldState.setInitial(newInitial)` — replaces the field's baseline value. Non-dirty fields sync to `newInitial`; dirty fields keep their user input but the new baseline is used for subsequent dirty-comparison / `reset()`. Exposed on the form proxy, so `taskForm.title.setInitial('…')` works.

**No breaking changes.** Static `initial: {...}` keeps the same semantics; only the functional form becomes reactive.

## Closes

Closes #2984

## Test plan

- [x] `vtz test src/form/__tests__/` — 194/194 pass in `@vertz/ui`
- [x] `tsgo --noEmit` clean
- [x] `oxfmt --check` / `oxlint` clean on changed files
- [x] 11 new tests covering:
  - reactive update on signal change
  - dirty-field preservation
  - `reset()` using latest baseline
  - nested paths (`address.city`)
  - dirty-comparison follows latest initial
  - `setInitial` accessible through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)