### PR TITLE
fix(compiler): use span-overlap check for signal mutation ranges (#2785)

### DIFF
--- a/.changeset/fix-mutation-range-overlap-2785.md
+++ b/.changeset/fix-mutation-range-overlap-2785.md
@@ -1,0 +1,12 @@
+---
+'@vertz/native-compiler': patch
+'vertz': patch
+---
+
+fix(compiler): use span-overlap (not point) check for mutation ranges in signal transformer
+
+Closes [#2785](https://github.com/vertz-dev/vertz/issues/2785).
+
+`is_in_mutation_range` tested whether `ident.span.start` was a member of a recorded mutation range (`pos >= start && pos < end`). That contract relied on `mutation_analyzer` always recording a span that begins exactly at the identifier's first character — so any future tightening (e.g., the operator-only span for `+=`, or a span recorded on an inner sub-expression) would silently misclassify the identifier as outside the range and double-handle it by appending `.value` on top of the mutation rewrite.
+
+Replaced the point check with a span-overlap check (`ident.start < range.end && ident.end > range.start`), renamed the predicate to `overlaps_mutation_range`, and applied it at all three call sites: identifier reads, assignment-expression LHS, and update-expression targets.

--- a/native/vertz-compiler-core/src/signal_transformer.rs
+++ b/native/vertz-compiler-core/src/signal_transformer.rs
@@ -129,10 +129,15 @@ impl<'a, 'b> RefTransformer<'a, 'b> {
         start >= self.component.body_start && end <= self.component.body_end
     }
 
-    fn is_in_mutation_range(&self, pos: u32) -> bool {
+    /// Does the half-open span `[ident_start, ident_end)` overlap any
+    /// recorded mutation range? Use span overlap, not a point check on the
+    /// identifier's start: `mutation_analyzer` is free to record a tighter
+    /// span than the full identifier (e.g., the operator-only span for `+=`),
+    /// and a point check on `ident.span.start` would silently miss those.
+    fn overlaps_mutation_range(&self, ident_start: u32, ident_end: u32) -> bool {
         self.mutation_ranges
             .iter()
-            .any(|(start, end)| pos >= *start && pos < *end)
+            .any(|(start, end)| ident_start < *end && ident_end > *start)
     }
 
     fn is_signal(&self, name: &str) -> bool {
@@ -153,7 +158,7 @@ impl<'a, 'b, 'c> Visit<'c> for RefTransformer<'a, 'b> {
         if !self.is_in_component(ident.span.start, ident.span.end) {
             return;
         }
-        if self.is_in_mutation_range(ident.span.start) {
+        if self.overlaps_mutation_range(ident.span.start, ident.span.end) {
             return;
         }
         if self.is_shadowed(name) {
@@ -187,7 +192,7 @@ impl<'a, 'b, 'c> Visit<'c> for RefTransformer<'a, 'b> {
         if let AssignmentTarget::AssignmentTargetIdentifier(ident) = &expr.left {
             let name = ident.name.as_str();
             if self.is_signal(name)
-                && !self.is_in_mutation_range(ident.span.start)
+                && !self.overlaps_mutation_range(ident.span.start, ident.span.end)
                 && !self.is_shadowed(name)
             {
                 self.ms.append_right(ident.span.end, ".value");
@@ -208,7 +213,7 @@ impl<'a, 'b, 'c> Visit<'c> for RefTransformer<'a, 'b> {
         if let SimpleAssignmentTarget::AssignmentTargetIdentifier(ref ident) = expr.argument {
             let name = ident.name.as_str();
             if self.is_signal(name)
-                && !self.is_in_mutation_range(ident.span.start)
+                && !self.overlaps_mutation_range(ident.span.start, ident.span.end)
                 && !self.is_shadowed(name)
             {
                 self.ms.append_right(ident.span.end, ".value");
@@ -857,6 +862,96 @@ mod tests {
         assert!(
             out.contains("x = 5"),
             "shadowed assignment should not get .value, got: {out}"
+        );
+    }
+
+    // ── Mutation range overlap: span check, not point check ──────────
+
+    /// Helper: run signal transforms with caller-provided mutation ranges.
+    /// Used to exercise the overlap behavior independently of mutation_analyzer.
+    fn transform_with_ranges(source: &str, ranges: Vec<(u32, u32)>) -> String {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let components = analyze_components(&parsed.program);
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, dynamic_configs) =
+            build_import_aliases(&parsed.program, &manifests, &HashSet::new());
+        let import_ctx = ImportContext {
+            aliases,
+            dynamic_configs,
+        };
+        let comp = &components[0];
+        let variables = analyze_reactivity(&parsed.program, comp, &import_ctx);
+        let mut ms = MagicString::new(source);
+        transform_signals(&mut ms, &parsed.program, comp, &variables, &ranges);
+        ms.to_string()
+    }
+
+    #[test]
+    fn ident_read_overlapping_mutation_range_starting_after_ident_is_suppressed() {
+        // Regression for #2785: `is_in_mutation_range` used a point check
+        // (`pos >= start && pos < end`) on `ident.span.start`. If the mutation
+        // range begins AFTER the identifier's start (e.g., a future analyzer
+        // records a tighter span like the operator-only span for `+=`), the
+        // point check returns false and `.value` is appended even though the
+        // identifier overlaps the mutation range.
+        //
+        // Use the JSX-read path (`{count}`) so the suppression is observable
+        // as the absence of `count.value` in the output.
+        let source = "function C() { let count = 0; return <div>{count}</div>; }";
+
+        // The `count` identifier inside `{count}` — find its position.
+        let jsx_count_pos = source.find("{count}").unwrap() + 1; // skip `{`
+        let ident_start = jsx_count_pos as u32;
+        // Range starts AFTER the first character of `count`, but still overlaps it.
+        let range_start = ident_start + 1;
+        let range_end = (jsx_count_pos + 5) as u32; // end of "count"
+
+        let out = transform_with_ranges(source, vec![(range_start, range_end)]);
+
+        // The JSX `{count}` overlaps the mutation range — `.value` must be suppressed.
+        assert!(
+            !out.contains("{count.value}"),
+            ".value must be suppressed when ident overlaps mutation range, got: {out}"
+        );
+    }
+
+    #[test]
+    fn ident_assignment_overlapping_mutation_range_starting_after_ident_is_suppressed() {
+        // Same regression at the assignment-expression site (line 190).
+        let source =
+            "function C() { let count = 0; const set = () => { count = 5; }; return <div>{count}</div>; }";
+
+        let assign_pos = source.find("count = 5").unwrap();
+        let ident_start = assign_pos as u32;
+        // Range starts AFTER the first char of the LHS identifier.
+        let range_start = ident_start + 1;
+        let range_end = (assign_pos + "count = 5".len()) as u32;
+
+        let out = transform_with_ranges(source, vec![(range_start, range_end)]);
+
+        assert!(
+            !out.contains("count.value = 5"),
+            ".value must be suppressed for LHS ident overlapping mutation range, got: {out}"
+        );
+    }
+
+    #[test]
+    fn ident_update_overlapping_mutation_range_starting_after_ident_is_suppressed() {
+        // Same regression at the update-expression site (line 211).
+        let source =
+            "function C() { let count = 0; const inc = () => { count++; }; return <div>{count}</div>; }";
+
+        let update_pos = source.find("count++").unwrap();
+        let ident_start = update_pos as u32;
+        let range_start = ident_start + 1;
+        let range_end = (update_pos + "count++".len()) as u32;
+
+        let out = transform_with_ranges(source, vec![(range_start, range_end)]);
+
+        assert!(
+            !out.contains("count.value++"),
+            ".value must be suppressed for update-expr ident overlapping mutation range, got: {out}"
         );
     }
 }

--- a/native/vertz-compiler-core/src/signal_transformer.rs
+++ b/native/vertz-compiler-core/src/signal_transformer.rs
@@ -134,6 +134,11 @@ impl<'a, 'b> RefTransformer<'a, 'b> {
     /// identifier's start: `mutation_analyzer` is free to record a tighter
     /// span than the full identifier (e.g., the operator-only span for `+=`),
     /// and a point check on `ident.span.start` would silently miss those.
+    ///
+    /// Today this is observationally equivalent to the old point check —
+    /// every recorded range happens to start at the identifier's start, so
+    /// `ident_start >= range.start` and overlap both hold. The change makes
+    /// the predicate robust to future tightenings of the recorded spans.
     fn overlaps_mutation_range(&self, ident_start: u32, ident_end: u32) -> bool {
         self.mutation_ranges
             .iter()


### PR DESCRIPTION
## Summary

Closes #2785.

`is_in_mutation_range` in `signal_transformer.rs` used a point-membership check on `ident.span.start` (`pos >= start && pos < end`). The contract relied on `mutation_analyzer` always recording a span that begins exactly at the identifier's first character — robust today, but silently broken by any future tightening (e.g., the operator-only span for `+=`, or a span recorded on an inner sub-expression).

Replaced the predicate with a half-open span-overlap check (`ident_start < range.end && ident_end > range.start`), renamed it to `overlaps_mutation_range`, and applied it at all three call sites:

- `visit_identifier_reference` (signal reads)
- `visit_assignment_expression` (LHS of `=`, `+=`, etc.)
- `visit_update_expression` (`++`, `--`)

Today this is observationally equivalent to the old check — every recorded range happens to start at the identifier's start, so both predicates agree. The change makes the predicate robust to future analyzer changes.

## Public API Changes

None — internal compiler logic only.

## Test plan

- [x] Three new regression tests in `signal_transformer::tests` inject a custom mutation range whose start is greater than the identifier's start and assert `.value` is suppressed at each call site.
- [x] All 32 prior `signal_transformer` tests still pass.
- [x] Adversarial review confirmed RED→GREEN: tests fail with the old point-check predicate and pass with the new overlap predicate.
- [x] `cargo test --all`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check` all green.
- [x] Pre-push hooks (build/typecheck/lint/rust-test/rust-clippy/rust-fmt/trojan-source) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)