### PR TITLE
fix(changeset): rename 'vtz' to 'vertz' in fix-fragment-root-hydration changeset

### DIFF
--- a/.changeset/fix-fragment-root-hydration-2784.md
+++ b/.changeset/fix-fragment-root-hydration-2784.md
@@ -1,5 +1,5 @@
 ---
-'vtz': patch
+'vertz': patch
 ---
 
 fix(compiler): AOT threads hydration id onto the first element child of a fragment root


### PR DESCRIPTION
## Summary

- `.changeset/fix-fragment-root-hydration-2784.md` listed `'vtz': patch`, but no workspace package is named `vtz` — the package is `vertz` (which exposes the `vtz` CLI bin).
- This made `vtzx changeset status` fail with `Found changeset fix-fragment-root-hydration-2784 for package vtz which is not in the workspace` and would have broken the publish pipeline at the next `changeset:version` run.
- Single-line fix: `'vtz'` → `'vertz'`. No other open changesets reference `'vtz'` (verified with `grep -rE "^['\"]vtz['\"]" .changeset/`).

Closes #2964

## Test plan

- [x] `vtzx changeset status` runs clean — `vertz` now appears in the list of packages to bump at patch.
- [x] No other `.changeset/*.md` files reference the nonexistent `'vtz'` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)