### PR TITLE
fix: add homepage and bugs metadata to vertz package.json

### DIFF
--- a/packages/vertz/package.json
+++ b/packages/vertz/package.json
@@ -28,6 +28,10 @@
     "url": "https://github.com/vertz-dev/vertz.git",
     "directory": "packages/vertz"
   },
+  "homepage": "https://github.com/vertz-dev/vertz#readme",
+  "bugs": {
+    "url": "https://github.com/vertz-dev/vertz/issues"
+  },
   "files": [
     "dist",
     "client.d.ts"


### PR DESCRIPTION
Adds missing `homepage` and `bugs` fields to package.json so npm consumers can discover the project's README and issue tracker.

Fixes charles-openclaw/charles-microbounties#1594