### PR TITLE
chore(examples): remove dead dev:legacy script from entity-todo

### DIFF
--- a/examples/entity-todo/package.json
+++ b/examples/entity-todo/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "scripts": {
     "dev": "vtz dev",
-    "dev:legacy": "vtz run src/dev-server.ts",
     "build": "vtz build",
     "deploy": "bash scripts/deploy.sh",
     "codegen": "vtz codegen",


### PR DESCRIPTION
## Summary
- `examples/entity-todo/package.json` referenced `src/dev-server.ts` via `dev:legacy`, but that file does not exist — the script was dead.
- Removed the script.

Closes #3008

## Test plan
- [x] `dev:legacy` no longer present in `examples/entity-todo/package.json`
- [x] Pre-push quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)