### PR TITLE
fix(vtz): heal cache + project bins corrupted by pre-#2908 vtz [#2952]

### DIFF
--- a/.changeset/fix-tsc-bin-stub-2952.md
+++ b/.changeset/fix-tsc-bin-stub-2952.md
@@ -1,0 +1,29 @@
+---
+'@vertz/runtime': patch
+---
+
+fix(vtz): heal store entries and project bin files corrupted by old vtz versions
+
+Closes [#2952](https://github.com/vertz-dev/vertz/issues/2952).
+
+Pre-#2908 vtz versions could overwrite a package's own bin file with the
+`.bin/<name>` shim contents — `std::fs::write` followed a stale
+`.bin/<name>` symlink straight into the package, and the hardlink to the
+global store carried the corruption back into `~/.vertz/cache/npm/store/`.
+#2908 stopped new corruption but didn't repair existing damage, so a
+fresh `vtz install` on any project would hardlink the broken bin from the
+cache (e.g. `node_modules/typescript/bin/tsc` ending up as a self-exec
+shell loop) and `bunx tsc` would fail with `SyntaxError: Unexpected
+identifier 'node'`.
+
+`TarballManager::is_valid_store_entry` now reads each declared bin file
+and rejects entries whose first bytes match the vtz shim shape; the
+existing `fetch_and_extract` flow then re-downloads a clean tarball.
+Re-extracted packages are added to a new `force_relink_packages` set
+threaded through `linker::link_packages_with_force` so the project's
+hardlinks (which still point at the orphaned corrupt inodes) are
+rebuilt from the freshly extracted store. A second pass —
+`linker::detect_corrupt_project_bins` — flags projects that were already
+installed against a corrupt cache and force-relinks them even if the
+cache has since been healed by an earlier install on a different
+project.

--- a/native/vtz/src/pm/linker.rs
+++ b/native/vtz/src/pm/linker.rs
@@ -279,10 +279,13 @@ pub fn detect_corrupt_project_bins(root_dir: &Path, graph: &ResolvedGraph) -> Ha
         let target = target_path(&node_modules, &pkg.name, &pkg.nest_path);
         for bin_rel in pkg.bin.values() {
             let stripped = bin_rel.trim_start_matches("./");
+            // Splits on both `/` and `\` so a Windows-style path can't smuggle
+            // a `..` segment past a forward-slash-only check.
             if stripped.is_empty()
                 || stripped.starts_with('/')
+                || stripped.starts_with('\\')
                 || stripped
-                    .split('/')
+                    .split(['/', '\\'])
                     .any(|seg| seg == ".." || seg.starts_with(".."))
             {
                 continue;

--- a/native/vtz/src/pm/linker.rs
+++ b/native/vtz/src/pm/linker.rs
@@ -1,5 +1,6 @@
 use crate::pm::resolver::ResolvedGraph;
 use crate::pm::scripts;
+use crate::pm::tarball;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -98,13 +99,44 @@ pub fn link_packages_incremental(
     force: bool,
     patched_packages: &HashSet<String>,
 ) -> Result<LinkResult, Box<dyn std::error::Error>> {
+    link_packages_with_force(
+        root_dir,
+        graph,
+        store_dir,
+        force,
+        patched_packages,
+        &HashSet::new(),
+    )
+}
+
+/// Link packages, additionally forcing a relink for any package whose
+/// `name@version` key is in `force_relink_packages` even if the manifest
+/// entry is unchanged. The install flow uses this for entries that
+/// `TarballManager::is_cached` flagged as corrupt and just re-extracted —
+/// the existing project hardlinks still point at the orphaned (corrupt)
+/// inode and need to be rewritten from the freshly extracted store.
+pub fn link_packages_with_force(
+    root_dir: &Path,
+    graph: &ResolvedGraph,
+    store_dir: &Path,
+    force: bool,
+    patched_packages: &HashSet<String>,
+    force_relink_packages: &HashSet<String>,
+) -> Result<LinkResult, Box<dyn std::error::Error>> {
     let node_modules = root_dir.join("node_modules");
     let new_manifest = build_manifest(graph, patched_packages);
 
     // Try incremental linking
     if !force {
         if let Some(old_manifest) = read_manifest(root_dir) {
-            return link_incremental(root_dir, graph, store_dir, &old_manifest, &new_manifest);
+            return link_incremental(
+                root_dir,
+                graph,
+                store_dir,
+                &old_manifest,
+                &new_manifest,
+                force_relink_packages,
+            );
         }
     }
 
@@ -156,6 +188,7 @@ fn link_incremental(
     store_dir: &Path,
     old_manifest: &LinkManifest,
     new_manifest: &LinkManifest,
+    force_relink_packages: &HashSet<String>,
 ) -> Result<LinkResult, Box<dyn std::error::Error>> {
     let node_modules = root_dir.join("node_modules");
     std::fs::create_dir_all(&node_modules)?;
@@ -177,9 +210,11 @@ fn link_incremental(
     for pkg in graph.packages.values() {
         let key = manifest_key(&pkg.name, &pkg.version, &pkg.nest_path);
         let new_entry = new_manifest.packages.get(&key).unwrap();
+        let force_key = format!("{}@{}", pkg.name, pkg.version);
+        let must_force = force_relink_packages.contains(&force_key);
 
         if let Some(old_entry) = old_manifest.packages.get(&key) {
-            if old_entry == new_entry {
+            if old_entry == new_entry && !must_force {
                 // Unchanged — skip (cached)
                 result.packages_cached += 1;
                 continue;
@@ -219,6 +254,47 @@ fn link_incremental(
     write_manifest(root_dir, new_manifest)?;
 
     Ok(result)
+}
+
+/// Scan node_modules for packages whose bin files look like vtz-generated
+/// shell shims. Such files indicate the project was linked when the global
+/// store held shim-corrupted bin files (see #2952): once the store is healed,
+/// the project's hardlinks still point at the orphaned (corrupt) inodes and
+/// must be relinked from the now-clean cache.
+///
+/// Returns `name@version` keys suitable for `link_packages_with_force`'s
+/// `force_relink_packages` argument. Missing bin files and unreadable paths
+/// are treated as "not corrupt" — the linker will surface real errors.
+pub fn detect_corrupt_project_bins(root_dir: &Path, graph: &ResolvedGraph) -> HashSet<String> {
+    let node_modules = root_dir.join("node_modules");
+    let mut corrupt = HashSet::new();
+    for pkg in graph.packages.values() {
+        if pkg.bin.is_empty() {
+            continue;
+        }
+        let key = format!("{}@{}", pkg.name, pkg.version);
+        if corrupt.contains(&key) {
+            continue;
+        }
+        let target = target_path(&node_modules, &pkg.name, &pkg.nest_path);
+        for bin_rel in pkg.bin.values() {
+            let stripped = bin_rel.trim_start_matches("./");
+            if stripped.is_empty()
+                || stripped.starts_with('/')
+                || stripped
+                    .split('/')
+                    .any(|seg| seg == ".." || seg.starts_with(".."))
+            {
+                continue;
+            }
+            let bin_abs = target.join(stripped);
+            if tarball::bin_file_looks_like_shim(&bin_abs) {
+                corrupt.insert(key.clone());
+                break;
+            }
+        }
+    }
+    corrupt
 }
 
 /// Compute target path in node_modules for a package
@@ -797,6 +873,179 @@ mod tests {
         assert_eq!(result.packages_linked, 1);
         assert_eq!(result.packages_cached, 0);
         assert!(root.join("node_modules/zod/index.js").exists());
+    }
+
+    /// Regression for #2952: when fetch_and_extract repairs a corrupt store
+    /// entry, the project's hardlinks still point at the old (corrupt) inode.
+    /// `force_relink_packages` lets the install flow surgically relink the
+    /// repaired packages without nuking node_modules.
+    #[test]
+    fn test_force_relink_packages_relinks_unchanged_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let store = dir.path().join("store");
+        std::fs::create_dir_all(&root).unwrap();
+
+        create_store_package(&store, "typescript", "5.9.3", &[("bin/tsc", "real")]);
+
+        let mut graph = ResolvedGraph::default();
+        graph.packages.insert(
+            "typescript@5.9.3".to_string(),
+            ResolvedPackage {
+                name: "typescript".to_string(),
+                version: "5.9.3".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        // First install — full link.
+        link_packages(&root, &graph, &store, &HashSet::new()).unwrap();
+        let linked_path = root.join("node_modules/typescript/bin/tsc");
+        assert!(linked_path.exists());
+
+        // Mark typescript@5.9.3 as needing a forced relink. Even though the
+        // manifest entry is unchanged, the linker must rebuild the package
+        // directory.
+        let mut force = HashSet::new();
+        force.insert("typescript@5.9.3".to_string());
+
+        let result =
+            link_packages_with_force(&root, &graph, &store, false, &HashSet::new(), &force)
+                .unwrap();
+
+        assert_eq!(
+            result.packages_linked, 1,
+            "force-relink package must be re-linked"
+        );
+        assert_eq!(
+            result.packages_cached, 0,
+            "force-relink package must not be reported as cached"
+        );
+        assert!(linked_path.exists());
+    }
+
+    /// Project-side scan: when the cache is already clean but the project
+    /// holds corrupt hardlinks from a previous old-vtz install, we still need
+    /// to relink. See `detect_corrupt_project_bins`.
+    #[test]
+    fn test_detect_corrupt_project_bins_flags_shim_in_node_modules() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let nm = root.join("node_modules");
+        std::fs::create_dir_all(nm.join("typescript/bin")).unwrap();
+        // Simulate the corruption: typescript/bin/tsc has the vtz shim format
+        std::fs::write(
+            nm.join("typescript/bin/tsc"),
+            "#!/bin/sh\nexec node \"$(dirname \"$0\")/../typescript/bin/tsc\" \"$@\"\n",
+        )
+        .unwrap();
+
+        let mut graph = ResolvedGraph::default();
+        let mut bin = BTreeMap::new();
+        bin.insert("tsc".to_string(), "./bin/tsc".to_string());
+        graph.packages.insert(
+            "typescript@5.9.3".to_string(),
+            ResolvedPackage {
+                name: "typescript".to_string(),
+                version: "5.9.3".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin,
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let corrupt = detect_corrupt_project_bins(&root, &graph);
+        assert!(corrupt.contains("typescript@5.9.3"));
+    }
+
+    #[test]
+    fn test_detect_corrupt_project_bins_ignores_real_bin_scripts() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let nm = root.join("node_modules");
+        std::fs::create_dir_all(nm.join("typescript/bin")).unwrap();
+        std::fs::write(
+            nm.join("typescript/bin/tsc"),
+            "#!/usr/bin/env node\nrequire('../lib/tsc.js')\n",
+        )
+        .unwrap();
+
+        let mut graph = ResolvedGraph::default();
+        let mut bin = BTreeMap::new();
+        bin.insert("tsc".to_string(), "./bin/tsc".to_string());
+        graph.packages.insert(
+            "typescript@5.9.3".to_string(),
+            ResolvedPackage {
+                name: "typescript".to_string(),
+                version: "5.9.3".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin,
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        let corrupt = detect_corrupt_project_bins(&root, &graph);
+        assert!(corrupt.is_empty());
+    }
+
+    /// Without the force set, an unchanged package stays cached (regression
+    /// guard so we don't accidentally start relinking everything).
+    #[test]
+    fn test_empty_force_relink_packages_keeps_caching() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let store = dir.path().join("store");
+        std::fs::create_dir_all(&root).unwrap();
+
+        create_store_package(&store, "zod", "3.24.4", &[("index.js", "zod")]);
+
+        let mut graph = ResolvedGraph::default();
+        graph.packages.insert(
+            "zod@3.24.4".to_string(),
+            ResolvedPackage {
+                name: "zod".to_string(),
+                version: "3.24.4".to_string(),
+                tarball_url: String::new(),
+                integrity: String::new(),
+                dependencies: BTreeMap::new(),
+                optional_dependencies: BTreeMap::new(),
+                bin: BTreeMap::new(),
+                nest_path: vec![],
+                os: None,
+                cpu: None,
+            },
+        );
+
+        link_packages(&root, &graph, &store, &HashSet::new()).unwrap();
+
+        let result = link_packages_with_force(
+            &root,
+            &graph,
+            &store,
+            false,
+            &HashSet::new(),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert_eq!(result.packages_cached, 1);
+        assert_eq!(result.packages_linked, 0);
     }
 
     #[test]

--- a/native/vtz/src/pm/mod.rs
+++ b/native/vtz/src/pm/mod.rs
@@ -373,6 +373,21 @@ pub async fn install(
         .filter(|pkg| !tarball_mgr.is_cached(&pkg.name, &pkg.version))
         .collect();
 
+    // Track packages whose store entry was missing or invalid. After their
+    // tarballs are re-extracted, the linker must rebuild them in node_modules
+    // even when the manifest entry is unchanged — the existing hardlinks
+    // there still reference the orphaned (corrupt) inodes from before the
+    // re-extract. See #2952.
+    let mut force_relink_packages: HashSet<String> = packages_to_download
+        .iter()
+        .map(|pkg| format!("{}@{}", pkg.name, pkg.version))
+        .collect();
+
+    // Also relink any project whose node_modules already holds shim-corrupted
+    // bin files but whose store entry was healed by an earlier install on a
+    // different project. See #2952.
+    force_relink_packages.extend(linker::detect_corrupt_project_bins(root_dir, &graph));
+
     let download_count = packages_to_download.len();
     if download_count > 0 {
         output.download_started(download_count);
@@ -425,8 +440,14 @@ pub async fn install(
     // Link packages into node_modules (incremental unless --force)
     output.link_started();
     let store_dir = cache_dir.join("store");
-    let link_result =
-        linker::link_packages_incremental(root_dir, &graph, &store_dir, force, &patched_packages)?;
+    let link_result = linker::link_packages_with_force(
+        root_dir,
+        &graph,
+        &store_dir,
+        force,
+        &patched_packages,
+        &force_relink_packages,
+    )?;
     output.link_complete(
         link_result.packages_linked,
         link_result.files_linked,

--- a/native/vtz/src/pm/tarball.rs
+++ b/native/vtz/src/pm/tarball.rs
@@ -70,10 +70,13 @@ impl TarballManager {
         for (_bin_name, bin_rel) in pkg.bin.to_map(pkg_name) {
             let stripped = bin_rel.trim_start_matches("./");
             // Defense in depth: refuse to read outside the store entry.
+            // Splits on both `/` and `\` so a Windows-style path can't smuggle
+            // a `..` segment past a forward-slash-only check.
             if stripped.is_empty()
                 || stripped.starts_with('/')
+                || stripped.starts_with('\\')
                 || stripped
-                    .split('/')
+                    .split(['/', '\\'])
                     .any(|seg| seg == ".." || seg.starts_with(".."))
             {
                 continue;
@@ -1179,5 +1182,21 @@ mod tests {
         .unwrap();
         // Traversal path is silently ignored — entry is otherwise valid.
         assert!(mgr.is_cached("evil", "1.0.0"));
+    }
+
+    /// Defense in depth against a Windows-style traversal path. `Path::join`
+    /// treats `\` as a separator on Windows; the guard must split on both.
+    #[test]
+    fn test_is_cached_does_not_follow_backslash_traversal_in_bin_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("evil-win", "1.0.0");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"evil-win","version":"1.0.0","bin":{"evil":"..\\..\\..\\etc\\passwd"}}"#,
+        )
+        .unwrap();
+        assert!(mgr.is_cached("evil-win", "1.0.0"));
     }
 }

--- a/native/vtz/src/pm/tarball.rs
+++ b/native/vtz/src/pm/tarball.rs
@@ -1,3 +1,4 @@
+use crate::pm::types::PackageJson;
 use flate2::read::GzDecoder;
 use sha2::{Digest, Sha256, Sha512};
 use std::io::Read;
@@ -44,18 +45,45 @@ impl TarballManager {
         Self::is_valid_store_entry(&self.store_path(name, version))
     }
 
-    /// Validate that a store entry directory contains a non-empty `package.json`.
-    /// This catches corrupt cache entries where files are 0 bytes due to
-    /// interrupted extraction or disk errors.
+    /// Validate that a store entry directory contains a non-empty `package.json`
+    /// and that its declared bin files don't look like leaked vtz shims.
+    ///
+    /// The bin-shim check guards against #2952: pre-#2908 vtz versions could
+    /// overwrite a package's own bin file with `.bin/<name>` shim content
+    /// (because `std::fs::write` followed a stale `.bin/<name>` symlink into
+    /// the package). Hardlinking from the global store then propagated the
+    /// corruption back into the cache. Once detected, the existing
+    /// `fetch_and_extract` flow removes the entry and re-downloads it.
     fn is_valid_store_entry(path: &Path) -> bool {
         if !path.is_dir() {
             return false;
         }
-        let pkg_json = path.join("package.json");
-        match std::fs::metadata(&pkg_json) {
-            Ok(meta) => meta.len() > 0,
-            Err(_) => false,
+        let pkg_json_path = path.join("package.json");
+        let pkg_json_bytes = match std::fs::read(&pkg_json_path) {
+            Ok(content) if !content.is_empty() => content,
+            _ => return false,
+        };
+        let Ok(pkg) = serde_json::from_slice::<PackageJson>(&pkg_json_bytes) else {
+            return true; // Unparseable manifest is left to the linker; not our concern.
+        };
+        let pkg_name = pkg.name.as_deref().unwrap_or("");
+        for (_bin_name, bin_rel) in pkg.bin.to_map(pkg_name) {
+            let stripped = bin_rel.trim_start_matches("./");
+            // Defense in depth: refuse to read outside the store entry.
+            if stripped.is_empty()
+                || stripped.starts_with('/')
+                || stripped
+                    .split('/')
+                    .any(|seg| seg == ".." || seg.starts_with(".."))
+            {
+                continue;
+            }
+            let bin_abs = path.join(stripped);
+            if bin_file_looks_like_shim(&bin_abs) {
+                return false;
+            }
         }
+        true
     }
 
     /// Download, verify, and extract a tarball
@@ -214,6 +242,31 @@ impl TarballManager {
             }
         }
     }
+}
+
+/// Detect a file whose first bytes match a vtz-generated `.bin/<name>` shim.
+///
+/// vtz writes one of two shim shapes (see `pm::bin::write_bin_stub`):
+///   `#!/bin/sh\nexec node "$(dirname "$0")/<rel>" "$@"\n`
+///   `#!/bin/sh\nexec "$(dirname "$0")/<rel>" "$@"\n`
+///
+/// A real npm bin is overwhelmingly `#!/usr/bin/env node …`, so a file in the
+/// store whose first ~64 bytes match the shim shape was almost certainly
+/// truncated through a stale symlink by an old vtz install. Missing files and
+/// I/O errors return `false` — the caller treats those as "not corrupt" and
+/// lets the linker raise the real error.
+pub(crate) fn bin_file_looks_like_shim(path: &Path) -> bool {
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut buf = [0u8; 64];
+    let n = f.read(&mut buf).unwrap_or(0);
+    let head = &buf[..n];
+    let Some(rest) = head.strip_prefix(b"#!/bin/sh\n") else {
+        return false;
+    };
+    rest.starts_with(b"exec node \"$(dirname \"$0\")/")
+        || rest.starts_with(b"exec \"$(dirname \"$0\")/")
 }
 
 /// Verify the integrity hash of downloaded bytes.
@@ -999,5 +1052,132 @@ mod tests {
         // Directory exists but no package.json
         std::fs::create_dir_all(&store).unwrap();
         assert!(!mgr.is_cached("zod", "3.24.4"));
+    }
+
+    /// Regression for #2952: pre-#2908 vtz versions could overwrite a package's
+    /// own bin file with a vtz-generated shell shim (because `std::fs::write`
+    /// followed a stale `.bin/<name>` symlink straight into the package and the
+    /// hardlink propagated the corruption back into the global store). New vtz
+    /// versions don't introduce that corruption, but they keep hardlinking
+    /// already-corrupt cache entries into every project. Treat a store entry
+    /// whose declared bin file looks like a vtz shim as invalid so the existing
+    /// fetch-and-extract path re-downloads a clean copy.
+    #[test]
+    fn test_is_cached_false_when_bin_file_is_shim() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("typescript", "5.9.3");
+        std::fs::create_dir_all(store.join("bin")).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"typescript","version":"5.9.3","bin":{"tsc":"./bin/tsc","tsserver":"./bin/tsserver"}}"#,
+        )
+        .unwrap();
+        // tsserver is intact, tsc is corrupted — one corrupt bin invalidates the entry.
+        std::fs::write(
+            store.join("bin/tsc"),
+            "#!/bin/sh\nexec node \"$(dirname \"$0\")/../typescript/bin/tsc\" \"$@\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            store.join("bin/tsserver"),
+            "#!/usr/bin/env node\nrequire('../lib/tsserver.js')\n",
+        )
+        .unwrap();
+        assert!(!mgr.is_cached("typescript", "5.9.3"));
+    }
+
+    #[test]
+    fn test_is_cached_true_when_bin_files_are_real_node_scripts() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("typescript", "5.9.3");
+        std::fs::create_dir_all(store.join("bin")).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"typescript","version":"5.9.3","bin":{"tsc":"./bin/tsc"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            store.join("bin/tsc"),
+            "#!/usr/bin/env node\nrequire('../lib/tsc.js')\n",
+        )
+        .unwrap();
+        assert!(mgr.is_cached("typescript", "5.9.3"));
+    }
+
+    /// `bin` as a single string (not a map) — npm uses the package name as the
+    /// bin name. Validation must still find the file via the resolved path.
+    #[test]
+    fn test_is_cached_false_when_single_string_bin_is_shim() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("my-cli", "1.0.0");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"my-cli","version":"1.0.0","bin":"./cli.js"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            store.join("cli.js"),
+            "#!/bin/sh\nexec node \"$(dirname \"$0\")/../my-cli/cli.js\" \"$@\"\n",
+        )
+        .unwrap();
+        assert!(!mgr.is_cached("my-cli", "1.0.0"));
+    }
+
+    /// `.sh` bin shims are written without the `node` wrapper. Detect them too.
+    #[test]
+    fn test_is_cached_false_when_sh_bin_is_shim() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("@vertz/runtime", "0.1.0");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"@vertz/runtime","version":"0.1.0","bin":{"vtz":"./cli.sh"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            store.join("cli.sh"),
+            "#!/bin/sh\nexec \"$(dirname \"$0\")/../@vertz/runtime/cli.sh\" \"$@\"\n",
+        )
+        .unwrap();
+        assert!(!mgr.is_cached("@vertz/runtime", "0.1.0"));
+    }
+
+    /// Missing bin file isn't shim-corruption; let the linker surface that error.
+    /// Don't false-positive a missing file as corruption.
+    #[test]
+    fn test_is_cached_true_when_bin_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("zod", "3.24.4");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"zod","version":"3.24.4","bin":{"zod":"./bin/zod"}}"#,
+        )
+        .unwrap();
+        // bin/zod does not exist
+        assert!(mgr.is_cached("zod", "3.24.4"));
+    }
+
+    /// Reject path traversal in the declared bin path so a hostile package
+    /// can't trick the validator into reading a file outside the store entry.
+    #[test]
+    fn test_is_cached_does_not_follow_traversal_in_bin_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = TarballManager::new(dir.path());
+        let store = mgr.store_path("evil", "1.0.0");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("package.json"),
+            r#"{"name":"evil","version":"1.0.0","bin":{"evil":"../../../etc/passwd"}}"#,
+        )
+        .unwrap();
+        // Traversal path is silently ignored — entry is otherwise valid.
+        assert!(mgr.is_cached("evil", "1.0.0"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #2952.

Pre-#2908 vtz versions could overwrite a package's own bin file with the
`.bin/<name>` shim — `std::fs::write` followed a stale `.bin/<name>` symlink
straight into the package, and the hardlink to the global store carried the
corruption back into `~/.vertz/cache/npm/store/`. #2908 stopped *new*
corruption but left every machine that had run an old vtz with a broken
cache: a fresh `vtz install` would hardlink the corrupt
`typescript@5.9.3/bin/tsc` (a self-exec shell loop) into every project, and
`bunx tsc` would fail with `SyntaxError: Unexpected identifier 'node'`.

## What changed

- **`TarballManager::is_valid_store_entry`** now reads each bin file declared
  in the cached `package.json` and rejects entries whose first bytes match
  the vtz shim shape (`#!/bin/sh\nexec [node ]"$(dirname "$0")/...`). The
  existing `fetch_and_extract` flow then removes and re-downloads a clean
  tarball.
- **`linker::link_packages_with_force`** is a new entry point that takes a
  `force_relink_packages: &HashSet<String>`. `link_incremental` honours it
  to relink packages whose manifest entry is unchanged but whose hardlinks
  in `node_modules` still point at the orphaned (corrupt) inodes from
  before the cache was healed.
- **`linker::detect_corrupt_project_bins`** scans `node_modules` for
  shim-shaped bin files. The install flow merges its output into
  `force_relink_packages` so projects that were installed against a corrupt
  cache get healed even if the cache has since been cleaned up by a prior
  install on a different project.
- The `..` traversal guard splits on both `/` and `\` so a Windows-style
  `bin: "..\\..\\etc\\passwd"` can't slip past.

## Public API Changes

None. All new functions are inside `vtz`'s `pm` module; `link_packages` and
`link_packages_incremental` keep their existing signatures and delegate to
the new `link_packages_with_force` with an empty `force_relink_packages` set.

## Test plan

- [x] 7 new tests in `pm::tarball` covering shim detection across map/single-string/.sh bin shapes, real `#!/usr/bin/env node` scripts (no false positives), missing bin files, forward-slash and backslash traversal guards.
- [x] 4 new tests in `pm::linker` covering `link_packages_with_force` (force-relink behaviour, empty-set caching) and `detect_corrupt_project_bins` (positive + negative cases).
- [x] `cargo test --all` — green.
- [x] `cargo clippy -p vtz --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] End-to-end repro: corrupted `~/.vertz/cache/npm/store/typescript@5.9.3/bin/tsc` to the shim shape, ran `vtz install` on a fresh `{"dependencies":{"typescript":"5.9.3"}}` project — fixed binary downloads correctly, `bunx tsc --version` returns `5.9.3`. Repeated for the inverse scenario (clean cache, project corrupt from earlier old-vtz install) — `vtz install` detects and rebuilds the project's `typescript/bin/tsc`.
- [x] Adversarial review run — Windows backslash gap noted and addressed in commit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)