### PR TITLE
fix(compiler): make early-return guards reactive in component bodies

### DIFF
--- a/.changeset/fix-reactive-early-return-guards-2987.md
+++ b/.changeset/fix-reactive-early-return-guards-2987.md
@@ -1,0 +1,14 @@
+---
+'@vertz/native-compiler': patch
+'vertz': patch
+---
+
+fix(compiler): make early-return guards reactive in component bodies
+
+Closes [#2987](https://github.com/vertz-dev/vertz/issues/2987).
+
+A component of the shape `if (cond) return <Loading/>; return <Ready/>;` froze at the guard branch: the body ran once at mount and never re-ran when `cond` flipped. This broke the documented loading-UX pattern of `query().loading` + early return.
+
+The compiler now detects the guard shape (N consecutive `if (cond) return <jsx>;` at the top of a component body, followed by a single trailing `return <jsx>;`) and rewrites the body to wrap the main return in a chain of `__conditional(() => cond, () => branch, () => fallback)` calls, so the condition is re-evaluated reactively and the DOM swaps between branches without re-mounting the component.
+
+Guards with an `else` branch, multi-statement blocks, or non-guard statements between guards are left alone — the per-return mount-frame wrapper still handles them.

--- a/native/vertz-compiler-core/src/lib.rs
+++ b/native/vertz-compiler-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod mutation_transformer;
 pub mod prefetch_manifest;
 pub mod props_transformer;
 pub mod query_auto_thunk;
+pub mod reactive_guard_transformer;
 pub mod reactivity_analyzer;
 pub mod route_splitting;
 pub mod signal_api_registry;
@@ -439,9 +440,22 @@ pub fn compile(source: &str, options: CompileOptions) -> CompileResult {
                 hydration_id,
             );
 
+            // Reactive guard transform runs before the mount frame wrapper.
+            // When a component matches the `if (cond) return <jsx>; ... return <jsx>;`
+            // guard shape, it rewrites the body to wrap the final return in
+            // `__conditional(...)` so guard conditions stay reactive — and
+            // handles its own mount-frame wrapping, so we skip the default.
+            let handled_as_guard = reactive_guard_transformer::try_transform_reactive_guards(
+                &mut ms,
+                &parser_ret.program,
+                comp,
+            );
+
             // Mount frame wrapping runs AFTER all other transforms
             // Check if this is an arrow expression body first
-            if comp.is_arrow_expression {
+            if handled_as_guard {
+                // reactive_guard_transformer already injected push/try/catch + flush.
+            } else if comp.is_arrow_expression {
                 mount_frame_transformer::transform_arrow_expression_body(
                     &mut ms,
                     &parser_ret.program,

--- a/native/vertz-compiler-core/src/reactive_guard_transformer.rs
+++ b/native/vertz-compiler-core/src/reactive_guard_transformer.rs
@@ -1,0 +1,412 @@
+//! Reactive guard pattern transformer.
+//!
+//! Transforms a component body of the shape:
+//!
+//! ```ignore
+//! function Foo() {
+//!   <setup stmts>
+//!   if (cond1) return <jsxA>;
+//!   if (cond2) return <jsxB>;
+//!   return <jsxMain>;
+//! }
+//! ```
+//!
+//! into a mount-framed body that wraps the main return in a chain of
+//! `__conditional(() => cond, () => branch, () => fallback)` calls so the
+//! guard conditions are re-evaluated reactively:
+//!
+//! ```ignore
+//! function Foo() {
+//!   const __mfDepth = __pushMountFrame();
+//!   try {
+//!     <setup stmts>
+//!     const __mfResult0 = __conditional(
+//!       () => cond1,
+//!       () => <jsxA>,
+//!       () => __conditional(() => cond2, () => <jsxB>, () => <jsxMain>),
+//!     );
+//!     __flushMountFrame();
+//!     return __mfResult0;
+//!   } catch (__mfErr) { __discardMountFrame(__mfDepth); throw __mfErr; }
+//! }
+//! ```
+//!
+//! Runs AFTER the JSX transformer so that `get_transformed_slice` returns the
+//! already-generated `__element(...)` IIFE text for each JSX expression, and
+//! REPLACES the mount frame transformer for guard-pattern components.
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_span::GetSpan;
+
+use crate::component_analyzer::ComponentInfo;
+use crate::magic_string::MagicString;
+
+struct GuardInfo {
+    if_stmt_start: u32,
+    if_stmt_end: u32,
+    cond_start: u32,
+    cond_end: u32,
+    jsx_start: u32,
+    jsx_end: u32,
+}
+
+struct MainReturn {
+    return_start: u32,
+    return_end: u32,
+    jsx_start: u32,
+    jsx_end: u32,
+}
+
+struct GuardPattern {
+    guards: Vec<GuardInfo>,
+    main_return: MainReturn,
+}
+
+/// Attempt to transform the component as a reactive guard pattern.
+///
+/// Returns `true` if the pattern was recognised and transformed — the caller
+/// should then skip the regular mount-frame transformer for this component.
+pub fn try_transform_reactive_guards(
+    ms: &mut MagicString,
+    program: &Program,
+    component: &ComponentInfo,
+) -> bool {
+    // Arrow-expression bodies (no block) can't have an early-return guard.
+    if component.is_arrow_expression {
+        return false;
+    }
+
+    let Some(pattern) = detect_guard_pattern(program, component) else {
+        return false;
+    };
+
+    apply_transform(ms, component, &pattern);
+    true
+}
+
+fn apply_transform(ms: &mut MagicString, component: &ComponentInfo, pattern: &GuardPattern) {
+    // Read post-JSX-transform slices BEFORE we queue our own overwrites.
+    // get_transformed_slice() surfaces the __element(...) IIFE text produced
+    // by the JSX transformer and the `.value` appends from the signal
+    // transformer on the conditions.
+    let main_jsx_text =
+        ms.get_transformed_slice(pattern.main_return.jsx_start, pattern.main_return.jsx_end);
+
+    let guard_texts: Vec<(String, String)> = pattern
+        .guards
+        .iter()
+        .map(|g| {
+            let cond = ms.get_transformed_slice(g.cond_start, g.cond_end);
+            let jsx = ms.get_transformed_slice(g.jsx_start, g.jsx_end);
+            (cond, jsx)
+        })
+        .collect();
+
+    let mut conditional_chain = main_jsx_text;
+    for (cond, jsx) in guard_texts.iter().rev() {
+        conditional_chain =
+            format!("__conditional(() => ({cond}), () => ({jsx}), () => ({conditional_chain}))");
+    }
+
+    // 1. Inject mount-frame body wrapping (push + try-open after `{`).
+    ms.append_right(
+        component.body_start + 1,
+        " const __mfDepth = __pushMountFrame();\ntry {",
+    );
+
+    // 2. Remove each early `if (cond) return jsx;` statement.
+    for guard in &pattern.guards {
+        ms.overwrite(guard.if_stmt_start, guard.if_stmt_end, "");
+    }
+
+    // 3. Replace the entire main return statement with a mount-framed
+    //    `const __mfResult0 = <chain>; __flushMountFrame(); return __mfResult0;`.
+    //    Overwriting the whole return statement (rather than just the JSX
+    //    argument) wins over the JSX transformer's overwrite of the inner
+    //    JSX span because our range strictly contains it.
+    let main_replacement = format!(
+        "const __mfResult0 = {conditional_chain}; __flushMountFrame(); return __mfResult0;"
+    );
+    ms.overwrite(
+        pattern.main_return.return_start,
+        pattern.main_return.return_end,
+        &main_replacement,
+    );
+
+    // 4. Inject try-close/catch before the body's closing `}`.
+    //    body_end is exclusive (points AFTER the `}`), so subtract 1.
+    ms.prepend_left(
+        component.body_end - 1,
+        "\n} catch (__mfErr) { __discardMountFrame(__mfDepth); throw __mfErr; }\n",
+    );
+}
+
+// ─── Pattern detection ──────────────────────────────────────────────────────
+
+fn detect_guard_pattern(program: &Program, component: &ComponentInfo) -> Option<GuardPattern> {
+    let body = find_component_body_statements(program, component)?;
+
+    // Walk statements: skip any number of non-guard leading statements (setup),
+    // then collect consecutive guard ifs, then require a single main return as
+    // the last statement.
+    let mut i = 0;
+    let n = body.len();
+
+    // Phase 1: advance until we hit a guard-if or a bare return.
+    while i < n {
+        match body[i] {
+            Statement::IfStatement(_) => {
+                if extract_guard_from_if(&body[i]).is_some() {
+                    break;
+                }
+                // An if-statement that isn't a clean guard disqualifies the
+                // pattern — bail so we don't silently skip meaningful
+                // branching that the developer wrote.
+                return None;
+            }
+            Statement::ReturnStatement(_) => break,
+            _ => i += 1,
+        }
+    }
+
+    // Phase 2: collect guards.
+    let mut guards = Vec::new();
+    while i < n {
+        match body[i] {
+            Statement::IfStatement(_) => {
+                let guard = extract_guard_from_if(&body[i])?;
+                guards.push(guard);
+                i += 1;
+            }
+            _ => break,
+        }
+    }
+
+    if guards.is_empty() {
+        return None;
+    }
+
+    // Phase 3: final statement must be a `return <jsx>;` with nothing after.
+    if i != n - 1 {
+        return None;
+    }
+    let Statement::ReturnStatement(ret) = &body[i] else {
+        return None;
+    };
+    let arg = ret.argument.as_ref()?;
+    let jsx = find_jsx_in_expr(arg)?;
+    let jsx_span = jsx.span();
+
+    Some(GuardPattern {
+        guards,
+        main_return: MainReturn {
+            return_start: ret.span.start,
+            return_end: ret.span.end,
+            jsx_start: jsx_span.start,
+            jsx_end: jsx_span.end,
+        },
+    })
+}
+
+fn extract_guard_from_if(stmt: &Statement) -> Option<GuardInfo> {
+    let Statement::IfStatement(if_stmt) = stmt else {
+        return None;
+    };
+
+    // Reject if the guard has an `else` branch — a guard is a one-armed
+    // short-circuit; `if (...) return else ...` reshapes control flow in a
+    // way that the simple __conditional chain doesn't preserve.
+    if if_stmt.alternate.is_some() {
+        return None;
+    }
+
+    let (jsx_start, jsx_end) = extract_return_jsx_span(&if_stmt.consequent)?;
+    let cond_span = if_stmt.test.span();
+
+    Some(GuardInfo {
+        if_stmt_start: if_stmt.span.start,
+        if_stmt_end: if_stmt.span.end,
+        cond_start: cond_span.start,
+        cond_end: cond_span.end,
+        jsx_start,
+        jsx_end,
+    })
+}
+
+/// Extract the JSX span from the consequent of an `if` where the consequent
+/// is exactly `return <jsx>;` (braceless or in a single-statement block).
+fn extract_return_jsx_span(consequent: &Statement) -> Option<(u32, u32)> {
+    let ret = match consequent {
+        Statement::ReturnStatement(ret) => ret,
+        Statement::BlockStatement(block) => {
+            if block.body.len() != 1 {
+                return None;
+            }
+            if let Statement::ReturnStatement(ret) = &block.body[0] {
+                ret
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+    let arg = ret.argument.as_ref()?;
+    let jsx = find_jsx_in_expr(arg)?;
+    let span = jsx.span();
+    Some((span.start, span.end))
+}
+
+fn find_jsx_in_expr<'a, 'b>(expr: &'a Expression<'b>) -> Option<&'a Expression<'b>> {
+    match expr {
+        Expression::JSXElement(_) | Expression::JSXFragment(_) => Some(expr),
+        Expression::ParenthesizedExpression(paren) => find_jsx_in_expr(&paren.expression),
+        _ => None,
+    }
+}
+
+// ─── Locating the component body's statement list ───────────────────────────
+
+fn find_component_body_statements<'a, 'b>(
+    program: &'a Program<'b>,
+    component: &'a ComponentInfo,
+) -> Option<&'a [Statement<'b>]> {
+    let mut finder = BodyStmtsFinder {
+        component,
+        result: None,
+    };
+    for stmt in &program.body {
+        finder.visit_statement(stmt);
+        if finder.result.is_some() {
+            break;
+        }
+    }
+    finder.result
+}
+
+struct BodyStmtsFinder<'a, 'b> {
+    component: &'a ComponentInfo,
+    result: Option<&'a [Statement<'b>]>,
+}
+
+impl<'a, 'b> BodyStmtsFinder<'a, 'b> {
+    fn body_matches(&self, body: &oxc_span::Span) -> bool {
+        body.start == self.component.body_start && body.end == self.component.body_end
+    }
+}
+
+impl<'a, 'b> Visit<'b> for BodyStmtsFinder<'a, 'b> {
+    fn visit_function(&mut self, func: &Function<'b>, flags: oxc_syntax::scope::ScopeFlags) {
+        if let Some(ref body) = func.body {
+            if self.body_matches(&body.span) {
+                // SAFETY: the body's lifetime outlives this visitor — oxc stores
+                // the program in an arena, and the visitor's 'b parameter ties
+                // the returned slice to that arena.
+                let stmts: &[Statement<'b>] = unsafe {
+                    std::mem::transmute::<&[Statement<'b>], &'a [Statement<'b>]>(&body.statements)
+                };
+                self.result = Some(stmts);
+                return;
+            }
+        }
+        oxc_ast_visit::walk::walk_function(self, func, flags);
+    }
+
+    fn visit_arrow_function_expression(&mut self, func: &ArrowFunctionExpression<'b>) {
+        if self.body_matches(&func.body.span) {
+            let stmts: &[Statement<'b>] = unsafe {
+                std::mem::transmute::<&[Statement<'b>], &'a [Statement<'b>]>(&func.body.statements)
+            };
+            self.result = Some(stmts);
+            return;
+        }
+        oxc_ast_visit::walk::walk_arrow_function_expression(self, func);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> String {
+        compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        )
+        .code
+    }
+
+    #[test]
+    fn simple_guard_becomes_reactive_conditional() {
+        let out = compile_tsx(
+            "function App() {\n  if (props.loading) return <div>Loading</div>;\n  return <div>Content</div>;\n}",
+        );
+        assert!(
+            out.contains("__conditional(() =>"),
+            "expected __conditional wrapping, got: {out}"
+        );
+        // Only one mount frame flush — we produce a single final return.
+        let flushes = out.matches("__flushMountFrame()").count();
+        assert_eq!(flushes, 1, "expected single flush, got: {out}");
+    }
+
+    #[test]
+    fn non_guard_component_is_left_to_mount_frame() {
+        let out = compile_tsx("function App() { return <div>hi</div>; }");
+        assert!(
+            !out.contains("__conditional("),
+            "unexpected __conditional in plain component: {out}"
+        );
+        assert!(
+            out.contains("__pushMountFrame()"),
+            "expected mount frame: {out}"
+        );
+    }
+
+    #[test]
+    fn multiple_guards_nest_conditionals() {
+        let out = compile_tsx(
+            "function App(props) {\n  if (props.loading) return <div>L</div>;\n  if (props.error) return <div>E</div>;\n  return <div>ok</div>;\n}",
+        );
+        let conds = out.matches("__conditional(").count();
+        assert!(conds >= 2, "expected nested conditionals, got: {out}");
+    }
+
+    #[test]
+    fn braced_guard_block_is_recognised() {
+        let out = compile_tsx(
+            "function App(props) {\n  if (props.loading) {\n    return <div>L</div>;\n  }\n  return <div>ok</div>;\n}",
+        );
+        assert!(
+            out.contains("__conditional(() =>"),
+            "expected conditional wrap for braced guard, got: {out}"
+        );
+    }
+
+    #[test]
+    fn guard_with_else_branch_is_rejected() {
+        // An `if/else` both returning is NOT a guard — fall back to mount frame per-return.
+        let out = compile_tsx(
+            "function App(props) {\n  if (props.a) return <div>A</div>;\n  else return <div>B</div>;\n}",
+        );
+        assert!(
+            !out.contains("__conditional(() =>"),
+            "if/else with two returns should not be rewritten: {out}"
+        );
+    }
+
+    #[test]
+    fn non_guard_if_disqualifies_pattern() {
+        // An `if` without a return disqualifies — don't silently reorder logic.
+        let out = compile_tsx(
+            "function App(props) {\n  if (props.a) { doSomething(); }\n  if (props.b) return <div>B</div>;\n  return <div>main</div>;\n}",
+        );
+        assert!(
+            !out.contains("__conditional(() =>"),
+            "non-guard if should block the pattern, got: {out}"
+        );
+    }
+}

--- a/native/vertz-compiler/__tests__/mount-frame.test.ts
+++ b/native/vertz-compiler/__tests__/mount-frame.test.ts
@@ -33,11 +33,13 @@ describe('Feature: Mount frame transform', () => {
     });
   });
 
-  describe('Given a component with multiple return statements', () => {
+  describe('Given a component with multiple return statements that is NOT a guard pattern', () => {
     describe('When compiled', () => {
       it('Then inserts __flushMountFrame before each return', () => {
+        // Multi-statement if-block (log() + return) disqualifies the reactive
+        // guard pattern, so mount-frame handles each return independently.
         const code = compileAndGetCode(
-          `function MyComponent() {\n  if (true) { return <div>A</div>; }\n  return <div>B</div>;\n}`,
+          `function MyComponent() {\n  if (true) { log(); return <div>A</div>; }\n  return <div>B</div>;\n}`,
         );
         const flushCount = (code.match(/__flushMountFrame\(\)/g) ?? []).length;
         expect(flushCount).toBe(2);
@@ -45,7 +47,7 @@ describe('Feature: Mount frame transform', () => {
 
       it('Then uses unique variable names per return (__mfResult0, __mfResult1)', () => {
         const code = compileAndGetCode(
-          `function MyComponent() {\n  if (true) { return <div>A</div>; }\n  return <div>B</div>;\n}`,
+          `function MyComponent() {\n  if (true) { log(); return <div>A</div>; }\n  return <div>B</div>;\n}`,
         );
         expect(code).toContain('__mfResult0');
         expect(code).toContain('__mfResult1');
@@ -53,11 +55,14 @@ describe('Feature: Mount frame transform', () => {
     });
   });
 
-  describe('Given a braceless if with early return', () => {
+  describe('Given a braceless if with early return (not a guard pattern)', () => {
     describe('When compiled', () => {
       it('Then wraps the replacement in braces to produce valid JS', () => {
+        // A trailing expression statement between the if and the main return
+        // disqualifies the reactive guard pattern, so mount-frame falls back
+        // to per-return wrapping.
         const code = compileAndGetCode(
-          `function MyComponent() {\n  if (true) return <div>A</div>;\n  return <div>B</div>;\n}`,
+          `function MyComponent() {\n  if (true) return <div>A</div>;\n  log();\n  return <div>B</div>;\n}`,
         );
         // Braceless if should be wrapped in { } for valid JS
         expect(code).toMatch(/if \(.+\) \{ const __mfResult0/);

--- a/native/vertz-compiler/__tests__/reactive-guards.test.ts
+++ b/native/vertz-compiler/__tests__/reactive-guards.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from '@vertz/test';
+import { NATIVE_MODULE_PATH } from './load-compiler';
+
+function loadCompiler() {
+  return require(NATIVE_MODULE_PATH) as {
+    compile: (source: string, options?: { filename?: string }) => { code: string };
+  };
+}
+
+function compileAndGetCode(source: string): string {
+  const { compile } = loadCompiler();
+  const result = compile(source, { filename: 'test.tsx' });
+  return result.code;
+}
+
+describe('Feature: Reactive early-return guards', () => {
+  describe('Given a component with a signal-API guard followed by a main return', () => {
+    describe('When compiled', () => {
+      it('Then wraps the main return in __conditional with a thunk over the guard condition', () => {
+        const code = compileAndGetCode(
+          [
+            "import { query } from '@vertz/ui';",
+            'export function TestPage() {',
+            '  const data = query(() => api.tasks.list(), { key: "task-list" });',
+            '  if (data.loading) return <div>Loading...</div>;',
+            '  return <div>Loaded</div>;',
+            '}',
+          ].join('\n'),
+        );
+
+        // The guard condition must be wrapped in a thunk (reactive)
+        expect(code).toMatch(/__conditional\(\s*\(\)\s*=>\s*\(?data\.loading\.value\)?/);
+        // The early-return if-statement must not remain as a plain `if` gate
+        expect(code).not.toMatch(/if\s*\(data\.loading\.value\)\s*\{?\s*const __mfResult/);
+      });
+
+      it('Then flushes the mount frame exactly once for the guarded component', () => {
+        const code = compileAndGetCode(
+          [
+            "import { query } from '@vertz/ui';",
+            'export function TestPage() {',
+            '  const data = query(() => api.tasks.list(), { key: "task-list" });',
+            '  if (data.loading) return <div>Loading...</div>;',
+            '  return <div>Loaded</div>;',
+            '}',
+          ].join('\n'),
+        );
+
+        const flushCount = (code.match(/__flushMountFrame\(\)/g) ?? []).length;
+        expect(flushCount).toBe(1);
+      });
+    });
+  });
+
+  describe('Given a component with multiple consecutive guards', () => {
+    describe('When compiled', () => {
+      it('Then nests each guard in its own __conditional', () => {
+        const code = compileAndGetCode(
+          [
+            "import { query } from '@vertz/ui';",
+            'export function TestPage() {',
+            '  const data = query(() => api.tasks.list(), { key: "task-list" });',
+            '  if (data.loading) return <div>Loading</div>;',
+            '  if (data.error) return <div>Error</div>;',
+            '  return <div>Loaded</div>;',
+            '}',
+          ].join('\n'),
+        );
+
+        const condCount = (code.match(/__conditional\(/g) ?? []).length;
+        // Two guards → two nested __conditional wrappers (plus any existing ones in JSX)
+        expect(condCount).toBeGreaterThanOrEqual(2);
+        expect(code).toContain('data.loading.value');
+        expect(code).toContain('data.error.value');
+      });
+    });
+  });
+
+  describe('Given a component with a braced guard block', () => {
+    describe('When compiled', () => {
+      it('Then still wraps the main return in __conditional', () => {
+        const code = compileAndGetCode(
+          [
+            "import { query } from '@vertz/ui';",
+            'export function TestPage() {',
+            '  const data = query(() => api.tasks.list(), { key: "task-list" });',
+            '  if (data.loading) {',
+            '    return <div>Loading</div>;',
+            '  }',
+            '  return <div>Loaded</div>;',
+            '}',
+          ].join('\n'),
+        );
+
+        expect(code).toMatch(/__conditional\(\s*\(\)\s*=>/);
+        expect(code).toContain('data.loading.value');
+      });
+    });
+  });
+
+  describe('Given a component with a guard that uses a plain boolean prop', () => {
+    describe('When compiled', () => {
+      it('Then produces a reactive __conditional over the prop access', () => {
+        const code = compileAndGetCode(
+          [
+            'export function Greet(props) {',
+            '  if (props.loading) return <div>Loading</div>;',
+            '  return <div>Ready</div>;',
+            '}',
+          ].join('\n'),
+        );
+
+        expect(code).toMatch(/__conditional\(\s*\(\)\s*=>\s*\(?props\.loading\)?/);
+      });
+    });
+  });
+
+  describe('Given a component with no early-return guard', () => {
+    describe('When compiled', () => {
+      it('Then does not introduce a __conditional around the single return', () => {
+        const code = compileAndGetCode(
+          ['export function Plain() {', '  return <div>hi</div>;', '}'].join('\n'),
+        );
+
+        // A plain component has no ternary / guard, so no __conditional wraps the body.
+        // (It may still appear inside JSX for ternaries — but here there are none.)
+        expect(code).not.toContain('__conditional(');
+      });
+    });
+  });
+});

--- a/packages/ui/src/__tests__/reactive-guard-runtime.test.ts
+++ b/packages/ui/src/__tests__/reactive-guard-runtime.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Runtime regression for the compiler's reactive-guard transform (#2987).
+ *
+ * The compiler rewrites a component body of the shape
+ *
+ *   function Comp() {
+ *     if (cond) return <Loading/>;
+ *     return <Ready/>;
+ *   }
+ *
+ * into a single `__conditional(() => cond, () => Loading, () => Ready)` call
+ * so that the guard stays reactive. This test simulates exactly that emitted
+ * structure and asserts the DOM swaps when the condition signal flips —
+ * catching any regression where the guard collapses back to a static if.
+ */
+import { describe, expect, it } from '@vertz/test';
+import { __conditional } from '../dom/conditional';
+import { signal } from '../runtime/signal';
+
+describe('Reactive guard runtime contract (issue #2987)', () => {
+  describe('Given a compiler-emitted __conditional wrapping an early-return guard', () => {
+    describe('When the guard condition flips from true to false', () => {
+      it('Then the DOM swaps from the guard branch to the main branch', () => {
+        const loading = signal(true);
+
+        const container = document.createElement('div');
+        const fragment = __conditional(
+          () => loading.value,
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'Loading...';
+            return el;
+          },
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'Data loaded!';
+            return el;
+          },
+        );
+        container.appendChild(fragment);
+
+        expect(container.textContent).toContain('Loading...');
+
+        loading.value = false;
+
+        expect(container.textContent).toContain('Data loaded!');
+        expect(container.textContent).not.toContain('Loading...');
+      });
+    });
+
+    describe('When the guard condition flips back to true', () => {
+      it('Then the DOM swaps back to the guard branch', () => {
+        const loading = signal(false);
+
+        const container = document.createElement('div');
+        const fragment = __conditional(
+          () => loading.value,
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'Loading...';
+            return el;
+          },
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'Data loaded!';
+            return el;
+          },
+        );
+        container.appendChild(fragment);
+
+        expect(container.textContent).toContain('Data loaded!');
+
+        loading.value = true;
+
+        expect(container.textContent).toContain('Loading...');
+      });
+    });
+  });
+
+  describe('Given nested __conditional wrappers for multiple guards', () => {
+    describe('When the outer guard matches', () => {
+      it('Then the inner fallback branches are never constructed', () => {
+        const loading = signal(true);
+        const error = signal(false);
+        let readyBuilt = 0;
+
+        const container = document.createElement('div');
+        const fragment = __conditional(
+          () => loading.value,
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'L';
+            return el;
+          },
+          () =>
+            __conditional(
+              () => error.value,
+              () => {
+                const el = document.createElement('div');
+                el.textContent = 'E';
+                return el;
+              },
+              () => {
+                readyBuilt++;
+                const el = document.createElement('div');
+                el.textContent = 'R';
+                return el;
+              },
+            ),
+        );
+        container.appendChild(fragment);
+
+        expect(container.textContent).toContain('L');
+        expect(readyBuilt).toBe(0);
+      });
+    });
+
+    describe('When guards fall through to the main branch', () => {
+      it('Then the main branch renders and updates on further changes', () => {
+        const loading = signal(true);
+        const error = signal(false);
+
+        const container = document.createElement('div');
+        const fragment = __conditional(
+          () => loading.value,
+          () => {
+            const el = document.createElement('div');
+            el.textContent = 'L';
+            return el;
+          },
+          () =>
+            __conditional(
+              () => error.value,
+              () => {
+                const el = document.createElement('div');
+                el.textContent = 'E';
+                return el;
+              },
+              () => {
+                const el = document.createElement('div');
+                el.textContent = 'R';
+                return el;
+              },
+            ),
+        );
+        container.appendChild(fragment);
+
+        loading.value = false;
+        expect(container.textContent).toContain('R');
+
+        error.value = true;
+        expect(container.textContent).toContain('E');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Detects the `if (cond) return <jsx>; ... return <jsx>;` guard shape in component bodies and rewrites the body so the main return is wrapped in a reactive `__conditional(() => cond, () => branch, () => fallback)` chain.
- Closes #2987 — components like `if (data.loading) return <Loading/>; return <Ready/>;` now swap to the ready branch when `data.loading` flips, instead of staying frozen at the guard forever.
- Non-guard shapes (else branches, multi-statement blocks, intermediate statements between guards) are left alone so the per-return mount-frame wrapper keeps handling them.

## Public API Changes

No new or removed APIs. Behavior change only: the compiler's output structure for early-return guard components now uses `__conditional` so conditions are tracked reactively. This matches the documented loading-UX pattern.

## Test plan

- [x] Rust unit tests in `native/vertz-compiler-core/src/reactive_guard_transformer.rs` cover simple/multi/braced guards, else branches (rejected), non-guard ifs (rejected), and non-guard components (unchanged).
- [x] JS compiler tests in `native/vertz-compiler/__tests__/reactive-guards.test.ts` assert the emitted code has `__conditional(() => cond, ...)` and a single `__flushMountFrame()`.
- [x] Runtime regression in `packages/ui/src/__tests__/reactive-guard-runtime.test.ts` mounts the compiler-emitted structure and verifies DOM swaps both directions, including nested guards.
- [x] Updated two older mount-frame tests that used the now-reactive shape to intentionally non-guard shapes (multi-statement block, intermediate statement) so they still exercise per-return mount-frame wrapping.
- [x] Full quality gates green on push (rust clippy/fmt/test, TS typecheck/lint/test, trojan-source check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)