### PR TITLE
fix(build): assert bundle outputs land inside outDir [#2953]

### DIFF
--- a/.changeset/fix-build-outputs-outside-outdir-2953.md
+++ b/.changeset/fix-build-outputs-outside-outdir-2953.md
@@ -1,0 +1,25 @@
+---
+'@vertz/build': patch
+---
+
+fix(build): assert bundle outputs land inside the configured `outDir`
+
+Closes [#2953](https://github.com/vertz-dev/vertz/issues/2953).
+
+Adds a defensive guard around `bundle()`:
+
+- `outdir` is now passed to esbuild as the absolute path that was already being
+  computed, instead of the relative `'dist'` string. Same for `entryPoints`,
+  which are pre-resolved against the supplied `cwd`.
+- After bundling, every entry in `metafile.outputs` is checked against `outDir`
+  via `path.relative`. If anything escapes (empty/`.`, parent traversal, or a
+  different drive root), the build now throws a descriptive error pointing at
+  the issue, rather than silently overwriting a sibling package's `dist/`.
+
+This is a safety net for the corruption seen in #2953, where
+`packages/ui/dist/index.js` ended up byte-identical to
+`packages/ui-primitives/dist/index.js` after a tangled `vtz install` +
+workspace rebuild session. The exact race wasn't reproducible, but the
+asymmetric exposure was real — a relative `outdir` combined with `absWorkingDir`
+left no audit trail if anything ever wrote outside the package's own dist.
+Future occurrences will fail loudly instead.

--- a/.changeset/fix-build-outputs-outside-outdir-2953.md
+++ b/.changeset/fix-build-outputs-outside-outdir-2953.md
@@ -6,20 +6,19 @@ fix(build): assert bundle outputs land inside the configured `outDir`
 
 Closes [#2953](https://github.com/vertz-dev/vertz/issues/2953).
 
-Adds a defensive guard around `bundle()`:
+After bundling, every entry in `metafile.outputs` is now checked against
+`outDir`. If anything escapes (path equals `outDir`, parent traversal, or
+a different drive root), `bundle()` throws a descriptive error pointing
+at the issue, rather than silently overwriting a sibling package's
+`dist/`.
 
-- `outdir` is now passed to esbuild as the absolute path that was already being
-  computed, instead of the relative `'dist'` string. Same for `entryPoints`,
-  which are pre-resolved against the supplied `cwd`.
-- After bundling, every entry in `metafile.outputs` is checked against `outDir`
-  via `path.relative`. If anything escapes (empty/`.`, parent traversal, or a
-  different drive root), the build now throws a descriptive error pointing at
-  the issue, rather than silently overwriting a sibling package's `dist/`.
+The check normalizes both sides through `fs.realpathSync` so that
+symlinked layouts (devcontainers, pnpm `node_modules/.pnpm`,
+`/tmp` ↔ `/private/tmp` on macOS) and case-insensitive filesystems
+(macOS APFS, Windows) don't false-positive on a legitimate build.
 
-This is a safety net for the corruption seen in #2953, where
-`packages/ui/dist/index.js` ended up byte-identical to
-`packages/ui-primitives/dist/index.js` after a tangled `vtz install` +
-workspace rebuild session. The exact race wasn't reproducible, but the
-asymmetric exposure was real — a relative `outdir` combined with `absWorkingDir`
-left no audit trail if anything ever wrote outside the package's own dist.
-Future occurrences will fail loudly instead.
+Scope: the JS bundle path only. `generateDts` (which spawns `tsc` and
+has no metafile) is not covered here — if the same race ever hits
+`.d.ts` emission, this won't catch it. We'd need a separate post-build
+walk of the dts output to extend the guard, which is left for a
+follow-up.

--- a/packages/build/src/__tests__/bundle.test.ts
+++ b/packages/build/src/__tests__/bundle.test.ts
@@ -107,4 +107,13 @@ describe('bundle', () => {
     expect(utilsFile!.size).toBeGreaterThan(0);
     expect(utilsFile!.relativePath).toBe('utils.js');
   });
+
+  it('returns output paths inside the absolute outDir', async () => {
+    const result = await bundle({ entry: ['src/index.ts'] }, fixtureDir);
+
+    expect(result.outDir).toBe(outDir);
+    for (const file of result.outputFiles) {
+      expect(file.path.startsWith(`${outDir}/`)).toBe(true);
+    }
+  });
 });

--- a/packages/build/src/__tests__/validate.test.ts
+++ b/packages/build/src/__tests__/validate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@vertz/test';
+import { assertOutputsUnderOutDir } from '../validate';
+import type { OutputFileInfo } from '../types';
+
+function makeFile(path: string): OutputFileInfo {
+  return {
+    path,
+    relativePath: 'index.js',
+    entrypoint: 'src/index.ts',
+    kind: 'entry-point',
+    size: 0,
+  };
+}
+
+describe('assertOutputsUnderOutDir', () => {
+  it('returns silently when every output is inside outDir', () => {
+    const outDir = '/repo/packages/ui/dist';
+    const files = [
+      makeFile('/repo/packages/ui/dist/index.js'),
+      makeFile('/repo/packages/ui/dist/chunks/foo.js'),
+    ];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).not.toThrow();
+  });
+
+  it('throws when an output path is in a sibling package dist', () => {
+    // Mirrors #2953: the ui-primitives build emitting into ui's dist.
+    const outDir = '/repo/packages/ui-primitives/dist';
+    const files = [
+      makeFile('/repo/packages/ui-primitives/dist/index.js'),
+      makeFile('/repo/packages/ui/dist/index.js'),
+    ];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(
+      /outside the configured output directory/,
+    );
+  });
+
+  it('throws when an output path is an absolute parent traversal', () => {
+    const outDir = '/repo/packages/ui/dist';
+    const files = [makeFile('/repo/packages/ui/dist/../leaked.js')];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(/outside/);
+  });
+
+  it('error message includes both the bad path and the outDir', () => {
+    const outDir = '/repo/packages/ui/dist';
+    const stray = '/repo/packages/ui-primitives/dist/index.js';
+    const files = [makeFile(stray)];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(stray);
+    expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(outDir);
+  });
+
+  it('treats a path that equals outDir exactly as outside (outDir is not a file)', () => {
+    const outDir = '/repo/packages/ui/dist';
+    const files = [makeFile(outDir)];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(/outside/);
+  });
+});

--- a/packages/build/src/__tests__/validate.test.ts
+++ b/packages/build/src/__tests__/validate.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from '@vertz/test';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from '@vertz/test';
 import { assertOutputsUnderOutDir } from '../validate';
 import type { OutputFileInfo } from '../types';
 
@@ -11,6 +14,11 @@ function makeFile(path: string): OutputFileInfo {
     size: 0,
   };
 }
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
 
 describe('assertOutputsUnderOutDir', () => {
   it('returns silently when every output is inside outDir', () => {
@@ -57,5 +65,34 @@ describe('assertOutputsUnderOutDir', () => {
     const files = [makeFile(outDir)];
 
     expect(() => assertOutputsUnderOutDir(files, outDir)).toThrow(/outside/);
+  });
+
+  it('does not false-positive when outDir is a symlink to the file path’s parent', () => {
+    // Real-world layout: a workspace mounted via symlink (devcontainers,
+    // pnpm `node_modules/.pnpm`, /tmp ↔ /private/tmp on macOS). outDir and
+    // file.path point at the same on-disk directory through different
+    // symbolic routes — this must NOT trip the validator.
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'vtz-validate-'));
+    cleanups.push(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+    const realDir = join(tmpRoot, 'real-dist');
+    mkdirSync(realDir);
+    writeFileSync(join(realDir, 'index.js'), '');
+
+    const linkDir = join(tmpRoot, 'link-dist');
+    symlinkSync(realDir, linkDir);
+
+    expect(() =>
+      assertOutputsUnderOutDir([makeFile(join(realDir, 'index.js'))], linkDir),
+    ).not.toThrow();
+  });
+
+  it('does not false-positive when outDir has a trailing slash', () => {
+    // path.relative tolerates trailing slashes, but pin the invariant so
+    // a future refactor to string-prefix matching can’t silently break it.
+    const outDir = '/repo/packages/ui/dist/';
+    const files = [makeFile('/repo/packages/ui/dist/index.js')];
+
+    expect(() => assertOutputsUnderOutDir(files, outDir)).not.toThrow();
   });
 });

--- a/packages/build/src/bundle.ts
+++ b/packages/build/src/bundle.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import * as esbuild from 'esbuild';
 import { resolveExternals } from './externals.js';
 import type { BuildConfig, OutputFileInfo } from './types.js';
@@ -49,15 +49,11 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
     external.push('node:*');
   }
 
-  // Resolve entry points to absolute paths up front so an unexpected
-  // `process.cwd()` inside esbuild can never re-anchor them (#2953).
-  const entryPoints = config.entry.map((e) => (isAbsolute(e) ? e : resolve(cwd, e)));
-
   const result = await esbuild.build({
-    entryPoints,
+    entryPoints: config.entry,
     bundle: true,
     format: 'esm',
-    outdir: outDir,
+    outdir: config.outDir ?? 'dist',
     splitting: config.entry.length > 1,
     target: resolveTarget(config.target),
     platform:
@@ -78,7 +74,7 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
     for (const [outputPath, meta] of Object.entries(result.metafile.outputs)) {
       if (!outputPath.endsWith('.js')) continue;
 
-      const fullPath = isAbsolute(outputPath) ? outputPath : resolve(cwd, outputPath);
+      const fullPath = resolve(cwd, outputPath);
       const relativePath = relative(outDir, fullPath);
       const size = existsSync(fullPath) ? statSync(fullPath).size : 0;
 
@@ -92,8 +88,8 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
     }
   }
 
-  // Final safety net: if any output landed outside outDir, fail loudly
-  // instead of letting it silently overwrite a sibling package (#2953).
+  // Safety net for #2953: if any output landed outside outDir, fail loudly
+  // instead of letting it silently overwrite a sibling package's dist.
   assertOutputsUnderOutDir(outputFiles, outDir);
 
   return { outputFiles, outDir };

--- a/packages/build/src/bundle.ts
+++ b/packages/build/src/bundle.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import * as esbuild from 'esbuild';
 import { resolveExternals } from './externals.js';
 import type { BuildConfig, OutputFileInfo } from './types.js';
+import { assertOutputsUnderOutDir } from './validate.js';
 
 export interface BundleResult {
   outputFiles: OutputFileInfo[];
@@ -48,11 +49,15 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
     external.push('node:*');
   }
 
+  // Resolve entry points to absolute paths up front so an unexpected
+  // `process.cwd()` inside esbuild can never re-anchor them (#2953).
+  const entryPoints = config.entry.map((e) => (isAbsolute(e) ? e : resolve(cwd, e)));
+
   const result = await esbuild.build({
-    entryPoints: config.entry,
+    entryPoints,
     bundle: true,
     format: 'esm',
-    outdir: config.outDir ?? 'dist',
+    outdir: outDir,
     splitting: config.entry.length > 1,
     target: resolveTarget(config.target),
     platform:
@@ -73,7 +78,7 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
     for (const [outputPath, meta] of Object.entries(result.metafile.outputs)) {
       if (!outputPath.endsWith('.js')) continue;
 
-      const fullPath = resolve(cwd, outputPath);
+      const fullPath = isAbsolute(outputPath) ? outputPath : resolve(cwd, outputPath);
       const relativePath = relative(outDir, fullPath);
       const size = existsSync(fullPath) ? statSync(fullPath).size : 0;
 
@@ -86,6 +91,10 @@ export async function bundle(config: BuildConfig, cwd: string): Promise<BundleRe
       });
     }
   }
+
+  // Final safety net: if any output landed outside outDir, fail loudly
+  // instead of letting it silently overwrite a sibling package (#2953).
+  assertOutputsUnderOutDir(outputFiles, outDir);
 
   return { outputFiles, outDir };
 }

--- a/packages/build/src/validate.ts
+++ b/packages/build/src/validate.ts
@@ -1,5 +1,24 @@
-import { isAbsolute, relative } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { dirname, isAbsolute, relative } from 'node:path';
 import type { OutputFileInfo } from './types.js';
+
+/**
+ * Realpath-resolve a path so symlinks and case-insensitive aliases (macOS
+ * APFS, Windows) collapse to a single canonical form before comparison.
+ *
+ * If the path doesn’t exist on disk yet (rare — e.g. esbuild metafile
+ * mentions a chunk that wasn’t written), fall back to realpathing the
+ * deepest existing ancestor and re-appending the missing tail.
+ */
+function canonicalize(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    const parent = dirname(p);
+    if (parent === p) return p;
+    return canonicalize(parent) + p.slice(parent.length);
+  }
+}
 
 /**
  * Guards against the class of bug where a build emits files outside its
@@ -10,11 +29,14 @@ import type { OutputFileInfo } from './types.js';
  * `outDir`.
  */
 export function assertOutputsUnderOutDir(outputs: OutputFileInfo[], outDir: string): void {
+  const canonicalOutDir = canonicalize(outDir);
+
   for (const file of outputs) {
-    const rel = relative(outDir, file.path);
-    // Outside outDir if rel is empty / "." (path equals outDir itself, not a
-    // file), starts with ".." (parent traversal), or is absolute (different
-    // root, e.g. on Windows).
+    const rel = relative(canonicalOutDir, canonicalize(file.path));
+    // Outside outDir if rel is empty / "." (path equals outDir itself, not
+    // a file — Node returns "", the vtz runtime returns "."), starts with
+    // ".." (parent traversal), or is absolute (different drive root on
+    // Windows).
     const outside = rel === '' || rel === '.' || rel.startsWith('..') || isAbsolute(rel);
     if (outside) {
       throw new Error(

--- a/packages/build/src/validate.ts
+++ b/packages/build/src/validate.ts
@@ -1,0 +1,29 @@
+import { isAbsolute, relative } from 'node:path';
+import type { OutputFileInfo } from './types.js';
+
+/**
+ * Guards against the class of bug where a build emits files outside its
+ * own output directory — e.g. issue #2953, where `packages/ui/dist/index.js`
+ * was overwritten with `packages/ui-primitives` build output.
+ *
+ * Throws a descriptive error if any output path is not strictly inside
+ * `outDir`.
+ */
+export function assertOutputsUnderOutDir(outputs: OutputFileInfo[], outDir: string): void {
+  for (const file of outputs) {
+    const rel = relative(outDir, file.path);
+    // Outside outDir if rel is empty / "." (path equals outDir itself, not a
+    // file), starts with ".." (parent traversal), or is absolute (different
+    // root, e.g. on Windows).
+    const outside = rel === '' || rel === '.' || rel.startsWith('..') || isAbsolute(rel);
+    if (outside) {
+      throw new Error(
+        `Build output landed outside the configured output directory.\n` +
+          `  outDir: ${outDir}\n` +
+          `  path:   ${file.path}\n` +
+          `This usually means the build process resolved its working directory ` +
+          `incorrectly. See https://github.com/vertz-dev/vertz/issues/2953`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #2953. After bundling, `bundle()` now checks every entry in `metafile.outputs` against `outDir` (via `path.relative` on realpath-normalized paths). Anything that escapes throws a descriptive error pointing at the issue, instead of silently overwriting a sibling package's `dist/` (the corruption seen in the issue).
- Both sides of the comparison are run through `fs.realpathSync` (with a graceful fallback for paths that don't exist yet), so symlinked layouts (devcontainers, pnpm `node_modules/.pnpm`, `/tmp` ↔ `/private/tmp` on macOS) and case-insensitive filesystems (macOS APFS, Windows) don't false-positive on a legitimate build.

## Public API Changes

- **None.** `assertOutputsUnderOutDir` is internal to `@vertz/build`; it isn't exported from the package entry. Only the runtime behavior of `bundle()` changes — it can now throw on a corrupted build instead of silently propagating it.
- Patch-level changeset bumps `@vertz/build` only.

## Scope

- JS bundle path only. `generateDts` (which spawns `tsc` and has no metafile) is **not** covered here. If the same race ever hits `.d.ts` emission, this PR won't catch it. Adding a guard there requires a directory walk of the dts output and is left for a follow-up.
- The exact race in #2953 was not reproducible. The reporter speculated either Turbo cache restoration to the wrong dir, or `@vertz/build` resolving its outdir against the wrong cwd. I investigated both — Turbo cache keys include package identity (cache cross-pollination is unlikely), and esbuild already resolves relative paths against `absWorkingDir: cwd` (so the cwd theory doesn't hold under current esbuild). Rather than adding cosmetic defenses, this PR adds a single runtime invariant — outputs must live inside outDir — that turns any future regression into a loud, diagnostic error.

## Review history

The first commit (`1a88693bc`) also tried to switch esbuild's `outdir` and `entryPoints` to absolute paths. Adversarial review correctly flagged this as a regression risk: on layouts where the workspace cwd realpaths to a different prefix, esbuild emits metafile keys that, when re-resolved against the literal cwd, escape `outDir` and trip the new validator on a perfectly correct build. The second commit (`9d1f4961f`) reverts those changes and adds realpath normalization to the validator. Full review log lives at `reviews/dist-overwrite-2953/phase-01-bundle-outdir-guard.md` (gitignored per workflow policy).

## Test plan

- [x] `vtz test packages/build/src/__tests__/validate.test.ts` — 7/7 (helper-level coverage including symlink, trailing-slash, sibling-package, parent-traversal, exact-match-as-outside)
- [x] `vtz test packages/build/src/__tests__/bundle.test.ts` — 10/10 (positive integration test added: every output path lives under the absolute outDir)
- [x] Each `packages/build/src/__tests__/*.test.ts` file run individually — 52/52 (parallel runs flake on a shared fixture dir; pre-existing, not introduced here)
- [x] `vtzx -w @vertz/build tsgo --noEmit -p tsconfig.typecheck.json` — clean
- [x] `vtzx oxlint packages/build/` — 1 pre-existing `no-throw-plain-error` warning style match (warn severity, not gating); 0 errors
- [x] End-to-end rebuild of `@vertz/build` → `@vertz/ui-primitives` → `@vertz/ui` succeeds; resulting `packages/ui/dist/index.js` is 981 lines (correct), `packages/ui-primitives/dist/index.js` is 80 lines (correct)