### PR TITLE
chore: add npm bugs and homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
     "esbuild": "0.27.3",
     "rollup": "^4.59.0",
     "vite": "^7.3.1"
+  },
+  "homepage": "https://github.com/vertz-dev/vertz#readme",
+  "bugs": {
+    "url": "https://github.com/vertz-dev/vertz/issues"
   }
 }


### PR DESCRIPTION
Adds missing `bugs.url` and `homepage` to `package.json` so npm users can navigate to the issue tracker and README from the package page.