### PR TITLE
fix(server): type rules.entitlement() with registered Entitlement union [#2992]

### DIFF
--- a/.changeset/fix-rules-entitlement-typed-2992.md
+++ b/.changeset/fix-rules-entitlement-typed-2992.md
@@ -1,0 +1,9 @@
+---
+'@vertz/server': patch
+---
+
+fix(server): narrow `rules.entitlement()` to the registered `Entitlement` union
+
+Closes [#2992](https://github.com/vertz-dev/vertz/issues/2992).
+
+`rules.entitlement()` accepted any `string`, so typos like `rules.entitlement('task:udpate')` compiled cleanly and only surfaced at runtime. The parameter now uses the `Entitlement` type which narrows to the declared entitlement union when `@vertz/codegen` has run (via the existing `EntitlementRegistry` augmentation in `access.d.ts`) and falls back to `string` otherwise — so autocomplete and typo detection work end-to-end without requiring any user-side configuration beyond running codegen.

--- a/packages/integration-tests/src/__tests__/rules-entitlement-narrowing.test-d.ts
+++ b/packages/integration-tests/src/__tests__/rules-entitlement-narrowing.test-d.ts
@@ -1,0 +1,56 @@
+/**
+ * Type flow verification — rules.entitlement() narrowing via EntitlementRegistry [#2992]
+ *
+ * Simulates what `@vertz/codegen`'s AccessTypesGenerator emits into `access.d.ts`
+ * at build time and verifies the narrowing propagates end-to-end through the
+ * published `@vertz/server` package:
+ *
+ *   1. rules.entitlement('task:update') — declared, compiles clean
+ *   2. rules.entitlement('task:udpate') — typo, rejected at compile time
+ *   3. ctx.can('task:delete') / ctx.authorize('task:delete') — same narrowing
+ *
+ * If this file compiles clean, the augmentation flow the generator relies on
+ * still reaches the builder signature through the package boundary.
+ */
+import { rules } from '@vertz/server';
+import type { AccessContext } from '@vertz/server';
+
+// Augmentation mirrors what AccessTypesGenerator emits into access.d.ts:
+//   declare module '@vertz/server' {
+//     interface EntitlementRegistry {
+//       'task:update': true;
+//       ...
+//     }
+//   }
+// Entitlements that appear elsewhere in this package's type-checked files
+// are included so sibling `.test-d.ts` tests keep compiling.
+declare module '@vertz/server' {
+  interface EntitlementRegistry {
+    'task:update': true;
+    'task:delete': true;
+    'project:view': true;
+    'organization:manage': true;
+  }
+}
+
+// Positive: declared entitlement compiles.
+rules.entitlement('task:update');
+rules.entitlement('task:delete');
+
+// Negative: undeclared entitlement is rejected.
+// @ts-expect-error -- 'task:udpate' is not a registered entitlement
+rules.entitlement('task:udpate');
+
+// @ts-expect-error -- empty string is not a registered entitlement
+rules.entitlement('');
+
+// @ts-expect-error -- arbitrary string is not a registered entitlement
+rules.entitlement('unknown:action');
+
+// The same registry powers AccessContext — narrowing flows to can()/authorize().
+declare const ctx: AccessContext;
+void ctx.can('task:update');
+void ctx.authorize('task:delete');
+
+// @ts-expect-error -- narrowing reaches AccessContext.can() too
+void ctx.can('task:udpate');

--- a/packages/server/src/auth/rules.test-d.ts
+++ b/packages/server/src/auth/rules.test-d.ts
@@ -1,0 +1,21 @@
+import { expectTypeOf } from '@vertz/test';
+import type { Entitlement } from './access-context';
+import type { EntitlementRule } from './rules';
+import { rules } from './rules';
+
+// rules.entitlement must accept the narrowed Entitlement type.
+// When user code augments EntitlementRegistry via @vertz/codegen's
+// AccessTypesGenerator, `Entitlement` narrows to a literal-string union
+// and typos in rules.entitlement('...') become compile errors.
+expectTypeOf(rules.entitlement).toEqualTypeOf<(name: Entitlement) => EntitlementRule>();
+
+// Positive: any string is accepted when the registry is empty (fallback)
+const ok: EntitlementRule = rules.entitlement('task:update');
+void ok;
+
+// Negative: non-string inputs are rejected regardless of registry state
+// @ts-expect-error -- entitlement names must be strings
+rules.entitlement(42);
+
+// @ts-expect-error -- entitlement names must be defined
+rules.entitlement(undefined);

--- a/packages/server/src/auth/rules.ts
+++ b/packages/server/src/auth/rules.ts
@@ -5,6 +5,8 @@
  * The access context evaluates them at runtime (sub-phase 4).
  */
 
+import type { Entitlement } from './access-context';
+
 // ============================================================================
 // Rule Types
 // ============================================================================
@@ -84,7 +86,7 @@ export const rules = {
   },
 
   /** User has the specified entitlement (resolves role+plan+flag from defineAccess config) */
-  entitlement(name: string): EntitlementRule {
+  entitlement(name: Entitlement): EntitlementRule {
     return { type: 'entitlement', entitlement: name };
   },
 


### PR DESCRIPTION
## Summary

Closes #2992.

- `rules.entitlement(name)` accepted any `string`, so typos like `rules.entitlement('task:udpate')` compiled cleanly and only surfaced at runtime. Narrows the parameter to the `Entitlement` type so typos become TypeScript errors and autocomplete surfaces declared entitlements.
- The infrastructure was already in place — `@vertz/codegen`'s [`AccessTypesGenerator`](https://github.com/vertz-dev/vertz/blob/main/packages/codegen/src/generators/access-types-generator.ts) already emits `declare module '@vertz/server' { interface EntitlementRegistry { ... } }` into `access.d.ts`, and `Entitlement = keyof EntitlementRegistry extends never ? string : Extract<keyof EntitlementRegistry, string>` is defined in [`access-context.ts`](https://github.com/vertz-dev/vertz/blob/main/packages/server/src/auth/access-context.ts). The builder just wasn't consuming the `Entitlement` type.
- Falls back to `string` when the registry is empty, so projects that haven't run codegen keep compiling.

## Public API Changes

- [`packages/server/src/auth/rules.ts`](https://github.com/vertz-dev/vertz/blob/fix/rules-entitlement-typed/packages/server/src/auth/rules.ts) — `rules.entitlement(name: string)` → `rules.entitlement(name: Entitlement)`. Non-breaking when `EntitlementRegistry` is empty (parameter resolves to `string`); narrows in projects where codegen has emitted `access.d.ts`.

## Test plan

- [x] `tsgo --noEmit` clean on `@vertz/server` (both `tsconfig.json` and `tsconfig.typecheck.json`)
- [x] `oxlint` clean on changed files
- [x] `vtz test` — 2193 passed, 0 failed on `@vertz/server`, including the new `rules.test-d.ts`
- [x] Pre-push gates (build-typecheck, lint, test, trojan-source) all green
- [x] New `.test-d.ts` covers positive (accepts string fallback) and negative (`@ts-expect-error` on non-string inputs) cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)