### PR TITLE
fix(examples): align linear example on port 3001 [#3007]

### DIFF
--- a/examples/linear/.env.example
+++ b/examples/linear/.env.example
@@ -1,6 +1,6 @@
 GITHUB_CLIENT_ID=           # From GitHub OAuth App
 GITHUB_CLIENT_SECRET=       # From GitHub OAuth App
-APP_URL=http://localhost:3000
+APP_URL=http://localhost:3001
 
 # Generate with: openssl rand -hex 32
 OAUTH_ENCRYPTION_KEY=       # Required for OAuth state cookies

--- a/examples/linear/package.json
+++ b/examples/linear/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vtz dev",
+    "dev": "vtz dev --port 3001",
     "build": "vtz build",
     "codegen": "vtz codegen",
     "test": "vtz test",

--- a/examples/linear/playwright.config.ts
+++ b/examples/linear/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command: 'vtz dev',
+    command: 'vtz dev --port 3001',
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,

--- a/examples/linear/src/api/auth.ts
+++ b/examples/linear/src/api/auth.ts
@@ -2,7 +2,7 @@ import { defineAuth, github } from '@vertz/server';
 import { access } from './access';
 import { SEED_WORKSPACE_ID } from './schema';
 
-const APP_URL = process.env.APP_URL ?? 'http://localhost:3000';
+const APP_URL = process.env.APP_URL ?? 'http://localhost:3001';
 
 export const auth = defineAuth({
   session: { strategy: 'jwt', ttl: '15m', refreshTtl: '7d', cookie: { secure: false } },


### PR DESCRIPTION
## Summary

The Linear example had a port mismatch: `playwright.config.ts`, `e2e/linear.spec.ts`, and `src/api/server.ts` all expected the dev server on `localhost:3001`, but `package.json`'s `dev` script was just `vtz dev` (defaulting to port 3000). `src/api/auth.ts` also defaulted to 3000.

This was already broken pre-#3002 (the previous `bun run dev` invoked the same script), but #3002 made it visible because nothing else changes the port.

Fixed by aligning everything on 3001:
- `examples/linear/package.json` — `vtz dev --port 3001`
- `examples/linear/playwright.config.ts` — webServer `command: 'vtz dev --port 3001'`
- `examples/linear/src/api/auth.ts` — `APP_URL` default → `http://localhost:3001`
- `examples/linear/.env.example` — `APP_URL=http://localhost:3001`

Closes #3007

## Test plan

- [ ] `cd examples/linear && vtz dev` binds on port 3001
- [ ] `cd examples/linear && npx playwright test` boots dev server and reaches it on 3001
- [ ] No port mismatch between `package.json`, `playwright.config.ts`, `e2e/linear.spec.ts`, `src/api/server.ts`, and `src/api/auth.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)