### PR TITLE
fix(agents): opt-in d.jsonb<T>() for agent state/toolCalls [#2958]

### DIFF
--- a/.changeset/agent-columns-jsonb-opt-in-2958.md
+++ b/.changeset/agent-columns-jsonb-opt-in-2958.md
@@ -1,0 +1,36 @@
+---
+'@vertz/agents': patch
+---
+
+BREAKING: `agentSessionColumns` / `agentMessageColumns` are now functions — call them (`...agentSessionColumns()`), don't spread the bare identifier.
+
+```ts
+// Before (no longer compiles)
+d.table('agent_sessions', agentSessionColumns, { indexes: agentSessionIndexes });
+
+// After (default behavior unchanged — still d.text() on disk)
+d.table('agent_sessions', agentSessionColumns(), { indexes: agentSessionIndexes });
+```
+
+Closes [#2958](https://github.com/vertz-dev/vertz/issues/2958).
+
+Pass `{ useJsonb: true }` with a generic to opt each column into
+`d.jsonb<T>()`, which emits `JSONB` on Postgres (indexable, typed
+operators) and stays `TEXT` on SQLite (the driver auto-parses on read):
+
+```ts
+d.table(
+  'agent_sessions',
+  agentSessionColumns<AgentState>({ useJsonb: true }),
+  { indexes: agentSessionIndexes },
+);
+
+// Entity reads now return AgentState, not string.
+const { items } = await ctx.entities['agent-session'].list({});
+items[0]?.state.step; // typed
+```
+
+The `AgentStore` path (`sqliteStore` / `d1Store`) is orthogonal — it keeps
+its own `JSON.stringify` / `JSON.parse` wrapping and writes raw SQL, so
+on SQLite the on-disk shape is the same in both modes and store/entity
+readers share rows without coordination.

--- a/packages/agents/src/entities/__tests__/bridge.integration.test.ts
+++ b/packages/agents/src/entities/__tests__/bridge.integration.test.ts
@@ -73,10 +73,10 @@ describe('Feature: Agent store ↔ entity bridge (#2847)', () => {
   describe('Given run() persisted a session + messages via sqliteStore, and entities are registered on the same DB', () => {
     it('Then entity RLS isolates the session from a different user in a different tenant', async () => {
       // Schema: shared DB file used by BOTH the store and the entity-side createDb.
-      const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+      const sessionsTable = d.table('agent_sessions', agentSessionColumns(), {
         indexes: agentSessionIndexes,
       });
-      const messagesTable = d.table('agent_messages', agentMessageColumns, {
+      const messagesTable = d.table('agent_messages', agentMessageColumns(), {
         indexes: agentMessageIndexes,
       });
       const db = createDb({
@@ -174,12 +174,12 @@ describe('Feature: Agent store ↔ entity bridge (#2847)', () => {
       const sessionsTable = d.table(
         'agent_sessions',
         {
-          ...agentSessionColumns,
+          ...agentSessionColumns(),
           workspaceId: d.text(),
         },
         { indexes: [...agentSessionIndexes, d.index('workspaceId')] },
       );
-      const messagesTable = d.table('agent_messages', agentMessageColumns, {
+      const messagesTable = d.table('agent_messages', agentMessageColumns(), {
         indexes: agentMessageIndexes,
       });
       const db = createDb({
@@ -242,6 +242,128 @@ describe('Feature: Agent store ↔ entity bridge (#2847)', () => {
       expect(inWs1.ok).toBe(true);
       if (!inWs1.ok) throw inWs1.error;
       expect(inWs1.data.body.items).toHaveLength(1);
+    });
+  });
+
+  describe('Given agentSessionColumns({ useJsonb: true }) with a typed TState', () => {
+    it('Then entity reads round-trip `state` as a parsed object, not a JSON string (#2958)', async () => {
+      interface AgentState {
+        readonly step: number;
+        readonly notes: readonly string[];
+      }
+
+      const sessionsTable = d.table(
+        'agent_sessions',
+        agentSessionColumns<AgentState>({ useJsonb: true }),
+        { indexes: agentSessionIndexes },
+      );
+      const messagesTable = d.table('agent_messages', agentMessageColumns(), {
+        indexes: agentMessageIndexes,
+      });
+      const db = createDb({
+        dialect: 'sqlite',
+        path: dbPath,
+        migrations: { autoApply: true },
+        models: {
+          agentSessions: d.model(sessionsTable),
+          agentMessages: d.model(messagesTable, {
+            session: d.ref.one(() => sessionsTable, 'sessionId'),
+          }),
+        },
+      });
+
+      const { session: Session } = defineAgentEntities(db);
+      createServer({ db, entities: [Session] });
+
+      const registry = new EntityRegistry();
+      registry.register(Session.name, stubOps);
+      const asCtx = (userId: string | null, tenantId: string | null) =>
+        createEntityContext({ userId, tenantId, roles: [] }, stubOps, registry.createProxy());
+
+      const adapter = createDatabaseBridgeAdapter(db, 'agentSessions');
+      const handlers = createCrudHandlers(Session, adapter);
+
+      const stateValue: AgentState = { step: 2, notes: ['a', 'b'] };
+      const created = await handlers.create!(asCtx('user-a', 'ws-1'), {
+        agentName: 'coder',
+        state: stateValue,
+        createdAt: '2026-04-22T00:00:00.000Z',
+        updatedAt: '2026-04-22T00:00:00.000Z',
+      });
+      if (!created.ok) {
+        throw new Error(`create failed: ${JSON.stringify(created.error, null, 2)}`);
+      }
+
+      const listed = await handlers.list!(asCtx('user-a', 'ws-1'));
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) throw listed.error;
+      const items = listed.data.body.items as { state: unknown }[];
+      expect(items).toHaveLength(1);
+      // Round-trip: jsonb column is deserialized by the SQLite driver, so callers
+      // see a parsed object (not a string blob). Regression guard for #2958.
+      expect(items[0]?.state).toEqual(stateValue);
+    });
+
+    it('Then sqliteStore writes and entity reads cross-path round-trip `state` through jsonb (#2958)', async () => {
+      interface AgentState {
+        readonly step: number;
+      }
+      const sessionsTable = d.table(
+        'agent_sessions',
+        agentSessionColumns<AgentState>({ useJsonb: true }),
+        { indexes: agentSessionIndexes },
+      );
+      const messagesTable = d.table('agent_messages', agentMessageColumns(), {
+        indexes: agentMessageIndexes,
+      });
+      const db = createDb({
+        dialect: 'sqlite',
+        path: dbPath,
+        migrations: { autoApply: true },
+        models: {
+          agentSessions: d.model(sessionsTable),
+          agentMessages: d.model(messagesTable, {
+            session: d.ref.one(() => sessionsTable, 'sessionId'),
+          }),
+        },
+      });
+
+      const { session: Session } = defineAgentEntities(db);
+      createServer({ db, entities: [Session] });
+
+      // Store side — writes a session whose `state` is already a stringified JSON
+      // (the AgentStore contract). On SQLite this lands as TEXT bytes; the column
+      // type metadata says `jsonb`, so the driver will `JSON.parse` on entity reads.
+      const stateObj = { step: 7 };
+      const store = sqliteStore({ path: dbPath });
+      await store.saveSession({
+        ...makeSession({
+          id: 'sess_cross',
+          userId: 'user-x',
+          tenantId: 'ws-1',
+          state: JSON.stringify(stateObj),
+        }),
+      });
+
+      // Store read — sees the raw stringified form (AgentSession.state: string).
+      const loaded = await store.loadSession('sess_cross');
+      expect(loaded).toBeTruthy();
+      expect(typeof loaded?.state).toBe('string');
+      expect(JSON.parse(loaded!.state)).toEqual(stateObj);
+
+      // Entity read — same row, but the `jsonb` driver path parses on the way out.
+      const registry = new EntityRegistry();
+      registry.register(Session.name, stubOps);
+      const asCtx = (userId: string | null, tenantId: string | null) =>
+        createEntityContext({ userId, tenantId, roles: [] }, stubOps, registry.createProxy());
+      const adapter = createDatabaseBridgeAdapter(db, 'agentSessions');
+      const handlers = createCrudHandlers(Session, adapter);
+      const listed = await handlers.list!(asCtx('user-x', 'ws-1'));
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) throw listed.error;
+      const items = listed.data.body.items as { id: string; state: unknown }[];
+      expect(items).toHaveLength(1);
+      expect(items[0]?.state).toEqual(stateObj);
     });
   });
 });

--- a/packages/agents/src/entities/__tests__/columns.test-d.ts
+++ b/packages/agents/src/entities/__tests__/columns.test-d.ts
@@ -1,0 +1,69 @@
+import { describe, it } from '@vertz/test';
+import type { InferColumnType } from '@vertz/db';
+import { agentSessionColumns, agentMessageColumns } from '../columns';
+
+// Type-flow for the jsonb opt-in (#2958). When `useJsonb: true` is passed with
+// a TState / TToolCalls generic, the column's inferred row type must be T, not
+// string — that is the whole point of the migration.
+
+interface AgentState {
+  readonly step: number;
+  readonly notes: readonly string[];
+}
+
+describe('agentSessionColumns<TState>() — type flow', () => {
+  it('default options: state column infers as string', () => {
+    const cols = agentSessionColumns();
+    type State = InferColumnType<typeof cols.state>;
+    const _s: State = 'json-string';
+    // @ts-expect-error — default is TEXT so typed objects are rejected at the type level
+    const _bad: State = { step: 1 };
+    void _s;
+    void _bad;
+  });
+
+  it('with useJsonb + TState: state column infers as TState', () => {
+    const cols = agentSessionColumns<AgentState>({ useJsonb: true });
+    type State = InferColumnType<typeof cols.state>;
+    const ok: State = { step: 1, notes: ['a'] };
+    // @ts-expect-error — strings are no longer assignable once the generic is bound
+    const bad: State = 'json-string';
+    void ok;
+    void bad;
+  });
+});
+
+// Regression guard for dynamic-boolean call sites. Patterns like
+//   const opts = { useJsonb: true };
+//   agentSessionColumns(opts);
+// widen away from the literal `true` and would otherwise miss the typed
+// overloads. The fallback overload keeps the surface call-compatible.
+declare const _flag: boolean;
+// Session — dynamic boolean must compile.
+const _dynSession = agentSessionColumns({ useJsonb: _flag });
+_dynSession satisfies Record<string, unknown>;
+// Message — dynamic boolean must compile.
+const _dynMessage = agentMessageColumns({ useJsonb: _flag });
+_dynMessage satisfies Record<string, unknown>;
+// Natural widened-object pattern must also compile.
+const _widenedOpts = { useJsonb: true };
+const _dynSession2 = agentSessionColumns(_widenedOpts);
+_dynSession2 satisfies Record<string, unknown>;
+
+describe('agentMessageColumns<TToolCalls>() — type flow', () => {
+  interface ToolCallLike {
+    readonly name: string;
+  }
+
+  it('with useJsonb + TToolCalls: toolCalls column infers as T | null', () => {
+    const cols = agentMessageColumns<readonly ToolCallLike[]>({ useJsonb: true });
+    type Calls = InferColumnType<typeof cols.toolCalls>;
+    const ok: Calls = [{ name: 'search' }];
+    const asNull: Calls = null;
+    // @ts-expect-error — a plain string is no longer assignable
+    const bad: Calls = 'stringified';
+    void ok;
+    void asNull;
+    void bad;
+  });
+});

--- a/packages/agents/src/entities/__tests__/columns.test.ts
+++ b/packages/agents/src/entities/__tests__/columns.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@vertz/test';
+import { agentSessionColumns, agentMessageColumns } from '../columns';
+
+// Columns are factories so callers can opt into typed `d.jsonb<T>()` for
+// `state` / `toolCalls` while keeping the default `d.text()` shape for
+// byte-compat with the legacy `sqliteStore` / `d1Store` DDL. See #2958.
+
+function readSqlType(col: unknown): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- column meta shape is internal to @vertz/db
+  return (col as any)._meta.sqlType as string;
+}
+
+describe('Feature: agent column packs — d.jsonb opt-in (#2958)', () => {
+  describe('Given agentSessionColumns() is called with default options', () => {
+    it('Then `state` is d.text() (byte-compat with legacy DDL)', () => {
+      const cols = agentSessionColumns();
+      expect(readSqlType(cols.state)).toBe('text');
+    });
+  });
+
+  describe('Given agentSessionColumns({ useJsonb: true }) is called', () => {
+    it('Then `state` is d.jsonb<T>()', () => {
+      const cols = agentSessionColumns({ useJsonb: true });
+      expect(readSqlType(cols.state)).toBe('jsonb');
+    });
+  });
+
+  describe('Given agentMessageColumns() is called with default options', () => {
+    it('Then `toolCalls` is d.text().nullable() (byte-compat)', () => {
+      const cols = agentMessageColumns();
+      expect(readSqlType(cols.toolCalls)).toBe('text');
+    });
+  });
+
+  describe('Given agentMessageColumns({ useJsonb: true }) is called', () => {
+    it('Then `toolCalls` is d.jsonb<T>().nullable()', () => {
+      const cols = agentMessageColumns({ useJsonb: true });
+      expect(readSqlType(cols.toolCalls)).toBe('jsonb');
+    });
+  });
+
+  describe('Given the same pack is constructed twice with identical options', () => {
+    it('Then each call returns a fresh object (no shared column instances)', () => {
+      const a = agentSessionColumns();
+      const b = agentSessionColumns();
+      expect(a).not.toBe(b);
+      expect(a.state).not.toBe(b.state);
+    });
+  });
+});

--- a/packages/agents/src/entities/__tests__/define.test-d.ts
+++ b/packages/agents/src/entities/__tests__/define.test-d.ts
@@ -9,8 +9,12 @@ import {
 import { defineAgentEntities } from '../define';
 
 // Build a real createDb to drive the generic. Never executed — types only.
-const _sessions = d.table('agent_sessions', agentSessionColumns, { indexes: agentSessionIndexes });
-const _messages = d.table('agent_messages', agentMessageColumns, { indexes: agentMessageIndexes });
+const _sessions = d.table('agent_sessions', agentSessionColumns(), {
+  indexes: agentSessionIndexes,
+});
+const _messages = d.table('agent_messages', agentMessageColumns(), {
+  indexes: agentMessageIndexes,
+});
 
 // Don't bother plumbing the full generic here — the factory accepts DatabaseClient<any>
 // by design; the runtime check is the real contract.

--- a/packages/agents/src/entities/__tests__/define.test.ts
+++ b/packages/agents/src/entities/__tests__/define.test.ts
@@ -10,10 +10,10 @@ import {
 import { AgentBridgeMissingTableError, defineAgentEntities } from '../define';
 
 function makeDb() {
-  const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+  const sessionsTable = d.table('agent_sessions', agentSessionColumns(), {
     indexes: agentSessionIndexes,
   });
-  const messagesTable = d.table('agent_messages', agentMessageColumns, {
+  const messagesTable = d.table('agent_messages', agentMessageColumns(), {
     indexes: agentMessageIndexes,
   });
   return createDb({

--- a/packages/agents/src/entities/columns.ts
+++ b/packages/agents/src/entities/columns.ts
@@ -2,50 +2,104 @@ import { d } from '@vertz/db';
 import type { ColumnRecord, IndexDef } from '@vertz/db';
 
 /**
+ * Opt-in options for the column packs. `useJsonb` swaps `state` / `toolCalls`
+ * from `d.text()` to `d.jsonb<T>()`, which emits `JSONB` on Postgres (indexable,
+ * typed operators) and stays `TEXT` on SQLite. Default remains `d.text()` for
+ * byte-compat with the legacy `sqliteStore` / `d1Store` DDL. See #2958.
+ */
+export interface AgentColumnOptions {
+  readonly useJsonb?: boolean;
+}
+
+// Internal helpers. We keep the shared shape in one builder so overloads only
+// differ in the swapped column's type — each overload passes a different
+// factory result into the same builder, and TS threads the column type
+// through the returned object without a cast.
+
+function buildSessionCols<TStateCol>(state: TStateCol) {
+  return {
+    // `generate: 'uuid'` auto-generates an id when the entity CRUD pipeline creates a row
+    // (the pipeline excludes PK columns from $create_input unless they have a default).
+    // The `AgentStore` path (sqliteStore/d1Store) still provides its own id — `run()` mints
+    // `sess_<uuid>` via `generateSessionId()`. Both paths write to the same TEXT column;
+    // the DB doesn't care about the id format.
+    id: d.text().primary({ generate: 'uuid' }),
+    agentName: d.text(),
+    userId: d.text().nullable(),
+    tenantId: d.text().nullable(),
+    state,
+    createdAt: d.text(),
+    updatedAt: d.text(),
+  };
+}
+
+function buildMessageCols<TToolCallsCol>(toolCalls: TToolCallsCol) {
+  return {
+    id: d.integer().primary(),
+    sessionId: d.text(),
+    seq: d.integer(),
+    role: d.text(),
+    content: d.text(),
+    toolCallId: d.text().nullable(),
+    toolName: d.text().nullable(),
+    toolCalls,
+    userId: d.text().nullable(),
+    tenantId: d.text().nullable(),
+    createdAt: d.text(),
+  };
+}
+
+/**
  * Column pack for `agent_sessions`. Matches the legacy DDL in
  * `sqlite-store.ts` / `d1-store.ts` on every column.
  *
- * Spread into your own `d.table()` call. See `plans/agent-store-entity-bridge.md`
- * for the full usage pattern and the rationale for the ctx-wins `before.create`
- * hook that `defineAgentEntities()` installs.
+ * Spread into your own `d.table()` call. Pass `{ useJsonb: true }` to type
+ * `state` with the `TState` generic and emit `JSONB` on Postgres. See
+ * `plans/agent-store-entity-bridge.md` for the full usage pattern and the
+ * ctx-wins `before.create` hook that `defineAgentEntities()` installs.
  */
-export const agentSessionColumns = {
-  // `generate: 'uuid'` auto-generates an id when the entity CRUD pipeline creates a row
-  // (the pipeline excludes PK columns from $create_input unless they have a default).
-  // The `AgentStore` path (sqliteStore/d1Store) still provides its own id — `run()` mints
-  // `sess_<uuid>` via `generateSessionId()`. Both paths write to the same TEXT column;
-  // the DB doesn't care about the id format.
-  id: d.text().primary({ generate: 'uuid' }),
-  agentName: d.text(),
-  userId: d.text().nullable(),
-  tenantId: d.text().nullable(),
-  state: d.text(),
-  createdAt: d.text(),
-  updatedAt: d.text(),
-} satisfies ColumnRecord;
+export function agentSessionColumns(opts?: {
+  readonly useJsonb?: false;
+}): ReturnType<typeof buildSessionCols<ReturnType<typeof d.text>>>;
+export function agentSessionColumns<TState>(opts: {
+  readonly useJsonb: true;
+}): ReturnType<typeof buildSessionCols<ReturnType<typeof d.jsonb<TState>>>>;
+// Fallback for dynamic boolean — `{ useJsonb: flag }` where `flag: boolean`
+// widens away from the literal and would otherwise miss both typed overloads.
+export function agentSessionColumns(opts: AgentColumnOptions): ColumnRecord;
+export function agentSessionColumns<TState = unknown>(opts: AgentColumnOptions = {}): ColumnRecord {
+  const state = opts.useJsonb ? d.jsonb<TState>() : d.text();
+  return buildSessionCols(state);
+}
 
 /**
- * Column pack for `agent_messages`. Existing legacy columns + two new denormalized
+ * Column pack for `agent_messages`. Existing legacy columns + two denormalized
  * columns (`userId`, `tenantId`) that enable flat `rules.where({ userId: rules.user.id })`
  * on the `Message` entity without relation-traversing access rules.
  *
  * The agent store writes `userId` / `tenantId` from the session on every append —
  * which is why `AgentStore.appendMessages` gained a `session` parameter in the
  * same PR. See `plans/agent-store-entity-bridge.md`.
+ *
+ * Pass `{ useJsonb: true }` to type `toolCalls` with the `TToolCalls` generic
+ * (e.g. `readonly ToolCall[]`) and emit `JSONB` on Postgres.
  */
-export const agentMessageColumns = {
-  id: d.integer().primary(),
-  sessionId: d.text(),
-  seq: d.integer(),
-  role: d.text(),
-  content: d.text(),
-  toolCallId: d.text().nullable(),
-  toolName: d.text().nullable(),
-  toolCalls: d.text().nullable(),
-  userId: d.text().nullable(),
-  tenantId: d.text().nullable(),
-  createdAt: d.text(),
-} satisfies ColumnRecord;
+export function agentMessageColumns(opts?: {
+  readonly useJsonb?: false;
+}): ReturnType<typeof buildMessageCols<ReturnType<ReturnType<typeof d.text>['nullable']>>>;
+export function agentMessageColumns<TToolCalls>(opts: {
+  readonly useJsonb: true;
+}): ReturnType<
+  typeof buildMessageCols<ReturnType<ReturnType<typeof d.jsonb<TToolCalls>>['nullable']>>
+>;
+// Fallback for dynamic boolean — matches `{ useJsonb: boolean }`.
+export function agentMessageColumns(opts: AgentColumnOptions): ColumnRecord;
+export function agentMessageColumns<TToolCalls = unknown>(
+  opts: AgentColumnOptions = {},
+): ColumnRecord {
+  const toolCalls = opts.useJsonb ? d.jsonb<TToolCalls>().nullable() : d.text().nullable();
+  return buildMessageCols(toolCalls);
+}
 
 export const agentSessionIndexes: IndexDef[] = [
   d.index('agentName'),

--- a/packages/agents/src/entities/index.ts
+++ b/packages/agents/src/entities/index.ts
@@ -4,5 +4,6 @@ export {
   agentSessionIndexes,
   agentMessageIndexes,
 } from './columns';
+export type { AgentColumnOptions } from './columns';
 export { defineAgentEntities, AgentBridgeMissingTableError } from './define';
 export type { DefineAgentEntitiesOptions, EntityAccess } from './define';

--- a/packages/mint-docs/guides/agents/entity-bridge.mdx
+++ b/packages/mint-docs/guides/agents/entity-bridge.mdx
@@ -34,10 +34,10 @@ import {
   agentMessageIndexes,
 } from '@vertz/agents/entities';
 
-const sessionsTable = d.table('agent_sessions', agentSessionColumns, {
+const sessionsTable = d.table('agent_sessions', agentSessionColumns(), {
   indexes: agentSessionIndexes,
 });
-const messagesTable = d.table('agent_messages', agentMessageColumns, {
+const messagesTable = d.table('agent_messages', agentMessageColumns(), {
   indexes: agentMessageIndexes,
 });
 
@@ -154,7 +154,7 @@ your own `d.table()` — no special helper:
 const sessionsTable = d.table(
   'agent_sessions',
   {
-    ...agentSessionColumns,
+    ...agentSessionColumns(),
     projectId: d.uuid().nullable(),
   },
   { indexes: [...agentSessionIndexes, d.index('projectId')] },
@@ -182,7 +182,7 @@ relation on your extended session, drop `tenantId` from the spread to avoid
 a dead column:
 
 ```ts
-const { tenantId: _drop, ...sessionColsMinusTenant } = agentSessionColumns;
+const { tenantId: _drop, ...sessionColsMinusTenant } = agentSessionColumns();
 const sessionsTable = d.table(
   'agent_sessions',
   {
@@ -194,6 +194,78 @@ const sessionsTable = d.table(
   },
 );
 ```
+
+## Typed `state` / `toolCalls` (opt-in JSONB)
+
+The packs default to `d.text()` for `state` and `toolCalls` — a JSON string,
+byte-compatible with the legacy `sqliteStore` / `d1Store` DDL. Pass
+`{ useJsonb: true }` to opt each pack into `d.jsonb<T>()`: typed reads on the
+entity row, plus native `JSONB` emission on Postgres (indexable, typed
+operators). On SQLite the on-disk shape is still `TEXT`; the driver auto-parses
+`jsonb` columns on read.
+
+```ts
+import type { ToolCall } from '@vertz/agents';
+
+interface AgentState {
+  readonly step: number;
+  readonly notes: readonly string[];
+}
+
+const sessionsTable = d.table(
+  'agent_sessions',
+  agentSessionColumns<AgentState>({ useJsonb: true }),
+  { indexes: agentSessionIndexes },
+);
+const messagesTable = d.table(
+  'agent_messages',
+  agentMessageColumns<readonly ToolCall[]>({ useJsonb: true }),
+  { indexes: agentMessageIndexes },
+);
+
+// Entity reads now return `state: AgentState` (parsed object), not `string`.
+const listed = await ctx.entities['agent-session'].list({});
+listed.items[0]?.state.step; // typed — AgentState.step
+```
+
+The `AgentStore` path (`sqliteStore` / `d1Store`) is orthogonal — it keeps
+its own `JSON.stringify` / `JSON.parse` wrapping and writes raw SQL. On SQLite
+the column emission is still `TEXT`, so stores and entities share the same
+rows without coordination.
+
+### Migrating an existing database
+
+Fresh installs get the correct column type from the opt-in. Existing
+databases need a one-off migration only if you want the on-disk type to
+change (Postgres). On SQLite the on-disk type is `TEXT` in both modes, so
+no DDL change is required.
+
+**SQLite / D1:** no migration needed. `d.jsonb<T>()` emits the same `TEXT`
+storage — the only change is type-side (the driver parses `jsonb` columns
+on read, so entity callers see parsed objects; the `AgentStore` contract
+stays `AgentSession.state: string`). If you want to audit stored rows for
+malformed JSON before opting in, run
+`SELECT id FROM agent_sessions WHERE json_valid(state) = 0`.
+
+**Postgres:** the stores (`sqliteStore` / `d1Store`) are SQLite-only —
+pure-entity usage is the supported path on Postgres. Before running the
+ALTER, audit for rows that can't cast to JSONB:
+
+```sql
+-- Rows that would abort the ALTER. Fix or delete these first.
+SELECT id FROM agent_sessions
+WHERE state IS NOT NULL AND state !~ '^\s*[\[{"]';
+
+ALTER TABLE agent_sessions
+  ALTER COLUMN state TYPE JSONB USING state::JSONB;
+ALTER TABLE agent_messages
+  ALTER COLUMN tool_calls TYPE JSONB USING tool_calls::JSONB;
+```
+
+`ALTER ... TYPE JSONB USING ::JSONB` scans every row and aborts on the
+first value that isn't valid JSON. If the table has a non-JSON legacy
+value (e.g. an opaque token stored via a pre-bridge writer), the ALTER
+rolls back and the schema stays `TEXT`.
 
 ## Upgrade migration
 
@@ -224,9 +296,6 @@ Fresh installs get the columns automatically — the stores' built-in DDL was up
   app-side writes via entity handlers do fire hooks normally. Tracked as
   [#2957](https://github.com/vertz-dev/vertz/issues/2957) (registration-time
   rejection of hooks on factory-produced entities).
-- **Typed `state` / `toolCalls` columns.** Stored as `TEXT` (JSON string) for
-  byte-compat with the legacy DDL. Tracked as
-  [#2958](https://github.com/vertz-dev/vertz/issues/2958).
 - **RLS on in-loop reads.** `store.loadSession()` inside `run()` bypasses
   entity rules — identity is checked by `run()` directly against
   `session.userId` / `session.tenantId`. Same ownership story as before the


### PR DESCRIPTION
## Summary

Migrates `agent_sessions.state` and `agent_messages.toolCalls` to an opt-in `d.jsonb<T>()` path, closing #2958.

- Convert `agentSessionColumns` / `agentMessageColumns` from spread constants to factory functions. Default behavior unchanged — `d.text()` for byte-compat with the legacy `sqliteStore` / `d1Store` DDL.
- `{ useJsonb: true }` plus a generic flips each column to `d.jsonb<T>()`. Postgres emits `JSONB` (indexable, typed operators). SQLite stays `TEXT` with the driver auto-parsing on read.
- Three overloads per factory so `{ useJsonb: true }` (literal), `{ useJsonb: false }` (default), and `{ useJsonb: flag }` (dynamic boolean) all type-check cleanly.
- Stores are unchanged. They use raw SQL with manual `JSON.stringify` / `JSON.parse`, bypassing the row converter; entity reads deserialize via the `jsonb` path at `packages/db/src/client/sqlite-value-converter.ts:49` and `packages/db/src/client/sqlite-driver.ts:126`.

### Public API Changes

**Breaking** — pre-v1, no shim:

\`\`\`ts
// Before
d.table('agent_sessions', agentSessionColumns, { indexes: agentSessionIndexes });
// After (default — same on disk)
d.table('agent_sessions', agentSessionColumns(), { indexes: agentSessionIndexes });
// New — typed + JSONB on Postgres
d.table(
  'agent_sessions',
  agentSessionColumns<AgentState>({ useJsonb: true }),
  { indexes: agentSessionIndexes },
);
\`\`\`

**Additions:** `AgentColumnOptions` type export.

**Deferred:** validator escape hatch on the factory (\`d.jsonb<T>({ validator })\` passthrough) — will file as follow-up. Keeps this PR focused on the type + dialect opt-in.

## Tests

- `packages/agents/src/entities/__tests__/columns.test.ts` — runtime assertions on the sqlType flip (`'text'` default, `'jsonb'` when opted in), freshness of factory output.
- `packages/agents/src/entities/__tests__/columns.test-d.ts` — `InferColumnType` flow for TState / TToolCalls, `@ts-expect-error` negative cases, dynamic-boolean regression guard.
- `packages/agents/src/entities/__tests__/bridge.integration.test.ts` — entity round-trip (`state` stored & read as parsed object) and store↔entity cross-path round-trip.
- Existing `define.test.ts` / `define.test-d.ts` / `bridge.integration.test.ts` call-sites updated to the factory form; `createCrudHandlers` path exercises the full CRUD pipeline with the jsonb column type.

## Docs

- `packages/mint-docs/guides/agents/entity-bridge.mdx` gains a "Typed `state` / `toolCalls` (opt-in JSONB)" section with usage, migration notes, and audit queries. Postgres migration explicitly warns that `ALTER TABLE ... USING state::JSONB` aborts on malformed rows; SQLite section notes no DDL change is required. The pre-existing "#2958 tracked" caveat on the same page is removed.

## Adversarial review

Full local review at `reviews/2958-agent-columns-jsonb/phase-01-columns-factory.md`. Four should-fix items raised and all resolved in the same commit:

1. Dynamic-boolean overload missing — added third public overload + regression test.
2. Store↔entity cross-path integration test missing — added.
3. Postgres docs overstated (stores are SQLite-only; ALTER aborts on bad JSON) — docs corrected with audit query.
4. Changeset not break-first — rewritten to lead with the breaking migration snippet.

## Test plan

- [ ] CI green on GitHub (build-typecheck, test, lint, trojan-source, Rust hooks)
- [ ] Spot-check: fresh D1 install with `agentMessageColumns<readonly ToolCall[]>({ useJsonb: true })` ingests and returns parsed tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)