### PR TITLE
fix(ui,runtime): return correct HTTP status for SSR routes [#3001]

### DIFF
--- a/.changeset/fix-task-manager-ssr-404-3001.md
+++ b/.changeset/fix-task-manager-ssr-404-3001.md
@@ -1,0 +1,15 @@
+---
+'@vertz/ui': patch
+'@vertz/runtime': patch
+---
+
+fix(ui,runtime): return correct HTTP status for SSR routes
+
+Closes [#3001](https://github.com/vertz-dev/vertz/issues/3001).
+
+The dev server returned `404 GET /` for the task-manager example even though SSR rendered the page successfully. Two related bugs collapsed three states into two:
+
+- `matchForSSR()` only set `ctx.matchedRoutePatterns` when a route matched, leaving it `undefined` for an unmatched URL — indistinguishable from "no router was rendered". Now it explicitly records `[]` for "router rendered, no match".
+- The vtz JS↔Rust bridge in `persistent_isolate.rs` serialized `result.matchedRoutePatterns ?? null` instead of `|| []`, preserving the `undefined`-vs-empty distinction so the Rust handler can return `200` for routerless apps and `404` only when a router actually failed to match.
+
+Status mapping is now uniform across `@vertz/ui-server`'s handlers and the `vtz dev` server: missing/`null` → 200, `[]` → 404, `[…]` → 200.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -6579,7 +6579,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.2.78"
+version = "0.2.79"
 dependencies = [
  "napi",
  "napi-build",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.2.78"
+version = "0.2.79"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -6611,7 +6611,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.2.78"
+version = "0.2.79"
 dependencies = [
  "arboard",
  "async-stream",

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -1298,6 +1298,13 @@ const SSR_RENDER_FRAMEWORK_JS: &str = r#"
         }
     }
 
+    // matchedRoutePatterns is a 3-state field used to compute the HTTP status:
+    //   undefined  → no router was rendered (always 200)
+    //   []         → router rendered but no route matched (404)
+    //   [...]      → router rendered with these matched patterns (200)
+    // Preserve the undefined-vs-empty distinction by emitting `null` for
+    // undefined (the Rust JSON parser maps null and missing keys to None)
+    // and never collapsing it to []. (#3001)
     globalThis.__vertz_last_ssr_result = JSON.stringify({
         content: result.html || '',
         css: css,
@@ -1305,7 +1312,7 @@ const SSR_RENDER_FRAMEWORK_JS: &str = r#"
         headTags: result.headTags || '',
         redirect: result.redirect ? result.redirect.to : null,
         isSsr: (result.html || '').length > 0,
-        matchedRoutePatterns: result.matchedRoutePatterns || [],
+        matchedRoutePatterns: result.matchedRoutePatterns ?? null,
     });
 })()
 "#;
@@ -1348,6 +1355,26 @@ const SSR_RENDER_LEGACY_JS: &str = r#"
     });
 })()
 "#;
+
+/// Parse the `matchedRoutePatterns` field from the SSR result JSON.
+///
+/// Three states drive the HTTP status code (see http.rs):
+/// * Missing key OR `null` → `None`: no router was rendered (always 200).
+/// * `[]` → `Some(vec![])`: router rendered but no route matched (404).
+/// * `[...]` → `Some(vec![...])`: matched these patterns (200).
+///
+/// Non-array, non-null values (number, string, object) collapse to `None`
+/// to match the missing-key behavior; the JS bridge never produces these.
+fn parse_matched_route_patterns(parsed: &serde_json::Value) -> Option<Vec<String>> {
+    parsed
+        .get("matchedRoutePatterns")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+}
 
 /// Dispatch a single SSR render request in the V8 isolate.
 ///
@@ -1516,14 +1543,7 @@ async fn dispatch_ssr_request_inner(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let matched_route_patterns = parsed
-            .get("matchedRoutePatterns")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            });
+        let matched_route_patterns = parse_matched_route_patterns(&parsed);
 
         Ok(SsrResponse {
             content,
@@ -1890,6 +1910,33 @@ mod tests {
             Some(r#"<link rel="preload" href="/font.woff2" />"#.to_string())
         );
         assert!(resp.redirect.is_none());
+    }
+
+    /// Regression: matchedRoutePatterns must distinguish "no router used"
+    /// (missing/null → None → 200) from "router with no match"
+    /// (`[]` → Some(vec![]) → 404). See #3001.
+    #[test]
+    fn test_parse_matched_route_patterns_three_states() {
+        // Missing key — no router was registered → None (200)
+        let v: serde_json::Value = serde_json::from_str("{}").unwrap();
+        assert_eq!(parse_matched_route_patterns(&v), None);
+
+        // Explicit null — JS bridge emits this for `undefined` → None (200)
+        let v: serde_json::Value =
+            serde_json::from_str(r#"{"matchedRoutePatterns": null}"#).unwrap();
+        assert_eq!(parse_matched_route_patterns(&v), None);
+
+        // Empty array — router was rendered but no route matched → Some(vec![]) (404)
+        let v: serde_json::Value = serde_json::from_str(r#"{"matchedRoutePatterns": []}"#).unwrap();
+        assert_eq!(parse_matched_route_patterns(&v), Some(vec![]));
+
+        // Populated array — matched these patterns → Some(vec![...]) (200)
+        let v: serde_json::Value =
+            serde_json::from_str(r#"{"matchedRoutePatterns": ["/", "/projects"]}"#).unwrap();
+        assert_eq!(
+            parse_matched_route_patterns(&v),
+            Some(vec!["/".to_string(), "/projects".to_string()])
+        );
     }
 
     /// Helper: create an isolate with only a server entry (API-only mode).

--- a/packages/ui-server/src/__tests__/ssr-handler.test.ts
+++ b/packages/ui-server/src/__tests__/ssr-handler.test.ts
@@ -1114,4 +1114,79 @@ describe('createSSRHandler', () => {
       });
     });
   });
+
+  // Regression: see #3001 — task-manager dev server returned 404 for `/`
+  // even though SSR rendered successfully. The status code is derived from
+  // matchedRoutePatterns: undefined (no router) → 200, [] (router with no
+  // match) → 404, [...] (matched) → 200. A regression in either the JS
+  // bridge (collapsing undefined to []) or the discovery pass (failing to
+  // populate renderCtx.matchedRoutePatterns when a route DOES match) flips
+  // this.
+  describe('Given a router-using module', () => {
+    async function makeRoutedModule(): Promise<SSRModule> {
+      const { createRouter, defineRoutes, RouterView } = await import('@vertz/ui');
+      return {
+        default: () => {
+          const routes = defineRoutes({
+            '/': {
+              component: () => {
+                const el = document.createElement('div');
+                el.setAttribute('data-testid', 'home');
+                el.textContent = 'Home Page';
+                return el;
+              },
+            },
+            '/about': {
+              component: () => {
+                const el = document.createElement('div');
+                el.setAttribute('data-testid', 'about');
+                el.textContent = 'About Page';
+                return el;
+              },
+            },
+          });
+          const router = createRouter(routes);
+          return RouterView({
+            router,
+            fallback: () => {
+              const el = document.createElement('div');
+              el.setAttribute('data-testid', 'not-found');
+              el.textContent = 'Page not found';
+              return el;
+            },
+          });
+        },
+      };
+    }
+
+    it('Then returns 200 with rendered HTML when a route matches', async () => {
+      const handler = createSSRHandler({ module: await makeRoutedModule(), template });
+      const response = await handler(new Request('http://localhost/'));
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('Home Page');
+      expect(html).toContain('data-testid="home"');
+    });
+
+    it('Then returns 404 when no route matches', async () => {
+      const handler = createSSRHandler({ module: await makeRoutedModule(), template });
+      const response = await handler(new Request('http://localhost/does-not-exist'));
+
+      expect(response.status).toBe(404);
+      const html = await response.text();
+      expect(html).toContain('Page not found');
+    });
+  });
+
+  describe('Given a routerless module', () => {
+    it('Then returns 200 even for arbitrary paths (no router → no 404)', async () => {
+      const handler = createSSRHandler({ module: simpleModule, template });
+      const response = await handler(new Request('http://localhost/anything'));
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('Hello World');
+    });
+  });
 });

--- a/packages/ui/src/router/navigate.ts
+++ b/packages/ui/src/router/navigate.ts
@@ -247,15 +247,22 @@ export function createRouter<T extends Record<string, RouteConfigLike> = RouteDe
     function matchForSSR(ctx: NonNullable<typeof ssrCtx>): RouteMatch | null {
       registerRoutesForDiscovery(ctx);
       const m = matchRoute(routes, ctx.url);
-      if (m && !ctx.matchedRoutePatterns) {
-        // Build full paths by accumulating parent prefixes via joinPatterns.
-        const fullPaths: string[] = [];
-        let prefix = '';
-        for (const entry of m.matched) {
-          prefix = joinPatterns(prefix, entry.route.pattern);
-          fullPaths.push(prefix);
+      if (!ctx.matchedRoutePatterns) {
+        if (m) {
+          // Build full paths by accumulating parent prefixes via joinPatterns.
+          const fullPaths: string[] = [];
+          let prefix = '';
+          for (const entry of m.matched) {
+            prefix = joinPatterns(prefix, entry.route.pattern);
+            fullPaths.push(prefix);
+          }
+          ctx.matchedRoutePatterns = fullPaths;
+        } else {
+          // Router exists but no route matched — record an empty array so the
+          // SSR handler can return 404. `undefined` is reserved for "no router
+          // registered" (always 200). See ssr-handler.ts status mapping. (#3001)
+          ctx.matchedRoutePatterns = [];
         }
-        ctx.matchedRoutePatterns = fullPaths;
       }
       return m;
     }


### PR DESCRIPTION
## Summary

Closes #3001. The `task-manager` example dev server returned `HTTP 404 GET /` even though SSR rendered the page successfully — blocking the e2e suite. Two related bugs were collapsing the 3-state `matchedRoutePatterns` field (the field that drives the SSR status code) into 2 states.

### What broke

`matchedRoutePatterns` is meant to encode three distinct outcomes:

| Value | Meaning | Status |
|-------|---------|--------|
| missing / `null` | no router was rendered | 200 |
| `[]` | router rendered but no route matched | 404 |
| `[…]` | matched these patterns | 200 |

Two paths leaked the distinction:

1. **`@vertz/ui`** — `matchForSSR()` only wrote the field when a route matched, so an unmatched URL left it `undefined`, indistinguishable from "no router rendered". Result: routerless SSR-200 was correct, but a router with no match also returned 200 instead of 404.

2. **`vtz dev` (native runtime)** — the JS↔Rust bridge in `persistent_isolate.rs` serialized `result.matchedRoutePatterns || []`, collapsing `undefined` to `[]`. Combined with #1 above, this is what produced `404 GET /` on the task-manager example: the user-app compiler bug from #2897 left `renderCtx.matchedRoutePatterns` `undefined` for a matching `/`, the JS bridge clamped it to `[]`, and the Rust handler interpreted that as "router with no match" → 404.

### Fix

- `packages/ui/src/router/navigate.ts` — `matchForSSR()` now writes `[]` explicitly when the router runs but matches nothing. `undefined` is reserved for "no router".
- `native/vtz/src/runtime/persistent_isolate.rs` — bridge emits `result.matchedRoutePatterns ?? null`, preserving the `undefined`-vs-empty distinction. The Rust JSON parser already maps both missing-key and `null` to `None`. Extracted `parse_matched_route_patterns()` so the JSON shape is unit-testable.

Status mapping is now uniform across `@vertz/ui-server`'s handlers (already correct) and the `vtz dev` server.

## Public API Changes

None. The status-code state machine matches the existing comments and the `@vertz/ui-server` `createSSRHandler` / `createNodeHandler` behavior.

## Test plan

- [x] `vtz test packages/ui-server/src/__tests__/ssr-handler.test.ts` — 3 new scenarios (router+match → 200, router+no-match → 404, routerless → 200), all 44 tests pass.
- [x] `vtz test packages/ui/src/router` — 308 router tests pass.
- [x] `cargo test --lib persistent_isolate::tests` — 38 tests pass, including the new `test_parse_matched_route_patterns_three_states`.
- [x] End-to-end with rebuilt `vtz`:
  - `GET /` (task-manager) → 200
  - `GET /tasks/new` → 200
  - `GET /no-such-page` → 404
  - `GET /anything` (entity-todo, no router) → 200
- [x] `cargo fmt --check`, `cargo clippy --bin vtz -- -D warnings`, `oxfmt --check`, full pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)