### PR TITLE
docs: add vertz npm support metadata

### DIFF
--- a/packages/vertz/package.json
+++ b/packages/vertz/package.json
@@ -28,6 +28,10 @@
     "url": "https://github.com/vertz-dev/vertz.git",
     "directory": "packages/vertz"
   },
+  "homepage": "https://github.com/vertz-dev/vertz#readme",
+  "bugs": {
+    "url": "https://github.com/vertz-dev/vertz/issues"
+  },
   "files": [
     "dist",
     "client.d.ts"


### PR DESCRIPTION
## Summary
- add `homepage` metadata for the `vertz` npm package
- add `bugs.url` metadata pointing to the repository issue tracker
- keep runtime code, dependencies, version, package entry points, and lockfiles unchanged

## Verification
- `jq  packages/vertz/package.json`
- `git diff --check`
- `npm pack --dry-run --json ./packages/vertz`