### PR TITLE
fix(vtz): recover from wiped .vertz/deps/ and clear stale dep re-bundle errors [#2954]

### DIFF
--- a/.changeset/fix-dep-rebundle-stale-errors-2954.md
+++ b/.changeset/fix-dep-rebundle-stale-errors-2954.md
@@ -1,0 +1,28 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): recover from wiped `.vertz/deps/` and clear stale dep re-bundle errors
+
+Closes [#2954](https://github.com/vertz-dev/vertz/issues/2954).
+
+Two compounding bugs on the dev-server dep-watcher path caused a cluster of
+`Failed to re-bundle upstream dep @vertz/ui: Failed to write entry file:
+No such file or directory (os error 2)` errors to survive forever in the
+error overlay across every navigation — even though the app SSRed fine.
+The only cure used to be killing the dev server, deleting
+`.vertz/dev/errors.json`, and restarting.
+
+1. `prebundle_single` now calls `std::fs::create_dir_all(deps_dir)` before
+   writing the temporary entry file, so a wiped or missing `.vertz/deps/`
+   (manual cleanup, a clean clone, a workspace rebuild) no longer bubbles
+   up as ENOENT on the first upstream change.
+
+2. The dep-watcher handler in `server::http` now clears the `Build` error
+   category whenever at least one package re-bundles successfully, before
+   reporting the current cycle's failures. Stale `Failed to re-bundle
+   upstream dep X` entries no longer accumulate in `ErrorState` (or the
+   persisted `.vertz/dev/errors.json`) across successful cycles. The
+   error-broadcast side-effects were extracted into
+   `watcher::dep_watcher::apply_dep_error_state` so the behavior is covered
+   by regression tests without spinning up a full dev server.

--- a/.changeset/fix-dep-rebundle-stale-errors-2954.md
+++ b/.changeset/fix-dep-rebundle-stale-errors-2954.md
@@ -18,11 +18,16 @@ The only cure used to be killing the dev server, deleting
    (manual cleanup, a clean clone, a workspace rebuild) no longer bubbles
    up as ENOENT on the first upstream change.
 
-2. The dep-watcher handler in `server::http` now clears the `Build` error
-   category whenever at least one package re-bundles successfully, before
-   reporting the current cycle's failures. Stale `Failed to re-bundle
-   upstream dep X` entries no longer accumulate in `ErrorState` (or the
-   persisted `.vertz/dev/errors.json`) across successful cycles. The
-   error-broadcast side-effects were extracted into
-   `watcher::dep_watcher::apply_dep_error_state` so the behavior is covered
-   by regression tests without spinning up a full dev server.
+2. The dep-watcher handler in `server::http` now tags every re-bundle error
+   with a synthetic per-package key (`<dep>:{pkg}`) in the error's file
+   field, and clears that key with `clear_file(ErrorCategory::Build, …)`
+   for each package it touches this cycle before reporting the current
+   failure (if any). Stale `Failed to re-bundle upstream dep X` entries no
+   longer accumulate in `ErrorState` (or the persisted
+   `.vertz/dev/errors.json`) across successful cycles, and — crucially —
+   legitimate per-file compile errors in the same `Build` category (which
+   the module server and file-change handler report with real source
+   paths) are left untouched. The error-broadcast side effects were
+   extracted into `watcher::dep_watcher::apply_dep_error_state` so the
+   behavior is covered by regression tests without spinning up a full
+   dev server.

--- a/native/vtz/src/deps/prebundle.rs
+++ b/native/vtz/src/deps/prebundle.rs
@@ -53,6 +53,18 @@ pub fn prebundle_single(package: &str, root_dir: &Path, deps_dir: &Path) -> Preb
     let output_filename = package_to_filename(package);
     let output_path = deps_dir.join(&output_filename);
 
+    // `deps_dir` may have been wiped (manual cleanup, clean-clone, etc.) since
+    // startup. Recreate it here so the entry-file write below can't fail with
+    // ENOENT on the dep-watcher re-bundle path.
+    if let Err(e) = std::fs::create_dir_all(deps_dir) {
+        return PrebundleResult {
+            package: package.to_string(),
+            output_path,
+            success: false,
+            error: Some(format!("Failed to create deps dir: {}", e)),
+        };
+    }
+
     // Create a temporary entry file that re-exports the package
     let entry_content = format!("export * from '{}';\n", package);
     let entry_path = deps_dir.join(format!("_entry_{}.js", output_filename.replace(".js", "")));
@@ -205,5 +217,35 @@ mod tests {
 
         let result = resolve_deps_file("/@deps/nonexistent", &deps_dir);
         assert!(result.is_none());
+    }
+
+    // Regression: #2954. When the dev server's `.vertz/deps/` directory is
+    // wiped between startup and a dep-watcher re-bundle (manual cleanup, etc.),
+    // `prebundle_single` must recreate it rather than fail writing the entry
+    // file with ENOENT. Without this, a stale "Failed to write entry file:
+    // No such file or directory" overlay survives forever across navigations.
+    #[test]
+    fn test_prebundle_single_recreates_missing_deps_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_dir = tmp.path();
+        let deps_dir = root_dir.join(".vertz").join("deps");
+        // Intentionally do NOT create deps_dir — simulate the wiped state.
+        assert!(!deps_dir.exists());
+
+        let result = prebundle_single("nonexistent-package", root_dir, &deps_dir);
+
+        // esbuild will (correctly) fail to resolve a package that isn't
+        // installed, but the failure must NOT be the ENOENT write-entry path.
+        assert!(
+            deps_dir.exists(),
+            "prebundle_single should create deps_dir when missing",
+        );
+        assert!(!result.success);
+        let err = result.error.unwrap_or_default();
+        assert!(
+            !err.contains("Failed to write entry file"),
+            "expected esbuild-level failure, got entry-file ENOENT: {}",
+            err,
+        );
     }
 }

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -1814,17 +1814,11 @@ pub async fn start_server_with_lifecycle(
 
                                     match result {
                                         Ok(dep_result) => {
-                                            // Broadcast re-bundle errors to the overlay
-                                            for (pkg, err_msg) in &dep_result.failed {
-                                                let error = DevError::build(format!(
-                                                    "Failed to re-bundle upstream dep {}: {}",
-                                                    pkg, err_msg
-                                                ));
-                                                dep_state
-                                                    .error_broadcaster
-                                                    .report_error(error)
-                                                    .await;
-                                            }
+                                            crate::watcher::dep_watcher::apply_dep_error_state(
+                                                &dep_state.error_broadcaster,
+                                                &dep_result,
+                                            )
+                                            .await;
 
                                             if dep_result.should_clear_cache {
                                                 // Clear compilation cache

--- a/native/vtz/src/watcher/dep_watcher.rs
+++ b/native/vtz/src/watcher/dep_watcher.rs
@@ -328,24 +328,45 @@ pub fn handle_dep_changes(
     }
 }
 
+/// The pseudo-file key used to tag dep-rebundle errors.
+///
+/// User-source compile errors and dep-rebundle errors both live in
+/// `ErrorCategory::Build`. Tagging dep errors with this synthetic key lets us
+/// clear them via `clear_file` without touching legitimate per-file compile
+/// errors reported by the module server or the file-change handler.
+pub fn dep_error_file(package: &str) -> String {
+    format!("<dep>:{}", package)
+}
+
 /// Apply the error-broadcast side effects of a dep-change cycle.
 ///
-/// When at least one package re-bundled successfully, previously reported
-/// "Failed to re-bundle upstream dep X" errors are no longer current — clear
-/// the Build category before reporting the current cycle's failures. Without
-/// this, stale dep-rebundle errors persist in `ErrorState` (and the persisted
+/// For every package touched this cycle — whether it re-bundled successfully
+/// or failed — we first clear any stale `Failed to re-bundle upstream dep X`
+/// error from previous cycles, then report the new failure (if any). Errors
+/// are keyed by `dep_error_file(pkg)` so `clear_file` removes only the
+/// dep-rebundle entry for that package; file-scoped user-source compile
+/// errors in the same `Build` category are left untouched. Without this,
+/// stale dep-rebundle errors persist in `ErrorState` (and the persisted
 /// `.vertz/dev/errors.json`) across every subsequent page load until the
 /// dev server restarts *and* `errors.json` is manually deleted. See #2954.
 pub async fn apply_dep_error_state(broadcaster: &ErrorBroadcaster, result: &DepChangeResult) {
-    if !result.rebundled.is_empty() {
-        broadcaster.clear_category(ErrorCategory::Build).await;
+    for pkg in &result.rebundled {
+        broadcaster
+            .clear_file(ErrorCategory::Build, &dep_error_file(pkg))
+            .await;
+    }
+    for (pkg, _) in &result.failed {
+        broadcaster
+            .clear_file(ErrorCategory::Build, &dep_error_file(pkg))
+            .await;
     }
 
     for (pkg, err_msg) in &result.failed {
         let error = DevError::build(format!(
             "Failed to re-bundle upstream dep {}: {}",
             pkg, err_msg
-        ));
+        ))
+        .with_file(dep_error_file(pkg));
         broadcaster.report_error(error).await;
     }
 }
@@ -767,18 +788,23 @@ mod tests {
 
     // --- apply_dep_error_state tests ---
 
-    // Regression: #2954. A successful rebundle must clear stale Build-category
-    // "Failed to re-bundle upstream dep X" errors from earlier cycles.
+    // Regression: #2954. A successful rebundle must clear the stale
+    // "Failed to re-bundle upstream dep X" error for that package from
+    // earlier cycles.
     #[tokio::test]
     async fn test_apply_dep_error_state_clears_stale_build_errors_on_success() {
         let broadcaster = ErrorBroadcaster::new();
 
-        // Simulate a previous cycle that left a stale dep-rebundle error.
+        // Simulate a previous cycle that left a stale dep-rebundle error
+        // keyed by `dep_error_file("@vertz/ui")`.
         broadcaster
-            .report_error(DevError::build(
-                "Failed to re-bundle upstream dep @vertz/ui: Failed to write entry file: \
-                 No such file or directory (os error 2)",
-            ))
+            .report_error(
+                DevError::build(
+                    "Failed to re-bundle upstream dep @vertz/ui: Failed to write entry file: \
+                     No such file or directory (os error 2)",
+                )
+                .with_file(dep_error_file("@vertz/ui")),
+            )
             .await;
         assert!(broadcaster.has_errors().await);
 
@@ -799,10 +825,54 @@ mod tests {
         );
     }
 
+    // Regression: #2954, review-blocker B1. A successful dep rebundle must
+    // NOT clobber legitimate per-file `Build` errors reported for user source
+    // code by the module server or file-change handler. Those share
+    // `ErrorCategory::Build` with dep errors, and an indiscriminate
+    // `clear_category` would make them vanish.
+    #[tokio::test]
+    async fn test_apply_dep_error_state_preserves_user_compile_errors() {
+        let broadcaster = ErrorBroadcaster::new();
+
+        // A real per-file compile error (as reported from module_server.rs).
+        broadcaster
+            .report_error(
+                DevError::build("Unexpected token '{'")
+                    .with_file("/src/app.tsx")
+                    .with_location(12, 3),
+            )
+            .await;
+        // A stale dep-rebundle error from a previous cycle.
+        broadcaster
+            .report_error(
+                DevError::build("Failed to re-bundle upstream dep @vertz/ui: old")
+                    .with_file(dep_error_file("@vertz/ui")),
+            )
+            .await;
+
+        let result = DepChangeResult {
+            rebundled: vec!["@vertz/ui".to_string()],
+            failed: vec![],
+            has_unnamed_changes: false,
+            should_clear_cache: true,
+            reload_reason: "Upstream dep: @vertz/ui".to_string(),
+        };
+
+        apply_dep_error_state(&broadcaster, &result).await;
+
+        let all = broadcaster.all_errors_cloned().await;
+        assert_eq!(
+            all.len(),
+            1,
+            "user compile error must survive; only the dep-rebundle entry clears",
+        );
+        assert_eq!(all[0].file.as_deref(), Some("/src/app.tsx"));
+        assert_eq!(all[0].message, "Unexpected token '{'");
+    }
+
     #[tokio::test]
     async fn test_apply_dep_error_state_reports_new_failures() {
         let broadcaster = ErrorBroadcaster::new();
-        let mut rx = broadcaster.subscribe();
 
         let result = DepChangeResult {
             rebundled: vec![],
@@ -817,28 +887,38 @@ mod tests {
 
         apply_dep_error_state(&broadcaster, &result).await;
 
-        let msg = rx.recv().await.unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
-        assert_eq!(parsed["type"], "error");
-        assert_eq!(parsed["category"], "build");
-        assert_eq!(parsed["errors"].as_array().unwrap().len(), 1);
-        assert!(parsed["errors"][0]["message"]
-            .as_str()
-            .unwrap()
+        let all = broadcaster.all_errors_cloned().await;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].category, ErrorCategory::Build);
+        assert!(all[0]
+            .message
             .starts_with("Failed to re-bundle upstream dep @vertz/ui:"));
+        assert_eq!(
+            all[0].file.as_deref(),
+            Some(dep_error_file("@vertz/ui").as_str())
+        );
     }
 
     // Mixed cycle: one package succeeds, another fails in the same batch.
-    // Stale errors from earlier cycles clear (because something succeeded),
-    // and only the current cycle's failure remains in the overlay.
+    // Each package's stale dep-rebundle error (if any) is cleared, and only
+    // the current cycle's failure remains.
     #[tokio::test]
     async fn test_apply_dep_error_state_mixed_success_and_failure() {
         let broadcaster = ErrorBroadcaster::new();
 
+        // Stale error for @vertz/ui (will clear on success).
         broadcaster
-            .report_error(DevError::build(
-                "Failed to re-bundle upstream dep @vertz/icons: stale error",
-            ))
+            .report_error(
+                DevError::build("Failed to re-bundle upstream dep @vertz/ui: stale")
+                    .with_file(dep_error_file("@vertz/ui")),
+            )
+            .await;
+        // Stale error for @vertz/server (will be replaced by new failure).
+        broadcaster
+            .report_error(
+                DevError::build("Failed to re-bundle upstream dep @vertz/server: stale")
+                    .with_file(dep_error_file("@vertz/server")),
+            )
             .await;
 
         let result = DepChangeResult {
@@ -859,22 +939,30 @@ mod tests {
         assert!(all[0]
             .message
             .contains("Failed to re-bundle upstream dep @vertz/server"));
+        // Ensure the stale error text was replaced, not just deduped on equal message.
+        assert!(all[0].message.contains("esbuild failed: Could not resolve"));
     }
 
+    // An all-failure cycle still clears stale dep errors for the packages it
+    // touched before re-reporting their current failure, so stale-message
+    // text for the same package doesn't linger alongside the new one.
     #[tokio::test]
-    async fn test_apply_dep_error_state_no_successes_keeps_prior_errors() {
+    async fn test_apply_dep_error_state_all_failures_replace_stale_for_same_packages() {
         let broadcaster = ErrorBroadcaster::new();
 
         broadcaster
-            .report_error(DevError::build(
-                "Failed to re-bundle upstream dep @vertz/ui: old",
-            ))
+            .report_error(
+                DevError::build("Failed to re-bundle upstream dep @vertz/server: old message")
+                    .with_file(dep_error_file("@vertz/server")),
+            )
             .await;
 
-        // Current cycle: everything failed, nothing succeeded.
         let result = DepChangeResult {
             rebundled: vec![],
-            failed: vec![("@vertz/server".to_string(), "esbuild failed".to_string())],
+            failed: vec![(
+                "@vertz/server".to_string(),
+                "esbuild failed: new reason".to_string(),
+            )],
             has_unnamed_changes: false,
             should_clear_cache: false,
             reload_reason: String::new(),
@@ -883,10 +971,9 @@ mod tests {
         apply_dep_error_state(&broadcaster, &result).await;
 
         let all = broadcaster.all_errors_cloned().await;
-        // Both the prior @vertz/ui error and the new @vertz/server error are
-        // present — we only clear Build when at least one rebundle succeeds,
-        // so an all-failure cycle doesn't wipe legitimate prior errors.
-        assert_eq!(all.len(), 2);
+        assert_eq!(all.len(), 1);
+        assert!(all[0].message.contains("new reason"));
+        assert!(!all[0].message.contains("old message"));
     }
 
     #[tokio::test]

--- a/native/vtz/src/watcher/dep_watcher.rs
+++ b/native/vtz/src/watcher/dep_watcher.rs
@@ -1,6 +1,8 @@
 use super::backpressure::BackpressureWarner;
 use crate::deps::linked::WatchTarget;
 use crate::deps::prebundle::{prebundle_single, PrebundleResult};
+use crate::errors::broadcaster::ErrorBroadcaster;
+use crate::errors::categories::{DevError, ErrorCategory};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -323,6 +325,28 @@ pub fn handle_dep_changes(
         has_unnamed_changes: has_unnamed,
         should_clear_cache: should_clear,
         reload_reason,
+    }
+}
+
+/// Apply the error-broadcast side effects of a dep-change cycle.
+///
+/// When at least one package re-bundled successfully, previously reported
+/// "Failed to re-bundle upstream dep X" errors are no longer current — clear
+/// the Build category before reporting the current cycle's failures. Without
+/// this, stale dep-rebundle errors persist in `ErrorState` (and the persisted
+/// `.vertz/dev/errors.json`) across every subsequent page load until the
+/// dev server restarts *and* `errors.json` is manually deleted. See #2954.
+pub async fn apply_dep_error_state(broadcaster: &ErrorBroadcaster, result: &DepChangeResult) {
+    if !result.rebundled.is_empty() {
+        broadcaster.clear_category(ErrorCategory::Build).await;
+    }
+
+    for (pkg, err_msg) in &result.failed {
+        let error = DevError::build(format!(
+            "Failed to re-bundle upstream dep {}: {}",
+            pkg, err_msg
+        ));
+        broadcaster.report_error(error).await;
     }
 }
 
@@ -739,6 +763,130 @@ mod tests {
         assert!(result.is_err(), "Should NOT receive event for .map file");
 
         drop(watcher);
+    }
+
+    // --- apply_dep_error_state tests ---
+
+    // Regression: #2954. A successful rebundle must clear stale Build-category
+    // "Failed to re-bundle upstream dep X" errors from earlier cycles.
+    #[tokio::test]
+    async fn test_apply_dep_error_state_clears_stale_build_errors_on_success() {
+        let broadcaster = ErrorBroadcaster::new();
+
+        // Simulate a previous cycle that left a stale dep-rebundle error.
+        broadcaster
+            .report_error(DevError::build(
+                "Failed to re-bundle upstream dep @vertz/ui: Failed to write entry file: \
+                 No such file or directory (os error 2)",
+            ))
+            .await;
+        assert!(broadcaster.has_errors().await);
+
+        // Current cycle rebundles successfully.
+        let result = DepChangeResult {
+            rebundled: vec!["@vertz/ui".to_string()],
+            failed: vec![],
+            has_unnamed_changes: false,
+            should_clear_cache: true,
+            reload_reason: "Upstream dep: @vertz/ui".to_string(),
+        };
+
+        apply_dep_error_state(&broadcaster, &result).await;
+
+        assert!(
+            !broadcaster.has_errors().await,
+            "stale dep-rebundle errors must be cleared after a successful rebundle",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_dep_error_state_reports_new_failures() {
+        let broadcaster = ErrorBroadcaster::new();
+        let mut rx = broadcaster.subscribe();
+
+        let result = DepChangeResult {
+            rebundled: vec![],
+            failed: vec![(
+                "@vertz/ui".to_string(),
+                "Failed to write entry file: No such file or directory (os error 2)".to_string(),
+            )],
+            has_unnamed_changes: false,
+            should_clear_cache: false,
+            reload_reason: String::new(),
+        };
+
+        apply_dep_error_state(&broadcaster, &result).await;
+
+        let msg = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["type"], "error");
+        assert_eq!(parsed["category"], "build");
+        assert_eq!(parsed["errors"].as_array().unwrap().len(), 1);
+        assert!(parsed["errors"][0]["message"]
+            .as_str()
+            .unwrap()
+            .starts_with("Failed to re-bundle upstream dep @vertz/ui:"));
+    }
+
+    // Mixed cycle: one package succeeds, another fails in the same batch.
+    // Stale errors from earlier cycles clear (because something succeeded),
+    // and only the current cycle's failure remains in the overlay.
+    #[tokio::test]
+    async fn test_apply_dep_error_state_mixed_success_and_failure() {
+        let broadcaster = ErrorBroadcaster::new();
+
+        broadcaster
+            .report_error(DevError::build(
+                "Failed to re-bundle upstream dep @vertz/icons: stale error",
+            ))
+            .await;
+
+        let result = DepChangeResult {
+            rebundled: vec!["@vertz/ui".to_string()],
+            failed: vec![(
+                "@vertz/server".to_string(),
+                "esbuild failed: Could not resolve".to_string(),
+            )],
+            has_unnamed_changes: false,
+            should_clear_cache: true,
+            reload_reason: "Upstream dep: @vertz/ui".to_string(),
+        };
+
+        apply_dep_error_state(&broadcaster, &result).await;
+
+        let all = broadcaster.all_errors_cloned().await;
+        assert_eq!(all.len(), 1, "expected exactly the current-cycle failure");
+        assert!(all[0]
+            .message
+            .contains("Failed to re-bundle upstream dep @vertz/server"));
+    }
+
+    #[tokio::test]
+    async fn test_apply_dep_error_state_no_successes_keeps_prior_errors() {
+        let broadcaster = ErrorBroadcaster::new();
+
+        broadcaster
+            .report_error(DevError::build(
+                "Failed to re-bundle upstream dep @vertz/ui: old",
+            ))
+            .await;
+
+        // Current cycle: everything failed, nothing succeeded.
+        let result = DepChangeResult {
+            rebundled: vec![],
+            failed: vec![("@vertz/server".to_string(), "esbuild failed".to_string())],
+            has_unnamed_changes: false,
+            should_clear_cache: false,
+            reload_reason: String::new(),
+        };
+
+        apply_dep_error_state(&broadcaster, &result).await;
+
+        let all = broadcaster.all_errors_cloned().await;
+        // Both the prior @vertz/ui error and the new @vertz/server error are
+        // present — we only clear Build when at least one rebundle succeeds,
+        // so an all-failure cycle doesn't wipe legitimate prior errors.
+        assert_eq!(all.len(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #2954. Two compounding bugs in the dev-server dep-watcher path caused a cluster of `Failed to re-bundle upstream dep X: Failed to write entry file: No such file or directory (os error 2)` errors to survive forever in the `/__vertz_errors` overlay — even though the app SSRed fine. The only cure was killing the dev server, deleting `.vertz/dev/errors.json`, and restarting.

- **Bug 1** — `native/vtz/src/deps/prebundle.rs`: `prebundle_single` now `create_dir_all(deps_dir)` before writing the temporary entry file, so a wiped or missing `.vertz/deps/` no longer surfaces as ENOENT when the dep watcher triggers a re-bundle.
- **Bug 2** — `native/vtz/src/watcher/dep_watcher.rs` + `server/http.rs`: the dep-watcher handler now tags every re-bundle error with a synthetic per-package key (`<dep>:{pkg}`) in the error's `file` field, and `clear_file(ErrorCategory::Build, …)` each package it touches this cycle before reporting the current failure. Stale entries no longer linger in `ErrorState` / `.vertz/dev/errors.json`.

## Why targeted (not `clear_category`)

An adversarial review blocked the first attempt (`clear_category(Build)` on any successful rebundle): the module server and file-change handler report user-source compile errors under the same `Build` category, so clobbering the whole category on every successful rebundle would make real compile errors vanish from the overlay. The per-key clear avoids that, and is covered by `test_apply_dep_error_state_preserves_user_compile_errors`.

## Public API Changes

- None. `apply_dep_error_state` and `dep_error_file` are new public items in the internal `vtz` crate; they are not part of any SDK/library surface.

## Test plan

- [x] `cargo test --all` (TDD — RED verified on both fixes before GREEN)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New regression tests:
  - `test_prebundle_single_recreates_missing_deps_dir`
  - `test_apply_dep_error_state_clears_stale_build_errors_on_success`
  - `test_apply_dep_error_state_preserves_user_compile_errors` *(B1 review blocker)*
  - `test_apply_dep_error_state_reports_new_failures`
  - `test_apply_dep_error_state_mixed_success_and_failure`
  - `test_apply_dep_error_state_all_failures_replace_stale_for_same_packages`
- [x] Changeset added (`@vertz/runtime`, `patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)