### PR TITLE
docs(examples): fix entity-todo README stale references [#3005]

### DIFF
--- a/examples/entity-todo/README.md
+++ b/examples/entity-todo/README.md
@@ -71,14 +71,7 @@ return (
 
 ### 5. SSR — zero-config server rendering
 
-```ts
-// vite.config.ts
-export default defineConfig({
-  plugins: [vertzPlugin({ ssr: true })],
-});
-```
-
-That's it. The framework auto-detects the entry point and renders the app server-side.
+`vtz dev` and `vtz build` auto-detect the entry point (`src/index.ts`) and render the app server-side. No config required.
 
 ## File Structure
 
@@ -88,7 +81,7 @@ src/
   entities.ts            — entity() API definition
   server.ts              — API server entry
 
-  generated/             — Pre-committed SDK (bun run codegen to regenerate)
+  generated/             — Pre-committed SDK (vtz codegen to regenerate)
     client.ts            — Client interface + factory
     entities/todos.ts    — Typed CRUD methods
     index.ts             — Barrel export
@@ -115,22 +108,23 @@ src/
 ## Run it
 
 ```bash
-bun run dev
+vtz dev
 ```
 
-This starts both the API server (port 3000) and the Vite dev server (port 5173) with a proxy for `/api`.
+This starts the Vertz dev server on port 3000, serving the API under `/api` and the SSR-rendered UI on the same origin.
 
-Open `http://localhost:5173` to see the app.
+Open `http://localhost:3000` to see the app.
 
 ## Scripts
 
 | Script | Description |
 |--------|-------------|
-| `bun run dev` | Start API + UI dev servers |
-| `bun run dev:api` | Start API server only |
-| `bun run dev:ui` | Start Vite UI only |
-| `bun run codegen` | Regenerate SDK from entity definition |
-| `bun run test` | Run all tests (API + UI + SSR) |
+| `vtz dev` | Start the dev server (API + SSR UI on port 3000) |
+| `vtz build` | Build for production |
+| `vtz codegen` | Regenerate SDK from entity definitions |
+| `vtz test` | Run all tests |
+| `vtz run typecheck` | Run codegen, then `tsc --noEmit` |
+| `npx playwright test` | Run e2e tests |
 
 ## What This Proves
 


### PR DESCRIPTION
## Summary

- Replace \`bun run\` invocations with \`vtz\` in \`examples/entity-todo/README.md\` (rule violation).
- Drop the Vite reference (Vertz doesn't use Vite) — replace the \`vite.config.ts\` SSR snippet with a one-liner explaining \`vtz dev\` / \`vtz build\` auto-detect the entry.
- Rewrite the Scripts table to match the actual scripts in \`examples/entity-todo/package.json\` — drop the non-existent \`dev:api\` / \`dev:ui\` rows.

Closes #3005

## Public API Changes

None — docs-only.

## Test plan

- [x] Grep confirms no \`bun run\`, \`vite\`, or \`Vite\` in the README
- [x] Scripts table cross-checked against \`examples/entity-todo/package.json\`
- [x] Verified \`vtz dev\` does bind port 3000 (matches \`playwright.config.ts\` baseURL) and \`src/index.ts\` exists (matches the SSR auto-detect claim)

## Follow-up

Adversarial review found a pre-existing doc bug in the same README (the "Reactive UI" snippet uses the obsolete \`let\` + \`effect()\` pattern instead of \`const\` derived signals + \`watch()\`). Filed separately as #3012 — not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)