### PR TITLE
fix(ui,fetch): map server 422 validation errors to form field signals [#2981]

### DIFF
--- a/.changeset/fix-form-server-422-errors-2981.md
+++ b/.changeset/fix-form-server-422-errors-2981.md
@@ -11,5 +11,5 @@ Server 422 responses were being swallowed. The server emits per-field errors und
 
 Two changes make the round-trip work:
 
-- `@vertz/fetch` now reads `error.details` (matching `packages/server/src/entity/error-handler.ts`) and normalizes array paths (e.g. `['items', 0, 'name']`) to dot-notation strings so they line up with form field names. `FetchValidationError` and `isFetchValidationError` are re-exported from `@vertz/fetch` for consumer use.
-- `form()` checks for `FetchValidationError` in `submitPipeline` and walks `.errors`, writing each message to the matching field's `error` signal (empty path → `_form`). `onError` receives the same per-field record. Non-validation errors keep the existing `_form` fallback.
+- `@vertz/fetch` now reads `error.details` (matching `packages/server/src/entity/error-handler.ts`) and normalizes paths: array paths (e.g. `['items', 0, 'name']`) become dot-notation strings, and empty paths (`''` / `[]`) become `_form` — matching the convention already used by client-side validation. An empty `details` array falls through to the regular HTTP error path so the top-level message still reaches the UI. `FetchValidationError` and `isFetchValidationError` are re-exported from `@vertz/fetch` for consumer use.
+- `form()` checks for `FetchValidationError` in `submitPipeline` and walks the already-normalized `.errors`, writing each message to the matching field's `error` signal. `onError` receives the same per-field record. Non-validation errors keep the existing `_form` fallback.

--- a/.changeset/fix-form-server-422-errors-2981.md
+++ b/.changeset/fix-form-server-422-errors-2981.md
@@ -1,0 +1,15 @@
+---
+'@vertz/ui': patch
+'@vertz/fetch': patch
+---
+
+fix(ui,fetch): map server 422 validation errors back to form field error signals
+
+Closes [#2981](https://github.com/vertz-dev/vertz/issues/2981).
+
+Server 422 responses were being swallowed. The server emits per-field errors under `body.error.details`, but the fetch client was looking at `body.error.errors`, so `FetchValidationError` never fired. `form()` then fell back to the generic `_form` handler, and per-field UI feedback never appeared.
+
+Two changes make the round-trip work:
+
+- `@vertz/fetch` now reads `error.details` (matching `packages/server/src/entity/error-handler.ts`) and normalizes array paths (e.g. `['items', 0, 'name']`) to dot-notation strings so they line up with form field names. `FetchValidationError` and `isFetchValidationError` are re-exported from `@vertz/fetch` for consumer use.
+- `form()` checks for `FetchValidationError` in `submitPipeline` and walks `.errors`, writing each message to the matching field's `error` signal (empty path → `_form`). `onError` receives the same per-field record. Non-validation errors keep the existing `_form` fallback.

--- a/packages/fetch/src/client.test.ts
+++ b/packages/fetch/src/client.test.ts
@@ -827,9 +827,13 @@ describe('FetchClient parse and validation errors', () => {
     }
   });
 
-  it('should return FetchValidationError with errors array', async () => {
+  it('should return FetchValidationError with details from server (string path)', async () => {
     const body = {
-      error: { code: 'ValidationError', errors: [{ path: 'email', message: 'Invalid email' }] },
+      error: {
+        code: 'ValidationError',
+        message: 'Validation failed',
+        details: [{ path: 'email', message: 'Invalid email' }],
+      },
     };
     const mockFetch = mock().mockResolvedValue(new Response(JSON.stringify(body), { status: 422 }));
     const client = new FetchClient({ baseURL: 'http://localhost', fetch: mockFetch });
@@ -837,7 +841,37 @@ describe('FetchClient parse and validation errors', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBeInstanceOf(FetchValidationError);
-      expect((result.error as FetchValidationError).errors).toHaveLength(1);
+      const err = result.error as FetchValidationError;
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0]).toEqual({ path: 'email', message: 'Invalid email' });
+    }
+  });
+
+  it('normalizes array paths to dot-notation (EntityValidationError shape)', async () => {
+    const body = {
+      error: {
+        code: 'ValidationError',
+        message: 'Validation failed',
+        details: [
+          {
+            path: ['status'],
+            message: "Invalid enum value. Expected 'todo' | 'done', received ''",
+          },
+          { path: ['items', 0, 'name'], message: 'Name is required' },
+        ],
+      },
+    };
+    const mockFetch = mock().mockResolvedValue(new Response(JSON.stringify(body), { status: 422 }));
+    const client = new FetchClient({ baseURL: 'http://localhost', fetch: mockFetch });
+    const result = await client.get('/test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(FetchValidationError);
+      const err = result.error as FetchValidationError;
+      expect(err.errors).toEqual([
+        { path: 'status', message: "Invalid enum value. Expected 'todo' | 'done', received ''" },
+        { path: 'items.0.name', message: 'Name is required' },
+      ]);
     }
   });
 });

--- a/packages/fetch/src/client.test.ts
+++ b/packages/fetch/src/client.test.ts
@@ -847,6 +847,51 @@ describe('FetchClient parse and validation errors', () => {
     }
   });
 
+  it('normalizes empty paths to `_form`', async () => {
+    const body = {
+      error: {
+        code: 'ValidationError',
+        message: 'Validation failed',
+        details: [
+          { path: '', message: 'Form-level error' },
+          { path: [], message: 'Another form-level error' },
+        ],
+      },
+    };
+    const mockFetch = mock().mockResolvedValue(new Response(JSON.stringify(body), { status: 422 }));
+    const client = new FetchClient({ baseURL: 'http://localhost', fetch: mockFetch });
+    const result = await client.get('/test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(FetchValidationError);
+      const err = result.error as FetchValidationError;
+      expect(err.errors).toEqual([
+        { path: '_form', message: 'Form-level error' },
+        { path: '_form', message: 'Another form-level error' },
+      ]);
+    }
+  });
+
+  it('falls back to UnprocessableEntityError when `details` is empty', async () => {
+    const body = {
+      error: {
+        code: 'ValidationError',
+        message: 'Validation failed',
+        details: [],
+      },
+    };
+    const mockFetch = mock().mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 422, statusText: 'Unprocessable Entity' }),
+    );
+    const client = new FetchClient({ baseURL: 'http://localhost', fetch: mockFetch });
+    const result = await client.get('/test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Does NOT produce a FetchValidationError — nothing to map per-field.
+      expect(result.error).not.toBeInstanceOf(FetchValidationError);
+    }
+  });
+
   it('normalizes array paths to dot-notation (EntityValidationError shape)', async () => {
     const body = {
       error: {

--- a/packages/fetch/src/client.ts
+++ b/packages/fetch/src/client.ts
@@ -131,11 +131,22 @@ export class FetchClient {
             // `error.details` (see packages/server/src/entity/error-handler.ts).
             // Path may be a string ("email") or an array (["address", "street"]
             // or ["items", 0, "name"]) — normalize to dot-notation for form fields.
-            if (errorObj?.code === 'ValidationError' && Array.isArray(errorObj.details)) {
-              const normalized = errorObj.details.map((d) => ({
-                path: Array.isArray(d.path) ? d.path.join('.') : d.path,
-                message: d.message,
-              }));
+            // An empty path (top-level form error) normalizes to "_form" to match
+            // the convention used by client-side validation in @vertz/ui.
+            // An empty details array falls through to the regular HTTP error path
+            // so the top-level message still reaches the UI via the generic handler.
+            if (
+              errorObj?.code === 'ValidationError' &&
+              Array.isArray(errorObj.details) &&
+              errorObj.details.length > 0
+            ) {
+              const normalized = errorObj.details.map((d) => {
+                const joined = Array.isArray(d.path) ? d.path.join('.') : d.path;
+                return {
+                  path: joined === '' ? '_form' : joined,
+                  message: d.message,
+                };
+              });
               return err(
                 new FetchValidationError(errorObj.message ?? 'Validation failed', normalized),
               );

--- a/packages/fetch/src/client.ts
+++ b/packages/fetch/src/client.ts
@@ -114,15 +114,31 @@ export class FetchClient {
           let serverCode: string | undefined;
           if (body && typeof body === 'object' && 'error' in body) {
             const errorObj = body.error as
-              | { code?: string; errors?: Array<{ path: string; message: string }> }
+              | {
+                  code?: string;
+                  message?: string;
+                  details?: ReadonlyArray<{
+                    path: string | ReadonlyArray<string | number>;
+                    message: string;
+                  }>;
+                }
               | undefined;
             if (errorObj && typeof errorObj.code === 'string') {
               serverCode = errorObj.code;
             }
 
-            // Check for validation errors
-            if (errorObj?.code === 'ValidationError' && Array.isArray(errorObj.errors)) {
-              return err(new FetchValidationError('Validation failed', errorObj.errors));
+            // Check for validation errors. Server emits per-field errors under
+            // `error.details` (see packages/server/src/entity/error-handler.ts).
+            // Path may be a string ("email") or an array (["address", "street"]
+            // or ["items", 0, "name"]) — normalize to dot-notation for form fields.
+            if (errorObj?.code === 'ValidationError' && Array.isArray(errorObj.details)) {
+              const normalized = errorObj.details.map((d) => ({
+                path: Array.isArray(d.path) ? d.path.join('.') : d.path,
+                message: d.message,
+              }));
+              return err(
+                new FetchValidationError(errorObj.message ?? 'Validation failed', normalized),
+              );
             }
           }
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -27,6 +27,7 @@ export {
   UnauthorizedError,
   UnprocessableEntityError,
 } from './errors';
+export { FetchValidationError, isFetchValidationError } from '@vertz/errors';
 export type {
   AuthStrategy,
   EntityQueryMeta,

--- a/packages/integration-tests/src/__tests__/errors-as-values-e2e.test.ts
+++ b/packages/integration-tests/src/__tests__/errors-as-values-e2e.test.ts
@@ -258,9 +258,10 @@ describe('Fetch client → Result flow', () => {
           JSON.stringify({
             error: {
               code: 'ValidationError',
-              errors: [
+              message: 'Validation failed',
+              details: [
                 { path: 'email', message: 'Invalid email format' },
-                { path: 'age', message: 'Must be positive' },
+                { path: ['age'], message: 'Must be positive' },
               ],
             },
           }),
@@ -282,9 +283,12 @@ describe('Fetch client → Result flow', () => {
       });
 
       expect(isErr(result)).toBe(true);
+      expect(isErr(result) && result.error instanceof FetchValidationError).toBe(true);
       if (isErr(result) && result.error instanceof FetchValidationError) {
         expect(result.error.errors).toHaveLength(2);
         expect(result.error.errors[0]?.path).toBe('email');
+        // Array path normalized to dot-notation
+        expect(result.error.errors[1]?.path).toBe('age');
       }
     });
   });

--- a/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
+++ b/packages/integration-tests/src/__tests__/form-walkthrough.test.ts
@@ -12,7 +12,7 @@
 // ===========================================================================
 
 import { describe, expect, it, mock } from '@vertz/test';
-import { err, ok } from '@vertz/fetch';
+import { err, FetchValidationError, ok } from '@vertz/fetch';
 import { s } from '@vertz/schema';
 import type { FormOptions, SdkMethod, SdkMethodWithMeta } from '@vertz/ui/form';
 import { form, formDataToObject } from '@vertz/ui/form';
@@ -157,6 +157,37 @@ describe('Form API Developer Walkthrough', () => {
       expect(onError).toHaveBeenCalled();
       const errors = onError.mock.calls[0]?.[0] as Record<string, string>;
       expect(errors._form).toBeDefined();
+    });
+
+    it('submit() maps server 422 validation errors to per-field signals', async () => {
+      const failingSdk: SdkMethod<CreateUserBody, User> = Object.assign(
+        async () =>
+          err(
+            new FetchValidationError('Validation failed', [
+              { path: 'name', message: 'Name already taken' },
+              { path: 'email', message: 'Invalid email format' },
+            ]),
+          ),
+        { url: '/api/users', method: 'POST' },
+      );
+
+      const onError = mock();
+      const userForm = form(failingSdk, {
+        schema: createUserSchema,
+        onError,
+      });
+
+      const fd = new FormData();
+      fd.append('name', 'Alice');
+      fd.append('email', 'alice@test.com');
+      await userForm.submit(fd);
+
+      expect(userForm.name.error.peek()).toBe('Name already taken');
+      expect(userForm.email.error.peek()).toBe('Invalid email format');
+      expect(onError).toHaveBeenCalledWith({
+        name: 'Name already taken',
+        email: 'Invalid email format',
+      });
     });
   });
 

--- a/packages/ui/src/__tests__/form-integration.test.ts
+++ b/packages/ui/src/__tests__/form-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock } from '@vertz/test';
-import { ok } from '@vertz/fetch';
+import { err, FetchValidationError, ok } from '@vertz/fetch';
 import { s } from '@vertz/schema';
 import { form } from '../form/form';
 import { formDataToObject } from '../form/form-data';
@@ -43,6 +43,18 @@ function mockSdkMethod<TBody, TResult>(config: {
 }) {
   const wrappedHandler = async (body: TBody) => ok(await config.handler(body));
   const fn = wrappedHandler as ((body: TBody) => Promise<{ ok: true; data: TResult }>) & {
+    url: string;
+    method: string;
+  };
+  fn.url = config.url;
+  fn.method = config.method;
+  return fn;
+}
+
+/** Helper: creates a mock SDK method that always returns an error result. */
+function mockFailingSdkMethod<TBody>(config: { url: string; method: string; error: Error }) {
+  const wrappedHandler = async (_body: TBody) => err(config.error);
+  const fn = wrappedHandler as ((body: TBody) => Promise<ReturnType<typeof err>>) & {
     url: string;
     method: string;
   };
@@ -135,6 +147,77 @@ describe('Integration Tests — Forms', () => {
       name: 'Name is required',
       email: 'Valid email is required',
     });
+  });
+
+  // IT-3-2b: form() maps server 422 validation errors to field error signals
+  test('form() maps server 422 validation errors to per-field error signals', async () => {
+    const validationError = new FetchValidationError('Validation failed', [
+      { path: 'title', message: 'Title is required' },
+      { path: 'status', message: "Invalid enum value. Expected 'todo' | 'done', received ''" },
+    ]);
+    const sdk = mockFailingSdkMethod<{ title: string; status: string }>({
+      url: '/api/tasks',
+      method: 'POST',
+      error: validationError,
+    });
+
+    const schema: FormSchema<{ title: string; status: string }> = {
+      parse(data: unknown) {
+        return { ok: true as const, data: data as { title: string; status: string } };
+      },
+    };
+
+    const onSuccess = mock();
+    const onError = mock();
+
+    const taskForm = form(sdk, { schema, onSuccess, onError });
+
+    const fd = new FormData();
+    fd.append('title', '');
+    fd.append('status', '');
+
+    await taskForm.submit(fd);
+
+    // Per-field errors are mapped from the server response to field signals
+    expect(taskForm.title.error.peek()).toBe('Title is required');
+    expect(taskForm.status.error.peek()).toBe(
+      "Invalid enum value. Expected 'todo' | 'done', received ''",
+    );
+    // onError is called with the mapped per-field record
+    expect(onError).toHaveBeenCalledWith({
+      title: 'Title is required',
+      status: "Invalid enum value. Expected 'todo' | 'done', received ''",
+    });
+    // onSuccess was NOT called because submission failed
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // IT-3-2c: form() falls back to _form error for non-validation failures
+  test('form() falls back to _form error for non-validation SDK errors', async () => {
+    const sdk = mockFailingSdkMethod<{ name: string }>({
+      url: '/api/users',
+      method: 'POST',
+      error: new Error('Network is unreachable'),
+    });
+
+    const schema: FormSchema<{ name: string }> = {
+      parse(data: unknown) {
+        return { ok: true as const, data: data as { name: string } };
+      },
+    };
+
+    const onError = mock();
+    const userForm = form(sdk, { schema, onError });
+
+    const fd = new FormData();
+    fd.append('name', 'Alice');
+
+    await userForm.submit(fd);
+
+    // Generic errors still land on the `_form` pseudo-field,
+    // and `name` is untouched
+    expect(userForm.name.error.peek()).toBeUndefined();
+    expect(onError).toHaveBeenCalledWith({ _form: 'Network is unreachable' });
   });
 
   // IT-3-3: formDataToObject converts FormData with proper handling

--- a/packages/ui/src/__tests__/form-integration.test.ts
+++ b/packages/ui/src/__tests__/form-integration.test.ts
@@ -63,6 +63,26 @@ function mockFailingSdkMethod<TBody>(config: { url: string; method: string; erro
   return fn;
 }
 
+/** Helper: creates a mock SDK method whose errors are driven by a sequence. */
+function mockSequencedFailingSdk<TBody>(config: {
+  url: string;
+  method: string;
+  errors: readonly Error[];
+}) {
+  let i = 0;
+  const wrappedHandler = async (_body: TBody) => {
+    const e = config.errors[Math.min(i++, config.errors.length - 1)] ?? new Error('unexpected');
+    return err(e);
+  };
+  const fn = wrappedHandler as ((body: TBody) => Promise<ReturnType<typeof err>>) & {
+    url: string;
+    method: string;
+  };
+  fn.url = config.url;
+  fn.method = config.method;
+  return fn;
+}
+
 describe('Integration Tests — Forms', () => {
   // IT-3-1: form() submits valid data through SDK method
   test('form() submits valid data through SDK method', async () => {
@@ -190,6 +210,75 @@ describe('Integration Tests — Forms', () => {
     });
     // onSuccess was NOT called because submission failed
     expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // IT-3-2b-form: form() maps a `_form` path (top-level validation error) to the _form field
+  test('form() maps `_form` path server error to the _form pseudo-field', async () => {
+    const validationError = new FetchValidationError('Validation failed', [
+      { path: '_form', message: 'Cross-field constraint violated' },
+    ]);
+    const sdk = mockFailingSdkMethod<{ start: string; end: string }>({
+      url: '/api/events',
+      method: 'POST',
+      error: validationError,
+    });
+
+    const schema: FormSchema<{ start: string; end: string }> = {
+      parse(data: unknown) {
+        return { ok: true as const, data: data as { start: string; end: string } };
+      },
+    };
+
+    const onError = mock();
+    const eventForm = form(sdk, { schema, onError });
+
+    const fd = new FormData();
+    fd.append('start', '2026-01-02');
+    fd.append('end', '2026-01-01');
+
+    await eventForm.submit(fd);
+
+    expect(onError).toHaveBeenCalledWith({ _form: 'Cross-field constraint violated' });
+  });
+
+  // IT-3-2b-reset: server field errors from a prior submission clear on the next submission
+  test('form() clears stale server field errors on the next submission', async () => {
+    const schema: FormSchema<{ name: string; email: string }> = {
+      parse(data: unknown) {
+        return { ok: true as const, data: data as { name: string; email: string } };
+      },
+    };
+
+    const sdk = mockSequencedFailingSdk<{ name: string; email: string }>({
+      url: '/api/users',
+      method: 'POST',
+      errors: [
+        new FetchValidationError('Validation failed', [
+          { path: 'name', message: 'Name taken' },
+          { path: 'email', message: 'Email taken' },
+        ]),
+        new FetchValidationError('Validation failed', [
+          { path: 'name', message: 'Name still taken' },
+        ]),
+      ],
+    });
+
+    const userForm = form(sdk, { schema });
+
+    const fd1 = new FormData();
+    fd1.append('name', 'Alice');
+    fd1.append('email', 'alice@test.com');
+    await userForm.submit(fd1);
+    expect(userForm.name.error.peek()).toBe('Name taken');
+    expect(userForm.email.error.peek()).toBe('Email taken');
+
+    const fd2 = new FormData();
+    fd2.append('name', 'Alice');
+    fd2.append('email', 'alice2@test.com');
+    await userForm.submit(fd2);
+    // `name` re-fails with a new message; `email` is cleared on re-submission.
+    expect(userForm.name.error.peek()).toBe('Name still taken');
+    expect(userForm.email.error.peek()).toBeUndefined();
   });
 
   // IT-3-2c: form() falls back to _form error for non-validation failures

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -295,13 +295,12 @@ export function form<TBody, TResult>(
       if (!result.ok) {
         if (isFetchValidationError(result.error)) {
           const fieldErrors: Record<string, string> = {};
+          // First error per field wins — matches the shape of result.errors
+          // produced by client-side validation above. Paths are already
+          // normalized by the fetch client (empty → `_form`, arrays → dot-path).
           for (const { path, message } of result.error.errors) {
-            // Empty path (top-level form error) lands on `_form`.
-            const key = path === '' ? '_form' : path;
-            // First error per field wins — matches the shape of result.errors
-            // produced by client-side validation above.
-            if (fieldErrors[key] === undefined) {
-              fieldErrors[key] = message;
+            if (fieldErrors[path] === undefined) {
+              fieldErrors[path] = message;
             }
           }
           for (const [fieldName, message] of Object.entries(fieldErrors)) {

--- a/packages/ui/src/form/form.ts
+++ b/packages/ui/src/form/form.ts
@@ -1,4 +1,4 @@
-import type { Result } from '@vertz/fetch';
+import { isFetchValidationError, type Result } from '@vertz/fetch';
 import { coerceFormDataToSchema, coerceLeaf } from '@vertz/schema';
 import { computed, lifecycleEffect, signal } from '../runtime/signal';
 import type { ReadonlySignal, Signal } from '../runtime/signal-types';
@@ -293,6 +293,23 @@ export function form<TBody, TResult>(
 
       const result = await sdkMethod(data as TBody);
       if (!result.ok) {
+        if (isFetchValidationError(result.error)) {
+          const fieldErrors: Record<string, string> = {};
+          for (const { path, message } of result.error.errors) {
+            // Empty path (top-level form error) lands on `_form`.
+            const key = path === '' ? '_form' : path;
+            // First error per field wins — matches the shape of result.errors
+            // produced by client-side validation above.
+            if (fieldErrors[key] === undefined) {
+              fieldErrors[key] = message;
+            }
+          }
+          for (const [fieldName, message] of Object.entries(fieldErrors)) {
+            getOrCreateField(fieldName).error.value = message;
+          }
+          options?.onError?.(fieldErrors);
+          return true;
+        }
         const message = result.error.message;
         getOrCreateField('_form').error.value = message;
         options?.onError?.({ _form: message });


### PR DESCRIPTION
## Summary

Closes [#2981](https://github.com/vertz-dev/vertz/issues/2981). Server 422 responses now surface as per-field error signals on `form()` instead of being silently swallowed.

The server emits per-field errors under `body.error.details`, but the fetch client was reading `body.error.errors` — so `FetchValidationError` never fired and `form()` fell back to the generic `_form` message.

## Changes

### `@vertz/fetch`
- Read `body.error.details` (matches [`packages/server/src/entity/error-handler.ts`](https://github.com/vertz-dev/vertz/blob/main/packages/server/src/entity/error-handler.ts))
- Normalize array paths (`['items', 0, 'name']` → `'items.0.name'`) to dot-notation so they match form field names
- Normalize empty paths (`''` / `[]`) → `'_form'`, matching client-side validation convention
- Fall through to the regular HTTP error path when `details: []` (so the top-level message still reaches the UI via the generic `_form` fallback)
- Re-export `FetchValidationError` and `isFetchValidationError` so consumers can import them from `@vertz/fetch`

### `@vertz/ui` `form()`
- In `submitPipeline`, detect `FetchValidationError` on the SDK error and walk `.errors`, writing each message to the matching field's `error` signal
- `onError` receives the same per-field `Record<string, string>`
- Non-validation errors keep the existing `_form` fallback

## Public API Changes

**Additions:**
- `FetchValidationError` and `isFetchValidationError` re-exported from `@vertz/fetch`

**Behavior change (fix):**
- `form()` now populates per-field `error` signals from server 422 responses. Consumers that relied on all server errors landing on `_form` will need to update — but this was a bug, not a contract.

**Breaking:** None (pre-v1, the old behavior was a bug that no app could rely on).

## Test Plan

- [x] Fetch client unit tests: `details` parsing, array path normalization, empty-path → `_form`, empty `details` fallback (`packages/fetch/src/client.test.ts`)
- [x] Form integration tests: per-field mapping, `_form` path round-trip, stale error clearing across submissions, non-validation error fallback (`packages/ui/src/__tests__/form-integration.test.ts`)
- [x] Public-API walkthrough: 422 → per-field signals using only public imports (`packages/integration-tests/src/__tests__/form-walkthrough.test.ts`)
- [x] Fixed dead e2e test that mocked the old `errors` shape (`packages/integration-tests/src/__tests__/errors-as-values-e2e.test.ts`)
- [x] Quality gates: `@vertz/ui`, `@vertz/fetch`, `@vertz/integration-tests` — test + typecheck clean (55/55 fetch, 14/14 form-integration, 25/25 errors-as-values, 380/380 integration-tests)
- [x] `oxlint` + `oxfmt` clean on all changed files
- [x] Adversarial review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)